### PR TITLE
fix: intialize Endpoint Status field with UP by default since lombook…

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,6 +33,7 @@ import lombok.Builder;
  */
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class Endpoint implements Serializable {
 
     private static final String DEFAULT_TYPE = "http";
@@ -47,6 +49,7 @@ public class Endpoint implements Serializable {
     private String target;
 
     @JsonProperty("weight")
+    @Builder.Default
     private int weight = DEFAULT_WEIGHT;
 
     @JsonProperty("backup")
@@ -60,7 +63,8 @@ public class Endpoint implements Serializable {
     private List<String> tenants; // TODO was not serialized
 
     @JsonProperty("type")
-    private final String type;
+    @Builder.Default
+    private String type = DEFAULT_TYPE;
 
     @JsonProperty("inherit")
     private Boolean inherit;
@@ -71,18 +75,12 @@ public class Endpoint implements Serializable {
     @JsonIgnore
     private transient String configuration;
 
-    public Endpoint() {
-        this(null, null, null);
-    }
-
-    public Endpoint(String name, String target) {
-        this(null, name, target);
-    }
-
     public Endpoint(String type, String name, String target) {
         this.type = type != null ? type : DEFAULT_TYPE;
         this.name = name;
         this.target = target;
+        this.status = Status.UP;
+        this.weight = DEFAULT_WEIGHT;
     }
 
     public String getName() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Property.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Property.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -28,6 +29,7 @@ import lombok.experimental.SuperBuilder;
  * @author GraviteeSource Team
  */
 @AllArgsConstructor
+@NoArgsConstructor
 @SuperBuilder
 public class Property implements Serializable {
 
@@ -44,8 +46,6 @@ public class Property implements Serializable {
     @JsonProperty(value = "encrypted")
     @Builder.Default
     private boolean encrypted = false;
-
-    public Property() {}
 
     public Property(String key, String value) {
         this.key = key;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
@@ -175,7 +175,7 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
         final String serviceName = "sd#" + service.id().replaceAll(":", "#");
         String target = scheme + "://" + service.host() + (service.port() > 0 ? ":" + service.port() : "") + basePath;
 
-        io.gravitee.definition.model.Endpoint endpoint = new Endpoint(serviceName, target);
+        io.gravitee.definition.model.Endpoint endpoint = Endpoint.builder().name(serviceName).target(target).build();
 
         endpoint.setConfiguration(getEndpointConfiguration(group, endpoint, scheme));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -380,13 +380,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
 
         if (endpoints == null) {
-            group.setEndpoints(singleton(new Endpoint("default", null)));
+            group.setEndpoints(singleton(Endpoint.builder().name("default").build()));
         } else if (endpoints.length == 1) {
-            group.setEndpoints(singleton(new Endpoint("default", endpoints[0])));
+            group.setEndpoints(singleton(Endpoint.builder().name("default").target(endpoints[0]).build()));
         } else {
             group.setEndpoints(new HashSet<>());
             for (int i = 0; i < endpoints.length; i++) {
-                group.getEndpoints().add(new Endpoint("server" + (i + 1), endpoints[i]));
+                group.getEndpoints().add(Endpoint.builder().name("server" + (i + 1)).target(endpoints[i]).build());
             }
         }
         proxy.setGroups(singleton(group));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -145,15 +145,15 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
             defaultGroup.setName("default-group");
 
             if (evaluatedServerUrl == null) {
-                defaultGroup.setEndpoints(singleton(new Endpoint("default", defaultEndpoint)));
+                defaultGroup.setEndpoints(singleton(Endpoint.builder().name("default").target(defaultEndpoint).build()));
             } else if (evaluatedServerUrl.size() == 1) {
                 defaultEndpoint = evaluatedServerUrl.get(0);
-                defaultGroup.setEndpoints(singleton(new Endpoint("default", defaultEndpoint)));
+                defaultGroup.setEndpoints(singleton(Endpoint.builder().name("default").target(defaultEndpoint).build()));
             } else {
                 defaultEndpoint = evaluatedServerUrl.get(0);
                 defaultGroup.setEndpoints(new HashSet<>());
                 for (int i = 0; i < evaluatedServerUrl.size(); i++) {
-                    defaultGroup.getEndpoints().add(new Endpoint("server" + (i + 1), evaluatedServerUrl.get(i)));
+                    defaultGroup.getEndpoints().add(Endpoint.builder().name("server" + (i + 1)).target(evaluatedServerUrl.get(i)).build());
                 }
             }
             proxy.setGroups(singleton(defaultGroup));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsCustomResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsCustomResourceTest.java
@@ -200,7 +200,7 @@ public class ApiExportService_ExportAsCustomResourceTest extends ApiExportServic
         proxy.setLogging(logging);
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("default-group");
-        Endpoint endpoint = new Endpoint("default", "http://test");
+        Endpoint endpoint = Endpoint.builder().name("default").target("http://test").build();
         endpointGroup.setEndpoints(Collections.singleton(endpoint));
         LoadBalancer loadBalancer = new LoadBalancer();
         loadBalancer.setType(LoadBalancerType.ROUND_ROBIN);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
@@ -178,7 +178,7 @@ public class ApiExportService_ExportAsJsonTest extends ApiExportService_ExportAs
         proxy.setStripContextPath(false);
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("default-group");
-        Endpoint endpoint = new Endpoint("default", "http://test");
+        Endpoint endpoint = Endpoint.builder().name("default").target("http://test").build();
         endpointGroup.setEndpoints(Collections.singleton(endpoint));
         LoadBalancer loadBalancer = new LoadBalancer();
         loadBalancer.setType(LoadBalancerType.ROUND_ROBIN);
@@ -186,7 +186,7 @@ public class ApiExportService_ExportAsJsonTest extends ApiExportService_ExportAs
 
         EndpointGroup endpointGroup2 = new EndpointGroup();
         endpointGroup2.setName("backup-group");
-        Endpoint endpoint2 = new Endpoint("backup", "http://test2");
+        Endpoint endpoint2 = Endpoint.builder().name("backup").target("http://test2").build();
         endpointGroup2.setEndpoints(Collections.singleton(endpoint2));
         proxy.setGroups(new HashSet<>(Arrays.asList(endpointGroup, endpointGroup2)));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
@@ -172,7 +172,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
         proxy.setLogging(logging);
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("default-group");
-        Endpoint endpoint = new Endpoint("default", "http://test");
+        Endpoint endpoint = Endpoint.builder().name("default").target("http://test").build();
         endpointGroup.setEndpoints(Collections.singleton(endpoint));
         LoadBalancer loadBalancer = new LoadBalancer();
         loadBalancer.setType(LoadBalancerType.ROUND_ROBIN);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
@@ -181,7 +181,7 @@ public class ApiExportService_gRPC_ExportAsJsonTestSetup {
         proxy.setLogging(logging);
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("default-group");
-        Endpoint endpoint = new Endpoint("default", "http://test");
+        Endpoint endpoint = Endpoint.builder().name("default").target("http://test").build();
         Endpoint endPointGrpc = new Endpoint("grpc", "EndPoint GRPC", "grpc://localhost:8888");
         HttpClientOptions httpClientOptions = new HttpClientOptions();
         httpClientOptions.setVersion(ProtocolVersion.HTTP_2);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
@@ -123,7 +123,7 @@ public class ApiService_CreateWithDefinitionTest {
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/context")));
@@ -163,7 +163,7 @@ public class ApiService_CreateWithDefinitionTest {
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/context")));
@@ -196,7 +196,7 @@ public class ApiService_CreateWithDefinitionTest {
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/context")));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -445,7 +445,7 @@ public class ApiService_UpdateTest {
         final Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -551,7 +551,7 @@ public class ApiService_UpdateTest {
         final Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -625,7 +625,7 @@ public class ApiService_UpdateTest {
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("EndpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -649,7 +649,7 @@ public class ApiService_UpdateTest {
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("endpointGroupName");
-        Endpoint endpoint = new Endpoint("endpointName", null);
+        Endpoint endpoint = Endpoint.builder().name("endpointName").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -771,7 +771,7 @@ public class ApiService_UpdateTest {
         updateApiEntity.setTags(singleton("private"));
         final Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
-        Endpoint endpoint = new Endpoint("default", null);
+        Endpoint endpoint = Endpoint.builder().name("default").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -790,7 +790,7 @@ public class ApiService_UpdateTest {
         updateApiEntity.setTags(singleton("private"));
         final Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
-        Endpoint endpoint = new Endpoint("default", null);
+        Endpoint endpoint = Endpoint.builder().name("default").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         updateApiEntity.setProxy(proxy);
@@ -814,7 +814,7 @@ public class ApiService_UpdateTest {
 
         final Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
-        Endpoint endpoint = new Endpoint("default", null);
+        Endpoint endpoint = Endpoint.builder().name("default").build();
         endpointGroup.setEndpoints(singleton(endpoint));
         proxy.setGroups(singleton(endpointGroup));
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/context")));


### PR DESCRIPTION
… erased the default value


## Description

Since Endpoint model object has    @Builder.Default annotation coming from Lombox, the default status is erased from the generated class. That lead to NullPointerException in the EndpointRuleHandler.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ufukzwyjfz.chromatic.com)
<!-- Storybook placeholder end -->
