### PR TITLE
Console - Add API top banners to deploy, review ext..

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
@@ -67,9 +67,18 @@ export interface BaseApi {
    */
   groups?: string[];
   /**
-   * The status of the API regarding the gateway.
+   * The status of the API regarding the gateway(s).
    */
-  state?: StateEnum;
+  state?: ApiState;
+
+  /**
+   * The deployment state of the API regarding the gateway(s).
+   */
+  deploymentState?: ApiDeploymentState;
+
+  /**
+   * The visibility of the resource regarding the portal.
+   */
   visibility?: ApiVisibility;
   /**
    * The free list of labels associated with this API.
@@ -96,4 +105,5 @@ export interface BaseApi {
   _links?: { [key: string]: string };
 }
 
-export type StateEnum = 'CLOSED' | 'INITIALIZED' | 'STARTED' | 'STOPPED' | 'STOPPING';
+export type ApiState = 'CLOSED' | 'INITIALIZED' | 'STARTED' | 'STOPPED' | 'STOPPING';
+export type ApiDeploymentState = 'NEED_REDEPLOY' | 'DEPLOYED';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/baseApi.ts
@@ -95,7 +95,7 @@ export interface BaseApi {
   categories?: string[];
   definitionContext?: DefinitionContext;
   /**
-   * The API logo URL.
+   * The status of the API regarding the review feature.
    */
   workflowState?: ApiWorkflowState;
   responseTemplates?: { [key: string]: { [key: string]: ResponseTemplate } };

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import { castArray, flatMap } from 'lodash';
@@ -49,7 +49,7 @@ interface GroupItem {
   template: require('./api-navigation.component.html'),
   styles: [require('./api-navigation.component.scss')],
 })
-export class ApiNavigationComponent implements OnInit {
+export class ApiNavigationComponent implements OnInit, OnDestroy {
   @Input()
   public apiName: string;
   @Input()
@@ -112,6 +112,10 @@ export class ApiNavigationComponent implements OnInit {
     });
   }
 
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
   private appendDesign() {
     this.subMenuItems.push({
       displayName: 'Policy Studio',

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.html
@@ -1,0 +1,36 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 matDialogTitle>Deploy your API</h2>
+
+<mat-dialog-content class="content">
+  <div class="mat-body-1">Provide a label to identify your deployment.</div>
+  <mat-form-field appearance="outline" class="content__deploymentLabel">
+    <mat-label>Deployment label</mat-label>
+    <input #input matInput [formControl]="deploymentLabel" maxlength="32" />
+    <mat-hint align="end">{{ input.value.length }}/32</mat-hint>
+  </mat-form-field>
+
+  <gio-banner-warning *ngIf="hasPlatformPolicies$ | async">
+    Some policies are defined on the platform and may conflict with your API policies on flows.
+    <div gioBannerBody>Contact your administrator for further information.</div>
+  </gio-banner-warning>
+</mat-dialog-content>
+<mat-dialog-actions class="actions" align="end">
+  <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+  <button color="primary" mat-raised-button aria-label="Deploy the API" (click)="onDeploy()">Deploy</button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.scss
@@ -1,0 +1,4 @@
+.content {
+  display: flex;
+  flex-direction: column;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import {
+  ApiConfirmDeploymentDialogComponent,
+  ApiConfirmDeploymentDialogData,
+  ApiConfirmDeploymentDialogResult,
+} from './api-confirm-deployment-dialog.component';
+
+import { ApiNgNavigationModule } from '../api-ng-navigation.module';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+
+const API_ID = 'apiId';
+@Component({
+  selector: 'gio-dialog-test',
+  template: `<button mat-button id="open-dialog-test" (click)="openDialog()">Open dialog</button>`,
+})
+class TestComponent {
+  public result?: any;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<ApiConfirmDeploymentDialogComponent, ApiConfirmDeploymentDialogData, ApiConfirmDeploymentDialogResult>(
+        ApiConfirmDeploymentDialogComponent,
+        {
+          data: {
+            apiId: API_ID,
+          },
+          role: 'alertdialog',
+        },
+      )
+      .afterClosed()
+      .subscribe((result) => (this.result = result));
+  }
+}
+
+describe('ApiConfirmDeploymentDialogComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [ApiNgNavigationModule, NoopAnimationsModule, MatDialogModule, MatIconTestingModule, GioHttpTestingModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const openDialogButton = await loader.getHarness(MatButtonHarness.with({ selector: '#open-dialog-test' }));
+    await openDialogButton.click();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should deploy api', async () => {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.org.baseURL}/configuration/flows`,
+        method: 'GET',
+      })
+      .flush({
+        has_policies: true,
+      });
+
+    const dialog = await loader.getHarness(MatDialogHarness);
+
+    expect(await dialog.getText()).toContain('Some policies are defined on the platform and may conflict with your API policies on flows.');
+
+    const messageInput = await dialog.getHarness(MatInputHarness.with({ ancestor: '.content__deploymentLabel' }));
+    await messageInput.setValue('Deployment label');
+
+    const deployBtn = await dialog.getHarness(MatButtonHarness.with({ text: 'Deploy' }));
+    await deployBtn.click();
+
+    const req = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/deployments`,
+      method: 'POST',
+    });
+
+    expect(req.request.body).toEqual({ deploymentLabel: 'Deployment label' });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-confirm-deployment-dialog/api-confirm-deployment-dialog.component.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnDestroy } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { map, takeUntil } from 'rxjs/operators';
+
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { FlowService } from '../../../../services-ngx/flow.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+export interface ApiConfirmDeploymentDialogData {
+  apiId: string;
+}
+export type ApiConfirmDeploymentDialogResult = void;
+@Component({
+  selector: 'api-confirm-deployment-dialog',
+  template: require('./api-confirm-deployment-dialog.component.html'),
+  styles: [require('./api-confirm-deployment-dialog.component.scss')],
+})
+export class ApiConfirmDeploymentDialogComponent implements OnDestroy {
+  private unsubscribe$ = new Subject<void>();
+
+  public deploymentLabel = new FormControl();
+
+  public hasPlatformPolicies$ = this.flowService.getConfiguration().pipe(map((configuration) => configuration.has_policies));
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiConfirmDeploymentDialogComponent, ApiConfirmDeploymentDialogResult>,
+    @Inject(MAT_DIALOG_DATA) private readonly dialogData: ApiConfirmDeploymentDialogData,
+
+    private readonly snackBarService: SnackBarService,
+    private readonly apiV2Service: ApiV2Service,
+    private readonly flowService: FlowService,
+  ) {}
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onDeploy() {
+    this.apiV2Service
+      .deploy(this.dialogData.apiId, this.deploymentLabel.value)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(
+        () => {
+          this.dialogRef.close();
+          this.snackBarService.success('API successfully deployed.');
+        },
+        () => {
+          this.snackBarService.error('An error occurred while deploying the API.');
+        },
+      );
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.html
@@ -94,6 +94,15 @@
         [tabMenuItems]="this.selectedItemWithTabs.tabs"
       ></api-ng-navigation-tabs>
 
+      <div class="api-navigation__content__view__banners" *ngIf="banners$ | async as banners">
+        <gio-banner *ngFor="let banner of banners" [type]="banner.type">
+          {{ banner.title }}
+          <div *ngIf="banner.action" gioBannerAction>
+            <button mat-stroked-button color="basic" (click)="banner.action.onClick()">{{ banner.action.btnText }}</button>
+          </div>
+        </gio-banner>
+      </div>
+
       <ui-view class="api-navigation__content__view__ui"></ui-view>
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.scss
@@ -65,6 +65,10 @@ $textColor: map.get(gio.$mat-dove-palette, default);
       &__ui {
         height: 100%;
       }
+
+      &__banners {
+        padding: 0 32px;
+      }
     }
 
     &__tabs {

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.spec.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { UIRouterModule } from '@uirouter/angular';
+
+import { ApiNgNavigationModule } from './api-ng-navigation.module';
+import { ApiNgNavigationComponent } from './api-ng-navigation.component';
+
+import { CurrentUserService, UIRouterState, UIRouterStateParams } from '../../../ajs-upgraded-providers';
+import { GioUiRouterTestingModule } from '../../../shared/testing/gio-uirouter-testing-module';
+import { User as DeprecatedUser } from '../../../entities/user';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { fakeApiV4 } from '../../../entities/management-api-v2';
+
+describe('ApiNgNavigationComponent', () => {
+  const fakeUiRouter = { go: jest.fn() };
+  let fixture: ComponentFixture<ApiNgNavigationComponent>;
+  let apiNgNavigationComponent: ApiNgNavigationComponent;
+  let httpTestingController: HttpTestingController;
+  let apiV2Service: ApiV2Service;
+  const currentUser = new DeprecatedUser();
+  currentUser.userPermissions = ['environment-api-c'];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without quality score', () => {
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [
+          ApiNgNavigationModule,
+          MatIconTestingModule,
+          GioUiRouterTestingModule,
+          NoopAnimationsModule,
+          GioHttpTestingModule,
+          UIRouterModule.forRoot({
+            useHash: true,
+          }),
+        ],
+        providers: [
+          { provide: UIRouterState, useValue: fakeUiRouter },
+          { provide: UIRouterStateParams, useValue: {} },
+          { provide: CurrentUserService, useValue: { currentUser } },
+          { provide: 'Constants', useValue: CONSTANTS_TESTING },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ApiNgNavigationComponent);
+      apiNgNavigationComponent = await fixture.componentInstance;
+      httpTestingController = TestBed.inject(HttpTestingController);
+      apiV2Service = TestBed.inject(ApiV2Service);
+    });
+    describe('Banners', () => {
+      it('should display "Out of sync" banner', async (done) => {
+        const API_ID = 'apiId';
+        apiV2Service.get(API_ID).subscribe();
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`,
+            method: 'GET',
+          })
+          .flush(
+            fakeApiV4({
+              id: API_ID,
+              deploymentState: 'NEED_REDEPLOY',
+            }),
+          );
+
+        apiNgNavigationComponent.banners$.subscribe((banners) => {
+          expect(banners).toEqual([
+            {
+              title: 'This API is out of sync.',
+              type: 'warning',
+            },
+          ]);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
@@ -13,19 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, Input, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import { castArray, flatMap } from 'lodash';
-import { takeUntil } from 'rxjs/operators';
-import { GioMenuService } from '@gravitee/ui-particles-angular';
-import { Subject } from 'rxjs';
+import { takeUntil, map } from 'rxjs/operators';
+import { GIO_DIALOG_WIDTH, GioMenuService } from '@gravitee/ui-particles-angular';
+import { Observable, Subject } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+
+import {
+  ApiConfirmDeploymentDialogComponent,
+  ApiConfirmDeploymentDialogData,
+  ApiConfirmDeploymentDialogResult,
+} from './api-confirm-deployment-dialog/api-confirm-deployment-dialog.component';
+import { ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult } from './api-review-dialog/api-review-dialog.component';
 
 import { AjsRootScope, CurrentUserService, UIRouterState } from '../../../ajs-upgraded-providers';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import UserService from '../../../services/user.service';
 import { Constants } from '../../../entities/Constants';
 import { Api } from '../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 
 export interface MenuItem {
   targetRoute?: string;
@@ -39,12 +48,21 @@ interface GroupItem {
   items: MenuItem[];
 }
 
+type TopBanner = {
+  title: string;
+  text: 'info' | 'warning' | 'error' | 'success';
+  action?: {
+    btnText: string;
+    onClick: () => void;
+  };
+};
+
 @Component({
   selector: 'api-ng-navigation',
   template: require('./api-ng-navigation.component.html'),
   styles: [require('./api-ng-navigation.component.scss')],
 })
-export class ApiNgNavigationComponent implements OnInit {
+export class ApiNgNavigationComponent implements OnInit, OnDestroy {
   @Input()
   public currentApi: Api;
 
@@ -56,9 +74,173 @@ export class ApiNgNavigationComponent implements OnInit {
   public selectedItemWithTabs: MenuItem = undefined;
   public bannerState: string;
   public hasBreadcrumb = false;
-  private unsubscribe$ = new Subject();
   public breadcrumbItems: string[] = [];
+  public banners$: Observable<TopBanner[]> = this.apiV2Service.getLastApiFetch().pipe(
+    map((api) => {
+      const banners = [];
 
+      const isApiReviewer = this.permissionService.hasAnyMatching(['api-reviews-u']);
+      // Only for API reviewer
+      if (isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'IN_REVIEW') {
+        // 'api-reviews-u'
+        banners.push({
+          title: 'As an API reviewer, there are some changes made on this API that required a review before been applied.',
+          type: 'info',
+          action: {
+            btnText: 'Review changes',
+            onClick: () => {
+              this.matDialog
+                .open<ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult>(ApiReviewDialogComponent, {
+                  data: {
+                    apiId: api.id,
+                  },
+                  role: 'alertdialog',
+                  id: 'gioApiReviewDialog',
+                  width: GIO_DIALOG_WIDTH.MEDIUM,
+                })
+                .afterClosed()
+                .pipe(takeUntil(this.unsubscribe$))
+                .subscribe(() => {
+                  this.ajsState.reload();
+                });
+            },
+          },
+        });
+      }
+      if (isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'REVIEW_OK') {
+        banners.push({
+          title: 'As an API reviewer, you have accepted the changes made on this API.',
+          type: 'success',
+          action: {
+            btnText: 'Review changes',
+            onClick: () => {
+              this.matDialog
+                .open<ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult>(ApiReviewDialogComponent, {
+                  data: {
+                    apiId: api.id,
+                  },
+                  role: 'alertdialog',
+                  id: 'gioApiReviewDialog',
+                  width: GIO_DIALOG_WIDTH.MEDIUM,
+                })
+                .afterClosed()
+                .pipe(takeUntil(this.unsubscribe$))
+                .subscribe(() => {
+                  this.ajsState.reload();
+                });
+            },
+          },
+        });
+      }
+      if (isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'REQUEST_FOR_CHANGES') {
+        banners.push({
+          title: 'As an API reviewer, you have rejected the changes made on this API.',
+          type: 'warning',
+          action: {
+            btnText: 'Review changes',
+            onClick: () => {
+              this.matDialog
+                .open<ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult>(ApiReviewDialogComponent, {
+                  data: {
+                    apiId: api.id,
+                  },
+                  role: 'alertdialog',
+                  id: 'gioApiReviewDialog',
+                  width: GIO_DIALOG_WIDTH.MEDIUM,
+                })
+                .afterClosed()
+                .pipe(takeUntil(this.unsubscribe$))
+                .subscribe(() => {
+                  this.ajsState.reload();
+                });
+            },
+          },
+        });
+      }
+
+      // Only for not API reviewer
+      if (!isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'IN_REVIEW') {
+        // not 'api-reviews-u'
+        banners.push({
+          title: 'The API reviewer has been asked to review the changes.',
+          type: 'info',
+        });
+      }
+      if (!isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'REVIEW_OK') {
+        // not 'api-reviews-u'
+        banners.push({
+          title: 'The API reviewer has accepted the changes made on this API.',
+          type: 'success',
+        });
+      }
+      if (!isApiReviewer && this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'REQUEST_FOR_CHANGES') {
+        // not 'api-reviews-u'
+        banners.push({
+          title: 'The API reviewer has asked for changes to be made on this API.',
+          type: 'warning',
+        });
+      }
+
+      // Other banners
+      if (this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'DRAFT') {
+        banners.push({
+          title: 'This API is a draft.',
+          type: 'info',
+        });
+      }
+
+      const apiReviewIsOKOrNotNeeded =
+        (this.constants.env.settings?.apiReview?.enabled && api.workflowState === 'REVIEW_OK') ||
+        !this.constants.env.settings?.apiReview?.enabled;
+      const canUpdateApiDefinition = this.permissionService.hasAnyMatching(['api-definition-u']);
+      if (api.deploymentState === 'NEED_REDEPLOY' && apiReviewIsOKOrNotNeeded) {
+        banners.push(
+          canUpdateApiDefinition
+            ? {
+                title: 'This API is out of sync.',
+                type: 'warning',
+                action: {
+                  btnText: 'Deploy API',
+                  onClick: () => {
+                    this.matDialog
+                      .open<ApiConfirmDeploymentDialogComponent, ApiConfirmDeploymentDialogData, ApiConfirmDeploymentDialogResult>(
+                        ApiConfirmDeploymentDialogComponent,
+                        {
+                          data: {
+                            apiId: api.id,
+                          },
+                          role: 'alertdialog',
+                          id: 'gioApiConfirmDeploymentDialog',
+                          width: GIO_DIALOG_WIDTH.MEDIUM,
+                        },
+                      )
+                      .afterClosed()
+                      .pipe(takeUntil(this.unsubscribe$))
+                      .subscribe(() => {
+                        this.ajsState.reload();
+                      });
+                  },
+                },
+              }
+            : {
+                title: 'This API is out of sync.',
+                type: 'warning',
+              },
+        );
+      }
+
+      if (api.lifecycleState === 'DEPRECATED') {
+        banners.push({
+          title: 'This API is deprecated.',
+          type: 'error',
+        });
+      }
+
+      return banners;
+    }),
+  );
+
+  private unsubscribe$ = new Subject();
   constructor(
     @Inject(UIRouterState) private readonly ajsState: StateService,
     private readonly permissionService: GioPermissionService,
@@ -66,6 +248,8 @@ export class ApiNgNavigationComponent implements OnInit {
     @Inject('Constants') private readonly constants: Constants,
     @Inject(AjsRootScope) private readonly ajsRootScope: IScope,
     private readonly gioMenuService: GioMenuService,
+    private readonly apiV2Service: ApiV2Service,
+    private readonly matDialog: MatDialog,
   ) {}
 
   ngOnInit() {
@@ -86,6 +270,11 @@ export class ApiNgNavigationComponent implements OnInit {
     this.ajsRootScope.$on('$locationChangeStart', () => {
       this.selectedItemWithTabs = this.findMenuItemWithTabs();
     });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
   }
 
   private appendPolicyStudio() {

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.module.ts
@@ -15,28 +15,59 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { GioBreadcrumbModule, GioIconsModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import {
+  GioBannerModule,
+  GioBreadcrumbModule,
+  GioFormSlideToggleModule,
+  GioIconsModule,
+  GioLoaderModule,
+  GioSubmenuModule,
+} from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
 import { UIRouterModule } from '@uirouter/angular';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
-import { ApiNgNavigationComponent } from './api-ng-navigation.component';
-import { ApiNgNavigationTitleComponent } from './api-ng-navigation-title/api-ng-navigation-title.component';
+import { ApiReviewDialogComponent } from './api-review-dialog/api-review-dialog.component';
+import { ApiConfirmDeploymentDialogComponent } from './api-confirm-deployment-dialog/api-confirm-deployment-dialog.component';
 import { ApiNgNavigationTabsComponent } from './api-ng-navigation-tabs/api-ng-navigation-tabs.component';
+import { ApiNgNavigationTitleComponent } from './api-ng-navigation-title/api-ng-navigation-title.component';
+import { ApiNgNavigationComponent } from './api-ng-navigation.component';
 
 @NgModule({
   imports: [
     CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
     GioSubmenuModule,
     GioIconsModule,
     MatButtonModule,
     MatTooltipModule,
     MatTabsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSlideToggleModule,
     GioBreadcrumbModule,
+    GioBannerModule,
+    GioFormSlideToggleModule,
+    GioLoaderModule,
+    MatSnackBarModule,
     UIRouterModule,
   ],
-  declarations: [ApiNgNavigationComponent, ApiNgNavigationTitleComponent, ApiNgNavigationTabsComponent],
+  declarations: [
+    ApiNgNavigationComponent,
+    ApiNgNavigationTitleComponent,
+    ApiNgNavigationTabsComponent,
+    ApiConfirmDeploymentDialogComponent,
+    ApiReviewDialogComponent,
+  ],
   exports: [ApiNgNavigationComponent],
 })
 export class ApiNgNavigationModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.html
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 matDialogTitle>API Review</h2>
+<ng-container *ngIf="!isLoading; else loader">
+  <mat-dialog-content class="content">
+    <div *ngIf="qualityRules.length" class="mat-body-strong">Quality rules</div>
+    <gio-form-slide-toggle *ngFor="let qualityRule of qualityRules">
+      <gio-form-label>{{ qualityRule.name }}</gio-form-label>
+      {{ qualityRule.description }}
+      <mat-slide-toggle gioFormSlideToggle [name]="qualityRule.name" [(ngModel)]="qualityRule.checked"></mat-slide-toggle>
+    </gio-form-slide-toggle>
+    <mat-form-field appearance="outline" class="content__comments">
+      <mat-label>Review comments</mat-label>
+      <textarea #input matInput aria-label="Review comments" [formControl]="reviewComments" maxlength="500" rows="2"></textarea>
+      <mat-hint align="end">{{ input.value.length }}/500</mat-hint>
+    </mat-form-field>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions" align="end">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button color="primary" mat-raised-button aria-label="Accept the review" (click)="onConfirm(true)">Accept</button>
+    <button color="warn" mat-raised-button aria-label="Reject the review" (click)="onConfirm(false)">Reject</button>
+  </mat-dialog-actions>
+</ng-container>
+
+<ng-template #loader>
+  <mat-dialog-content class="content">
+    <gio-loader></gio-loader>
+  </mat-dialog-content>
+</ng-template>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.scss
@@ -1,0 +1,4 @@
+.content {
+  display: flex;
+  flex-direction: column;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.spec.ts
@@ -151,7 +151,7 @@ describe('ApiReviewDialogComponent', () => {
     createApiQualityRuleReq.flush({});
 
     const acceptReq = httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/reviews?action=ACCEPT`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/reviews/_accept`,
       method: 'POST',
     });
     expect(acceptReq.request.body).toEqual({ message: 'Review comments' });
@@ -182,7 +182,7 @@ describe('ApiReviewDialogComponent', () => {
     await rejectBtn.click();
 
     const rejectReq = httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/reviews?action=REJECT`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/reviews/_reject`,
       method: 'POST',
     });
     expect(rejectReq.request.body).toEqual({ message: null });

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.spec.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { Component } from '@angular/core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+
+import { ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult } from './api-review-dialog.component';
+
+import { QualityRule } from '../../../../entities/qualityRule';
+import { ApiQualityRule } from '../../../../entities/apiQualityRule';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { ApiNgNavigationModule } from '../api-ng-navigation.module';
+
+const API_ID = 'apiId';
+@Component({
+  selector: 'gio-dialog-test',
+  template: `<button mat-button id="open-dialog-test" (click)="openDialog()">Open dialog</button>`,
+})
+class TestComponent {
+  public result?: any;
+  constructor(private readonly matDialog: MatDialog) {}
+
+  public openDialog() {
+    this.matDialog
+      .open<ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult>(ApiReviewDialogComponent, {
+        data: {
+          apiId: API_ID,
+        },
+        role: 'alertdialog',
+      })
+      .afterClosed()
+      .subscribe((result) => (this.result = result));
+  }
+}
+
+describe('ApiReviewDialogComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [ApiNgNavigationModule, NoopAnimationsModule, MatDialogModule, MatIconTestingModule, GioHttpTestingModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    const openDialogButton = await loader.getHarness(MatButtonHarness.with({ selector: '#open-dialog-test' }));
+    await openDialogButton.click();
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should Accept the review', async () => {
+    const dialog = await loader.getHarness(MatDialogHarness);
+
+    // Expect Loading... state
+    expect(await dialog.getText()).toEqual('API Review');
+
+    const qualityRules: QualityRule[] = [
+      { id: 'withoutApiValue', name: 'QR withoutApiValue', description: 'description', weight: 42 },
+      { id: 'withApiValue', name: 'QR withApiValue', description: 'description', weight: 42 },
+    ];
+    const apiQualityRules: ApiQualityRule[] = [
+      {
+        quality_rule: 'withApiValue',
+        api: API_ID,
+        checked: true,
+        createdAt: '',
+        updatedAt: '',
+      },
+    ];
+
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/quality-rules`,
+        method: 'GET',
+      })
+      .flush(qualityRules);
+
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/quality-rules`,
+        method: 'GET',
+      })
+      .flush(apiQualityRules);
+
+    const qrWithoutApiValueToggle = await dialog.getHarness(
+      MatSlideToggleHarness.with({
+        name: 'QR withoutApiValue',
+      }),
+    );
+    expect(await qrWithoutApiValueToggle.isChecked()).toBe(false);
+    await qrWithoutApiValueToggle.toggle();
+
+    const qrWithApiValueToggle = await dialog.getHarness(
+      MatSlideToggleHarness.with({
+        name: 'QR withApiValue',
+      }),
+    );
+    expect(await qrWithApiValueToggle.isChecked()).toBe(true);
+    await qrWithApiValueToggle.toggle();
+
+    const reviewCommentsInput = await dialog.getHarness(MatInputHarness.with({ ancestor: '.content__comments' }));
+    await reviewCommentsInput.setValue('Review comments');
+
+    const deployBtn = await dialog.getHarness(MatButtonHarness.with({ text: 'Accept' }));
+    await deployBtn.click();
+
+    const updateApiQualityRuleReq = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/quality-rules/withApiValue`,
+      method: 'PUT',
+    });
+    expect(updateApiQualityRuleReq.request.body).toEqual({ checked: false });
+    updateApiQualityRuleReq.flush({});
+
+    const createApiQualityRuleReq = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/quality-rules`,
+      method: 'POST',
+    });
+    expect(createApiQualityRuleReq.request.body).toEqual({ api: API_ID, quality_rule: 'withoutApiValue', checked: true });
+    createApiQualityRuleReq.flush({});
+
+    const acceptReq = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/reviews?action=ACCEPT`,
+      method: 'POST',
+    });
+    expect(acceptReq.request.body).toEqual({ message: 'Review comments' });
+    acceptReq.flush({});
+  });
+
+  it('should Reject the review', async () => {
+    const dialog = await loader.getHarness(MatDialogHarness);
+
+    // Expect Loading... state
+    expect(await dialog.getText()).toEqual('API Review');
+
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/quality-rules`,
+        method: 'GET',
+      })
+      .flush([]);
+
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/quality-rules`,
+        method: 'GET',
+      })
+      .flush([]);
+
+    const rejectBtn = await dialog.getHarness(MatButtonHarness.with({ text: 'Reject' }));
+    await rejectBtn.click();
+
+    const rejectReq = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/reviews?action=REJECT`,
+      method: 'POST',
+    });
+    expect(rejectReq.request.body).toEqual({ message: null });
+    rejectReq.flush({});
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnDestroy } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl } from '@angular/forms';
+import { combineLatest, of, Subject } from 'rxjs';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
+
+import { FlowService } from '../../../../services-ngx/flow.service';
+import { QualityRuleService } from '../../../../services-ngx/quality-rule.service';
+import { ApiService } from '../../../../services-ngx/api.service';
+import { ApiQualityRuleService } from '../../../../services-ngx/api-quality-rule.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+
+export interface ApiReviewDialogData {
+  apiId: string;
+}
+export type ApiReviewDialogResult = void;
+
+type QualityRuleVM = {
+  id: string;
+  name: string;
+  description: string;
+  hasApiQualityRule: boolean;
+  checked: boolean;
+};
+
+@Component({
+  selector: 'api-review-dialog',
+  template: require('./api-review-dialog.component.html'),
+  styles: [require('./api-review-dialog.component.scss')],
+})
+export class ApiReviewDialogComponent implements OnDestroy {
+  private unsubscribe$ = new Subject<void>();
+
+  public isLoading = true;
+
+  public reviewComments = new FormControl();
+
+  public qualityRules: QualityRuleVM[] = [];
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiReviewDialogComponent, ApiReviewDialogResult>,
+    @Inject(MAT_DIALOG_DATA) private readonly dialogData: ApiReviewDialogData,
+    private readonly snackBarService: SnackBarService,
+    private readonly qualityRuleService: QualityRuleService,
+    private readonly flowService: FlowService,
+    private readonly apiQualityRuleService: ApiQualityRuleService,
+    private readonly apiService: ApiService,
+  ) {}
+
+  ngOnInit() {
+    combineLatest([this.qualityRuleService.list(), this.apiQualityRuleService.getQualityRules(this.dialogData.apiId)])
+      .pipe(
+        tap(([qualityRules, apiQualityRules]) => {
+          if (qualityRules.length === 0) {
+            return;
+          }
+
+          this.qualityRules = qualityRules.map((qualityRule) => {
+            const apiQualityRule = apiQualityRules.find((qr) => qr.quality_rule === qualityRule.id);
+            const qualityRuleVM: QualityRuleVM = {
+              id: qualityRule.id,
+              name: qualityRule.name,
+              description: qualityRule.description,
+              hasApiQualityRule: !!apiQualityRule,
+              checked: apiQualityRule ? apiQualityRule.checked : false,
+            };
+            return qualityRuleVM;
+          });
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this.isLoading = false;
+      });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onConfirm(accept: boolean) {
+    const apiQualityRulesToSave$ = this.qualityRules.map((qualityRule) => {
+      if (qualityRule.hasApiQualityRule) {
+        return this.apiQualityRuleService.updateQualityRule(this.dialogData.apiId, qualityRule.id, qualityRule.checked);
+      } else {
+        return this.apiQualityRuleService.createQualityRule(this.dialogData.apiId, qualityRule.id, qualityRule.checked);
+      }
+    });
+
+    const acceptRejectToSave$ = accept
+      ? this.apiService.acceptReview(this.dialogData.apiId, this.reviewComments.value)
+      : this.apiService.rejectReview(this.dialogData.apiId, this.reviewComments.value);
+
+    combineLatest([
+      ...apiQualityRulesToSave$,
+      // Default observable if no quality rules
+      of({}),
+    ])
+      .pipe(
+        switchMap(() => acceptRejectToSave$),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        () => {
+          this.dialogRef.close();
+          this.snackBarService.success('API review saved.');
+        },
+        () => {
+          this.snackBarService.error('An error occurred while saving API review.');
+        },
+      );
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-review-dialog/api-review-dialog.component.ts
@@ -21,9 +21,9 @@ import { switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { FlowService } from '../../../../services-ngx/flow.service';
 import { QualityRuleService } from '../../../../services-ngx/quality-rule.service';
-import { ApiService } from '../../../../services-ngx/api.service';
 import { ApiQualityRuleService } from '../../../../services-ngx/api-quality-rule.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiReviewV2Service } from '../../../../services-ngx/api-review-v2.service';
 
 export interface ApiReviewDialogData {
   apiId: string;
@@ -59,7 +59,7 @@ export class ApiReviewDialogComponent implements OnDestroy {
     private readonly qualityRuleService: QualityRuleService,
     private readonly flowService: FlowService,
     private readonly apiQualityRuleService: ApiQualityRuleService,
-    private readonly apiService: ApiService,
+    private readonly apiReviewV2Service: ApiReviewV2Service,
   ) {}
 
   ngOnInit() {
@@ -104,8 +104,8 @@ export class ApiReviewDialogComponent implements OnDestroy {
     });
 
     const acceptRejectToSave$ = accept
-      ? this.apiService.acceptReview(this.dialogData.apiId, this.reviewComments.value)
-      : this.apiService.rejectReview(this.dialogData.apiId, this.reviewComments.value);
+      ? this.apiReviewV2Service.accept(this.dialogData.apiId, this.reviewComments.value)
+      : this.apiReviewV2Service.reject(this.dialogData.apiId, this.reviewComments.value);
 
     combineLatest([
       ...apiQualityRulesToSave$,

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -33,7 +33,7 @@ import { CurrentUserService, UIRouterState, UIRouterStateParams } from '../../..
 import { User as DeprecatedUser } from '../../../entities/user';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
-import { fakePagedResult, fakeApiV2, fakeApiV4, ApiLifecycleState, Api, StateEnum, OriginEnum } from '../../../entities/management-api-v2';
+import { fakePagedResult, fakeApiV2, fakeApiV4, ApiLifecycleState, Api, ApiState, OriginEnum } from '../../../entities/management-api-v2';
 
 describe('ApisListComponent', () => {
   const fakeUiRouter = { go: jest.fn() };
@@ -279,7 +279,7 @@ describe('ApisListComponent', () => {
           owner: 'admin',
           ownerEmail: 'admin@gio.com',
           picture: null,
-          state: 'CREATED' as StateEnum,
+          state: 'CREATED' as ApiState,
           lifecycleState: 'PUBLISHED' as ApiLifecycleState,
           workflowState: 'REVIEW_OK',
           visibility: { label: 'PUBLIC', icon: 'public' },

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -31,7 +31,7 @@ import {
   ApisResponse,
   ApiV2,
   ApiV4,
-  StateEnum,
+  ApiState,
   OriginEnum,
   HttpListener,
   PagedResult,
@@ -47,7 +47,7 @@ export type ApisTableDS = {
   owner: string;
   ownerEmail: string;
   picture: string;
-  state: StateEnum;
+  state: ApiState;
   lifecycleState: ApiLifecycleState;
   workflowBadge?: { text: string; class: string };
   isNotSynced$?: Observable<boolean>;

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details-danger-zone/api-portal-details-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details-danger-zone/api-portal-details-danger-zone.component.spec.ts
@@ -120,7 +120,7 @@ describe('ApiPortalDetailsDangerZoneComponent', () => {
     httpTestingController
       .expectOne({
         method: 'POST',
-        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/reviews?action=ASK`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/reviews/_ask`,
       })
       .flush({});
 

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details-danger-zone/api-portal-details-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details-danger-zone/api-portal-details-danger-zone.component.ts
@@ -29,11 +29,11 @@ import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operato
 import { UIRouterState } from '../../../../../ajs-upgraded-providers';
 import { Constants } from '../../../../../entities/Constants';
 import { Api, ApiV4, UpdateApi } from '../../../../../entities/management-api-v2';
-import { ApiService } from '../../../../../services-ngx/api.service';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { GioLicenseService } from '../../../../../shared/components/gio-license/gio-license.service';
 import { GioLicenseDialog } from '../../../../../shared/components/gio-license/gio-license.dialog';
+import { ApiReviewV2Service } from '../../../../../services-ngx/api-review-v2.service';
 import { UTMMedium } from '../../../../../shared/components/gio-license/gio-license-utm';
 import { Feature } from '../../../../../shared/components/gio-license/gio-license-features';
 
@@ -85,8 +85,7 @@ export class ApiPortalDetailsDangerZoneComponent implements OnChanges, OnDestroy
 
   constructor(
     @Inject(UIRouterState) private readonly ajsState: StateService,
-    // TODO: we should remove this service as soon as everything is migrated to management API v2
-    private readonly legacyApiService: ApiService,
+    private readonly apiReviewV2Service: ApiReviewV2Service,
     private readonly apiService: ApiV2Service,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
@@ -144,7 +143,7 @@ export class ApiPortalDetailsDangerZoneComponent implements OnChanges, OnDestroy
       .afterClosed()
       .pipe(
         filter((confirm) => confirm === true),
-        switchMap(() => this.legacyApiService.askForReview(this.api.id)),
+        switchMap(() => this.apiReviewV2Service.ask(this.api.id)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;

--- a/gravitee-apim-console-webui/src/services-ngx/api-quality-rule.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-quality-rule.service.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiQualityRuleService } from './api-quality-rule.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+
+describe('ApiQualityRuleService', () => {
+  let httpTestingController: HttpTestingController;
+  let apiQualityRuleService: ApiQualityRuleService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    apiQualityRuleService = TestBed.inject<ApiQualityRuleService>(ApiQualityRuleService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('getQualityRules', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+
+      apiQualityRuleService.getQualityRules(apiId).subscribe((response) => {
+        expect(response).toEqual([
+          {
+            id: 'api#1',
+          },
+        ]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/quality-rules`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush([
+        {
+          id: 'api#1',
+        },
+      ]);
+    });
+  });
+
+  describe('createQualityRule', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+      const qualityRuleId = 'qualityRule#1';
+
+      apiQualityRuleService.createQualityRule(apiId, qualityRuleId, true).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/quality-rules`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual({
+        api: apiId,
+        quality_rule: qualityRuleId,
+        checked: true,
+      });
+
+      req.flush({});
+    });
+  });
+
+  describe('updateQualityRule', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+      const qualityRuleId = 'qualityRule#1';
+
+      apiQualityRuleService.updateQualityRule(apiId, qualityRuleId, false).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/quality-rules/${qualityRuleId}`);
+      expect(req.request.method).toEqual('PUT');
+      expect(req.request.body).toEqual({
+        checked: false,
+      });
+
+      req.flush({});
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-quality-rule.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-quality-rule.service.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { IScope } from 'angular';
+
+import { Constants } from '../entities/Constants';
+import { AjsRootScope } from '../ajs-upgraded-providers';
+import { ApiQualityRule } from '../entities/apiQualityRule';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiQualityRuleService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject('Constants') private readonly constants: Constants,
+    @Inject(AjsRootScope) private readonly ajsRootScope: IScope,
+  ) {}
+
+  getQualityRules(apiId: string): Observable<ApiQualityRule[]> {
+    return this.http.get<ApiQualityRule[]>(`${this.constants.env.baseURL}/apis/${apiId}/quality-rules`);
+  }
+
+  createQualityRule(apiId: string, qualityRuleId: string, checked: boolean): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.baseURL}/apis/${apiId}/quality-rules`, {
+      api: apiId,
+      quality_rule: qualityRuleId,
+      checked: checked,
+    });
+  }
+
+  updateQualityRule(apiId: string, qualityRuleId: string, checked: boolean): Observable<void> {
+    return this.http.put<void>(`${this.constants.env.baseURL}/apis/${apiId}/quality-rules/${qualityRuleId}`, {
+      checked: checked,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api-review-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-review-v2.service.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiReviewV2Service } from './api-review-v2.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+
+describe('ApiReviewV2Service', () => {
+  let httpTestingController: HttpTestingController;
+  let apiReviewV2Service: ApiReviewV2Service;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    apiReviewV2Service = TestBed.inject<ApiReviewV2Service>(ApiReviewV2Service);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('ask', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api-id';
+      const reviewMessage = 'review-message';
+
+      apiReviewV2Service.ask(apiId, reviewMessage).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/reviews/_ask`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ message: reviewMessage });
+
+      req.flush({});
+    });
+  });
+
+  describe('accept', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api-id';
+      const reviewMessage = 'review-message';
+
+      apiReviewV2Service.accept(apiId, reviewMessage).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/reviews/_accept`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ message: reviewMessage });
+
+      req.flush({});
+    });
+  });
+
+  describe('reject', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api-id';
+      const reviewMessage = 'review-message';
+
+      apiReviewV2Service.reject(apiId, reviewMessage).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/reviews/_reject`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ message: reviewMessage });
+
+      req.flush({});
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-review-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-review-v2.service.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiReviewV2Service {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  ask(apiId: string, message?: string): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/reviews/_ask`, { message });
+  }
+
+  accept(apiId: string, message?: string): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/reviews/_accept`, { message });
+  }
+
+  reject(apiId: string, message?: string): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/reviews/_reject`, { message });
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -158,6 +158,26 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('deploy', () => {
+    it('should call the API', (done) => {
+      const fakeApi = fakeApiV4();
+
+      apiV2Service.deploy(fakeApi.id, 'Deployment label').subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${fakeApi.id}/deployments`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual({
+        deploymentLabel: 'Deployment label',
+      });
+      req.flush(fakeApi);
+    });
+  });
+
   describe('export', () => {
     it('should call the API', (done) => {
       const fakeApi = fakeApiV4();

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
@@ -219,6 +219,36 @@ describe('ApiService', () => {
     });
   });
 
+  describe('acceptReview', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+
+      apiService.acceptReview(apiId).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/reviews?action=ACCEPT`);
+      expect(req.request.method).toEqual('POST');
+
+      req.flush({});
+    });
+  });
+
+  describe('rejectReview', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+
+      apiService.rejectReview(apiId).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/reviews?action=REJECT`);
+      expect(req.request.method).toEqual('POST');
+
+      req.flush({});
+    });
+  });
+
   describe('start', () => {
     it('should call the API', (done) => {
       const apiId = 'api#1';

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -130,6 +130,14 @@ export class ApiService {
     return this.http.post<void>(`${this.constants.env.baseURL}/apis/${apiId}/reviews?action=ASK`, { message });
   }
 
+  acceptReview(apiId: string, message?: string): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.baseURL}/apis/${apiId}/reviews?action=ACCEPT`, { message });
+  }
+
+  rejectReview(apiId: string, message?: string): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.baseURL}/apis/${apiId}/reviews?action=REJECT`, { message });
+  }
+
   start(apiId: string): Observable<void> {
     return this.http.post<void>(`${this.constants.env.baseURL}/apis/` + apiId + '?action=START', {});
   }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
@@ -44,11 +44,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
-            <artifactId>gravitee-apim-plugin-entrypoint-webhook</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-handler</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.management.v2.rest.utils.ManagementApiLinkHelper;
+import io.gravitee.rest.api.model.ReviewEntity;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
@@ -141,4 +142,6 @@ public interface ApiMapper {
     }
 
     BaseApi map(GenericApiEntity apiEntity);
+
+    ReviewEntity map(ApiReview apiReview);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -424,6 +424,92 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    # API Reviews
+    /environments/{envId}/apis/{apiId}/reviews/_ask:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Ask for a review
+            description: |-
+                Ask for a review
+
+                Return a 400 HTTP Error:
+                 - when user tries to change reviews state of an ARCHIVED API
+                 - when user tries to change reviews state of an API already in review
+                
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: reviewsAsk
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiReview"
+                required: true
+            responses:
+                "204":
+                    description: API successfully change review state
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/reviews/_accept:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Accept a review
+            description: |-
+                Accept a review
+
+                Return a 400 HTTP Error:
+                 - when user tries to change reviews state of an ARCHIVED API
+                 - when user tries to change reviews state of an API that is not in review
+                
+                User must have the API_REVIEWS[UPDATE] permission.
+            operationId: reviewsAccept
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiReview"
+                required: true
+            responses:
+                "204":
+                    description: API successfully change review state
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/reviews/_reject:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Reject a review
+            description: |-
+                Reject a review
+
+                Return a 400 HTTP Error:
+                 - when user tries to change reviews state of an ARCHIVED API
+                 - when user tries to change reviews state of an API that is not in review
+                
+                User must have the API_REVIEWS[UPDATE] permission.
+            operationId: reviewsReject
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiReview"
+                required: true
+            responses:
+                "204":
+                    description: API successfully change review state
+                default:
+                    $ref: "#/components/responses/Error"
+
     # API Members
     /environments/{envId}/apis/{apiId}/members:
         parameters:
@@ -2982,6 +3068,13 @@ components:
                 overrideAccess:
                     type: boolean
                     default: false
+
+        ApiReview:
+            type: object
+            properties:
+                message:
+                    type: string
+                    description: Optional message from the API reviewer.
 
         BasePlan:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.management.v2.rest.spring.ResourceContextConfigurati
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
+import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanService;
@@ -107,6 +108,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected ApiLicenseService apiLicenseService;
+
+    @Autowired
+    protected ApiWorkflowStateService apiWorkflowStateService;
 
     @Before
     public void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -47,7 +47,8 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
             workflowService,
             apiServiceV4,
             apiService,
-            apiLicenseService
+            apiLicenseService,
+            apiWorkflowStateService
         );
         GraviteeContext.cleanContext();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ReviewsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ReviewsTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.ApiFixtures;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.v2.rest.model.ApiReview;
+import io.gravitee.rest.api.model.ReviewEntity;
+import io.gravitee.rest.api.model.WorkflowState;
+import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import org.junit.Test;
+
+public class ApiResource_ReviewsTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/reviews";
+    }
+
+    @Test
+    public void should_ask_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        when(
+            apiWorkflowStateService.askForReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        )
+            .thenReturn(apiEntity);
+
+        final Response response = rootTarget("_ask").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        verify(apiWorkflowStateService)
+            .askForReview(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(API),
+                eq(USER_NAME),
+                argThat(reviewEntity -> reviewEntity.getMessage().equals(apiReview.getMessage()))
+            );
+    }
+
+    @Test
+    public void should_return_400_when_asking_review_still_in_progress() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).workflowState(WorkflowState.IN_REVIEW).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_ask").request().post(Entity.json(apiReview));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiWorkflowStateService, never()).askForReview(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_return_400_when_API_is_ARCHIVED() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures
+            .aModelApiV4()
+            .toBuilder()
+            .id(API)
+            .lifecycleState(ApiLifecycleState.ARCHIVED)
+            .updatedAt(new Date())
+            .build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_ask").request().post(Entity.json(apiReview));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiWorkflowStateService, never()).askForReview(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_accept_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        when(
+            apiWorkflowStateService.acceptReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        )
+            .thenReturn(apiEntity);
+
+        final Response response = rootTarget("_accept").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        verify(apiWorkflowStateService)
+            .acceptReview(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(API),
+                eq(USER_NAME),
+                argThat(reviewEntity -> reviewEntity.getMessage().equals(apiReview.getMessage()))
+            );
+    }
+
+    @Test
+    public void should_return_400_when_accept_review_on_DRAFT_API() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).workflowState(WorkflowState.DRAFT).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_accept").request().post(Entity.json(apiReview));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiWorkflowStateService, never()).askForReview(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_reject_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        when(
+            apiWorkflowStateService.rejectReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        )
+            .thenReturn(apiEntity);
+
+        final Response response = rootTarget("_reject").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        verify(apiWorkflowStateService)
+            .rejectReview(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(API),
+                eq(USER_NAME),
+                argThat(reviewEntity -> reviewEntity.getMessage().equals(apiReview.getMessage()))
+            );
+    }
+
+    @Test
+    public void should_return_400_when_reject_review_on_DRAFT_API() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelApiV4().toBuilder().id(API).workflowState(WorkflowState.DRAFT).updatedAt(new Date()).build();
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API))).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_reject").request().post(Entity.json(apiReview));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        verify(apiWorkflowStateService, never()).askForReview(any(), any(), any(), any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
+import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
@@ -188,5 +189,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiLicenseService apiLicenseService() {
         return mock(ApiLicenseService.class);
+    }
+
+    @Bean
+    public ApiWorkflowStateService apiWorkflowStateService() {
+        return mock(ApiWorkflowStateService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.rest.api.model.v4.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.search.Indexable;
 import java.util.Date;
@@ -69,6 +71,8 @@ public interface GenericApiEntity extends Indexable {
     Set<String> getCategories();
 
     DefinitionContext getDefinitionContext();
+
+    WorkflowState getWorkflowState();
 
     String getPicture();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiWorkflowStateService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiWorkflowStateService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4;
+
+import io.gravitee.rest.api.model.ReviewEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface ApiWorkflowStateService {
+    GenericApiEntity askForReview(ExecutionContext executionContext, String apiId, String userId, ReviewEntity reviewEntity);
+    GenericApiEntity acceptReview(ExecutionContext executionContext, String apiId, String userId, ReviewEntity reviewEntity);
+    GenericApiEntity rejectReview(ExecutionContext executionContext, String apiId, String userId, ReviewEntity reviewEntity);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiWorkflowStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiWorkflowStateServiceImpl.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_ACCEPTED;
+import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_ASKED;
+import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_REJECTED;
+import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
+import static java.util.stream.Collectors.toSet;
+
+import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.Workflow;
+import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.ReviewEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.WorkflowReferenceType;
+import io.gravitee.rest.api.model.WorkflowState;
+import io.gravitee.rest.api.model.permissions.ApiPermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.ApiMetadataService;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@Component
+public class ApiWorkflowStateServiceImpl implements ApiWorkflowStateService {
+
+    private final AuditService auditService;
+    private final ApiMetadataService apiMetadataService;
+    private final WorkflowService workflowService;
+    private final RoleService roleService;
+    private final UserService userService;
+    private final NotifierService notifierService;
+    private final MembershipService membershipService;
+    private final EmailService emailService;
+    private final ApiSearchService apiSearchService;
+
+    public ApiWorkflowStateServiceImpl(
+        final AuditService auditService,
+        @Lazy final ApiMetadataService apiMetadataService,
+        final WorkflowService workflowService,
+        @Lazy final RoleService roleService,
+        final UserService userService,
+        final NotifierService notifierService,
+        final MembershipService membershipService,
+        final EmailService emailService,
+        final ApiSearchService apiSearchService
+    ) {
+        this.auditService = auditService;
+        this.apiMetadataService = apiMetadataService;
+        this.workflowService = workflowService;
+        this.roleService = roleService;
+        this.userService = userService;
+        this.notifierService = notifierService;
+        this.membershipService = membershipService;
+        this.emailService = emailService;
+        this.apiSearchService = apiSearchService;
+    }
+
+    @Override
+    public GenericApiEntity askForReview(
+        ExecutionContext executionContext,
+        final String apiId,
+        final String userId,
+        final ReviewEntity reviewEntity
+    ) {
+        log.debug("Ask for review API {}", apiId);
+        return updateWorkflowReview(
+            executionContext,
+            apiId,
+            userId,
+            ApiHook.ASK_FOR_REVIEW,
+            WorkflowState.IN_REVIEW,
+            reviewEntity.getMessage()
+        );
+    }
+
+    @Override
+    public GenericApiEntity acceptReview(
+        ExecutionContext executionContext,
+        final String apiId,
+        final String userId,
+        final ReviewEntity reviewEntity
+    ) {
+        log.debug("Accept review API {}", apiId);
+        return updateWorkflowReview(executionContext, apiId, userId, ApiHook.REVIEW_OK, WorkflowState.REVIEW_OK, reviewEntity.getMessage());
+    }
+
+    @Override
+    public GenericApiEntity rejectReview(
+        ExecutionContext executionContext,
+        final String apiId,
+        final String userId,
+        final ReviewEntity reviewEntity
+    ) {
+        log.debug("Reject review API {}", apiId);
+        return updateWorkflowReview(
+            executionContext,
+            apiId,
+            userId,
+            ApiHook.REQUEST_FOR_CHANGES,
+            WorkflowState.REQUEST_FOR_CHANGES,
+            reviewEntity.getMessage()
+        );
+    }
+
+    private GenericApiEntity updateWorkflowReview(
+        ExecutionContext executionContext,
+        final String apiId,
+        final String userId,
+        final ApiHook hook,
+        final WorkflowState workflowState,
+        final String workflowMessage
+    ) {
+        Workflow workflow = workflowService.create(WorkflowReferenceType.API, apiId, REVIEW, userId, workflowState, workflowMessage);
+
+        // Get updated API with new workflow state for notification
+        GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiId);
+
+        final UserEntity user = userService.findById(executionContext, userId);
+        GenericApiEntity apiWithMetadata = apiMetadataService.fetchMetadataForApi(executionContext, genericApiEntity);
+        notifierService.trigger(
+            executionContext,
+            hook,
+            genericApiEntity.getId(),
+            new NotificationParamsBuilder().api(apiWithMetadata).user(user).build()
+        );
+
+        // Find all reviewers of the API and send them a notification email
+        if (hook.equals(ApiHook.ASK_FOR_REVIEW)) {
+            List<String> reviewersEmail = findAllReviewersEmail(executionContext, genericApiEntity);
+            this.emailService.sendAsyncEmailNotification(
+                    executionContext,
+                    new EmailNotificationBuilder()
+                        .params(new NotificationParamsBuilder().api(genericApiEntity).user(user).build())
+                        .to(reviewersEmail.toArray(new String[reviewersEmail.size()]))
+                        .template(EmailNotificationBuilder.EmailTemplate.API_ASK_FOR_REVIEW)
+                        .build()
+                );
+        }
+
+        Map<Audit.AuditProperties, String> properties = new HashMap<>();
+        properties.put(Audit.AuditProperties.USER, userId);
+        properties.put(Audit.AuditProperties.API, genericApiEntity.getId());
+
+        Workflow.AuditEvent evtType = null;
+        switch (workflowState) {
+            case REQUEST_FOR_CHANGES:
+                evtType = API_REVIEW_REJECTED;
+                break;
+            case REVIEW_OK:
+                evtType = API_REVIEW_ACCEPTED;
+                break;
+            default:
+                evtType = API_REVIEW_ASKED;
+                break;
+        }
+
+        auditService.createApiAuditLog(executionContext, genericApiEntity.getId(), properties, evtType, new Date(), null, workflow);
+        return genericApiEntity;
+    }
+
+    private List<String> findAllReviewersEmail(ExecutionContext executionContext, GenericApiEntity genericApiEntity) {
+        final RolePermissionAction[] acls = { RolePermissionAction.UPDATE };
+
+        // find direct members of the API
+        Set<String> reviewerEmails = roleService
+            .findByScope(RoleScope.API, executionContext.getOrganizationId())
+            .stream()
+            .filter(role -> this.roleService.hasPermission(role.getPermissions(), ApiPermission.REVIEWS, acls))
+            .flatMap(role ->
+                this.membershipService.getMembershipsByReferenceAndRole(MembershipReferenceType.API, genericApiEntity.getId(), role.getId())
+                    .stream()
+            )
+            .filter(m -> m.getMemberType().equals(MembershipMemberType.USER))
+            .map(MembershipEntity::getMemberId)
+            .distinct()
+            .map(id -> this.userService.findById(executionContext, id))
+            .map(UserEntity::getEmail)
+            .filter(Objects::nonNull)
+            .collect(toSet());
+
+        // find reviewers in group attached to the API
+        final Set<String> groups = genericApiEntity.getGroups();
+        if (groups != null && !groups.isEmpty()) {
+            groups.forEach(group -> {
+                reviewerEmails.addAll(
+                    roleService
+                        .findByScope(RoleScope.API, executionContext.getOrganizationId())
+                        .stream()
+                        .filter(role -> this.roleService.hasPermission(role.getPermissions(), ApiPermission.REVIEWS, acls))
+                        .flatMap(role ->
+                            this.membershipService.getMembershipsByReferenceAndRole(MembershipReferenceType.GROUP, group, role.getId())
+                                .stream()
+                        )
+                        .filter(m -> m.getMemberType().equals(MembershipMemberType.USER))
+                        .map(MembershipEntity::getMemberId)
+                        .distinct()
+                        .map(id -> this.userService.findById(executionContext, id))
+                        .map(UserEntity::getEmail)
+                        .filter(Objects::nonNull)
+                        .collect(toSet())
+                );
+            });
+        }
+
+        return new ArrayList<>(reviewerEmails);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiWorkflowStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiWorkflowStateServiceImplTest.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.model.Workflow;
+import io.gravitee.rest.api.model.ReviewEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.WorkflowReferenceType;
+import io.gravitee.rest.api.model.WorkflowState;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.ApiMetadataService;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.ApiNotificationService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiWorkflowStateServiceImplTest {
+
+    private static final String API_ID = "id-api";
+    private static final String USER_ID = "id-user";
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private ApiNotificationService apiNotificationService;
+
+    @Mock
+    private ApiSearchService apiSearchService;
+
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private NotifierService notifierService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private EmailService emailService;
+
+    private ApiWorkflowStateService apiWorkflowStateService;
+
+    @AfterClass
+    public static void cleanSecurityContextHolder() {
+        // reset authentication to avoid side effect during test executions.
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
+        );
+    }
+
+    @Before
+    public void setUp() {
+        apiWorkflowStateService =
+            new ApiWorkflowStateServiceImpl(
+                auditService,
+                apiMetadataService,
+                workflowService,
+                roleService,
+                userService,
+                notifierService,
+                membershipService,
+                emailService,
+                apiSearchService
+            );
+    }
+
+    @Test
+    public void shouldAskForReview() {
+        final GenericApiEntity genericApiEntity = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        genericApiEntity.setId(API_ID);
+
+        final ReviewEntity reviewEntity = new ReviewEntity();
+        reviewEntity.setMessage("Test Review msg");
+
+        when(workflowService.create(WorkflowReferenceType.API, API_ID, REVIEW, USER_ID, WorkflowState.IN_REVIEW, reviewEntity.getMessage()))
+            .thenReturn(null);
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(genericApiEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(new UserEntity());
+
+        apiWorkflowStateService.askForReview(GraviteeContext.getExecutionContext(), API_ID, USER_ID, reviewEntity);
+
+        verify(workflowService)
+            .create(WorkflowReferenceType.API, API_ID, REVIEW, USER_ID, WorkflowState.IN_REVIEW, reviewEntity.getMessage());
+        verify(auditService)
+            .createApiAuditLog(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(apiId -> apiId.equals(API_ID)),
+                anyMap(),
+                argThat(evt -> Workflow.AuditEvent.API_REVIEW_ASKED.equals(evt)),
+                any(),
+                any(),
+                any()
+            );
+        verify(apiNotificationService, times(0)).triggerUpdateNotification(eq(GraviteeContext.getExecutionContext()), any(ApiEntity.class));
+    }
+
+    @Test
+    public void shouldAcceptReview() {
+        final GenericApiEntity genericApiEntity = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        genericApiEntity.setId(API_ID);
+
+        final ReviewEntity reviewEntity = new ReviewEntity();
+        reviewEntity.setMessage("Test Review msg");
+
+        when(workflowService.create(WorkflowReferenceType.API, API_ID, REVIEW, USER_ID, WorkflowState.REVIEW_OK, reviewEntity.getMessage()))
+            .thenReturn(null);
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(genericApiEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(new UserEntity());
+
+        apiWorkflowStateService.acceptReview(GraviteeContext.getExecutionContext(), API_ID, USER_ID, reviewEntity);
+
+        verify(workflowService)
+            .create(WorkflowReferenceType.API, API_ID, REVIEW, USER_ID, WorkflowState.REVIEW_OK, reviewEntity.getMessage());
+        verify(auditService)
+            .createApiAuditLog(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(apiId -> apiId.equals(API_ID)),
+                anyMap(),
+                argThat(evt -> Workflow.AuditEvent.API_REVIEW_ACCEPTED.equals(evt)),
+                any(),
+                any(),
+                any()
+            );
+        verify(apiNotificationService, times(0)).triggerUpdateNotification(eq(GraviteeContext.getExecutionContext()), any(ApiEntity.class));
+    }
+
+    @Test
+    public void shouldRejectReview() {
+        final GenericApiEntity genericApiEntity = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        genericApiEntity.setId(API_ID);
+
+        final ReviewEntity reviewEntity = new ReviewEntity();
+        reviewEntity.setMessage("Test Review msg");
+
+        when(
+            workflowService.create(
+                WorkflowReferenceType.API,
+                API_ID,
+                REVIEW,
+                USER_ID,
+                WorkflowState.REQUEST_FOR_CHANGES,
+                reviewEntity.getMessage()
+            )
+        )
+            .thenReturn(null);
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(genericApiEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(new UserEntity());
+
+        apiWorkflowStateService.rejectReview(GraviteeContext.getExecutionContext(), API_ID, USER_ID, reviewEntity);
+
+        verify(workflowService)
+            .create(WorkflowReferenceType.API, API_ID, REVIEW, USER_ID, WorkflowState.REQUEST_FOR_CHANGES, reviewEntity.getMessage());
+        verify(auditService)
+            .createApiAuditLog(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(apiId -> apiId.equals(API_ID)),
+                anyMap(),
+                argThat(evt -> Workflow.AuditEvent.API_REVIEW_REJECTED.equals(evt)),
+                any(),
+                any(),
+                any()
+            );
+        verify(apiNotificationService, times(0)).triggerUpdateNotification(eq(GraviteeContext.getExecutionContext()), any(ApiEntity.class));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <!-- Version properties -->
         <revision>4.0.0</revision>
-        <sha1/>
+        <sha1>-alpha.1</sha1>
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1224
https://gravitee.atlassian.net/browse/APIM-1905

## Description

Sorry for long PR. A lot of changes has been done in 🤝  with @phiz71  

Console :
Migrate all API top banners for Angular and use it for V4.
Note : Quality is not ready for v4 but this banners contain the necessary for

REST API :
Migrate reviews ask accept reject endpoint into v2


## Additional context
All posible banners :

<img width="970" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4974420/e0f8307e-0155-4952-b9ea-4f734e0fa5cd">

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hegpsjaliq.chromatic.com)
<!-- Storybook placeholder end -->
