### PR TITLE
test(sdk): allow to manually manage api deployment from test

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/README.adoc
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/README.adoc
@@ -72,7 +72,7 @@ class MockPolicyIntegrationTest extends AbstractPolicyTest<MockPolicy, MockPolic
 ** Annotated at class level, it will deploy the APIs once for the gateway instance, it means all the method annotated with `@Test` will use the same deployed APIs.
 ** Annotated at method level, it will deploy the APIs only for the lifetime of the test method. After its execution, the APIs will be undeployed
 * `AbstractPolicyTest<MockPolicy, MockPolicyConfiguration>`: extends from this abstract class allows to automatically configure the policy you are working on. We will see more details about this abstract class, but it helps you configure a lot of stuff to test your policy.
-* `WebClient client`: You can see it as a parameter of your test method. This https://vertx.io/docs/apidocs/io/vertx/reactivex/ext/web/client/WebClient.html[Vertx Reactive Webclient] is injected by the SDK and automatically configured to reach the test gateway.
+* `HttpClient client`: You can see it as a parameter of your test method. This https://vertx.io/docs/4.2.7/apidocs/io/vertx/rxjava3/core/http/class-use/HttpClient.html[Vertx RxJava3 HttpClient] is injected by the SDK and automatically configured to reach the test gateway.
 * `wiremock`: is an object inherited from `AbstractPolicyTest` allowing you to mock your endpoints behavior. It is configured automatically to be used by your deployed apis.
 
 == Installation Guide
@@ -307,6 +307,20 @@ public void configureApi(Api api) {
 You can also use the field `deployedApis` to access and modify the deployed APIs *at method level*.
 
 WARNING: With this method, you can modify easily some properties of the API (for example, the state of the endpoints). You have to keep in mind that some properties will not be modifiable, for example, the configuration of the policies.
+
+==== Deploying and undeploying an API from a test
+
+`AbstractGatewayTest` provides those methods to manually control the deployment cycle of an API.
+ * deploy(ReactableApi api)
+ * undeploy(String api)
+ * redeploy(ReactableApi api): will undeploy then deploy
+
+⚠️ You cannot deploy or undeploy an api with the same id as an api declared at class level
+
+To modify an already deployed api, you can inject them as parameter of your test:
+ * to inject an API with its id: `@InjectApi(apiId = "my-api") ReactableApi<?> reactableApi`
+ * to inject all APIs : `Map<String, ReactableApi<?>> reactableApis)`
+
 
 ==== Plugin registration
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AllApisParameterResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AllApisParameterResolver.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk;
+
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayTestParameterResolver;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AllApisParameterResolver implements GatewayTestParameterResolver {
+
+    @Override
+    public boolean supports(ParameterContext parameterContext) {
+        try {
+            final ParameterizedType parameterizedType = (ParameterizedType) parameterContext.getParameter().getParameterizedType();
+            final Type key = parameterizedType.getActualTypeArguments()[0];
+            final Type value = ((ParameterizedType) parameterizedType.getActualTypeArguments()[1]).getRawType();
+            return parameterContext.getParameter().getType() == Map.class && key == String.class && value == ReactableApi.class;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public Object resolve(ExtensionContext extensionContext, ParameterContext parameterContext, AbstractGatewayTest gatewayTest) {
+        return new HashMap<>(gatewayTest.deployedApis);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/ApiParameterResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/ApiParameterResolver.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.InjectApi;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayTestParameterResolver;
+import io.gravitee.gateway.reactor.ReactableApi;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.platform.commons.PreconditionViolationException;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApiParameterResolver implements GatewayTestParameterResolver {
+
+    @Override
+    public boolean supports(ParameterContext parameterContext) {
+        return (
+            parameterContext.getParameter().getType() == ReactableApi.class &&
+            parameterContext.getParameter().isAnnotationPresent(InjectApi.class)
+        );
+    }
+
+    @Override
+    public Object resolve(ExtensionContext extensionContext, ParameterContext parameterContext, AbstractGatewayTest gatewayTest) {
+        final InjectApi annotation = parameterContext.getParameter().getAnnotation(InjectApi.class);
+        final ReactableApi<?> reactableApi = gatewayTest.deployedApis.get(annotation.apiId());
+        if (reactableApi == null) {
+            throw new PreconditionViolationException("Not api found for [" + annotation.apiId() + "] deployed at method level");
+        }
+        return reactableApi;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/HttpClientParameterResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/HttpClientParameterResolver.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk;
+
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayTestParameterResolver;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.junit5.ScopedObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Objects;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpClientParameterResolver implements GatewayTestParameterResolver {
+
+    @Override
+    public boolean supports(ParameterContext parameterContext) {
+        return parameterContext.getParameter().getType() == HttpClient.class;
+    }
+
+    @Override
+    public Object resolve(ExtensionContext extensionContext, ParameterContext parameterContext, AbstractGatewayTest gatewayTest) {
+        Vertx vertx = getStoredVertx(extensionContext);
+
+        final HttpClientOptions httpClientOptions = new HttpClientOptions()
+            .setDefaultPort(gatewayTest.gatewayPort())
+            .setDefaultHost("localhost");
+        gatewayTest.configureHttpClient(httpClientOptions);
+        return vertx.createHttpClient(httpClientOptions);
+    }
+
+    private Vertx getStoredVertx(ExtensionContext extensionContext) {
+        ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+        ScopedObject scopedObject = store.get(VertxExtension.VERTX_INSTANCE_KEY, ScopedObject.class);
+        Objects.requireNonNull(scopedObject, "A Vertx instance must exist, try adding the Vertx parameter as the first method argument");
+        return (Vertx) scopedObject.get();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/InjectApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/InjectApi.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface InjectApi {
+    String apiId() default "my-api";
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/parameters/GatewayTestParameterResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/parameters/GatewayTestParameterResolver.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.parameters;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface GatewayTestParameterResolver {
+    boolean supports(ParameterContext parameterContext);
+    Object resolve(ExtensionContext extensionContext, ParameterContext parameterContext, AbstractGatewayTest gatewayTest);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiDeployer.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.runner;
+
+import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.util.function.Consumer;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ApiDeployer {
+    void setDeployCallback(Consumer<ReactableApi<?>> apiDeployer);
+
+    void setUndeployCallback(Consumer<String> apiUndeployer);
+
+    void deploy(ReactableApi<?> reactableApi);
+
+    void redeploy(ReactableApi<?> reactableApi);
+
+    void undeploy(String apiId);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
@@ -56,6 +56,36 @@ class GatewayTestingExtensionTest {
     }
 
     @Test
+    void should_redeploy_tests() {
+        EngineTestKit
+            .engine("junit-jupiter")
+            .selectors(selectClass(ManuallyRedeployTestCase.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.started(4).succeeded(4));
+    }
+
+    @Test
+    void should_undeploy_tests() {
+        EngineTestKit
+            .engine("junit-jupiter")
+            .selectors(selectClass(ManuallyUndeployTestCase.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.started(1).succeeded(1));
+    }
+
+    @Test
+    void should_deploy_class_level_tests() {
+        EngineTestKit
+            .engine("junit-jupiter")
+            .selectors(selectClass(ManuallyDeployTestCase.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.started(2).failed(2));
+    }
+
+    @Test
     void should_success_all_http2_tests() {
         EngineTestKit
             .engine("junit-jupiter")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyDeployTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyDeployTestCase.java
@@ -1,0 +1,51 @@
+package testcases;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@EnableForGatewayTestingExtensionTesting
+@DeployApi({ "/apis/success-flow.json" })
+public class ManuallyDeployTestCase extends AbstractGatewayTest {
+
+    @Test
+    @DisplayName("Should not deploy an api that is deployed at class level")
+    void shouldNotDeployApiThatIsDeployedAtClassLevel() {
+        final io.gravitee.definition.model.Api definition = new io.gravitee.definition.model.Api();
+        definition.setId("my-api");
+        final Api api = new Api(definition);
+        deploy(api);
+    }
+
+    @Test
+    @DisplayName("Should not undeploy an api that is deployed at class level")
+    void shouldNotUnDeployApiThatIsDeployedAtClassLevel() {
+        undeploy("my-api");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyRedeployTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyRedeployTestCase.java
@@ -1,0 +1,216 @@
+package testcases;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.InjectApi;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Header1Policy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.OnRequestPolicy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Stream1Policy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Stream2Policy;
+import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@EnableForGatewayTestingExtensionTesting
+public class ManuallyRedeployTestCase extends AbstractGatewayTest {
+
+    public static final String ON_REQUEST_POLICY = "on-request-policy";
+
+    @Test
+    @DisplayName("Should modify and redeploy an API")
+    @DeployApi({ "/apis/success-flow.json" })
+    void shouldRedeployAnApi(HttpClient httpClient, @InjectApi(apiId = "my-api") ReactableApi<?> reactableApi) throws InterruptedException {
+        wiremock.stubFor(get("/team/my_team").willReturn(ok()));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("OnResponseContent2Policy");
+                return true;
+            })
+            .assertNoErrors();
+
+        if (isLegacyApi(reactableApi.getDefinition().getClass())) {
+            Api api = (Api) reactableApi.getDefinition();
+            api.getProxy().getVirtualHosts().get(0).setPath("/new_test");
+            redeploy(reactableApi);
+        }
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(404);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("No context-path matches the request URI.");
+                return true;
+            })
+            .assertNoErrors();
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/new_test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("OnResponseContent2Policy");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/team/my_team"))
+                .withHeader("X-Gravitee-Policy", equalTo("request-header1"))
+                .withHeader(ON_REQUEST_POLICY, equalTo("invoked"))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    @DisplayName("Should modify and redeploy all APIs without conflicts for parameter resolution")
+    @DeployApi({ "/apis/success-flow.json" })
+    void shouldRedeployAllApisWithoutParameterConflict(
+        Map<String, String> injectedParams,
+        HttpClient httpClient,
+        Map<String, ReactableApi<?>> reactableApis
+    ) throws InterruptedException {
+        wiremock.stubFor(get("/team/my_team").willReturn(ok()));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("OnResponseContent2Policy");
+                return true;
+            })
+            .assertNoErrors();
+
+        reactableApis.forEach((name, reactableApi) -> {
+            if (isLegacyApi(reactableApi.getDefinition().getClass())) {
+                Api api = (Api) reactableApi.getDefinition();
+                api.getProxy().getVirtualHosts().get(0).setPath("/new_test");
+                redeploy(reactableApi);
+            }
+        });
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(404);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("No context-path matches the request URI.");
+                return true;
+            })
+            .assertNoErrors();
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/new_test/my_team")
+            .flatMap(request -> request.rxSend())
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("OnResponseContent2Policy");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(
+            getRequestedFor(urlPathEqualTo("/team/my_team"))
+                .withHeader("X-Gravitee-Policy", equalTo("request-header1"))
+                .withHeader(ON_REQUEST_POLICY, equalTo("invoked"))
+        );
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("header-policy1", PolicyBuilder.build("header-policy1", Header1Policy.class));
+        policies.put(ON_REQUEST_POLICY, PolicyBuilder.build(ON_REQUEST_POLICY, OnRequestPolicy.class));
+        policies.put("stream-policy", PolicyBuilder.build("stream-policy", Stream1Policy.class));
+        policies.put("stream-policy2", PolicyBuilder.build("stream-policy2", Stream2Policy.class));
+    }
+
+    public Stream<Arguments> provideParameters() {
+        return Stream.of(
+            Arguments.of(Map.of()),
+            Arguments.of(Map.of("key", "value")),
+            Arguments.of(Map.of("key", "value", "key2", "value2"))
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyUndeployTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ManuallyUndeployTestCase.java
@@ -1,0 +1,60 @@
+package testcases;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Header1Policy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.OnRequestPolicy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Stream1Policy;
+import io.gravitee.apim.gateway.tests.sdk.policy.fakes.Stream2Policy;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@EnableForGatewayTestingExtensionTesting
+public class ManuallyUndeployTestCase extends AbstractGatewayTest {
+
+    public static final String ON_REQUEST_POLICY = "on-request-policy";
+
+    @Test
+    @DisplayName("Should undeploy one api")
+    @DeployApi({ "/apis/success-flow.json", "/apis/teams.json" })
+    void shouldUndeployOneApi() throws InterruptedException {
+        assertThat(deployedApis).hasSize(2);
+        undeploy("api-test");
+        assertThat(deployedApis).hasSize(1);
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("header-policy1", PolicyBuilder.build("header-policy1", Header1Policy.class));
+        policies.put(ON_REQUEST_POLICY, PolicyBuilder.build(ON_REQUEST_POLICY, OnRequestPolicy.class));
+        policies.put("stream-policy", PolicyBuilder.build("stream-policy", Stream1Policy.class));
+        policies.put("stream-policy2", PolicyBuilder.build("stream-policy2", Stream2Policy.class));
+    }
+}


### PR DESCRIPTION
## Description

This PR allows the developper to:
- inject one API or all apis deployed at method level as a parameter of a test method
- provide api deployment methods to be able to deploy, undeploy or redeploy an api manually from a test

⚠️ Apis deployed at class level are untouchable to avoid weird behavior between test cases depending on the order of execution

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dypdlcmrew.chromatic.com)
<!-- Storybook placeholder end -->
