### PR TITLE
[helm] fix indentation in `api` section of M API and Gateway config maps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1704,6 +1704,8 @@ workflows:
                   docker-image-name: apim-portal-ui
                   requires:
                       - Setup
+            - job-lint-test-charts:
+                  name: Helm Chart - Lint & Test
             - job-deploy-on-azure-cluster:
                   context: cicd-orchestrator
                   requires:

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.18.29
 
 - Add attribute `gateway.ssl.keystore.watch` to disable watch of Gateway keystore
+- Fix indentation in `api` section of the Management API and Gateway configmaps
 
 ### 3.20.12
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -20,3 +20,4 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
     - Add attribute `gateway.ssl.keystore.watch` to disable watch of Gateway keystore
+    - Fix indentation in `api` section of the Management API and Gateway configmaps

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -495,7 +495,7 @@ data:
     {{- end }}
     # APIs specific configuration
     {{- if .Values.api.api }}
-      api: {{- toYaml .Values.api.api | nindent 6 -}}
+    api: {{- toYaml .Values.api.api | nindent 6 -}}
     {{- end}}
     {{- end }}
     {{- if .Values.api.logging.debug }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -422,7 +422,7 @@ data:
 
     # APIs specific configuration
     {{- if .Values.gateway.api }}
-      api: {{- toYaml .Values.gateway.api | nindent 6 -}}
+    api: {{- toYaml .Values.gateway.api | nindent 6 -}}
     {{- end}}
 
     gracefulShutdown:

--- a/helm/tests/api/configmap_api_properties_test.yaml
+++ b/helm/tests/api/configmap_api_properties_test.yaml
@@ -7,8 +7,9 @@ tests:
     asserts:
       - notMatchRegex:
           path: data.[gravitee.yml]
-          pattern: " *api:\n
-                     *  properties:\n"
+          pattern: |
+            api:
+              properties:
   - it: Set the API properties
     template: api/api-configmap.yaml
     set:
@@ -20,7 +21,8 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " *api:\n
-                     *  properties:\n
-                     *    encryption:\n
-                     *      secret: aSecret"
+          pattern: |
+            api:
+              properties:
+                encryption:
+                  secret: aSecret

--- a/helm/tests/gateway/configmap_api_properties_test.yaml
+++ b/helm/tests/gateway/configmap_api_properties_test.yaml
@@ -7,8 +7,9 @@ tests:
     asserts:
       - notMatchRegex:
           path: data.[gravitee.yml]
-          pattern: " *api:\n
-                     *  properties:\n"
+          pattern: |
+            api:
+              properties:
   - it: Set the API properties
     template: gateway/gateway-configmap.yaml
     set:
@@ -20,7 +21,8 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " *api:\n
-                     *  properties:\n
-                     *    encryption:\n
-                     *      secret: aSecret"
+          pattern: |
+            api:
+              properties:
+                encryption:
+                  secret: aSecret


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2151
https://github.com/gravitee-io/issues/issues/9120

## Description

Remove the 2 extra spaces

Port of https://github.com/gravitee-io/helm-charts/pull/397 on APIM repo.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-abwauhkjpl.chromatic.com)
<!-- Storybook placeholder end -->
