### PR TITLE
Test/another fix for api creation test run e2e

### DIFF
--- a/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
@@ -66,7 +66,7 @@ export function deleteApi(auth: BasicAuthentication, apiId: string, failOnStatus
 export function deleteV4Api(auth: BasicAuthentication, apiId: string, closePlans: boolean, failOnStatusCode = false) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${apiId}?closePlans:${closePlans}`,
+    url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${apiId}?closePlans=${closePlans}`,
     auth,
     failOnStatusCode,
   });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
@@ -92,9 +92,8 @@ describe('API creation workflow', () => {
     });
 
     it('should successfully connect to created API', function () {
-      cy.request(`${Cypress.env('gatewayServer')}/${apiPath}`).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.message).to.eq('Hello, World!');
+      cy.callGateway(`${apiPath}`).then((response) => {
+        expect(response.body.message).to.eq('Hello, World!'); // from wiremock
       });
     });
 

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -36,10 +36,36 @@ declare global {
       teardownApi(api: ApiImport): void;
       teardownV4Api(apiId: string): void;
       createAndStartApiFromSwagger(swaggerImport: string, attributes?: Partial<ImportSwaggerDescriptorEntity>): any;
+      callGateway(contextPath: string, maxRetries?: number, retryDelay?: number): any;
     }
   }
 }
 export {};
+
+Cypress.Commands.add('callGateway', (contextPath, maxRetries = 5, retryDelay = 1500) => {
+  let retries = 0;
+
+  const sendRequest = () => {
+    retries++;
+    const url = `${Cypress.env('gatewayServer')}/${contextPath}`;
+    cy.log(`Calling gateway: ${url} - Attempt ${retries} of ${maxRetries}`);
+
+    return cy.request({ url, failOnStatusCode: false }).then((response) => {
+      if (response.status === 200) {
+        return response;
+      } else if (retries >= maxRetries) {
+        throw new Error('Maximum retries reached, request failed');
+      } else {
+        // Retry after delay
+        return new Cypress.Promise((resolve) => {
+          setTimeout(resolve, retryDelay);
+        }).then(sendRequest);
+      }
+    });
+  };
+
+  return sendRequest();
+});
 
 Cypress.Commands.add('teardownApi', (api) => {
   cy.log(`----- Removing API "${api.name}" -----`);


### PR DESCRIPTION
## Description
This is another fix for the API creation workflow test set. 

It seems that the problem was that the newly created API was called on the gateway before it was deployed and Cypress immediately stopped after receiving a 404 status code. So, a custom Cypress function (`cy.callGateway()`) was implemented to call the gateway (with a limited number of retries) until it's successful. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hwhbkbkbrc.chromatic.com)
<!-- Storybook placeholder end -->
