### PR TITLE
[helm] Add missing mongo truststore and keystore config in configmap

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 - Add attribute `gateway.ssl.keystore.watch` to disable watch of Gateway keystore
 - Fix indentation in `api` section of the Management API and Gateway configmaps
+- Add truststore and keystore attributes to the MongoDB Rate Limit section of the Gateway configmap
 
 ### 3.20.12
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,3 +21,4 @@ annotations:
   artifacthub.io/changes: |
     - Add attribute `gateway.ssl.keystore.watch` to disable watch of Gateway keystore
     - Fix indentation in `api` section of the Management API and Gateway configmaps
+    - Add truststore and keystore attributes to the MongoDB Rate Limit section of the Gateway configmap 

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -171,6 +171,12 @@ data:
         {{- else }}
         uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
         {{- end }}
+        {{- if .Values.mongo.keystore }}
+        keystore:{{- toYaml .Values.mongo.keystore | nindent 10 }}
+        {{- end }}
+        {{- if .Values.mongo.truststore }}
+        truststore:{{- toYaml .Values.mongo.truststore | nindent 10 }}
+        {{- end }}
       {{- else if (eq .Values.ratelimit.type "jdbc") }}
       jdbc:
         url: {{ .Values.jdbc.url }}

--- a/helm/tests/gateway/configmap_mongodb_test.yaml
+++ b/helm/tests/gateway/configmap_mongodb_test.yaml
@@ -17,10 +17,13 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " * mongodb:\n
-                     *  sslEnabled: true\n
-                     *  socketKeepAlive: true\n
-                     *  uri: mongodb://mongo-mongodb-replicaset:27017/gravitee"
+          pattern: |
+            management:
+              type: mongodb
+              mongodb:
+                sslEnabled: true
+                socketKeepAlive: true
+                uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
   - it: Set common value and servers
     template: gateway/gateway-configmap.yaml
     set:
@@ -41,19 +44,22 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " * mongodb:\n
-                     *   sslEnabled: true\n
-                     *   socketKeepAlive: true\n
-                     *   servers:\n
-                     *     - host: mongo1\n
-                     *       port: 27017\n
-                     *     - host: mongo2\n
-                     *       port: 27017\n
-                     *\n
-                     *   dbname: dbname\n
-                     *   username: username\n
-                     *   password: password\n
-                     *   authSource: authSource"
+          pattern: |
+            management:
+              type: mongodb
+              mongodb:
+                sslEnabled: true
+                socketKeepAlive: true
+                servers:
+                  - host: mongo1
+                    port: 27017
+                  - host: mongo2
+                    port: 27017
+            (.|\n)*
+                dbname: dbname
+                username: username
+                password: password
+                authSource: authSource
   - it: Set common value and properties one by one
     template: gateway/gateway-configmap.yaml
     set:
@@ -73,10 +79,13 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " * mongodb:\n
-                     *   sslEnabled: true\n
-                     *   socketKeepAlive: true\n
-                     *   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000"
+          pattern: |
+            management:
+              type: mongodb
+              mongodb:
+                sslEnabled: true
+                socketKeepAlive: true
+                uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000
   - it: Set mongo keystore attributes with provided values
     template: gateway/gateway-configmap.yaml
     set:
@@ -89,13 +98,26 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " * mongodb:\n
-                    (.|\n)*\n
-                     *   keystore:\n
-                     *     keyPassword: keyPassword\n
-                     *     password: keystorePassword\n
-                     *     path: /path/to/keystore.p12\n
-                     *     type: pkcs12"
+          pattern: |
+            management:
+              type: mongodb
+              mongodb:
+              (.|\n)*
+                keystore:
+                  keyPassword: keyPassword
+                  password: keystorePassword
+                  path: /path/to/keystore.p12
+                  type: pkcs12
+            (.|\n)*
+            ratelimit:
+              type: mongodb
+              mongodb:
+              (.|\n)*
+                keystore:
+                  keyPassword: keyPassword
+                  password: keystorePassword
+                  path: /path/to/keystore.p12
+                  type: pkcs12
   - it: Set mongo truststore attributes with provided values
     template: gateway/gateway-configmap.yaml
     set:
@@ -107,9 +129,21 @@ tests:
     asserts:
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: " * mongodb:\n
-                    (.|\n)*\n
-                     *   truststore:\n
-                     *     password: truststorePassword\n
-                     *     path: /path/to/truststore.jks\n
-                     *     type: jks"
+          pattern: |
+            management:
+              type: mongodb
+              mongodb:
+              (.|\n)*
+                truststore:
+                  password: truststorePassword
+                  path: /path/to/truststore.jks
+                  type: jks
+            (.|\n)*
+            ratelimit:
+              type: mongodb
+              mongodb:
+              (.|\n)*
+                truststore:
+                  password: truststorePassword
+                  path: /path/to/truststore.jks
+                  type: jks


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1770
https://github.com/gravitee-io/issues/issues/9067

## Description


When deploying to a Mongo instance with TLS enabled the truststore configuration was missing on the ratelimit section of the Gravitee Gateway config, This PR adds this section back in to match the Management section and the API configmap management section.

Port of https://github.com/gravitee-io/helm-charts/pull/384 on APIM repo.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yhvsodgdrk.chromatic.com)
<!-- Storybook placeholder end -->
