### PR TITLE
chore: add logs to be able to investigate issues while an exception o…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/processor/chain/AbstractStreamableProcessorChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/processor/chain/AbstractStreamableProcessorChain.java
@@ -20,8 +20,11 @@ import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
 import io.gravitee.gateway.api.stream.WriteStream;
+import io.gravitee.gateway.core.endpoint.lifecycle.impl.EndpointGroupLifecycleManager;
 import io.gravitee.gateway.core.processor.RuntimeProcessorFailure;
 import io.gravitee.gateway.core.processor.StreamableProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -30,6 +33,8 @@ import io.gravitee.gateway.core.processor.StreamableProcessor;
 public abstract class AbstractStreamableProcessorChain<T, S, P extends StreamableProcessor<T, S>>
     extends AbstractProcessorChain<T, P>
     implements StreamableProcessorChain<T, S, P> {
+
+    private final Logger logger = LoggerFactory.getLogger(AbstractStreamableProcessorChain.class);
 
     private P streamableProcessorChain;
     private Handler<ProcessorFailure> streamErrorHandler;
@@ -61,6 +66,7 @@ public abstract class AbstractStreamableProcessorChain<T, S, P extends Streamabl
                     .streamErrorHandler(failure -> streamErrorHandler.handle(failure))
                     .handle(data);
             } catch (Exception ex) {
+                logger.error("Unexpected error while handling the streamable processor chain", ex);
                 errorHandler.handle(new RuntimeProcessorFailure(ex.getMessage()));
             }
         } else {


### PR DESCRIPTION
…ccurs during the processing of a streamable processor chain

## Issue

https://gravitee.atlassian.net/browse/APIM-1965

## Description

Added an error log when an issue occur while processing the streamable chain. Currently the error is sent back to the payload of the response but it would be better to have it in our logs to investigate.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aapycuzral.chromatic.com)
<!-- Storybook placeholder end -->
