### PR TITLE
test: add webhook connector test with mock endpoint

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnector.java
@@ -27,13 +27,15 @@ import io.reactivex.rxjava3.core.Maybe;
  */
 public class PersistentMockEndpointConnector extends MockEndpointConnector {
 
-    public PersistentMockEndpointConnector(MockEndpointConnectorConfiguration configuration) {
+    private final MessageStorage messageStorage;
+
+    public PersistentMockEndpointConnector(MockEndpointConnectorConfiguration configuration, MessageStorage messageStorage) {
         super(configuration);
+        this.messageStorage = messageStorage;
     }
 
     @Override
     public Completable publish(ExecutionContext ctx) {
-        final MessageStorage messageStorage = ctx.getComponent(MessageStorage.class);
         return Completable
             .defer(() ->
                 ctx

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnectorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnectorFactory.java
@@ -57,7 +57,8 @@ public class PersistentMockEndpointConnectorFactory implements EndpointAsyncConn
     ) {
         try {
             return new PersistentMockEndpointConnector(
-                pluginConfigurationHelper.readConfiguration(MockEndpointConnectorConfiguration.class, configuration)
+                pluginConfigurationHelper.readConfiguration(MockEndpointConnectorConfiguration.class, configuration),
+                deploymentContext.getComponent(MessageStorage.class)
             );
         } catch (PluginConfigurationException e) {
             return null;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/ForceClientIdentifierPolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/ForceClientIdentifierPolicy.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.fake;
+
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * This policy forces the client identifier with 'custom' value.
+ * It is specifically useful when running parallel tests with webhook when there is no real http request and it is not possible to specify a particular request header to override it.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ForceClientIdentifierPolicy implements Policy {
+
+    @Override
+    public String id() {
+        return "force-client-identifier";
+    }
+
+    @Override
+    public Completable onRequest(HttpExecutionContext ctx) {
+        ((MutableExecutionContext) ctx).request().clientIdentifier("custom");
+        return Policy.super.onRequest(ctx);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractMqtt5EndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractMqtt5EndpointIntegrationTest.java
@@ -227,8 +227,7 @@ public abstract class AbstractMqtt5EndpointIntegrationTest extends AbstractGatew
 
     @NonNull
     protected Completable publishMessagesWhenReady(List<Completable> readyObs, String topic, MqttQos publishQos) {
-        return Completable.defer(() -> Completable.merge(readyObs).andThen((publishToMqtt5(topic, "message", publishQos).ignoreElements()))
-        );
+        return Completable.defer(() -> Completable.merge(readyObs).andThen(publishToMqtt5(topic, "message", publishQos).ignoreElements()));
     }
 
     protected String extractTransactionId(HttpClientResponse response) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMqttEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMqttEndpointIntegrationTest.java
@@ -15,22 +15,24 @@
  */
 package io.gravitee.apim.integration.tests.messages.webhook;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.graviteesource.entrypoint.webhook.WebhookEntrypointConnectorFactory;
 import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
-import io.gravitee.apim.integration.tests.fake.MessageFlowReadyPolicy;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.fake.ForceClientIdentifierPolicy;
 import io.gravitee.apim.integration.tests.messages.AbstractMqtt5EndpointIntegrationTest;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.reactive.api.qos.Qos;
 import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.policy.PolicyPlugin;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -47,159 +50,184 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@GatewayTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class WebhookEntrypointMqttEndpointIntegrationTest extends AbstractMqtt5EndpointIntegrationTest {
+class WebhookEntrypointMqttEndpointIntegrationTest {
 
     private static final String WEBHOOK_URL_PATH = "/webhook";
 
     private WebhookTestingActions webhookActions;
 
-    @Override
-    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
-        entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
-    }
+    @Nested
+    @GatewayTest
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class SingleTest extends AbstractMqtt5EndpointIntegrationTest {
 
-    @BeforeEach
-    void setUp() {
-        webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
-    }
-
-    @ParameterizedTest
-    @MethodSource("allQosParameters")
-    @DeployApi(
-        {
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
         }
-    )
-    void should_receive_messages_single(Qos qos, MqttQos publishQos) throws JsonProcessingException {
-        final int messageCount = 10;
-        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
-        final List<Completable> readyObs = new ArrayList<>();
 
-        final Subscription subscription = createSubscription(qos, callbackPath, readyObs);
-
-        final TestObserver<Void> obs = Completable
-            .mergeArray(
-                webhookActions.dispatchSubscription(subscription),
-                publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
-            )
-            .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
-            .test();
-
-        obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
-
-        // Verify requests received by wiremock
-        verifyMessages(messageCount, callbackPath);
-    }
-
-    @ParameterizedTest
-    @MethodSource("allQosParameters")
-    @DeployApi(
-        {
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
+        @BeforeEach
+        void setUp() {
+            webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
         }
-    )
-    void should_receive_all_messages_with_additional_headers(Qos qos, MqttQos publishQos) throws JsonProcessingException {
-        final int messageCount = 10;
-        final String callbackPath = WEBHOOK_URL_PATH + "/with-header";
-        final List<Completable> readyObs = new ArrayList<>();
 
-        final List<HttpHeader> headers = List.of(
-            new HttpHeader("Header1", "my-header-1-value"),
-            new HttpHeader("Header2", "my-header-2-value")
-        );
-
-        final Subscription subscription = createSubscription(qos, callbackPath, headers, readyObs);
-
-        final TestObserver<Void> obs = Completable
-            .mergeArray(
-                webhookActions.dispatchSubscription(subscription),
-                publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
-            )
-            .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
-            .test();
-
-        obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
-
-        // Verify requests received by wiremock
-        verifyMessagesWithHeaders(messageCount, callbackPath, headers);
-    }
-
-    @ParameterizedTest
-    @MethodSource("allQosParameters")
-    @DeployApi(
-        {
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
-            "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
-        }
-    )
-    void should_receive_messages_parallel(Qos qos, MqttQos publishQos) throws JsonProcessingException {
-        final int messageCount = 40;
-        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
-        final List<Completable> readyObs = new ArrayList<>();
-
-        // Simulate the same subscription running on 2 different instances.
-        final Subscription subscriptionInstance1 = createSubscription(qos, callbackPath, readyObs);
-        final Subscription subscriptionInstance2 = createSubscription(qos, callbackPath, readyObs);
-        subscriptionInstance2.setId(subscriptionInstance1.getId());
-
-        final TestObserver<Void> obs = Completable
-            .mergeArray(
-                webhookActions.dispatchSubscription(subscriptionInstance1),
-                webhookActions.dispatchSubscription(subscriptionInstance2),
-                publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
-            )
-            .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
-            .test();
-
-        obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
-
-        // Verify requests received by wiremock has no duplicates.
-        verifyMessages(messageCount, callbackPath);
-    }
-
-    private void verifyMessages(int messageCount, String callbackPath) {
-        for (int i = 0; i < messageCount; i++) {
-            wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message-" + i)));
-        }
-    }
-
-    private void verifyMessagesWithHeaders(int messageCount, String callbackPath, List<HttpHeader> headers) {
-        for (int i = 0; i < messageCount; i++) {
-            final RequestPatternBuilder requestPatternBuilder = postRequestedFor(urlPathEqualTo(callbackPath))
-                .withRequestBody(equalTo("message-" + i));
-
-            for (HttpHeader header : headers) {
-                requestPatternBuilder.withHeader(header.getName(), equalTo(header.getValue()));
+        @ParameterizedTest
+        @MethodSource("allQosParameters")
+        @DeployApi(
+            {
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
             }
+        )
+        void should_receive_messages_single(Qos qos, MqttQos publishQos) throws JsonProcessingException {
+            final int messageCount = 10;
+            final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+            final List<Completable> readyObs = new ArrayList<>();
 
-            wiremock.verify(1, requestPatternBuilder);
+            final Subscription subscription = webhookActions.createSubscription(
+                "mqtt5-endpoint-qos-" + qos.getLabel(),
+                callbackPath,
+                readyObs
+            );
+
+            final TestObserver<Void> obs = Completable
+                .mergeArray(
+                    webhookActions.dispatchSubscription(subscription),
+                    publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
+                )
+                .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
+                .test();
+
+            obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
+
+            // Verify requests received by wiremock
+            webhookActions.verifyMessages(messageCount, callbackPath);
+        }
+
+        @ParameterizedTest
+        @MethodSource("allQosParameters")
+        @DeployApi(
+            {
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
+            }
+        )
+        void should_receive_all_messages_with_additional_headers(Qos qos, MqttQos publishQos) throws JsonProcessingException {
+            final int messageCount = 10;
+            final String callbackPath = WEBHOOK_URL_PATH + "/with-header";
+            final List<Completable> readyObs = new ArrayList<>();
+
+            final List<HttpHeader> headers = List.of(
+                new HttpHeader("Header1", "my-header-1-value"),
+                new HttpHeader("Header2", "my-header-2-value")
+            );
+
+            final Subscription subscription = webhookActions.createSubscription(
+                "mqtt5-endpoint-qos-" + qos.getLabel(),
+                callbackPath,
+                headers,
+                readyObs
+            );
+
+            final TestObserver<Void> obs = Completable
+                .mergeArray(
+                    webhookActions.dispatchSubscription(subscription),
+                    publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
+                )
+                .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
+                .test();
+
+            obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
+
+            // Verify requests received by wiremock
+            webhookActions.verifyMessagesWithHeaders(messageCount, callbackPath, headers);
         }
     }
 
-    private Subscription createSubscription(Qos qos, String callbackPath, List<Completable> readyObs) throws JsonProcessingException {
-        return this.createSubscription(qos, callbackPath, null, readyObs);
-    }
+    @Nested
+    @GatewayTest
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class ParallelTest extends AbstractMqtt5EndpointIntegrationTest {
 
-    private Subscription createSubscription(Qos qos, String callbackPath, List<HttpHeader> headers, List<Completable> readyObs)
-        throws JsonProcessingException {
-        final Subscription subscription = webhookActions.configureSubscriptionAndCallback(
-            "mqtt5-endpoint-qos-" + qos.getLabel(),
-            callbackPath,
-            null,
-            headers
-        );
-        readyObs.add(MessageFlowReadyPolicy.readyObs(subscription));
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
+        }
 
-        return subscription;
+        @BeforeEach
+        void setUp() {
+            webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            super.configurePolicies(policies);
+            policies.putIfAbsent(
+                "force-client-identifier",
+                PolicyBuilder.build("force-client-identifier", ForceClientIdentifierPolicy.class)
+            );
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
+
+            if (definitionClass.isAssignableFrom(Api.class)) {
+                Api apiDefinition = (Api) api.getDefinition();
+                apiDefinition
+                    .getFlows()
+                    .get(0)
+                    .setRequest(
+                        List.of(Step.builder().name("Force client identifier").policy("force-client-identifier").enabled(true).build())
+                    );
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("allQosParameters")
+        @DeployApi(
+            {
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-auto.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-none.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-most-once.json",
+                "/apis/v4/messages/mqtt5/mqtt5-endpoint-qos-at-least-once.json",
+            }
+        )
+        void should_receive_messages_parallel(Qos qos, MqttQos publishQos) throws JsonProcessingException {
+            final int messageCount = 40;
+            final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+            final List<Completable> readyObs = new ArrayList<>();
+
+            // Simulate the same subscription running on 2 different instances.
+            final Subscription subscriptionInstance1 = webhookActions.createSubscription(
+                "mqtt5-endpoint-qos-" + qos.getLabel(),
+                callbackPath,
+                readyObs
+            );
+            final Subscription subscriptionInstance2 = webhookActions.createSubscription(
+                "mqtt5-endpoint-qos-" + qos.getLabel(),
+                callbackPath,
+                readyObs
+            );
+
+            final TestObserver<Void> obs = Completable
+                .mergeArray(
+                    webhookActions.dispatchSubscription(subscriptionInstance1),
+                    webhookActions.dispatchSubscription(subscriptionInstance2),
+                    publishMessagesWhenReady(readyObs, TEST_TOPIC + "-qos-" + qos.getLabel(), publishQos)
+                )
+                .takeUntil(webhookActions.waitForRequestsOnCallback(messageCount, callbackPath))
+                .test();
+
+            obs.awaitDone(30, TimeUnit.SECONDS).assertComplete();
+
+            // Verify requests received by wiremock has no duplicates.
+            webhookActions.verifyMessages(messageCount, callbackPath);
+        }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/websocket/WebsocketEntrypointMqtt5EndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/websocket/WebsocketEntrypointMqtt5EndpointIntegrationTest.java
@@ -170,6 +170,7 @@ class WebsocketEntrypointMqtt5EndpointIntegrationTest extends AbstractMqtt5Endpo
 
         createWSRequest("/test-publish", UUID.random().toString(), httpClient)
             .flatMapCompletable(webSocket -> webSocket.writeFinalTextFrame("message"))
+            .delaySubscription(100, TimeUnit.MILLISECONDS) // No way to know if mqtt5 subscription is ok, let's apply a small delay.
             .test()
             .awaitDone(30, TimeUnit.SECONDS)
             .assertComplete()

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-4xx.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-4xx.json
@@ -1,5 +1,5 @@
 {
-  "id": "my-api",
+  "id": "webhook-entrypoint-mock-endpoint",
   "name": "my-api",
   "apiVersion": "1.0",
   "definitionVersion": "4.0.0",
@@ -15,7 +15,12 @@
       ],
       "entrypoints": [
         {
-          "type": "webhook"
+          "type": "webhook",
+          "configuration": {
+            "http": {
+              "maxConcurrentConnections": 1
+            }
+          }
         }
       ]
     }
@@ -28,16 +33,28 @@
         {
           "name": "default",
           "type": "mock",
-          "weight": 1,
           "inheritConfiguration": false,
           "configuration": {
-            "messageInterval": 5,
-            "messageContent": "Mock data",
-            "messageCount": 7
+            "messageInterval": 10,
+            "messageContent": "message",
+            "messageCount": 3
           }
         }
       ]
     }
   ],
-  "flows": []
+  "flows": [
+    {
+      "name": "Flow ready",
+      "enabled": true,
+      "subscribe": [
+        {
+          "name": "Message Flow Ready",
+          "description": "Detect the message flow is ready",
+          "enabled": true,
+          "policy": "message-flow-ready"
+        }
+      ]
+    }
+  ]
 }

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-5xx.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-5xx.json
@@ -1,0 +1,60 @@
+{
+  "id": "webhook-entrypoint-mock-endpoint",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook",
+          "configuration": {
+            "http": {
+              "maxConcurrentConnections": 1
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 0,
+            "messageContent": "message",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow ready",
+      "enabled": true,
+      "subscribe": [
+        {
+          "name": "Message Flow Ready",
+          "description": "Detect the message flow is ready",
+          "enabled": true,
+          "policy": "message-flow-ready"
+        }
+      ]
+    }
+  ]
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-dlq.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-dlq.json
@@ -1,0 +1,61 @@
+{
+  "id": "webhook-entrypoint-mock-endpoint",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook",
+          "dlq": "mock",
+          "configuration": {
+            "http": {
+              "maxConcurrentConnections": 1
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "mock",
+          "type": "mock",
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 10,
+            "messageContent": "message",
+            "messageCount": 3
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow ready",
+      "enabled": true,
+      "subscribe": [
+        {
+          "name": "Message Flow Ready",
+          "description": "Detect the message flow is ready",
+          "enabled": true,
+          "policy": "message-flow-ready"
+        }
+      ]
+    }
+  ]
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-oauth2-renew.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint-oauth2-renew.json
@@ -1,0 +1,60 @@
+{
+  "id": "webhook-entrypoint-mock-endpoint",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook",
+          "configuration": {
+            "http": {
+              "maxConcurrentConnections": 1
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 10,
+            "messageContent": "message",
+            "messageCount": 3
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow ready",
+      "enabled": true,
+      "subscribe": [
+        {
+          "name": "Message Flow Ready",
+          "description": "Detect the message flow is ready",
+          "enabled": true,
+          "policy": "message-flow-ready"
+        }
+      ]
+    }
+  ]
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mock-endpoint.json
@@ -1,0 +1,42 @@
+{
+  "id": "webhook-entrypoint-mock-endpoint",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "message",
+            "messageCount": 10
+          }
+        }
+      ]
+    }
+  ],
+  "flows": []
+}

--- a/pom.xml
+++ b/pom.xml
@@ -256,14 +256,14 @@
         <gravitee-entrypoint-http-get.version>1.0.0-alpha.6</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.0.0-alpha.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>3.1.0-alpha.3</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>1.1.0-alpha.5</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>1.1.0-alpha.7</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.0-alpha.3</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>1.3.0-alpha.9</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>1.2.0-alpha.9</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>1.0.0-alpha.6</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.0.0-alpha.8</gravitee-endpoint-solace.version>
         <gravitee-resource-schema-registry-confluent.version>1.0.0-alpha.10</gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>1.0.0-alpha.10</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.11</gravitee-reactor-message.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Description

This PR adds V4 testing use cases for Webhook with a mock endpoint. Here is the list of use cases added:

- Nominal case
- Nominal case with headers added by the subscriber to call the webhook
- Basic auth
- Basic auth with unauthorize
- Token auth
- Token auth with unauthorize
- Oauth2 auth
- Oauth2 auth with unauthorize
- Oauth2 auth with token expiration and renewal
- Retry in case of an error
- Max retry then interrupt
- Stop on 4xx returned by the webhook
- Put in dlq on 4xx and continue message consumption

This PR is linked to https://github.com/gravitee-io/gravitee-entrypoint-webhook/pull/31 which comes with some fixes.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fwnrazukrt.chromatic.com)
<!-- Storybook placeholder end -->
