### PR TITLE
fix(rest-api-v2): allow non-v4 apis to be deleted

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -225,11 +225,7 @@ public class ApiPlansResource extends AbstractResource {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
-        if (planEntity instanceof PlanEntity) {
-            return Response.ok(planMapper.map(planServiceV4.close(executionContext, planId))).build();
-        }
-
-        return Response.ok(planMapper.map(planServiceV2.close(executionContext, planId))).build();
+        return Response.ok(planMapper.mapGenericPlan(planServiceV4.close(executionContext, planId))).build();
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource_CloseTest.java
@@ -57,7 +57,6 @@ public class ApiPlansResource_CloseTest extends ApiPlansResourceTest {
         assertEquals("Plan [" + PLAN + "] cannot be found.", error.getMessage());
 
         verify(planServiceV4, never()).close(any(), any());
-        verify(planServiceV2, never()).close(any(), any());
     }
 
     @Test
@@ -74,7 +73,6 @@ public class ApiPlansResource_CloseTest extends ApiPlansResourceTest {
         assertEquals("Plan [" + PLAN + "] cannot be found.", error.getMessage());
 
         verify(planServiceV4, never()).close(any(), any());
-        verify(planServiceV2, never()).close(any(), any());
     }
 
     @Test
@@ -97,7 +95,6 @@ public class ApiPlansResource_CloseTest extends ApiPlansResourceTest {
         assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
 
         verify(planServiceV4, never()).close(any(), any());
-        verify(planServiceV2, never()).close(any(), any());
     }
 
     @Test
@@ -121,7 +118,7 @@ public class ApiPlansResource_CloseTest extends ApiPlansResourceTest {
         final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
 
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
-        when(planServiceV2.close(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+        when(planServiceV4.close(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
 
         final Response response = rootTarget().request().post(Entity.json(null));
         assertEquals(OK_200, response.getStatus());
@@ -129,6 +126,6 @@ public class ApiPlansResource_CloseTest extends ApiPlansResourceTest {
         var plan = response.readEntity(PlanV2.class);
         assertEquals(planEntity.getId(), plan.getId());
 
-        verify(planServiceV2, times(1)).close(GraviteeContext.getExecutionContext(), PLAN);
+        verify(planServiceV4, times(1)).close(GraviteeContext.getExecutionContext(), PLAN);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
@@ -17,10 +17,7 @@ package io.gravitee.rest.api.service.v4;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PlansConfigurationEntity;
-import io.gravitee.rest.api.model.v4.plan.NewPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanQuery;
-import io.gravitee.rest.api.model.v4.plan.UpdatePlanEntity;
+import io.gravitee.rest.api.model.v4.plan.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +36,7 @@ public interface PlanService {
 
     PlanEntity update(final ExecutionContext executionContext, final UpdatePlanEntity plan);
 
-    PlanEntity close(final ExecutionContext executionContext, final String plan);
+    GenericPlanEntity close(final ExecutionContext executionContext, final String plan);
 
     void delete(final ExecutionContext executionContext, final String plan);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -64,6 +64,7 @@ import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.AlertService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -555,6 +556,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
     }
 
+    /**
+     * Delete an Api regardless of version
+     *
+     * @param executionContext
+     * @param apiId
+     * @param closePlans
+     */
     @Override
     public void delete(ExecutionContext executionContext, String apiId, boolean closePlans) {
         try {
@@ -565,20 +573,20 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 throw new ApiRunningStateException(apiId);
             }
 
-            Set<PlanEntity> plans = planService.findByApi(executionContext, apiId);
+            Set<GenericPlanEntity> plans = planSearchService.findByApi(executionContext, apiId);
             if (closePlans) {
                 plans =
                     plans
                         .stream()
-                        .filter(plan -> plan.getStatus() != PlanStatus.CLOSED)
+                        .filter(plan -> plan.getPlanStatus() != PlanStatus.CLOSED)
                         .map(plan -> planService.close(executionContext, plan.getId()))
                         .collect(Collectors.toSet());
             }
 
             Set<String> plansNotClosed = plans
                 .stream()
-                .filter(plan -> plan.getStatus() == PlanStatus.PUBLISHED)
-                .map(PlanEntity::getName)
+                .filter(plan -> plan.getPlanStatus() == PlanStatus.PUBLISHED)
+                .map(GenericPlanEntity::getName)
                 .collect(toSet());
 
             if (!plansNotClosed.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -584,7 +584,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
-        when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
@@ -600,7 +600,7 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.CLOSED);
-        when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -610,7 +610,7 @@ public class ApiServiceImplTest {
     }
 
     @Test
-    public void shouldDeleteWithStatingPlan() throws TechnicalException {
+    public void shouldDeleteWithStatingPlanV4() throws TechnicalException {
         Api api = new Api();
         api.setId(API_ID);
         api.setLifecycleState(LifecycleState.STOPPED);
@@ -619,7 +619,29 @@ public class ApiServiceImplTest {
         PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.STAGING);
-        when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
+
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
+
+        verify(planService, times(1)).delete(GraviteeContext.getExecutionContext(), PLAN_ID);
+        verify(apiQualityRuleRepository, times(1)).deleteByApi(API_ID);
+        verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
+        verify(mediaService, times(1)).deleteAllByApi(API_ID);
+        verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, null);
+    }
+
+    @Test
+    public void shouldDeleteWithStatingPlanV2() throws TechnicalException {
+        Api api = new Api();
+        api.setId(API_ID);
+        api.setLifecycleState(LifecycleState.STOPPED);
+
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+        io.gravitee.rest.api.model.PlanEntity planEntity = new io.gravitee.rest.api.model.PlanEntity();
+        planEntity.setId(PLAN_ID);
+        planEntity.setStatus(io.gravitee.rest.api.model.PlanStatus.STAGING);
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(singleton(planEntity));
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
@@ -663,7 +685,7 @@ public class ApiServiceImplTest {
         final PlanEntity closedPlan = new PlanEntity();
         closedPlan.setId(PLAN_ID);
         closedPlan.setStatus(PlanStatus.CLOSED);
-        when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
+        when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
         when(planService.close(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(closedPlan);
 
         apiService.delete(GraviteeContext.getExecutionContext(), API_ID, true);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2138

## Description

Allow non-v4 apis to be deleted via rest-api-v2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oytxtpeajb.chromatic.com)
<!-- Storybook placeholder end -->
