### PR TITLE
Management API v2 - set deploymentState to API output

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
@@ -64,7 +64,13 @@ export class Step2Entrypoints1ListComponent implements OnInit, OnDestroy {
       .listAsyncEntrypointPlugins()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((entrypointPlugins) => {
-        this.entrypoints = entrypointPlugins.map((entrypoint) => fromConnector(this.iconService, entrypoint));
+        this.entrypoints = entrypointPlugins
+          .map((entrypoint) => fromConnector(this.iconService, entrypoint))
+          .sort((entrypoint1, entrypoint2) => {
+            const name1 = entrypoint1.name.toUpperCase();
+            const name2 = entrypoint2.name.toUpperCase();
+            return name1 < name2 ? -1 : name1 > name2 ? 1 : 0;
+          });
         this.changeDetectorRef.detectChanges();
       });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -563,8 +563,9 @@ public class ApiResource extends AbstractResource {
     }
 
     private Response apiResponse(GenericApiEntity apiEntity) {
+        boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
         return Response
-            .ok(ApiMapper.INSTANCE.map(apiEntity, uriInfo))
+            .ok(ApiMapper.INSTANCE.map(apiEntity, uriInfo, isSynchronized))
             .tag(Long.toString(apiEntity.getUpdatedAt().getTime()))
             .lastModified(apiEntity.getUpdatedAt())
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -47,6 +47,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
+                - $ref: "#/components/parameters/apiExpandsParam"
             tags:
                 - APIs
             summary: List APIs
@@ -123,6 +124,7 @@ paths:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
                 - $ref: "#/components/parameters/apiSortByParam"
+                - $ref: "#/components/parameters/apiExpandsParam"
             tags:
                 - APIs
             summary: Search APIs
@@ -1826,7 +1828,7 @@ components:
                               type: string
                       state:
                           type: string
-                          description: The status of the API regarding the gateway.
+                          description: The state of the API regarding the gateway(s).
                           example: STARTED
                           enum:
                               - CLOSED
@@ -1834,6 +1836,13 @@ components:
                               - STARTED
                               - STOPPED
                               - STOPPING
+                      deploymentState:
+                            type: string
+                            description: The deployment state of the API regarding the gateway(s).
+                            example: DEPLOYED
+                            enum:
+                                - NEED_REDEPLOY
+                                - DEPLOYED
                       visibility:
                           $ref: "#/components/schemas/Visibility"
                       labels:
@@ -5075,6 +5084,19 @@ components:
             schema:
                 type: integer
                 default: 10
+        ###############################
+        # Other Query Parameters      #
+        ###############################
+        apiExpandsParam:
+          name: expands
+          in: query
+          description: Expansion of data to return in APIs.
+          schema:
+              type: array
+              items:
+                  type: string
+                  enum:
+                      - deploymentState
     responses:
         EnvironmentsResponse:
             description: Page of environments

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -92,12 +92,14 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API)).thenReturn(apiEntity);
         when(apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME)))
             .thenReturn(apiEntity);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), eq(apiEntity))).thenReturn(true);
 
         final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
         assertEquals(OK_200, response.getStatus());
 
         final ApiV4 apiV4 = response.readEntity(ApiV4.class);
         assertEquals(API, apiV4.getId());
+        assertEquals(GenericApi.DeploymentStateEnum.DEPLOYED, apiV4.getDeploymentState());
 
         verify(apiServiceV4)
             .update(
@@ -143,12 +145,14 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
             )
         )
             .thenReturn(apiEntity);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), eq(apiEntity))).thenReturn(false);
 
         final Response response = rootTarget(API).request().put(Entity.json(updateApiV2));
         assertEquals(OK_200, response.getStatus());
 
         final ApiV2 apiV2 = response.readEntity(ApiV2.class);
         assertEquals(API, apiV2.getId());
+        assertEquals(GenericApi.DeploymentStateEnum.NEED_REDEPLOY, apiV2.getDeploymentState());
 
         verify(apiService)
             .update(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -52,6 +52,7 @@ import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.EndpointGroupV4;
+import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -78,6 +79,8 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
     public void should_get_api_V4() throws JsonProcessingException {
         doReturn(this.fakeApiEntityV4()).when(apiSearchServiceV4).findGenericById(GraviteeContext.getExecutionContext(), API);
 
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(false);
+
         final Response response = rootTarget(API).request().get();
 
         assertEquals(OK_200, response.getStatus());
@@ -86,6 +89,7 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
 
         assertNotNull(responseApi);
         assertEquals(API, responseApi.getName());
+        assertEquals(GenericApi.DeploymentStateEnum.NEED_REDEPLOY, responseApi.getDeploymentState());
         assertNotNull(responseApi.getLinks());
         assertNotNull(responseApi.getLinks().getPictureUrl());
         assertTrue(responseApi.getLinks().getPictureUrl().contains("environments/my-env/apis/my-api/picture"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
@@ -273,6 +274,7 @@ public class ApisResource_CreateApiTest extends AbstractResourceTest {
         returnedApi.setName("My beautiful api");
         returnedApi.setApiVersion("v1");
         returnedApi.setDescription("my description");
+        returnedApi.setDefinitionVersion(DefinitionVersion.V4);
         returnedApi.setType(io.gravitee.definition.model.v4.ApiType.PROXY);
 
         var listener = new io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener();
@@ -294,6 +296,7 @@ public class ApisResource_CreateApiTest extends AbstractResourceTest {
 
         when(apiServiceV4.create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME)))
             .thenReturn(returnedApi);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), eq(returnedApi))).thenReturn(true);
 
         final Response response = rootTarget().request().post(Entity.json(Json.encode(api)));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
@@ -301,6 +304,7 @@ public class ApisResource_CreateApiTest extends AbstractResourceTest {
 
         var body = response.readEntity(ApiV4.class);
         assertNotNull(body);
+        assertEquals(GenericApi.DeploymentStateEnum.DEPLOYED, body.getDeploymentState());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiStateService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiStateService.java
@@ -35,4 +35,6 @@ public interface ApiStateService {
     ApiEntity start(ExecutionContext executionContext, String apiId, String userId);
 
     ApiEntity stop(ExecutionContext executionContext, String apiId, String userId);
+
+    boolean isSynchronized(ExecutionContext executionContext, GenericApiEntity apiEntity);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -144,6 +144,7 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.NotifierServiceImpl;
 import io.gravitee.rest.api.service.impl.upgrade.initializer.DefaultMetadataInitializer;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.*;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
@@ -288,6 +289,9 @@ public class ApiServiceImplTest {
     @Mock
     private TagsValidationService tagsValidationService;
 
+    @InjectMocks
+    private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
+
     private ApiMapper apiMapper;
     private ApiService apiService;
     private ApiSearchService apiSearchService;
@@ -377,7 +381,10 @@ public class ApiServiceImplTest {
                 eventService,
                 objectMapper,
                 apiMetadataService,
-                apiValidationService
+                apiValidationService,
+                planSearchService,
+                apiConverter,
+                synchronizationService
             );
         //        when(virtualHostService.sanitizeAndValidate(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
         reset(searchEngineService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -48,11 +48,14 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
+import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiNotificationService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.ApiService;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.gravitee.rest.api.service.v4.FlowService;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
@@ -134,6 +137,12 @@ public class ApiStateServiceImplTest {
     @InjectMocks
     private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
 
+    @Mock
+    private PlanSearchService planSearchService;
+
+    @InjectMocks
+    private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
+
     private Api api;
     private Api updatedApi;
     private ApiStateService apiStateService;
@@ -177,7 +186,10 @@ public class ApiStateServiceImplTest {
                 eventService,
                 objectMapper,
                 apiMetadataService,
-                apiValidationService
+                apiValidationService,
+                planSearchService,
+                apiConverter,
+                synchronizationService
             );
         reset(searchEngineService);
         UserEntity admin = new UserEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -48,6 +48,7 @@ import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApiNotManagedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.*;
 import io.gravitee.rest.api.service.v4.PlanService;
@@ -125,6 +126,12 @@ public class ApiStateServiceImpl_DeployTest {
     @InjectMocks
     private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
 
+    @Mock
+    private PlanSearchService planSearchService;
+
+    @InjectMocks
+    private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
+
     private Api api;
     private Api updatedApi;
     private ApiStateService apiStateService;
@@ -168,7 +175,10 @@ public class ApiStateServiceImpl_DeployTest {
                 eventService,
                 objectMapper,
                 apiMetadataService,
-                apiValidationService
+                apiValidationService,
+                planSearchService,
+                apiConverter,
+                synchronizationService
             );
         reset(searchEngineService);
         UserEntity admin = new UserEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -1,0 +1,493 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static io.gravitee.rest.api.model.EventType.PUBLISH_API;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.PropertyFilter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.repository.management.api.ApiQualityRuleRepository;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.EventEntity;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.converter.ApiConverter;
+import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.processor.SynchronizationService;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.v4.ApiService;
+import io.gravitee.rest.api.service.v4.PlanService;
+import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
+import io.gravitee.rest.api.service.v4.mapper.CategoryMapper;
+import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
+import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiStateServiceImpl_IsSynchronizedTest {
+
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PlanService planService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private PrimaryOwnerService primaryOwnerService;
+
+    @Mock
+    private ApiNotificationService apiNotificationService;
+
+    @Mock
+    private ApiSearchService apiSearchService;
+
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private ApiValidationService apiValidationService;
+
+    @Mock
+    private ApiConverter apiConverter;
+
+    @Mock
+    private PlanSearchService planSearchService;
+
+    @InjectMocks
+    private SynchronizationService synchronizationService = Mockito.spy(new SynchronizationService(this.objectMapper));
+
+    private ApiStateService apiStateService;
+
+    @AfterClass
+    public static void cleanSecurityContextHolder() {
+        // reset authentication to avoid side effect during test executions.
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
+        );
+    }
+
+    @Before
+    public void setUp() {
+        PropertyFilter apiMembershipTypeFilter = new ApiPermissionFilter();
+        objectMapper.setFilterProvider(
+            new SimpleFilterProvider(Collections.singletonMap("apiMembershipTypeFilter", apiMembershipTypeFilter))
+        );
+
+        ApiMapper apiMapper = new ApiMapper(
+            new ObjectMapper(),
+            planService,
+            flowService,
+            parameterService,
+            workflowService,
+            new CategoryMapper(categoryService)
+        );
+        GenericApiMapper genericApiMapper = new GenericApiMapper(apiMapper, apiConverter);
+        apiStateService =
+            new ApiStateServiceImpl(
+                apiSearchService,
+                apiRepository,
+                apiMapper,
+                genericApiMapper,
+                apiNotificationService,
+                primaryOwnerService,
+                auditService,
+                eventService,
+                objectMapper,
+                apiMetadataService,
+                apiValidationService,
+                planSearchService,
+                apiConverter,
+                synchronizationService
+            );
+        reset(searchEngineService);
+    }
+
+    @Test
+    public void should_return_true_for_V4_API() throws JsonProcessingException {
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isTrue();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_true_for_V2_API() throws JsonProcessingException {
+        io.gravitee.rest.api.model.api.ApiEntity apiEntity = new io.gravitee.rest.api.model.api.ApiEntity();
+        apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+
+        // Add flow
+        io.gravitee.definition.model.flow.Flow flow = new io.gravitee.definition.model.flow.Flow();
+        apiEntity.setFlows(Collections.singletonList(flow));
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        // Mock apiConverter to return the defined apiEntity
+        when(apiConverter.toApiEntity(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(null), eq(false)))
+            .thenReturn(apiEntity);
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isTrue();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_false_for_V2_API() throws JsonProcessingException {
+        io.gravitee.rest.api.model.api.ApiEntity apiEntity = new io.gravitee.rest.api.model.api.ApiEntity();
+        apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+
+        // Add flow
+        io.gravitee.definition.model.flow.Flow flow = new io.gravitee.definition.model.flow.Flow();
+        apiEntity.setFlows(Collections.singletonList(flow));
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        // Mock apiConverter to return the defined apiEntity
+        when(apiConverter.toApiEntity(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(null), eq(false)))
+            .thenReturn(apiEntity);
+
+        // Add second flow to simulate a change
+        io.gravitee.definition.model.flow.Flow secondFlow = new io.gravitee.definition.model.flow.Flow();
+        apiEntity.setFlows(List.of(flow, secondFlow));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isTrue();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_false_for_V4_API() throws JsonProcessingException {
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        // Add Flows to make API not synchronized
+        List<Flow> apiFlows = List.of(mock(Flow.class), mock(Flow.class));
+        apiEntity.setFlows(apiFlows);
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isFalse();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_true_when_no_plan_change() throws JsonProcessingException {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+        apiEntity.setDeployedAt(nowDate);
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        final PlanEntity planPublished = new PlanEntity();
+        planPublished.setStatus(PlanStatus.PUBLISHED);
+        // Same date as API -> No redeploy needed
+        planPublished.setNeedRedeployAt(nowDate);
+
+        final PlanEntity planStaging = new PlanEntity();
+        planStaging.setStatus(PlanStatus.STAGING);
+        // Date after API but not published -> No redeploy needed
+        planStaging.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
+
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId())))
+            .thenReturn(Set.of(planPublished, planStaging));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isTrue();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any());
+    }
+
+    @Test
+    public void should_return_false_when_plan_change() throws JsonProcessingException {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("apiId");
+        apiEntity.setName("Api name");
+        apiEntity.setDeployedAt(nowDate);
+
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setType(EventType.PUBLISH_API);
+        eventEntity.setPayload(objectMapper.writeValueAsString(apiEntity));
+
+        when(
+            eventService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(singletonList(eventEntity), 0, 1, 1));
+
+        final PlanEntity planPublished = new PlanEntity();
+        planPublished.setStatus(PlanStatus.PUBLISHED);
+        // Date after API -> Redeploy needed
+        planPublished.setNeedRedeployAt(Date.from(now.plus(1, ChronoUnit.DAYS)));
+
+        when(planSearchService.findByApi(eq(GraviteeContext.getExecutionContext()), eq(apiEntity.getId())))
+            .thenReturn(Set.of(planPublished));
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isFalse();
+
+        verify(eventService, times(1))
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(Arrays.asList(PUBLISH_API, EventType.UNPUBLISH_API)),
+                any(),
+                eq(0L),
+                eq(0L),
+                eq(0),
+                eq(1),
+                any()
+            );
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+        verify(planSearchService, times(1)).findByApi(any(), any());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1226
## Description

1. sort entrypoints by name like endpoints

3. set deploymentState to API output for management-v2-rest

in management v2 the sync state of an api is transformed into a deploymentState with :
NEED_REDEPLOY == !sync
DEPLOYED == sync



- returned by default when you create, get, update an API
- returned if the query params expands contains deploymentState for search and get APIs



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uxayzeioru.chromatic.com)
<!-- Storybook placeholder end -->
