### PR TITLE
Automatically scroll to top of content component on API view

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apiAdmin.html
+++ b/gravitee-apim-console-webui/src/management/api/apiAdmin.html
@@ -74,6 +74,7 @@
       }"
       ui-view
       layout="column"
+      autoscroll="true"
     ></div>
   </div>
 </api-navigation>


### PR DESCRIPTION
## Issue

https://graviteeio.slack.com/archives/C04FFDFK3K7/p1688588458344749

## Description

When navigating with API menu, the scroll is not set to the top of the content view when changing content component. And as the menu is long, if the content component has a short height, we do not see it, and see only a white screen.

![image (1)](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/9a73f318-893c-4d45-b472-dccaac98d514)

I used the autoscroll feature of ui-router to handle this
https://github.com/angular-ui/ui-router/wiki/Quick-Reference#autoscroll
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4553.team-apim.gravitee.dev/console](https://4553.team-apim.gravitee.dev/console)
      Portal: [https://4553.team-apim.gravitee.dev/portal](https://4553.team-apim.gravitee.dev/portal)
      Management-api: [https://4553.team-apim.gravitee.dev/api/management](https://4553.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4553.team-apim.gravitee.dev](https://4553.team-apim.gravitee.dev)
      Gateway v3: [https://4553.gateway-v3.team-apim.gravitee.dev](https://4553.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
