### PR TITLE
Allow to subscribe to a push plan from the console

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -31,10 +31,11 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import {
   GioAvatarModule,
-  GioClipboardModule
+  GioClipboardModule,
+  GioFormJsonSchemaModule,
   GioIconsModule,
-  GioLoaderModule
-} from "@gravitee/ui-particles-angular";
+  GioLoaderModule,
+} from '@gravitee/ui-particles-angular';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
 
@@ -90,6 +91,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioLoaderModule,
     GioPermissionModule,
     GioTableWrapperModule,
+    GioFormJsonSchemaModule,
     GioAvatarModule,
   ],
   providers: [DatePipe, { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -29,7 +29,12 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { GioClipboardModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import {
+  GioAvatarModule,
+  GioClipboardModule
+  GioIconsModule,
+  GioLoaderModule
+} from "@gravitee/ui-particles-angular";
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
 
@@ -85,6 +90,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioLoaderModule,
     GioPermissionModule,
     GioTableWrapperModule,
+    GioAvatarModule,
   ],
   providers: [DatePipe, { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],
 })

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
@@ -34,11 +34,15 @@
         />
 
         <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayApplication">
-          <mat-option *ngFor="let application of applications$ | async" [value]="application" class="subscription-creation__content__applications__option">
+          <mat-option
+            *ngFor="let application of applications$ | async"
+            [value]="application"
+            class="subscription-creation__content__applications__option"
+          >
             <div class="subscription-creation__content__applications__option__title">
               <gio-avatar [src]="application.picture_url" [name]="application.name" size="32" [roundedBorder]="true"></gio-avatar>
               {{ application.name }}
-              <small>({{application.owner?.displayName}})</small>
+              <small>({{ application.owner?.displayName }})</small>
             </div>
           </mat-option>
           <mat-option *ngIf="(applications$ | async)?.length === 0" disabled>No application matching</mat-option>
@@ -47,7 +51,7 @@
           >Please select an application from the list</mat-error
         >
         <mat-error *ngIf="form.get('selectedApplication').hasError('clientIdRequired')"
-          >JWT and OAUth2 plans require an application with a clientId</mat-error
+          >JWT and OAuth2 plans require an application with a clientId</mat-error
         >
       </mat-form-field>
 
@@ -58,7 +62,7 @@
         arial-label="Select an plan"
         class="subscription-creation__content__plans"
       >
-        <mat-radio-button *ngFor="let plan of plans" [value]="plan" [disabled]="!!plan.generalConditions || plan.mode === 'PUSH'">
+        <mat-radio-button *ngFor="let plan of plans" [value]="plan" [disabled]="!!plan.generalConditions">
           {{ plan.name }}
         </mat-radio-button>
       </mat-radio-group>
@@ -68,6 +72,29 @@
         <input matInput type="text" formControlName="customApiKey" />
         <mat-hint>You can provide a custom API key if you already have one. Leave it blank to get a generated apikey</mat-hint>
       </mat-form-field>
+
+      <ng-container *ngIf="form.get('selectedEntrypoint')">
+        <mat-form-field>
+          <mat-label>Select the entrypoint to subscribe</mat-label>
+          <mat-select formControlName="selectedEntrypoint" placeholder="Select an entrypoint">
+            <mat-option *ngFor="let entrypoint of availableSubscriptionEntrypoints" [value]="entrypoint.type">
+              <mat-icon [svgIcon]="entrypoint.icon"></mat-icon> {{ entrypoint.name }}
+            </mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field class="subscription-creation__content__channel">
+          <mat-label>Channel</mat-label>
+          <input matInput type="text" formControlName="channel" />
+          <mat-hint>You can provide a channel for the subscription</mat-hint>
+        </mat-form-field>
+
+        <gio-form-json-schema
+          *ngIf="form.get('entrypointConfiguration') && selectedSchema"
+          [jsonSchema]="selectedSchema"
+          formControlName="entrypointConfiguration"
+        ></gio-form-json-schema>
+      </ng-container>
     </ng-container>
     <ng-template #noPlansForCreation>
       <div>You don't have any available plan. To subscribe, you need to have at least one published plan whose type is not Keyless.</div>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
@@ -69,11 +69,11 @@
   <mat-dialog-actions class="actions">
     <button class="actions__cancelBtn" mat-flat-button [mat-dialog-close]="false">Cancel</button>
     <button
-      class="actions__saveBtn"
+      class="actions__createBtn"
       color="primary"
       mat-stroked-button
       role="dialog"
-      (click)="onSave()"
+      (click)="onCreate()"
       [disabled]="this.form.invalid || this.form.pristine"
     >
       Create

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
@@ -20,7 +20,8 @@
 
   <mat-dialog-content class="subscription-creation__content">
     <ng-container *ngIf="plans?.length > 0; else noPlansForCreation">
-      <mat-form-field class="subscription-creation__content__applications" #searchField>
+      <label id="application-label">Select an application</label>
+      <mat-form-field class="subscription-creation__content__applications" #searchField aria-labelledby="application-label">
         <mat-icon matPrefix>search</mat-icon>
         <mat-label>Search an application by name</mat-label>
         <!--Using focus workaround to avoid label overlapping border https://github.com/angular/components/issues/15027#issuecomment-1335147036-->
@@ -33,13 +34,20 @@
         />
 
         <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayApplication">
-          <mat-option *ngFor="let application of applications$ | async" [value]="application">
-            {{ application.name }}
+          <mat-option *ngFor="let application of applications$ | async" [value]="application" class="subscription-creation__content__applications__option">
+            <div class="subscription-creation__content__applications__option__title">
+              <gio-avatar [src]="application.picture_url" [name]="application.name" size="32" [roundedBorder]="true"></gio-avatar>
+              {{ application.name }}
+              <small>({{application.owner?.displayName}})</small>
+            </div>
           </mat-option>
           <mat-option *ngIf="(applications$ | async)?.length === 0" disabled>No application matching</mat-option>
         </mat-autocomplete>
         <mat-error *ngIf="form.get('selectedApplication').hasError('selectionRequired')"
           >Please select an application from the list</mat-error
+        >
+        <mat-error *ngIf="form.get('selectedApplication').hasError('clientIdRequired')"
+          >JWT and OAUth2 plans require an application with a clientId</mat-error
         >
       </mat-form-field>
 
@@ -62,7 +70,7 @@
       </mat-form-field>
     </ng-container>
     <ng-template #noPlansForCreation>
-      <div>No plans available to subscribe</div>
+      <div>You don't have any available plan. To subscribe, you need to have at least one published plan whose type is not Keyless.</div>
     </ng-template>
   </mat-dialog-content>
 

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
@@ -12,6 +12,17 @@
       align-items: flex-start;
       gap: 8px;
     }
+
+    &__applications__option {
+      border: solid 1px lightgrey;
+
+      &__title {
+        display: flex;
+        flex-direction: row;
+        gap: 8px;
+        align-items: center;
+      }
+    }
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.spec.ts
@@ -21,15 +21,33 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { CreateSubscription, Entrypoint, fakePlanV4, Plan } from "../../../../../../entities/management-api-v2";
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { set } from 'lodash';
+
+import { ApiPortalSubscriptionCreationDialogHarness } from './api-portal-subscription-creation-dialog.harness';
 import {
   ApiPortalSubscriptionCreationDialogComponent,
   ApiPortalSubscriptionCreationDialogData,
   ApiPortalSubscriptionCreationDialogResult,
 } from './api-portal-subscription-creation-dialog.component';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../../shared/testing';
 import { ApiPortalSubscriptionsModule } from '../../api-portal-subscriptions.module';
-import { ApiPortalSubscriptionCreationDialogHarness } from './api-portal-subscription-creation-dialog.harness';
+import {
+  ConnectorPlugin,
+  CreateSubscription,
+  Entrypoint,
+  entrypointsGetResponse,
+  fakeApiV4,
+  fakePlanV4,
+  Plan,
+} from '../../../../../../entities/management-api-v2';
+import { Application } from '../../../../../../entities/application/application';
+import { PagedResult } from '../../../../../../entities/pagedResult';
+import { fakeApplication } from '../../../../../../entities/application/Application.fixture';
 
 @Component({
   selector: 'gio-dialog-test',
@@ -37,28 +55,30 @@ import { ApiPortalSubscriptionCreationDialogHarness } from './api-portal-subscri
 })
 class TestComponent {
   public plans?: Plan[];
+  public availableSubscriptionEntrypoints?: Entrypoint[];
   public subscriptionToCreate: CreateSubscription;
+  public dialog: MatDialogRef<ApiPortalSubscriptionCreationDialogComponent>;
   constructor(private readonly matDialog: MatDialog) {}
 
   public openDialog() {
-    this.matDialog
-      .open<
-        ApiPortalSubscriptionCreationDialogComponent,
-        ApiPortalSubscriptionCreationDialogData,
-        ApiPortalSubscriptionCreationDialogResult
-      >(ApiPortalSubscriptionCreationDialogComponent, {
-        data: {
-          plans: this.plans,
-        },
-        role: 'alertdialog',
-        id: 'testDialog',
-      })
-      .afterClosed()
-      .subscribe((result) => {
-        if (result) {
-          this.subscriptionToCreate = result.subscriptionToCreate;
-        }
-      });
+    this.dialog = this.matDialog.open<
+      ApiPortalSubscriptionCreationDialogComponent,
+      ApiPortalSubscriptionCreationDialogData,
+      ApiPortalSubscriptionCreationDialogResult
+    >(ApiPortalSubscriptionCreationDialogComponent, {
+      data: {
+        plans: this.plans,
+        availableSubscriptionEntrypoints: this.availableSubscriptionEntrypoints,
+      },
+      role: 'alertdialog',
+      id: 'testDialog',
+    });
+
+    this.dialog.afterClosed().subscribe((result) => {
+      if (result) {
+        this.subscriptionToCreate = result.subscriptionToCreate;
+      }
+    });
   }
 }
 
@@ -66,51 +86,50 @@ describe('Subscription creation dialog', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
   let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
 
-  describe('With custom apikey enabled', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestComponent],
-        imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule],
-        providers: [
-          {
-            provide: InteractivityChecker,
-            useValue: {
-              isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
-              isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
-            },
-          },
-          {
-            provide: 'Constants',
-            useValue: {
-              env: {
-                settings: {
-                  plan: {
-                    security: {
-                      customApiKey: {
-                        enabled: true,
-                      },
-                    },
-                  },
-                },
+  describe('Test customApikey input', () => {
+    describe('With custom apikey enabled', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestComponent],
+          imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
+          providers: [
+            {
+              provide: InteractivityChecker,
+              useValue: {
+                isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+                isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
               },
             },
-          },
-        ],
+            {
+              provide: 'Constants',
+              useFactory: () => {
+                const constants = CONSTANTS_TESTING;
+                set(constants, 'env.settings.plan.security', {
+                  customApiKey: { enabled: true },
+                });
+                return constants;
+              },
+            },
+          ],
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        httpTestingController = TestBed.inject(HttpTestingController);
+        fixture.detectChanges();
+        component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
       });
-      fixture = TestBed.createComponent(TestComponent);
-      component = fixture.componentInstance;
-      loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-    });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
+      afterEach(() => {
+        jest.clearAllMocks();
+        httpTestingController.verify();
+      });
 
-    describe('Test customApikey input', () => {
-      it('should have input with API KEY Plan', async () => {
+      it('should have input with API Key Plan', async () => {
         const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
         component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
         await componentTestingOpenDialog();
 
         const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
@@ -120,9 +139,84 @@ describe('Subscription creation dialog', () => {
 
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
       });
+      it('should have input when selecting non API Key plan and then select an API Key Plan', async () => {
+        const apiKeyPlanV4 = fakePlanV4({
+          name: 'API Key plan',
+          mode: 'STANDARD',
+          security: { type: 'API_KEY' },
+          generalConditions: undefined,
+        });
+        const jwtPlanV4 = fakePlanV4({ name: 'JWT Plan', mode: 'STANDARD', security: { type: 'JWT' }, generalConditions: undefined });
+        component.plans = [apiKeyPlanV4, jwtPlanV4];
+        component.availableSubscriptionEntrypoints = [];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+        await harness.choosePlan(jwtPlanV4.name);
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+        await harness.choosePlan(apiKeyPlanV4.name);
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
+      });
       it('should not have input with OAUTH2 Plan', async () => {
         const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'OAUTH2' }, generalConditions: undefined });
         component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+        await harness.choosePlan(planV4.name);
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      });
+    });
+    describe('With custom apikey disabled', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestComponent],
+          imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
+          providers: [
+            {
+              provide: InteractivityChecker,
+              useValue: {
+                isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+                isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
+              },
+            },
+            {
+              provide: 'Constants',
+              useFactory: () => {
+                const constants = CONSTANTS_TESTING;
+                set(constants, 'env.settings.plan.security', {
+                  customApiKey: { enabled: false },
+                });
+                return constants;
+              },
+            },
+          ],
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        httpTestingController = TestBed.inject(HttpTestingController);
+        fixture.detectChanges();
+        component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+        httpTestingController.verify();
+      });
+
+      it('should not have input with API Key Plan', async () => {
+        const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+        component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
         await componentTestingOpenDialog();
 
         const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
@@ -135,11 +229,11 @@ describe('Subscription creation dialog', () => {
     });
   });
 
-  describe('With custom apikey disabled', () => {
+  describe('Test Push plan form', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TestComponent],
-        imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule],
+        imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
         providers: [
           {
             provide: InteractivityChecker,
@@ -148,50 +242,199 @@ describe('Subscription creation dialog', () => {
               isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
             },
           },
-          {
-            provide: 'Constants',
-            useValue: {
-              env: {
-                settings: {
-                  plan: {
-                    security: {
-                      customApiKey: {
-                        enabled: false,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
         ],
       });
       fixture = TestBed.createComponent(TestComponent);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      fixture.detectChanges();
       component = fixture.componentInstance;
       loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     });
 
     afterEach(() => {
       jest.clearAllMocks();
+      httpTestingController.verify();
     });
 
-    it('should not have input with API KEY Plan', async () => {
-      const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+    it('should have Push Plan configuration form', async () => {
+      const planV4 = fakePlanV4({ mode: 'PUSH', generalConditions: undefined });
+      const apiV4 = fakeApiV4({ listeners: [{ type: 'SUBSCRIPTION', entrypoints: [{ type: 'webhook' }] }] });
       component.plans = [planV4];
+      component.availableSubscriptionEntrypoints = apiV4.listeners[0].entrypoints;
       await componentTestingOpenDialog();
+      expectListEntrypoints(entrypointsGetResponse);
 
       const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
-      expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      expect(await harness.isChannelInputDisplayed()).toBeFalsy();
+      expect(await harness.isEntrypointSelectDisplayed()).toBeFalsy();
+      expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeFalsy();
 
       await harness.choosePlan(planV4.name);
 
-      expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      expect(await harness.isChannelInputDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointSelectDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeFalsy();
+
+      await harness.selectEntrypoint('Webhook');
+      expectEntrypointSubscriptionSchema('webhook');
+
+      expect(await harness.isChannelInputDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointSelectDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeTruthy();
+    });
+
+    it('should remove Push Plan configuration form when select another plan', async () => {
+      const pushPlanV4 = fakePlanV4({ name: 'push plan', mode: 'PUSH', generalConditions: undefined });
+      const jwtPlanV4 = fakePlanV4({ name: 'JWT plan', mode: 'STANDARD', security: { type: 'JWT' }, generalConditions: undefined });
+      const apiV4 = fakeApiV4({ listeners: [{ type: 'SUBSCRIPTION', entrypoints: [{ type: 'webhook' }] }] });
+      component.plans = [pushPlanV4, jwtPlanV4];
+      component.availableSubscriptionEntrypoints = apiV4.listeners[0].entrypoints;
+      await componentTestingOpenDialog();
+      expectListEntrypoints(entrypointsGetResponse);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+      await harness.choosePlan(pushPlanV4.name);
+      await harness.selectEntrypoint('Webhook');
+      expectEntrypointSubscriptionSchema('webhook');
+
+      expect(await harness.isChannelInputDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointSelectDisplayed()).toBeTruthy();
+      expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeTruthy();
+
+      await harness.choosePlan(jwtPlanV4.name);
+      expect(await harness.isChannelInputDisplayed()).toBeFalsy();
+      expect(await harness.isEntrypointSelectDisplayed()).toBeFalsy();
+      expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeFalsy();
+    });
+  });
+
+  describe('Test JWT & OAuth2 plans', () => {
+    describe('Test clientId', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestComponent],
+          imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
+          providers: [
+            {
+              provide: InteractivityChecker,
+              useValue: {
+                isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+                isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
+              },
+            },
+          ],
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        httpTestingController = TestBed.inject(HttpTestingController);
+        fixture.detectChanges();
+        component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+        httpTestingController.verify();
+      });
+
+      it('Should not have error if application has clientId', async () => {
+        const applicationWithClientId = fakeApplication({ name: 'withClientId', settings: { app: { client_id: 'clientId' } } });
+        const jwtPlanV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'JWT' }, generalConditions: undefined });
+        component.plans = [jwtPlanV4];
+        component.availableSubscriptionEntrypoints = [];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+
+        await harness.searchApplication('withClientId');
+        expectApplicationsSearch('withClientId', [applicationWithClientId]);
+        await harness.selectApplication(applicationWithClientId.name);
+
+        await harness.choosePlan(jwtPlanV4.name);
+
+        const errors = fixture.componentInstance.dialog.componentInstance.form.get('selectedApplication').errors;
+        expect(errors).toBeNull();
+
+        expect(await (await harness.getCreateButton()).isDisabled()).toBeFalsy();
+      });
+
+      it('Should have error if application has no clientId', async () => {
+        const applicationWithoutClientId = fakeApplication({ name: 'withoutClientId', settings: { app: {} } });
+        const jwtPlanV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'JWT' }, generalConditions: undefined });
+        component.plans = [jwtPlanV4];
+        component.availableSubscriptionEntrypoints = [];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+
+        await harness.searchApplication('withoutClientId');
+        expectApplicationsSearch('withoutClientId', [applicationWithoutClientId]);
+        await harness.selectApplication(applicationWithoutClientId.name);
+
+        await harness.choosePlan(jwtPlanV4.name);
+
+        const errors = fixture.componentInstance.dialog.componentInstance.form.get('selectedApplication').errors;
+        expect(errors).toEqual({ clientIdRequired: true });
+
+        expect(await (await harness.getCreateButton()).isDisabled()).toBeTruthy();
+      });
     });
   });
 
   async function componentTestingOpenDialog() {
     const openDialogButton = await loader.getHarness(MatButtonHarness);
     await openDialogButton.click();
+    fixture.detectChanges();
+  }
+
+  function expectListEntrypoints(entrypoints: ConnectorPlugin[]) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`,
+        method: 'GET',
+      })
+      .flush(entrypoints);
+    fixture.detectChanges();
+  }
+
+  function expectEntrypointSubscriptionSchema(entrypointId: string) {
+    const response: GioJsonSchema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        foo: {
+          type: 'string',
+        },
+      },
+    };
+
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`,
+        method: 'GET',
+      })
+      .flush(response);
+    fixture.detectChanges();
+  }
+
+  function expectApplicationsSearch(searchTerm: string, applications: Application[]) {
+    const response: PagedResult<Application> = new PagedResult<Application>();
+    response.populate({
+      data: applications,
+      page: {
+        per_page: 20,
+        total_elements: applications.length,
+        current: 1,
+        size: applications.length,
+        total_pages: 1,
+      },
+      metadata: {},
+    });
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/_paged?page=1&size=20&status=ACTIVE&query=${searchTerm}&order=name`,
+        method: 'GET',
+      })
+      .flush(response);
     fixture.detectChanges();
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.spec.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CreateSubscription, Entrypoint, fakePlanV4, Plan } from "../../../../../../entities/management-api-v2";
+import { MatDialog } from '@angular/material/dialog';
+import {
+  ApiPortalSubscriptionCreationDialogComponent,
+  ApiPortalSubscriptionCreationDialogData,
+  ApiPortalSubscriptionCreationDialogResult,
+} from './api-portal-subscription-creation-dialog.component';
+import { ApiPortalSubscriptionsModule } from '../../api-portal-subscriptions.module';
+import { ApiPortalSubscriptionCreationDialogHarness } from './api-portal-subscription-creation-dialog.harness';
+
+@Component({
+  selector: 'gio-dialog-test',
+  template: `<button mat-button id="open-dialog" (click)="openDialog()">Open dialog</button>`,
+})
+class TestComponent {
+  public plans?: Plan[];
+  public subscriptionToCreate: CreateSubscription;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionCreationDialogComponent,
+        ApiPortalSubscriptionCreationDialogData,
+        ApiPortalSubscriptionCreationDialogResult
+      >(ApiPortalSubscriptionCreationDialogComponent, {
+        data: {
+          plans: this.plans,
+        },
+        role: 'alertdialog',
+        id: 'testDialog',
+      })
+      .afterClosed()
+      .subscribe((result) => {
+        if (result) {
+          this.subscriptionToCreate = result.subscriptionToCreate;
+        }
+      });
+  }
+}
+
+describe('Subscription creation dialog', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+
+  describe('With custom apikey enabled', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestComponent],
+        imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule],
+        providers: [
+          {
+            provide: InteractivityChecker,
+            useValue: {
+              isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+              isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
+            },
+          },
+          {
+            provide: 'Constants',
+            useValue: {
+              env: {
+                settings: {
+                  plan: {
+                    security: {
+                      customApiKey: {
+                        enabled: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('Test customApikey input', () => {
+      it('should have input with API KEY Plan', async () => {
+        const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+        component.plans = [planV4];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+        await harness.choosePlan(planV4.name);
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
+      });
+      it('should not have input with OAUTH2 Plan', async () => {
+        const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'OAUTH2' }, generalConditions: undefined });
+        component.plans = [planV4];
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+        await harness.choosePlan(planV4.name);
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      });
+    });
+  });
+
+  describe('With custom apikey disabled', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestComponent],
+        imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule],
+        providers: [
+          {
+            provide: InteractivityChecker,
+            useValue: {
+              isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+              isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
+            },
+          },
+          {
+            provide: 'Constants',
+            useValue: {
+              env: {
+                settings: {
+                  plan: {
+                    security: {
+                      customApiKey: {
+                        enabled: false,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+      fixture = TestBed.createComponent(TestComponent);
+      component = fixture.componentInstance;
+      loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should not have input with API KEY Plan', async () => {
+      const planV4 = fakePlanV4({ mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+      component.plans = [planV4];
+      await componentTestingOpenDialog();
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+      expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+
+      await harness.choosePlan(planV4.name);
+
+      expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+    });
+  });
+
+  async function componentTestingOpenDialog() {
+    const openDialogButton = await loader.getHarness(MatButtonHarness);
+    await openDialogButton.click();
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
@@ -81,15 +81,15 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
     );
   }
 
-  onSave() {
-    this.dialogRef.close({
+  onCreate() {
+    const dialogResult = {
       subscriptionToCreate: {
         planId: this.form.getRawValue().selectedPlan.id,
         applicationId: this.form.getRawValue().selectedApplication.id,
-        customApiKey:
-          this.shouldDisplayCustomApiKey() && this.form.getRawValue().customApiKey ? this.form.getRawValue().customApiKey : undefined,
+        ...(this.shouldDisplayCustomApiKey()  && this.form.getRawValue().customApiKey ? { customApiKey: this.form.getRawValue().customApiKey } : undefined),
       },
-    });
+    };
+    this.dialogRef.close(dialogResult);
   }
 
   ngOnDestroy() {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
@@ -45,9 +45,22 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   public applications$: Observable<Application[]> = new Observable<Application[]>();
   public showGeneralConditionsMsg: boolean;
   public canUseCustomApikey: boolean;
+
+  applicationSelectionRequiredValidator: ValidatorFn = (control): ValidationErrors | null => {
+    const value = control?.value;
+    if (!value || typeof value === 'string' || !('id' in value) || !('name' in value)) {
+      return { selectionRequired: true };
+    }
+    if (this.form.get('selectedPlan').value?.security?.type === 'JWT' || this.form.get('selectedPlan').value?.security?.type === 'OAUTH2') {
+      return value.settings?.app?.client_id ? null : { clientIdRequired: true }
+    }
+
+    return null;
+  };
+
   public form: FormGroup = new FormGroup({
     selectedPlan: new FormControl(undefined, [Validators.required]),
-    selectedApplication: new FormControl(undefined, [applicationSelectionRequiredValidator]),
+    selectedApplication: new FormControl(undefined, [this.applicationSelectionRequiredValidator]),
   });
 
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
@@ -106,10 +119,3 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   }
 }
 
-const applicationSelectionRequiredValidator: ValidatorFn = (control): ValidationErrors | null => {
-  const value = control?.value;
-  if (value && typeof value !== 'string' && 'id' in value && 'name' in value) {
-    return null;
-  }
-  return { selectionRequired: true };
-};

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.harness.ts
@@ -18,28 +18,49 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 import { MatRadioGroupHarness } from '@angular/material/radio/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 
 export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness {
   static hostSelector = 'api-portal-subscription-creation-dialog';
 
   protected getApplicationAutocomplete = this.locatorFor(MatAutocompleteHarness);
   protected getInputApplicationSearch = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="selectedApplication"]' }));
+  public getSelectedApplicationFormField = this.locatorFor(
+    MatFormFieldHarness.with({ selector: '.subscription-creation__content__applications' }),
+  );
   protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
   protected getCustomApikeyInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="customApiKey"]' }));
+  protected getSelectEntrypointSelect = this.locatorForOptional(
+    MatSelectHarness.with({ selector: '[formControlName="selectedEntrypoint"]' }),
+  );
+  protected getChannelInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="channel"]' }));
+  protected entrypointConfigurationForm = this.locatorForOptional('gio-form-json-schema');
 
   protected getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
-  protected getCreateButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__createBtn' }));
+  public getCreateButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__createBtn' }));
 
+  // Applications
   public async searchApplication(applicationNameToSearch: string) {
-    const matAutocompleteHarness = await this.getInputApplicationSearch();
-    return await matAutocompleteHarness.setValue(applicationNameToSearch);
+    const matInputHarness = await this.getInputApplicationSearch();
+    return await matInputHarness.setValue(applicationNameToSearch);
   }
 
   public async selectApplication(applicationName: string) {
     const matAutocompleteHarness = await this.getApplicationAutocomplete();
-    return await matAutocompleteHarness.selectOption({ text: applicationName });
+    const regex = new RegExp(`.*${applicationName}.*`);
+    await matAutocompleteHarness.selectOption({ text: regex });
   }
 
+  public async getApplicationErrors() {
+    const selectedApplicationFormField = await this.getSelectedApplicationFormField();
+    if (await selectedApplicationFormField.hasErrors()) {
+      return await selectedApplicationFormField.getTextErrors();
+    }
+    return [];
+  }
+
+  // Plans
   public async getRadioButtons() {
     return (await this.getPlansRadioGroup()).getRadioButtons();
   }
@@ -49,6 +70,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
     return await matRadioGroupHarness.checkRadioButton({ label: planName });
   }
 
+  // Custom API Key
   public async isCustomApiKeyInputDisplayed() {
     const matInputHarness = await this.getCustomApikeyInput();
     return matInputHarness !== null;
@@ -57,6 +79,31 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
   public async addCustomKey(customApikey: string) {
     const matInputHarness = await this.getCustomApikeyInput();
     return await matInputHarness.setValue(customApikey);
+  }
+
+  // PUSH Plan
+  public async isEntrypointSelectDisplayed() {
+    const matSelectHarness = await this.getSelectEntrypointSelect();
+    return matSelectHarness !== null;
+  }
+
+  public async selectEntrypoint(entrypointId: string) {
+    const matSelectHarness = await this.getSelectEntrypointSelect();
+    return await matSelectHarness.clickOptions({ text: entrypointId });
+  }
+
+  public async isChannelInputDisplayed() {
+    const matInputHarness = await this.getChannelInput();
+    return matInputHarness !== null;
+  }
+
+  public async addChannel(channel: string) {
+    const matInputHarness = await this.getChannelInput();
+    return await matInputHarness.setValue(channel);
+  }
+
+  public async isEntrypointConfigurationFormDisplayed() {
+    return (await this.entrypointConfigurationForm()) !== null;
   }
 
   public async cancelSubscription() {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.harness.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
+import { MatRadioGroupHarness } from '@angular/material/radio/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+
+export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness {
+  static hostSelector = 'api-portal-subscription-creation-dialog';
+
+  protected getApplicationAutocomplete = this.locatorFor(MatAutocompleteHarness);
+  protected getInputApplicationSearch = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="selectedApplication"]' }));
+  protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
+  protected getCustomApikeyInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="customApiKey"]' }));
+
+  protected getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
+  protected getCreateButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__createBtn' }));
+
+  public async searchApplication(applicationNameToSearch: string) {
+    const matAutocompleteHarness = await this.getInputApplicationSearch();
+    return await matAutocompleteHarness.setValue(applicationNameToSearch);
+  }
+
+  public async selectApplication(applicationName: string) {
+    const matAutocompleteHarness = await this.getApplicationAutocomplete();
+    return await matAutocompleteHarness.selectOption({ text: applicationName });
+  }
+
+  public async getRadioButtons() {
+    return (await this.getPlansRadioGroup()).getRadioButtons();
+  }
+
+  public async choosePlan(planName: string) {
+    const matRadioGroupHarness = await this.getPlansRadioGroup();
+    return await matRadioGroupHarness.checkRadioButton({ label: planName });
+  }
+
+  public async isCustomApiKeyInputDisplayed() {
+    const matInputHarness = await this.getCustomApikeyInput();
+    return matInputHarness !== null;
+  }
+
+  public async addCustomKey(customApikey: string) {
+    const matInputHarness = await this.getCustomApikeyInput();
+    return await matInputHarness.setValue(customApikey);
+  }
+
+  public async cancelSubscription() {
+    const matButtonHarness = await this.getCancelButton();
+    return await matButtonHarness.click();
+  }
+
+  public async createSubscription() {
+    const matButtonHarness = await this.getCreateButton();
+    return await matButtonHarness.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
@@ -39,28 +39,28 @@
 
 <mat-card class="subscriptions__filters" [formGroup]="filtersForm">
   <div class="subscriptions__filters__inputs">
-    <mat-form-field class="subscriptions__filters__field">
+    <mat-form-field class="subscriptions__filters__inputs__field">
       <mat-label>Plan</mat-label>
       <mat-select formControlName="planIds" [multiple]="true">
         <mat-option *ngFor="let plan of plans" [value]="plan.id">{{ plan.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="subscriptions__filters__field">
+    <mat-form-field class="subscriptions__filters__inputs__field">
       <mat-label>Application</mat-label>
       <mat-select formControlName="applicationIds" [multiple]="true">
         <mat-option *ngFor="let application of applications$ | async" [value]="application.id">{{ application.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="subscriptions__filters__field">
+    <mat-form-field class="subscriptions__filters__inputs__field">
       <mat-label>Status</mat-label>
       <mat-select formControlName="statuses" [multiple]="true">
         <mat-option *ngFor="let status of statuses" [value]="status.id">{{ status.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="subscriptions__filters__field">
+    <mat-form-field class="subscriptions__filters__inputs__field">
       <mat-label>API key</mat-label>
       <input matInput formControlName="apikey" />
     </mat-form-field>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.scss
@@ -44,7 +44,7 @@ $foreground: map.get(gio.$mat-theme, foreground);
       gap: 8px;
       &__field {
         flex: 1;
-          padding-bottom: 0px;
+        padding-bottom: 0px;
       }
     }
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.scss
@@ -35,21 +35,16 @@ $foreground: map.get(gio.$mat-theme, foreground);
 
   &__filters {
     display: flex;
+    flex-direction: column;
     margin-bottom: 8px;
 
-    &__field {
-      padding-bottom: 0px;
-      margin-right: 8px;
-    }
-
-    &__buttons {
-      flex: 1;
+    &__inputs {
       display: flex;
-      justify-content: flex-end;
-      align-items: center;
-
-      & button {
-        margin-left: 8px;
+      flex-direction: row;
+      gap: 8px;
+      &__field {
+        flex: 1;
+          padding-bottom: 0px;
       }
     }
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.spec.ts
@@ -270,7 +270,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
       const planV4 = fakePlanV4({ generalConditions: undefined });
       const application = fakeApplication();
 
-      await initComponent([], anAPI, [planV4]);
+      await initComponent([], fakeApiV4({ id: API_ID, listeners: [] }), [planV4]);
       const harness = await loader.getHarness(ApiPortalSubscriptionListHarness);
 
       const createSubBtn = await harness.getCreateSubscriptionButton();
@@ -302,7 +302,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
     }));
 
     it('should not create subscription on cancel', fakeAsync(async () => {
-      await initComponent([]);
+      await initComponent([], fakeApiV4({ id: API_ID, listeners: [] }));
 
       const harness = await loader.getHarness(ApiPortalSubscriptionListHarness);
       const createSubBtn = await harness.getCreateSubscriptionButton();

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.ts
@@ -27,7 +27,7 @@ import { GioTableWrapperFilters } from '../../../../../shared/components/gio-tab
 import { ApiSubscriptionV2Service } from '../../../../../services-ngx/api-subscription-v2.service';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
-import { Api, Plan } from '../../../../../entities/management-api-v2';
+import { Api, ApiV4, Plan } from '../../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
 import {
@@ -245,6 +245,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
         role: 'alertdialog',
         id: 'createSubscriptionDialog',
         data: {
+          availableSubscriptionEntrypoints: this.getApiSubscriptionEntrypoints(this.api),
           plans: this.plans.filter((plan) => plan.status),
         },
       })
@@ -303,5 +304,13 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
         apikey: undefined,
       },
     });
+  }
+
+  private getApiSubscriptionEntrypoints(api: Api) {
+    if (api.definitionVersion !== 'V4') {
+      return [];
+    }
+
+    return (api as ApiV4).listeners.filter((listener) => listener.type === 'SUBSCRIPTION').flatMap((listener) => listener.entrypoints);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
@@ -29,6 +29,7 @@ export class ApiPortalSubscriptionListHarness extends ComponentHarness {
   public getResetFilterButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Reset filters"]' }));
 
   public async openCreationDialog(): Promise<void> {
-    return this.getCreateSubscriptionButton().then((btn) => btn.click());
+    const matButtonHarness = await this.getCreateSubscriptionButton();
+    return await matButtonHarness.click();
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
@@ -15,6 +15,7 @@
  */
 import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 
 import { ConnectorPluginsV2Service } from './connector-plugins-v2.service';
 
@@ -106,6 +107,32 @@ describe('Installation Plugins Service', () => {
             method: 'GET',
           })
           .flush(fakeConnectors);
+      });
+    });
+
+    describe('getSubscriptionSchema', () => {
+      it('should call the API', (done) => {
+        const expectedSchema: GioJsonSchema = {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+            },
+          },
+        };
+
+        installationPluginsService.getEntrypointPluginSubscriptionSchema('entrypoint-id').subscribe((schema) => {
+          expect(schema).toMatchObject(expectedSchema);
+          done();
+        });
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/entrypoint-id/subscription-schema`,
+            method: 'GET',
+          })
+          .flush(expectedSchema);
       });
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
@@ -68,6 +68,10 @@ export class ConnectorPluginsV2Service {
     return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/schema`);
   }
 
+  getEntrypointPluginSubscriptionSchema(entrypointId: string): Observable<GioJsonSchema> {
+    return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`);
+  }
+
   getEntrypointPluginMoreInformation(entrypointId: string): Observable<MoreInformation> {
     return this.http.get<MoreInformation>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/more-information`);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <gravitee-entrypoint-http-get.version>1.0.0-alpha.6</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.0.0-alpha.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>3.1.0-alpha.3</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>1.1.0-alpha.4</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>1.1.0-alpha.5</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.0-alpha.3</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>1.3.0-alpha.9</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>1.2.0-alpha.9</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2023

## Description

- Creation of a harness for the create subscription component
- Minor UI improvement
  - add a label on top of the application selection field
  - add a validator to detect if the selected application has a clientId when a JWT or OAUTH2 plan has been selected.
  - move "reset filters" button under the filter fields.
  - add icon and owner name in the list of applications
- Handle GioJSonSchemaForm component and subscription schema for push plan.

## Additional information

Before:
<img width="1217" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/11a34a03-6127-4dde-8722-3a1f95261d94">
<img width="645" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/0780b89c-41ac-4e92-bd98-4f603e82e842">

After:
<img width="1212" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/f0e4440a-42de-428d-823b-b0f06421d954">
<img width="619" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/fa1008e8-7eae-482e-93c7-c3533360a656">
<img width="619" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/640879bb-f814-4719-a607-442411724551">
<img width="626" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/5f0993d8-e088-4ec7-a435-302e180ca1c2">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bjdzmguyyh.chromatic.com)
<!-- Storybook placeholder end -->
