### PR TITLE
test: fixed API creation workflow test

### DIFF
--- a/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
@@ -66,7 +66,7 @@ export function deleteApi(auth: BasicAuthentication, apiId: string, failOnStatus
 export function deleteV4Api(auth: BasicAuthentication, apiId: string, closePlans: boolean, failOnStatusCode = false) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${apiId}?closePlans:${closePlans}`,
+    url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${apiId}?closePlans=${closePlans}`,
     auth,
     failOnStatusCode,
   });


### PR DESCRIPTION
## Description
This fixes a bug in the API creation workflow test. 

The deleteV4Api call in the after() hook section contained a little typo that prevented it from deleting the API which also caused problems in another test set (api-list).


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gyodzdukmn.chromatic.com)
<!-- Storybook placeholder end -->
