### PR TITLE
Apim 2164 add api key validation to create dialog

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/plan.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/plan.fixture.ts
@@ -25,6 +25,7 @@ export function fakeBasePlan(modifier?: Partial<BasePlan> | ((base: BasePlan) =>
     id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
     name: 'Default plan',
     description: 'Default plan',
+    apiId: '117e79a3-6023-4b72-be79-a36023ab72f9',
     characteristics: [],
     status: 'PUBLISHED',
     validation: 'AUTO',

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.ts
@@ -69,7 +69,7 @@ export class ApiKeyValidationComponent implements OnInit, ControlValueAccessor, 
   ngOnInit() {
     this.apiKeyFormControl?.valueChanges
       .pipe(
-        tap((apiKey) => apiKey.length > 0 && this._onChange(apiKey)),
+        tap((apiKey) => this._onChange(apiKey)),
         takeUntil(this.unsubscribe$),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
@@ -67,11 +67,24 @@
         </mat-radio-button>
       </mat-radio-group>
 
-      <mat-form-field class="subscription-creation__content__custom-apikey" *ngIf="shouldDisplayCustomApiKey()">
-        <mat-label>Custom API-Key</mat-label>
-        <input matInput type="text" formControlName="customApiKey" />
-        <mat-hint>You can provide a custom API key if you already have one. Leave it blank to get a generated apikey</mat-hint>
-      </mat-form-field>
+      <ng-container
+        *ngIf="
+          canUseCustomApikey &&
+          form.get('selectedPlan').value?.security.type === 'API_KEY' &&
+          form.get('selectedPlan').value?.apiId &&
+          form.get('selectedApplication').value?.id
+        "
+      >
+        <div class="mat-body-1">
+          You can provide a custom API Key if you already have one. <br />
+          Leave it blank to get a generated API Key.
+        </div>
+        <api-key-validation
+          formControlName="customApiKey"
+          [applicationId]="form.get('selectedApplication').value.id"
+          [apiId]="form.get('selectedPlan').value.apiId"
+        ></api-key-validation>
+      </ng-container>
 
       <ng-container *ngIf="form.get('selectedEntrypoint')">
         <mat-form-field>
@@ -107,7 +120,7 @@
       type="submit"
       class="actions__createBtn"
       color="primary"
-      mat-stroked-button
+      mat-raised-button
       role="dialog"
       [disabled]="this.form.invalid || this.form.pristine"
     >

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -99,6 +99,9 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
         term.length > 0 ? this.applicationService.list('ACTIVE', term, 'name', 1, 20) : of(new PagedResult<Application>()),
       ),
       map((applicationsPage) => applicationsPage.data),
+      tap((_) => {
+        this.form.get('customApiKey')?.reset();
+      }),
       share(),
       takeUntil(this.unsubscribe$),
     );
@@ -160,9 +163,11 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
       subscriptionToCreate: {
         planId: this.form.getRawValue().selectedPlan.id,
         applicationId: this.form.getRawValue().selectedApplication.id,
-        ...(this.shouldDisplayCustomApiKey() && this.form.getRawValue().customApiKey
-          ? { customApiKey: this.form.getRawValue().customApiKey }
-          : undefined),
+        ...(this.form.getRawValue().customApiKey && this.form.getRawValue().customApiKey !== ''
+          ? {
+              customApiKey: this.form.getRawValue().customApiKey,
+            }
+          : {}),
         ...(this.form.getRawValue().selectedPlan.mode === 'PUSH'
           ? {
               consumerConfiguration: {
@@ -186,10 +191,6 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
 
   displayApplication(application: Application): string {
     return application?.name;
-  }
-
-  shouldDisplayCustomApiKey(): boolean {
-    return this.canUseCustomApikey && this.form.get('selectedPlan').value?.security?.type === 'API_KEY';
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
@@ -21,6 +21,8 @@ import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 
+import { ApiKeyValidationHarness } from '../../api-key-validation/api-key-validation.harness';
+
 export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness {
   static hostSelector = 'api-portal-subscription-creation-dialog';
 
@@ -30,7 +32,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
     MatFormFieldHarness.with({ selector: '.subscription-creation__content__applications' }),
   );
   protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
-  protected getCustomApikeyInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="customApiKey"]' }));
+  protected getCustomApikeyInput = this.locatorForOptional(ApiKeyValidationHarness);
   protected getSelectEntrypointSelect = this.locatorForOptional(
     MatSelectHarness.with({ selector: '[formControlName="selectedEntrypoint"]' }),
   );
@@ -78,7 +80,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
 
   public async addCustomKey(customApikey: string) {
     const matInputHarness = await this.getCustomApikeyInput();
-    return await matInputHarness.setValue(customApikey);
+    return await matInputHarness.setInputValue(customApikey);
   }
 
   // PUSH Plan

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
@@ -27,9 +27,4 @@ export class ApiPortalSubscriptionListHarness extends ComponentHarness {
   public getApiKeyInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="apikey"]' }));
   public getCreateSubscriptionButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Create a subscription"]' }));
   public getResetFilterButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Reset filters"]' }));
-
-  public async openCreationDialog(): Promise<void> {
-    const matButtonHarness = await this.getCreateSubscriptionButton();
-    return await matButtonHarness.click();
-  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2164

## Description

- fix tiny bug that didn't allow api-key-validation to be empty after filling in value
- add api-key-validation component to the creation dialog

![Screen Shot 2023-07-06 at 11 18 35](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/f4daa874-a8c6-4dcd-902d-4ba248683766)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dgjhvoadon.chromatic.com)
<!-- Storybook placeholder end -->
