### PR TITLE
fix(rest-api): simplify api doc transform when deleting from lucene

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -89,6 +89,11 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
         doc.add(new StringField(FIELD_ID, api.getId(), Field.Store.YES));
         doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
 
+        // If no definition version or name, the api is being deleted. No need for more info in doc.
+        if (api.getDefinitionVersion() == null && api.getName() == null) {
+            return doc;
+        }
+
         if (api.getDefinitionVersion() != null) {
             doc.add(new StringField(FIELD_DEFINITION_VERSION, api.getDefinitionVersion().getLabel(), Field.Store.NO));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -69,6 +69,17 @@ public class ApiDocumentTransformerTest {
         assertThat(doc.get("id")).isEqualTo(api.getId());
     }
 
+    @Test
+    public void shouldTransformWithoutError_V4ApiOnDeleteMode() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(null);
+        api.setName(null);
+
+        Document doc = cut.transform(api);
+        assertThat(doc.get("id")).isEqualTo(api.getId());
+    }
+
     @NotNull
     private ApiEntity getApiEntity() {
         ApiEntity toTransform = new ApiEntity();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2138

## Description

When deleting an API from Lucene, all attributes are set to null except ID. We will skip all the field assignments in transform to immediately return a simplified doc that Lucene can then use to delete from its cache.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nntpzhvppa.chromatic.com)
<!-- Storybook placeholder end -->
