### PR TITLE
fix: error logged in console when navigating to API V4

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -55,15 +55,13 @@ function apisRouterConfig($stateProvider: StateProvider) {
           Constants: any,
           EnvironmentService: EnvironmentService,
         ) {
-          const deferred = $q.defer();
           return ngApiV2Service
             .get($stateParams.apiId)
             .toPromise()
             .then((api) => {
-              // If api is V4 redirect to new Angular routing
+              // Should not land here for API V4
               if (isApiV4(api)) {
-                $state.go('management.apis.ng.general', { apiId: $stateParams.apiId });
-                return deferred.reject();
+                throw new Error(`Illegal state: V4 API should never trigger navigation to this route ${$state.current}`);
               }
               return ApiService.get($stateParams.apiId).catch((err) => {
                 if (err && err.interceptorFuture) {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-confirmation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-confirmation.component.html
@@ -26,7 +26,7 @@
         mat-flat-button
         color="primary"
         data-testid="open_api_in_api_management_button"
-        (click)="navigate('management.apis.detail.portal.general')"
+        (click)="navigate('management.apis.ng.general')"
       >
         Open my API in API Management
       </button>
@@ -38,14 +38,7 @@
           <h4>Policy configuration</h4>
           <div class="action__text__subtitle">Shape traffic reaching the gateway by configuring your policies with our flow editor</div>
         </div>
-        <button mat-stroked-button (click)="navigate('management.apis.detail.design.flowsNg.design')">Create policies</button>
-      </div>
-      <div class="action">
-        <div class="action__text">
-          <h4>Debug mode</h4>
-          <div class="action__text__subtitle">Debug your API flows during the Design phase and avoid common design errors</div>
-        </div>
-        <button mat-stroked-button (click)="navigate('management.apis.detail.design.flowsNg.debug')">Debug flows</button>
+        <button mat-stroked-button (click)="navigate('management.apis.ng.policyStudio')">Create policies</button>
       </div>
       <div class="action">
         <div class="action__text">
@@ -54,7 +47,7 @@
             Publish your API to the Developer Portal. From there, consumers can discover, learn about and use your API
           </div>
         </div>
-        <button mat-stroked-button (click)="navigate('management.apis.detail.portal.general')">Manage API visibility</button>
+        <button mat-stroked-button (click)="navigate('management.apis.ng.general')">Manage API visibility</button>
       </div>
       <div class="action">
         <div class="action__text">

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -49,7 +49,7 @@
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
       <td mat-cell *matCellDef="let element" title="{{ element.name }} ({{ element.version }})">
-        <a [uiSref]="'management.apis.detail.ng-redirect'" [uiParams]="{ apiId: element.id }">{{ element.name }} ({{ element.version }})</a>
+        <a [uiSref]="element.targetRoute" [uiParams]="{ apiId: element.id }">{{ element.name }} ({{ element.version }})</a>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -33,8 +33,7 @@ import { CurrentUserService, UIRouterState, UIRouterStateParams } from '../../..
 import { User as DeprecatedUser } from '../../../entities/user';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
-import { fakePagedResult } from '../../../entities/management-api-v2/pagedResult';
-import { fakeApiV2, fakeApiV4, ApiLifecycleState, Api, StateEnum, OriginEnum } from '../../../entities/management-api-v2';
+import { fakePagedResult, fakeApiV2, fakeApiV4, ApiLifecycleState, Api, StateEnum, OriginEnum } from '../../../entities/management-api-v2';
 
 describe('ApisListComponent', () => {
   const fakeUiRouter = { go: jest.fn() };
@@ -287,11 +286,12 @@ describe('ApisListComponent', () => {
           origin: 'management' as OriginEnum,
           readonly: false,
           definitionVersion: { label: 'v2', icon: '' },
+          targetRoute: 'route',
         };
 
         apiListComponent.onEditActionClicked(api);
 
-        expect(routerSpy).toHaveBeenCalledWith('management.apis.detail.portal.general', { apiId: api.id });
+        expect(routerSpy).toHaveBeenCalledWith('route', { apiId: api.id });
       });
     });
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -56,6 +56,7 @@ export type ApisTableDS = {
   origin: OriginEnum;
   readonly: boolean;
   definitionVersion: { label: string; icon?: string };
+  targetRoute: string;
 }[];
 
 @Component({
@@ -134,7 +135,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
   }
 
   onEditActionClicked(api: ApisTableDS[number]) {
-    this.ajsState.go('management.apis.detail.portal.general', { apiId: api.id });
+    this.ajsState.go(api.targetRoute, { apiId: api.id });
   }
 
   onAddApiClick() {
@@ -184,6 +185,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
               contextPath: this.getContextPath(apiv4),
               isNotSynced$: undefined,
               qualityScore$: null,
+              targetRoute: 'management.apis.ng.general',
             };
           } else {
             const apiv2 = api as ApiV2;
@@ -194,6 +196,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
               qualityScore$: this.isQualityDisplayed
                 ? this.apiService.getQualityMetrics(apiv2.id).pipe(map((a) => this.getQualityScore(Math.floor(a.score * 100))))
                 : null,
+              targetRoute: 'management.apis.detail.portal.general',
             };
           }
         })


### PR DESCRIPTION
## Issue

N.A.

## Description

When navigating to an API V4 from the API list, an error was logged in the console of the browser : 
```
Transition Rejection($id: 24 type: 2, message: The transition has been superseded by a different transition, detail: "null")
```

In this PR, I remove a `state.go` hidden in the apis routing config, and make sure we target the right URL for v4 APIs. This implies a change in the API list, and in the API creation workflow summary screen.

To reviewers: do you know any other places in the application where we target API page and that is compatible with V4 APIs ? (cc @phiz71)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vdbxofgoed.chromatic.com)
<!-- Storybook placeholder end -->
