### PR TITLE
fix(definition): handle none truststore and keystore

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/datatype/SslOptionsMapperTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/datatype/SslOptionsMapperTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.jackson.datatype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.definition.model.v4.ssl.SslOptions;
+import io.gravitee.definition.model.v4.ssl.none.NoneKeyStore;
+import io.gravitee.definition.model.v4.ssl.none.NoneTrustStore;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+class SslOptionsMapperTest {
+
+    GraviteeMapper mapper = new GraviteeMapper();
+
+    @Nested
+    class DeserializerTest {
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = {
+                "{ \"trustStore\": { \"type\": \"NONE\" } }",
+                "{ \"trustStore\": { \"type\": \"none\" } }",
+                "{ \"trustStore\": { \"type\": \"\" } }",
+            }
+        )
+        void should_deserialize_none_truststore(String json) throws JsonProcessingException {
+            var result = mapper.readValue(json, SslOptions.class);
+
+            assertThat(result).isInstanceOf(SslOptions.class).extracting(SslOptions::getTrustStore).isInstanceOf(NoneTrustStore.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = {
+                "{ \"keyStore\": { \"type\": \"NONE\" } }",
+                "{ \"keyStore\": { \"type\": \"none\" } }",
+                "{ \"keyStore\": { \"type\": \"\" } }",
+            }
+        )
+        void should_deserialize_none_keystore(String json) throws JsonProcessingException {
+            var result = mapper.readValue(json, SslOptions.class);
+
+            assertThat(result).isInstanceOf(SslOptions.class).extracting(SslOptions::getKeyStore).isInstanceOf(NoneKeyStore.class);
+        }
+    }
+
+    @Nested
+    class SslOptionsSerializerTest {
+
+        @Test
+        void should_serialize_none_truststore() throws Exception {
+            SslOptions sslOptions = new SslOptions();
+            sslOptions.setTrustStore(new NoneTrustStore());
+
+            var result = mapper.writeValueAsString(sslOptions);
+
+            JSONAssert.assertEquals("{\"hostnameVerifier\":true,\"trustAll\":false,\"trustStore\":{\"type\":\"NONE\"}}", result, true);
+        }
+
+        @Test
+        void should_serialize_none_keystore() throws Exception {
+            SslOptions sslOptions = new SslOptions();
+            sslOptions.setKeyStore(new NoneKeyStore());
+
+            var result = mapper.writeValueAsString(sslOptions);
+
+            JSONAssert.assertEquals("{\"hostnameVerifier\":true,\"trustAll\":false,\"keyStore\":{\"type\":\"NONE\"}}", result, true);
+        }
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/KeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/KeyStore.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.definition.model.v4.ssl;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.gravitee.definition.model.v4.ssl.jks.JKSKeyStore;
@@ -30,13 +29,13 @@ import lombok.experimental.SuperBuilder;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", defaultImpl = NoneKeyStore.class)
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(names = { "JKS", "jks" }, value = JKSKeyStore.class),
         @JsonSubTypes.Type(names = { "PEM", "pem" }, value = PEMKeyStore.class),
         @JsonSubTypes.Type(names = { "PKCS12", "pkcs12" }, value = PKCS12KeyStore.class),
-        @JsonSubTypes.Type(value = NoneKeyStore.class),
+        @JsonSubTypes.Type(names = { "NONE", "none" }, value = NoneKeyStore.class),
     }
 )
 @Getter

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/TrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/TrustStore.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.definition.model.v4.ssl;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.gravitee.definition.model.v4.ssl.jks.JKSTrustStore;
@@ -30,13 +29,18 @@ import lombok.experimental.SuperBuilder;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+    defaultImpl = NoneTrustStore.class
+)
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(names = { "JKS", "jks" }, value = JKSTrustStore.class),
         @JsonSubTypes.Type(names = { "PEM", "pem" }, value = PEMTrustStore.class),
         @JsonSubTypes.Type(names = { "PKCS12", "pkcs12" }, value = PKCS12TrustStore.class),
-        @JsonSubTypes.Type(value = NoneTrustStore.class),
+        @JsonSubTypes.Type(names = { "NONE", "none" }, value = NoneTrustStore.class),
     }
 )
 @Getter

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/none/NoneKeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/none/NoneKeyStore.java
@@ -28,7 +28,7 @@ public class NoneKeyStore extends KeyStore {
 
     private static final long serialVersionUID = -2540354913966457704L;
 
-    public NoneKeyStore(KeyStoreType type) {
-        super(type);
+    public NoneKeyStore() {
+        super(KeyStoreType.NONE);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/none/NoneTrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/none/NoneTrustStore.java
@@ -28,7 +28,7 @@ public class NoneTrustStore extends TrustStore {
 
     private static final long serialVersionUID = -6013813999148592319L;
 
-    public NoneTrustStore(TrustStoreType type) {
-        super(type);
+    public NoneTrustStore() {
+        super(TrustStoreType.NONE);
     }
 }


### PR DESCRIPTION
## Description

We were unable to deserialize SslOptions with "none" keystore/truststore

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cwcijmlvgo.chromatic.com)
<!-- Storybook placeholder end -->
