### PR TITLE
Add integration tests for plan selection

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandler.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.handlers.api.security;
 
+import static io.gravitee.gateway.security.core.AuthenticationContext.ATTR_INTERNAL_TOKEN_IDENTIFIED;
+
 import io.gravitee.definition.model.Plan;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.el.EvaluableRequest;
@@ -87,7 +89,12 @@ public abstract class PlanBasedAuthenticationHandler implements AuthenticationHa
                 evaluation.setVariable("request", new EvaluableRequest(authenticationContext.request()));
                 evaluation.setVariable("context", new EvaluableAuthenticationContext(authenticationContext));
 
-                return expression.getValue(evaluation, Boolean.class);
+                Boolean value = expression.getValue(evaluation, Boolean.class);
+                // Remove any security  token as the selection rule don't match
+                if (Boolean.FALSE.equals(value)) {
+                    authenticationContext.remove(ATTR_INTERNAL_TOKEN_IDENTIFIED);
+                }
+                return Boolean.TRUE.equals(value);
             } catch (ParseException | EvaluationException e) {
                 LOGGER.error("Plan selection rule execution failed", e);
                 return false;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlan.java
@@ -137,7 +137,14 @@ public class SecurityPlan {
         return ctx
             .getTemplateEngine()
             .eval(selectionRule, Boolean.class)
-            .map(matches -> matches && validateSubscription(ctx, securityToken));
+            .map(matches -> {
+                if (Boolean.TRUE.equals(matches)) {
+                    return validateSubscription(ctx, securityToken);
+                }
+                // Remove any security  token as the selection rule don't match
+                ctx.removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
+                return false;
+            });
     }
 
     private boolean validateSubscription(GenericExecutionContext ctx, SecurityToken securityToken) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlan.java
@@ -81,9 +81,11 @@ public class SecurityPlan {
         return policy
             .extractSecurityToken(ctx)
             .flatMap(securityToken -> {
-                final var canExec = isApplicableWithValidSubscription(ctx, securityToken);
                 ctx.setInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN, securityToken);
-                return canExec;
+                if (!securityToken.isInvalid()) {
+                    return isApplicableWithValidSubscription(ctx, securityToken);
+                }
+                return Maybe.empty();
             })
             .defaultIfEmpty(false);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -264,7 +264,7 @@ class SubscriptionCacheServiceTest {
         void should_get_subscription_by_api_id_and_apiKey() {
             Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
-            SecurityToken securityToken = new SecurityToken(SecurityToken.TokenType.API_KEY.name(), "apiKeyValue");
+            SecurityToken securityToken = SecurityToken.forApiKey("apiKeyValue");
             ApiKey apiKey = new ApiKey();
             apiKey.setSubscription(SUB_ID);
             when(apiKeyService.getByApiAndKey(API_ID, "apiKeyValue")).thenReturn(Optional.of(apiKey));
@@ -278,7 +278,7 @@ class SubscriptionCacheServiceTest {
         void should_not_get_subscription_by_api_id_without_apiKey() {
             Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
-            SecurityToken securityToken = new SecurityToken(SecurityToken.TokenType.API_KEY.name(), "apiKeyValue");
+            SecurityToken securityToken = SecurityToken.forApiKey("apiKeyValue");
             when(apiKeyService.getByApiAndKey(API_ID, "apiKeyValue")).thenReturn(Optional.empty());
 
             Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
@@ -289,7 +289,7 @@ class SubscriptionCacheServiceTest {
         void should_get_subscription_by_api_id_and_clientId() {
             Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
-            SecurityToken securityToken = new SecurityToken(SecurityToken.TokenType.CLIENT_ID.name(), CLIENT_ID);
+            SecurityToken securityToken = SecurityToken.forClientId(CLIENT_ID);
             Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
             assertThat(subscriptionOpt).isPresent();
             assertThat(subscriptionOpt.get()).isEqualTo(subscription);
@@ -299,7 +299,7 @@ class SubscriptionCacheServiceTest {
         void should_not_get_subscription_by_api_id_and_unknown_security_token() {
             Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);
-            SecurityToken securityToken = new SecurityToken("unknown", "unknown");
+            SecurityToken securityToken = SecurityToken.builder().tokenValue("unknown").tokenType("unknown").build();
             Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
             assertThat(subscriptionOpt).isEmpty();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
@@ -106,16 +106,29 @@ public class ApiKeyAuthenticationHandler implements AuthenticationHandler, Compo
     }
 
     private String readApiKey(Request request) {
+        String apiKey = null;
         logger.debug("Looking for an API Key from request header: {}", apiKeyHeader);
-        // 1_ First, search in HTTP headers
-        String apiKey = request.headers().getFirst(apiKeyHeader);
 
-        if (apiKey == null || apiKey.isEmpty()) {
-            logger.debug("Looking for an API Key from request query parameter: {}", apiKeyQueryParameter);
-            // 2_ If not found, search in query parameters
-            apiKey = request.parameters().getFirst(apiKeyQueryParameter);
+        // 1_ First, search in HTTP headers
+        if (request.headers().contains(apiKeyHeader)) {
+            apiKey = request.headers().get(apiKeyHeader);
+            if (apiKey == null) {
+                // Header is present but empty so init apiKey with empty string
+                apiKey = "";
+            }
         }
 
+        // 2_ If not found, search in query parameters
+        if (apiKey == null) {
+            logger.debug("Looking for an API Key from request query parameter: {}", apiKeyQueryParameter);
+            if (request.parameters().containsKey(apiKeyQueryParameter)) {
+                apiKey = request.parameters().getFirst(apiKeyQueryParameter);
+                if (apiKey == null) {
+                    // Header is present but empty so init apiKey with empty string
+                    apiKey = "";
+                }
+            }
+        }
         return apiKey;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/TokenExtractorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/TokenExtractorTest.java
@@ -21,25 +21,24 @@ import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.policy.jwt.utils.TokenExtractor;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@RunWith(MockitoJUnitRunner.class)
 public class TokenExtractorTest {
 
     @Mock
     private Request request;
-
-    @Before
-    public void init() {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Test
     public void shouldNotExtract_noAuthorizationHeader() {
@@ -66,14 +65,14 @@ public class TokenExtractorTest {
     }
 
     @Test
-    public void shouldNotExtract_bearerAuthorizationHeader_noValue() {
+    public void shouldExtract_bearerAuthorizationHeader_noValue() {
         HttpHeaders headers = HttpHeaders.create();
         headers.add(HttpHeaderNames.AUTHORIZATION, TokenExtractor.BEARER);
         when(request.headers()).thenReturn(headers);
 
         String token = TokenExtractor.extract(request);
 
-        Assert.assertNull(token);
+        Assert.assertEquals("", token);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandler.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.security.core.*;
 import io.gravitee.gateway.security.jwt.policy.CheckSubscriptionPolicy;
+import io.gravitee.policy.jwt.utils.TokenExtractor;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,9 +48,9 @@ public class JWTAuthenticationHandler implements AuthenticationHandler {
 
     @Override
     public boolean canHandle(AuthenticationContext context) {
-        final String token = readToken(context.request());
+        final String token = TokenExtractor.extract(context.request());
 
-        if (token == null || token.isEmpty()) {
+        if (token == null) {
             return false;
         }
 
@@ -61,10 +62,6 @@ public class JWTAuthenticationHandler implements AuthenticationHandler {
         }
 
         return true;
-    }
-
-    private String readToken(Request request) {
-        return TokenExtractor.extract(request);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandlerTest.java
@@ -138,16 +138,16 @@ public class JWTAuthenticationHandlerTest {
     }
 
     @Test
-    public void shouldNotHandleRequest_noBearerValue() {
+    public void shouldHandleRequest_noBearerValue() {
         HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
         headers.add(HttpHeaderNames.AUTHORIZATION, "Bearer ");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
-        assertFalse(handle);
-        assertNull(authenticationContext.get(JWTAuthenticationHandler.JWT_CONTEXT_ATTRIBUTE));
-        assertNull(authenticationContext.getInternalAttribute(ATTR_INTERNAL_TOKEN_IDENTIFIED));
+        assertTrue(handle);
+        assertNotNull(authenticationContext.get(JWTAuthenticationHandler.JWT_CONTEXT_ATTRIBUTE));
+        assertTrue(authenticationContext.getInternalAttribute(ATTR_INTERNAL_TOKEN_IDENTIFIED));
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
@@ -75,7 +75,7 @@ public class CheckSubscriptionPolicyTest {
         PolicyChain policyChain = mock(PolicyChain.class);
 
         // Search subscription now includes all criteria so the result is empty in case of bad clientId or planId.
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.empty());
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.empty());
 
         policy.execute(policyChain, executionContext);
 
@@ -102,7 +102,7 @@ public class CheckSubscriptionPolicyTest {
 
         Subscription subscription = new Subscription();
 
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -124,10 +124,10 @@ public class CheckSubscriptionPolicyTest {
 
         final Subscription subscription = new Subscription();
         subscription.setId("subscription-id");
-        subscription.setPlan("plan-id");
+        subscription.setPlan(PLAN_ID);
         subscription.setApplication("application-id");
 
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandler.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.security.core.*;
 import io.gravitee.gateway.security.oauth2.policy.CheckSubscriptionPolicy;
+import io.gravitee.policy.jwt.utils.TokenExtractor;
 import java.util.Arrays;
 import java.util.List;
 
@@ -49,9 +50,9 @@ public class OAuth2AuthenticationHandler implements AuthenticationHandler {
 
     @Override
     public boolean canHandle(AuthenticationContext context) {
-        String token = readToken(context.request());
+        String token = TokenExtractor.extract(context.request());
 
-        if (token == null || token.isEmpty()) {
+        if (token == null) {
             return false;
         }
 
@@ -63,10 +64,6 @@ public class OAuth2AuthenticationHandler implements AuthenticationHandler {
         }
 
         return true;
-    }
-
-    private String readToken(Request request) {
-        return TokenExtractor.extract(request);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicy.java
@@ -41,10 +41,7 @@ public class CheckSubscriptionPolicy implements Policy {
     static final String BEARER_AUTHORIZATION_TYPE = "Bearer";
     static final String GATEWAY_OAUTH2_ACCESS_DENIED_KEY = "GATEWAY_OAUTH2_ACCESS_DENIED";
     static final String GATEWAY_OAUTH2_INVALID_CLIENT_KEY = "GATEWAY_OAUTH2_INVALID_CLIENT";
-
-    private static final String OAUTH2_ERROR_ACCESS_DENIED = "access_denied";
-
-    private static final String OAUTH2_ERROR_SERVER_ERROR = "server_error";
+    static final String OAUTH2_UNAUTHORIZED_MESSAGE = "Unauthorized";
 
     @Override
     public void execute(PolicyChain policyChain, ExecutionContext executionContext) throws PolicyException {
@@ -56,24 +53,17 @@ public class CheckSubscriptionPolicy implements Policy {
 
         // client_id is mandatory
         if (clientId == null || clientId.trim().isEmpty()) {
-            sendError(
-                GATEWAY_OAUTH2_INVALID_CLIENT_KEY,
-                executionContext.response(),
-                policyChain,
-                "invalid_client",
-                "No client_id was supplied"
-            );
+            sendError(GATEWAY_OAUTH2_INVALID_CLIENT_KEY, executionContext.response(), policyChain);
             return;
         }
 
         executionContext.request().metrics().setSecurityType(OAUTH2);
         executionContext.request().metrics().setSecurityToken(clientId);
 
-        // FIXME: Use plan instead of `null` to properly handle plan selection in multi-plan context
         Optional<io.gravitee.gateway.api.service.Subscription> optionalSubscription = subscriptionService.getByApiAndClientIdAndPlan(
             api,
             clientId,
-            null
+            plan
         );
 
         if (optionalSubscription.isPresent()) {
@@ -96,12 +86,9 @@ public class CheckSubscriptionPolicy implements Policy {
             }
         }
 
-        // As per https://tools.ietf.org/html/rfc6749#section-4.1.2.1
-        sendUnauthorized(GATEWAY_OAUTH2_ACCESS_DENIED_KEY, policyChain, OAUTH2_ERROR_ACCESS_DENIED);
-    }
-
-    private void sendUnauthorized(String key, PolicyChain policyChain, String description) {
-        policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, description));
+        policyChain.failWith(
+            PolicyResult.failure(GATEWAY_OAUTH2_ACCESS_DENIED_KEY, HttpStatusCode.UNAUTHORIZED_401, OAUTH2_UNAUTHORIZED_MESSAGE)
+        );
     }
 
     /**
@@ -112,18 +99,10 @@ public class CheckSubscriptionPolicy implements Policy {
      *      error="invalid_token",
      *      error_description="The access token expired"
      */
-    private void sendError(String key, Response response, PolicyChain policyChain, String error, String description) {
-        String headerValue =
-            BEARER_AUTHORIZATION_TYPE +
-            " realm=\"gravitee.io\"," +
-            " error=\"" +
-            error +
-            "\"," +
-            " error_description=\"" +
-            description +
-            "\"";
+    private void sendError(String key, Response response, PolicyChain policyChain) {
+        String headerValue = BEARER_AUTHORIZATION_TYPE + " realm=\"gravitee.io\"";
         response.headers().add(HttpHeaders.WWW_AUTHENTICATE, headerValue);
-        policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, null));
+        policyChain.failWith(PolicyResult.failure(key, HttpStatusCode.UNAUTHORIZED_401, OAUTH2_UNAUTHORIZED_MESSAGE));
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandlerTest.java
@@ -124,14 +124,14 @@ public class OAuth2AuthenticationHandlerTest {
     }
 
     @Test
-    public void shouldNotHandleRequest_noBearerValue() {
+    public void shouldHandleRequest_noBearerValue() {
         HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
         headers.add(HttpHeaderNames.AUTHORIZATION, OAuth2AuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " ");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
-        Assert.assertFalse(handle);
+        Assert.assertTrue(handle);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
@@ -99,7 +99,7 @@ public class CheckSubscriptionPolicyTest {
         when(executionContext.getAttribute(ExecutionContext.ATTR_API)).thenReturn("api-id");
 
         // no subscription found in cache for this API / clientID
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.empty());
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.empty());
 
         policy.execute(policyChain, executionContext);
 
@@ -121,7 +121,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with end date in the past
         Subscription subscription = new Subscription();
         subscription.setEndingAt(new Date(currentTimeMillis() - 100000));
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -147,7 +147,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with a valid plan, and time
         Subscription subscription = new Subscription();
         subscription.setPlan(PLAN_ID);
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -170,7 +170,7 @@ public class CheckSubscriptionPolicyTest {
         subscription.setPlan(PLAN_ID);
         subscription.setApplication("application-id");
 
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -191,7 +191,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with an invalid plan
         Subscription subscription = new Subscription();
         subscription.setPlan("another-plan");
-        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, null)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -550,10 +550,7 @@ public class GatewayRunner {
     }
 
     private void ensureMinimalRequirementForPolicies(Map<String, PolicyPlugin> policies) {
-        policies.putIfAbsent("api-key", PolicyBuilder.build("api-key", KeylessPolicy.class));
         policies.putIfAbsent("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
-        policies.putIfAbsent("oauth2", PolicyBuilder.build("oauth2", KeylessPolicy.class));
-        policies.putIfAbsent("jwt", PolicyBuilder.build("jwt", KeylessPolicy.class));
     }
 
     private void registerConnectors(GatewayTestContainer container) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
@@ -15,12 +15,33 @@
  */
 package io.gravitee.apim.integration.tests.plan;
 
-import io.gravitee.gateway.api.service.Subscription;
-
-import java.time.Instant;
-import java.util.Date;
-
+import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
 import static java.time.temporal.ChronoUnit.HOURS;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -28,9 +49,28 @@ import static java.time.temporal.ChronoUnit.HOURS;
  */
 public class PlanHelper {
 
-    public static final String PLAN_ID = "plan-id";
+    public static final String PLAN_KEYLESS_ID = "plan-keyless-id";
+    public static final String PLAN_APIKEY_ID = "plan-apikey-id";
+    public static final String PLAN_JWT_ID = "plan-jwt-id";
+    public static final String PLAN_OAUTH2_ID = "plan-oauth2-id";
     public static final String APPLICATION_ID = "application-id";
     public static final String SUBSCRIPTION_ID = "subscription-id";
+
+    public static final String JWT_CLIENT_ID = "jwt-client-id";
+    public static final String JWT_SECRET;
+
+    public static String OAUTH2_CLIENT_ID = "oauth2-client-id";
+    public static String OAUTH2_SUCCESS_TOKEN = "success-token";
+    public static String OAUTH2_UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID = "unauthorized-token-without-client-id";
+    public static String OAUTH2_UNAUTHORIZED_WITH_INVALID_PAYLOAD = "unauthorized-token-with-invalid-payload";
+    public static String OAUTH2_UNAUTHORIZED_TOKEN = "unauthorized-token";
+
+    static {
+        SecureRandom random = new SecureRandom();
+        byte[] sharedSecret = new byte[32];
+        random.nextBytes(sharedSecret);
+        JWT_SECRET = new String(sharedSecret);
+    }
 
     public static String getApiPath(final String apiId) {
         return "/" + apiId;
@@ -40,15 +80,167 @@ public class PlanHelper {
      * Generate the Subscription object that would be returned by the SubscriptionService
      * @return the Subscription object
      */
-    public static Subscription createSubscription(final String apiId, final boolean isExpired) {
+    public static Subscription createSubscription(final String apiId, final String planId, final boolean isExpired) {
         final Subscription subscription = new Subscription();
         subscription.setApplication(APPLICATION_ID);
         subscription.setId(SUBSCRIPTION_ID);
-        subscription.setPlan(PLAN_ID);
+        subscription.setPlan(planId);
         subscription.setApi(apiId);
         if (isExpired) {
             subscription.setEndingAt(new Date(Instant.now().minus(1, HOURS).toEpochMilli()));
         }
         return subscription;
+    }
+
+    public static String generateJWT(long secondsToAdd) throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+            .claim("client_id", JWT_CLIENT_ID)
+            .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)))
+            .build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+    public static void configurePlans(final Api api, final Set<String> planIds) {
+        List<Plan> plans = new ArrayList<>();
+        if (planIds.contains("KEY_LESS")) {
+            io.gravitee.definition.model.Plan keylessPlan = new io.gravitee.definition.model.Plan();
+            keylessPlan.setId(PLAN_KEYLESS_ID);
+            keylessPlan.setApi(api.getId());
+            keylessPlan.setSecurity("KEY_LESS");
+            keylessPlan.setStatus("PUBLISHED");
+            plans.add(keylessPlan);
+        }
+
+        if (planIds.contains("API_KEY")) {
+            io.gravitee.definition.model.Plan apiKeyPlan = new io.gravitee.definition.model.Plan();
+            apiKeyPlan.setId(PLAN_APIKEY_ID);
+            apiKeyPlan.setApi(api.getId());
+            apiKeyPlan.setSecurity("API_KEY");
+            apiKeyPlan.setStatus("PUBLISHED");
+            plans.add(apiKeyPlan);
+        }
+
+        if (planIds.contains("JWT")) {
+            io.gravitee.definition.model.Plan jwtPlan = new Plan();
+            jwtPlan.setId(PLAN_JWT_ID);
+            jwtPlan.setApi(api.getId());
+            jwtPlan.setSecurity("JWT");
+            jwtPlan.setStatus("PUBLISHED");
+            JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+            configuration.setSignature(HMAC_HS256);
+            configuration.setResolverParameter(JWT_SECRET);
+            configuration.setPublicKeyResolver(GIVEN_KEY);
+            try {
+                jwtPlan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set JWT policy configuration", e);
+            }
+            plans.add(jwtPlan);
+        }
+
+        if (planIds.contains("OAUTH2")) {
+            Resource resource = new Resource(RESOURCE_ID, RESOURCE_ID, new ObjectMapper().createObjectNode());
+            api.getResources().add(resource);
+
+            Plan oauth2Plan = new Plan();
+            oauth2Plan.setId(PLAN_OAUTH2_ID);
+            oauth2Plan.setApi(api.getId());
+            oauth2Plan.setSecurity("OAUTH2");
+            oauth2Plan.setStatus("PUBLISHED");
+
+            OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
+            configuration.setOauthResource(RESOURCE_ID);
+            try {
+                oauth2Plan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
+            }
+            plans.add(oauth2Plan);
+        }
+        if (plans.isEmpty()) {
+            throw new IllegalArgumentException("No plan configured");
+        }
+
+        api.setPlans(plans);
+    }
+
+    public static void configurePlans(final io.gravitee.definition.model.v4.Api api, final Set<String> planIds) {
+        List<io.gravitee.definition.model.v4.plan.Plan> plans = new ArrayList<>();
+        if (planIds.contains("key-less")) {
+            io.gravitee.definition.model.v4.plan.Plan keylessPlan = io.gravitee.definition.model.v4.plan.Plan
+                .builder()
+                .id(PLAN_KEYLESS_ID)
+                .name("plan-name")
+                .security(PlanSecurity.builder().type("key-less").build())
+                .status(PlanStatus.PUBLISHED)
+                .mode(PlanMode.STANDARD)
+                .build();
+            plans.add(keylessPlan);
+        }
+
+        if (planIds.contains("api-key")) {
+            io.gravitee.definition.model.v4.plan.Plan apiKeyPlan = io.gravitee.definition.model.v4.plan.Plan
+                .builder()
+                .id(PLAN_APIKEY_ID)
+                .name("plan-apikey-name")
+                .security(PlanSecurity.builder().type("api-key").build())
+                .status(PlanStatus.PUBLISHED)
+                .mode(PlanMode.STANDARD)
+                .build();
+            plans.add(apiKeyPlan);
+        }
+
+        if (planIds.contains("jwt")) {
+            try {
+                JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+                configuration.setSignature(HMAC_HS256);
+                configuration.setResolverParameter(JWT_SECRET);
+                configuration.setPublicKeyResolver(GIVEN_KEY);
+
+                io.gravitee.definition.model.v4.plan.Plan jwtPlan = io.gravitee.definition.model.v4.plan.Plan
+                    .builder()
+                    .id(PLAN_JWT_ID)
+                    .name("plan-jwt-name")
+                    .security(
+                        PlanSecurity.builder().type("jwt").configuration(new ObjectMapper().writeValueAsString(configuration)).build()
+                    )
+                    .status(PlanStatus.PUBLISHED)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+                plans.add(jwtPlan);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set JWT policy configuration", e);
+            }
+        }
+
+        if (planIds.contains("oauth2")) {
+            List<io.gravitee.definition.model.v4.resource.Resource> resources = new ArrayList<>();
+            resources.add(io.gravitee.definition.model.v4.resource.Resource.builder().name(RESOURCE_ID).type(RESOURCE_ID).build());
+            api.setResources(resources);
+            try {
+                OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
+                configuration.setOauthResource(RESOURCE_ID);
+                io.gravitee.definition.model.v4.plan.Plan oauth2Plan = io.gravitee.definition.model.v4.plan.Plan
+                    .builder()
+                    .id(PLAN_OAUTH2_ID)
+                    .name("plan-oauth2-name")
+                    .security(
+                        PlanSecurity.builder().type("oauth2").configuration(new ObjectMapper().writeValueAsString(configuration)).build()
+                    )
+                    .status(PlanStatus.PUBLISHED)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+                plans.add(oauth2Plan);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
+            }
+        }
+        if (plans.isEmpty()) {
+            throw new IllegalArgumentException("No plan configured");
+        }
+
+        api.setPlans(plans);
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan;
+
+import io.gravitee.gateway.api.service.Subscription;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PlanHelper {
+
+    public static final String PLAN_ID = "plan-id";
+    public static final String APPLICATION_ID = "application-id";
+    public static final String SUBSCRIPTION_ID = "subscription-id";
+
+    public static String getApiPath(final String apiId) {
+        return "/" + apiId;
+    }
+
+    /**
+     * Generate the Subscription object that would be returned by the SubscriptionService
+     * @return the Subscription object
+     */
+    public static Subscription createSubscription(final String apiId, final boolean isExpired) {
+        final Subscription subscription = new Subscription();
+        subscription.setApplication(APPLICATION_ID);
+        subscription.setId(SUBSCRIPTION_ID);
+        subscription.setPlan(PLAN_ID);
+        subscription.setApi(apiId);
+        if (isExpired) {
+            subscription.setEndingAt(new Date(Instant.now().minus(1, HOURS).toEpochMilli()));
+        }
+        return subscription;
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
@@ -38,9 +38,9 @@ import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -93,11 +93,19 @@ public class PlanHelper {
     }
 
     public static String generateJWT(long secondsToAdd) throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+        return generateJWT(secondsToAdd, Map.of());
+    }
+
+    public static String generateJWT(long secondsToAdd, Map<String, String> customClaims) throws Exception {
+        JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder()
             .claim("client_id", JWT_CLIENT_ID)
-            .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)))
-            .build();
-        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+            .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)));
+
+        if (customClaims != null) {
+            customClaims.forEach(jwtClaimsSetBuilder::claim);
+        }
+
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSetBuilder.build());
         signedJWT.sign(new MACSigner(JWT_SECRET));
         return signedJWT.serialize();
     }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV3IntegrationTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.apikey;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+
+import static io.gravitee.definition.model.ExecutionMode.V3;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = V3)
+public class PlanApiKeyV3IntegrationTest extends PlanApiKeyV4EmulationIntegrationTest {
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4EmulationIntegrationTest.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.apikey;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
+import static io.vertx.core.http.HttpMethod.GET;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/plan/v2-api.json")
+public class PlanApiKeyV4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    /**
+     * Override api plans to have a published KEY_LESS one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        Plan plan = new Plan();
+        plan.setId("plan-id");
+        plan.setApi(api.getId());
+        plan.setSecurity("API_KEY");
+        plan.setStatus("PUBLISHED");
+        api.setPlans(Collections.singletonList(plan));
+    }
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("api-key", PolicyBuilder.build("api-key", ApiKeyPolicy.class, null, ApiKeyPolicyInitializer.class));
+    }
+
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v2-api", true)
+        );
+    }
+
+    protected Stream<Arguments> provideWrongSecurityHeaders() {
+        return provideApis().flatMap(arguments -> {
+            String apiId = (String) arguments.get()[0];
+            return Stream.of(
+                    Arguments.of(apiId, null, null),
+                    Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+            );
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_200_success_with_api_key_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) {
+        final ApiKey apiKey = createApiKey(apiId, false, false);
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), false)));
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client.rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(200);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body.toString()).contains("endpoint response");
+                            return true;
+                        }
+                );
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideWrongSecurityHeaders")
+    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    if (headerName != null && headerValue != null) {
+                        request.putHeader(headerName, headerValue);
+                    }
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_valid_api_key_but_no_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+        final ApiKey apiKey = createApiKey("another-api", false, false);
+        assertUnauthorizedWithKey(path, client, apiKey, false);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_expired_api_key_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+        final ApiKey apiKey = createApiKey("my-v2-api", true, false);
+        assertUnauthorizedWithKey(path, client, apiKey, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_revoked_api_key_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+        final ApiKey apiKey = createApiKey("my-v2-api", false, true);
+        assertUnauthorizedWithKey(path, client, apiKey, true);
+    }
+
+    private void assertUnauthorizedWithKey(final String apiId, final HttpClient client, final ApiKey apiKey, final boolean withSubscription) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
+
+        when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+        if (withSubscription) {
+            whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), false)));
+        } else {
+            whenSearchingSubscription(apiKey).thenReturn(Optional.empty());
+        }
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    /**
+     * Generate the ApiKey object that would be returned by the ApiKeyService
+     * @return the ApiKey object
+     */
+    private ApiKey createApiKey(final String apiId, final boolean isExpired, final boolean isRevoked) {
+        final ApiKey apiKey = new ApiKey();
+        apiKey.setApi(apiId);
+        apiKey.setApplication("application-id");
+        apiKey.setSubscription("subscription-id");
+        apiKey.setPlan(PLAN_ID);
+        apiKey.setKey("apiKeyValue");
+        if (isExpired) {
+            apiKey.setExpireAt(new Date(Instant.now().minus(1, HOURS).toEpochMilli()));
+        }
+        apiKey.setRevoked(isRevoked);
+        return apiKey;
+    }
+
+    private OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(ApiKey apiKey) {
+        return when(
+                getBean(SubscriptionService.class)
+                        .getByApiAndSecurityToken(eq(apiKey.getApi()), argThat(securityToken ->
+                                securityToken.getTokenType().equals(API_KEY.name()) && securityToken.getTokenValue().equals(apiKey.getKey())
+                        ), eq(apiKey.getPlan()))
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4EmulationIntegrationTest.java
@@ -15,6 +15,23 @@
  */
 package io.gravitee.apim.integration.tests.plan.apikey;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
+import static io.vertx.core.http.HttpMethod.GET;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
@@ -28,35 +45,20 @@ import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.apikey.ApiKeyPolicy;
 import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import io.vertx.rxjava3.core.http.HttpClient;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.stubbing.OngoingStubbing;
-
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
-import static io.gravitee.gateway.reactive.api.policy.SecurityToken.TokenType.API_KEY;
-import static io.vertx.core.http.HttpMethod.GET;
-import static java.time.temporal.ChronoUnit.HOURS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
 
 /**
  * @author GraviteeSource Team
@@ -65,73 +67,71 @@ import static org.mockito.Mockito.when;
 @DeployApi("/apis/plan/v2-api.json")
 public class PlanApiKeyV4EmulationIntegrationTest extends AbstractGatewayTest {
 
-    /**
-     * Override api plans to have a published KEY_LESS one.
-     * @param api is the api to apply this function code
-     */
     @Override
     public void configureApi(Api api) {
-        Plan plan = new Plan();
-        plan.setId("plan-id");
-        plan.setApi(api.getId());
-        plan.setSecurity("API_KEY");
-        plan.setStatus("PUBLISHED");
-        api.setPlans(Collections.singletonList(plan));
+        configurePlans(api, Set.of("API_KEY"));
     }
 
     @Override
     public void configurePolicies(final Map<String, PolicyPlugin> policies) {
-        policies.put("api-key", PolicyBuilder.build("api-key", ApiKeyPolicy.class, null, ApiKeyPolicyInitializer.class));
-    }
-
-    protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v2-api", true)
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
         );
     }
 
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v2-api", true));
+    }
+
     protected Stream<Arguments> provideWrongSecurityHeaders() {
-        return provideApis().flatMap(arguments -> {
-            String apiId = (String) arguments.get()[0];
-            return Stream.of(
+        return provideApis()
+            .flatMap(arguments -> {
+                String apiId = (String) arguments.get()[0];
+                return Stream.of(
                     Arguments.of(apiId, null, null),
                     Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "X-Gravitee-Api-Key", ""),
+                    Arguments.of(apiId, "Authorization", ""),
+                    Arguments.of(apiId, "Authorization", "Bearer"),
+                    Arguments.of(apiId, "Authorization", "Bearer "),
                     Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
-            );
-        });
+                );
+            });
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_200_success_with_api_key_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) {
+    void should_return_200_success_with_api_key_and_subscription_on_the_api(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) {
         final ApiKey apiKey = createApiKey(apiId, false, false);
         when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
-        whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), false)));
+        whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), PLAN_APIKEY_ID, false)));
 
         if (requireWiremock) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
         }
 
-        client.rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(200);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body.toString()).contains("endpoint response");
-                            return true;
-                        }
-                );
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
 
         if (requireWiremock) {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
@@ -140,89 +140,102 @@ public class PlanApiKeyV4EmulationIntegrationTest extends AbstractGatewayTest {
 
     @ParameterizedTest
     @MethodSource("provideWrongSecurityHeaders")
-    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+    void should_return_401_unauthorized_with_wrong_security(
+        final String apiId,
+        final String headerName,
+        final String headerValue,
+        final HttpClient client
+    ) {
         wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    if (headerName != null && headerValue != null) {
-                        request.putHeader(headerName, headerValue);
-                    }
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                if (headerName != null) {
+                    request.putHeader(headerName, headerValue);
+                }
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_valid_api_key_but_no_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+    void should_return_401_unauthorized_with_valid_api_key_but_no_subscription_on_the_api(
+        final String path,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) {
         final ApiKey apiKey = createApiKey("another-api", false, false);
         assertUnauthorizedWithKey(path, client, apiKey, false);
     }
 
-
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_expired_api_key_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+    void should_return_401_unauthorized_with_expired_api_key_and_subscription_on_the_api(
+        final String path,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) {
         final ApiKey apiKey = createApiKey("my-v2-api", true, false);
         assertUnauthorizedWithKey(path, client, apiKey, true);
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_revoked_api_key_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) {
+    void should_return_401_unauthorized_with_revoked_api_key_and_subscription_on_the_api(
+        final String path,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) {
         final ApiKey apiKey = createApiKey("my-v2-api", false, true);
         assertUnauthorizedWithKey(path, client, apiKey, true);
     }
 
-    private void assertUnauthorizedWithKey(final String apiId, final HttpClient client, final ApiKey apiKey, final boolean withSubscription) {
+    private void assertUnauthorizedWithKey(
+        final String apiId,
+        final HttpClient client,
+        final ApiKey apiKey,
+        final boolean withSubscription
+    ) {
         wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
 
         when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
         if (withSubscription) {
-            whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), false)));
+            whenSearchingSubscription(apiKey).thenReturn(Optional.of(createSubscription(apiKey.getApi(), PLAN_APIKEY_ID, false)));
         } else {
             whenSearchingSubscription(apiKey).thenReturn(Optional.empty());
         }
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("X-Gravitee-Api-Key", apiKey.getKey());
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
     }
@@ -236,7 +249,7 @@ public class PlanApiKeyV4EmulationIntegrationTest extends AbstractGatewayTest {
         apiKey.setApi(apiId);
         apiKey.setApplication("application-id");
         apiKey.setSubscription("subscription-id");
-        apiKey.setPlan(PLAN_ID);
+        apiKey.setPlan(PLAN_APIKEY_ID);
         apiKey.setKey("apiKeyValue");
         if (isExpired) {
             apiKey.setExpireAt(new Date(Instant.now().minus(1, HOURS).toEpochMilli()));
@@ -247,10 +260,14 @@ public class PlanApiKeyV4EmulationIntegrationTest extends AbstractGatewayTest {
 
     private OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(ApiKey apiKey) {
         return when(
-                getBean(SubscriptionService.class)
-                        .getByApiAndSecurityToken(eq(apiKey.getApi()), argThat(securityToken ->
-                                securityToken.getTokenType().equals(API_KEY.name()) && securityToken.getTokenValue().equals(apiKey.getKey())
-                        ), eq(apiKey.getPlan()))
+            getBean(SubscriptionService.class)
+                .getByApiAndSecurityToken(
+                    eq(apiKey.getApi()),
+                    argThat(securityToken ->
+                        securityToken.getTokenType().equals(API_KEY.name()) && securityToken.getTokenValue().equals(apiKey.getKey())
+                    ),
+                    eq(apiKey.getPlan())
+                )
         );
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4IntegrationTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.apikey;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+public class PlanApiKeyV4IntegrationTest extends PlanApiKeyV4EmulationIntegrationTest {
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass)) {
+            final Api definition = (Api) api.getDefinition();
+            Plan keylessPlan = Plan.builder()
+                    .id(PLAN_ID)
+                    .name("plan-name")
+                    .security(PlanSecurity.builder()
+                            .type("api-key")
+                            .build())
+                    .status(PlanStatus.PUBLISHED)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+            definition.setPlans(Collections.singletonList(keylessPlan));
+        }
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v4-proxy-api", true),
+                Arguments.of("v4-message-api", false)
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/apikey/PlanApiKeyV4IntegrationTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.apim.integration.tests.plan.apikey;
 
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
 import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
 import com.graviteesource.reactor.message.MessageApiReactorFactory;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
@@ -34,35 +37,23 @@ import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
-import org.junit.jupiter.params.provider.Arguments;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * @author GraviteeSource Team
  */
-@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+@DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
 public class PlanApiKeyV4IntegrationTest extends PlanApiKeyV4EmulationIntegrationTest {
 
     @Override
     public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
         if (isV4Api(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            Plan keylessPlan = Plan.builder()
-                    .id(PLAN_ID)
-                    .name("plan-name")
-                    .security(PlanSecurity.builder()
-                            .type("api-key")
-                            .build())
-                    .status(PlanStatus.PUBLISHED)
-                    .mode(PlanMode.STANDARD)
-                    .build();
-            definition.setPlans(Collections.singletonList(keylessPlan));
+            final Api apiDefinition = (Api) api.getDefinition();
+            configurePlans(apiDefinition, Set.of("api-key"));
         }
     }
 
@@ -85,9 +76,6 @@ public class PlanApiKeyV4IntegrationTest extends PlanApiKeyV4EmulationIntegratio
 
     @Override
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v4-proxy-api", true),
-                Arguments.of("v4-message-api", false)
-        );
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV3IntegrationTest.java
@@ -15,21 +15,21 @@
  */
 package io.gravitee.apim.integration.tests.plan.jwt;
 
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
-import org.mockito.stubbing.OngoingStubbing;
-
 import java.util.Optional;
-
-import static io.gravitee.definition.model.ExecutionMode.V3;
-import static org.mockito.Mockito.when;
+import org.mockito.stubbing.OngoingStubbing;
 
 /**
  * @author GraviteeSource Team
  */
 @GatewayTest(v2ExecutionMode = V3)
 public class PlanJwtV3IntegrationTest extends PlanJwtV4EmulationIntegrationTest {
+
     /**
      * This overrides subscription search :
      * - in jupiter its searched with getByApiAndSecurityToken

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV3IntegrationTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.jwt;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.util.Optional;
+
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = V3)
+public class PlanJwtV3IntegrationTest extends PlanJwtV4EmulationIntegrationTest {
+    /**
+     * This overrides subscription search :
+     * - in jupiter its searched with getByApiAndSecurityToken
+     * - in V3 its searches with api/clientId/plan
+     */
+    @Override
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4EmulationIntegrationTest.java
@@ -1,0 +1,264 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/plan/v2-api.json")
+public class PlanJwtV4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    protected static final String CLIENT_ID = "my-test-client-id";
+    protected static final String JWT_SECRET;
+
+    static {
+        SecureRandom random = new SecureRandom();
+        byte[] sharedSecret = new byte[32];
+        random.nextBytes(sharedSecret);
+        JWT_SECRET = new String(sharedSecret);
+    }
+
+    /**
+     * Override api plans to have a published KEY_LESS one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        Plan plan = new Plan();
+        plan.setId(PLAN_ID);
+        plan.setApi(api.getId());
+        plan.setSecurity("JWT");
+        plan.setStatus("PUBLISHED");
+
+        JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+        configuration.setSignature(HMAC_HS256);
+        configuration.setResolverParameter(JWT_SECRET);
+        configuration.setPublicKeyResolver(GIVEN_KEY);
+        try {
+            plan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to set JWT policy configuration", e);
+        }
+        api.setPlans(Collections.singletonList(plan));
+    }
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+    }
+
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v2-api", true)
+        );
+    }
+
+    protected Stream<Arguments> provideWrongSecurityHeaders() {
+        return provideApis().flatMap(arguments -> {
+            String apiId = (String) arguments.get()[0];
+            return Stream.of(
+                    Arguments.of(apiId, null, null),
+                    Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+            );
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_200_success_with_jwt_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
+        String jwtToken = getJsonWebToken(5000);
+        whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client.rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("Authorization", "Bearer " + jwtToken);
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(200);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(60, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body.toString()).contains("endpoint response");
+                            return true;
+                        }
+                );
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideWrongSecurityHeaders")
+    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    if (headerName != null && headerValue != null) {
+                        request.putHeader(headerName, headerValue);
+                    }
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_valid_jwt_but_no_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) throws Exception {
+        String jwtToken = getJsonWebToken(5000);
+        assertUnauthorizedWithJwt(path, client, jwtToken, false);
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_expired_jwt_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) throws Exception {
+        String jwtToken = getJsonWebToken(-5000);
+        assertUnauthorizedWithJwt(path, client, jwtToken, true);
+    }
+
+    private void assertUnauthorizedWithJwt(final String apiId, final HttpClient client, final String jwtToken, final boolean withSubscription) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
+
+        if (withSubscription) {
+            whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+        } else {
+            whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.empty());
+        }
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("Authorization", "Bearer " + jwtToken);
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+
+    private String getJsonWebToken(long secondsToAdd) throws Exception {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+                .claim("client_id", CLIENT_ID)
+                .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)))
+                .build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
+        signedJWT.sign(new MACSigner(JWT_SECRET));
+        return signedJWT.serialize();
+    }
+
+
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+        return when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(api), argThat(securityToken ->
+                securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) && securityToken.getTokenValue().equals(clientId)
+        ), eq(plan)));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4EmulationIntegrationTest.java
@@ -15,18 +15,27 @@
  */
 package io.gravitee.apim.integration.tests.plan.jwt;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.MACSigner;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.JWT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_JWT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.generateJWT;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
 import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.Plan;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
@@ -34,35 +43,15 @@ import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.jwt.JWTPolicy;
 import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.stubbing.OngoingStubbing;
-
-import java.security.SecureRandom;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
-import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
-import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
-import static io.vertx.core.http.HttpMethod.GET;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * @author GraviteeSource Team
@@ -71,38 +60,9 @@ import static org.mockito.Mockito.when;
 @DeployApi("/apis/plan/v2-api.json")
 public class PlanJwtV4EmulationIntegrationTest extends AbstractGatewayTest {
 
-    protected static final String CLIENT_ID = "my-test-client-id";
-    protected static final String JWT_SECRET;
-
-    static {
-        SecureRandom random = new SecureRandom();
-        byte[] sharedSecret = new byte[32];
-        random.nextBytes(sharedSecret);
-        JWT_SECRET = new String(sharedSecret);
-    }
-
-    /**
-     * Override api plans to have a published KEY_LESS one.
-     * @param api is the api to apply this function code
-     */
     @Override
     public void configureApi(Api api) {
-        Plan plan = new Plan();
-        plan.setId(PLAN_ID);
-        plan.setApi(api.getId());
-        plan.setSecurity("JWT");
-        plan.setStatus("PUBLISHED");
-
-        JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
-        configuration.setSignature(HMAC_HS256);
-        configuration.setResolverParameter(JWT_SECRET);
-        configuration.setPublicKeyResolver(GIVEN_KEY);
-        try {
-            plan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to set JWT policy configuration", e);
-        }
-        api.setPlans(Collections.singletonList(plan));
+        configurePlans(api, Set.of("JWT"));
     }
 
     @Override
@@ -111,52 +71,57 @@ public class PlanJwtV4EmulationIntegrationTest extends AbstractGatewayTest {
     }
 
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v2-api", true)
-        );
+        return Stream.of(Arguments.of("v2-api", true));
     }
 
     protected Stream<Arguments> provideWrongSecurityHeaders() {
-        return provideApis().flatMap(arguments -> {
-            String apiId = (String) arguments.get()[0];
-            return Stream.of(
+        return provideApis()
+            .flatMap(arguments -> {
+                String apiId = (String) arguments.get()[0];
+                return Stream.of(
                     Arguments.of(apiId, null, null),
+                    Arguments.of(apiId, "Authorization", ""),
+                    Arguments.of(apiId, "Authorization", "Basic 123456789"),
                     Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "X-Gravitee-Api-Key", ""),
+                    Arguments.of(apiId, "Authorization", "Bearer"),
+                    Arguments.of(apiId, "Authorization", "Bearer "),
                     Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
-            );
-        });
+                );
+            });
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_200_success_with_jwt_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
-        String jwtToken = getJsonWebToken(5000);
-        whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+    void should_return_200_success_with_jwt_and_subscription_on_the_api(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) throws Exception {
+        String jwtToken = generateJWT(5000);
+        whenSearchingSubscription(apiId, JWT_CLIENT_ID, PLAN_JWT_ID).thenReturn(Optional.of(createSubscription(apiId, PLAN_JWT_ID, false)));
 
         if (requireWiremock) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
         }
 
-        client.rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("Authorization", "Bearer " + jwtToken);
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(200);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(60, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body.toString()).contains("endpoint response");
-                            return true;
-                        }
-                );
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
 
         if (requireWiremock) {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
@@ -165,100 +130,106 @@ public class PlanJwtV4EmulationIntegrationTest extends AbstractGatewayTest {
 
     @ParameterizedTest
     @MethodSource("provideWrongSecurityHeaders")
-    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+    void should_return_401_unauthorized_with_wrong_security(
+        final String apiId,
+        final String headerName,
+        final String headerValue,
+        final HttpClient client
+    ) {
         wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    if (headerName != null && headerValue != null) {
-                        request.putHeader(headerName, headerValue);
-                    }
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                if (headerName != null) {
+                    request.putHeader(headerName, headerValue);
+                }
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_valid_jwt_but_no_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) throws Exception {
-        String jwtToken = getJsonWebToken(5000);
+    void should_return_401_unauthorized_with_valid_jwt_but_no_subscription_on_the_api(
+        final String path,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) throws Exception {
+        String jwtToken = generateJWT(5000);
         assertUnauthorizedWithJwt(path, client, jwtToken, false);
     }
 
-
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_expired_jwt_and_subscription_on_the_api(final String path, final boolean requireWiremock, final HttpClient client) throws Exception {
-        String jwtToken = getJsonWebToken(-5000);
+    void should_return_401_unauthorized_with_expired_jwt_and_subscription_on_the_api(
+        final String path,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) throws Exception {
+        String jwtToken = generateJWT(-5000);
         assertUnauthorizedWithJwt(path, client, jwtToken, true);
     }
 
-    private void assertUnauthorizedWithJwt(final String apiId, final HttpClient client, final String jwtToken, final boolean withSubscription) {
+    private void assertUnauthorizedWithJwt(
+        final String apiId,
+        final HttpClient client,
+        final String jwtToken,
+        final boolean withSubscription
+    ) {
         wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
 
         if (withSubscription) {
-            whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+            whenSearchingSubscription(apiId, JWT_CLIENT_ID, PLAN_JWT_ID)
+                .thenReturn(Optional.of(createSubscription(apiId, PLAN_JWT_ID, false)));
         } else {
-            whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.empty());
+            whenSearchingSubscription(apiId, JWT_CLIENT_ID, PLAN_JWT_ID).thenReturn(Optional.empty());
         }
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("Authorization", "Bearer " + jwtToken);
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
     }
 
-
-    private String getJsonWebToken(long secondsToAdd) throws Exception {
-        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
-                .claim("client_id", CLIENT_ID)
-                .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)))
-                .build();
-        SignedJWT signedJWT = new SignedJWT(new JWSHeader(HMAC_HS256.getAlg()), jwtClaimsSet);
-        signedJWT.sign(new MACSigner(JWT_SECRET));
-        return signedJWT.serialize();
-    }
-
-
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        return when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(api), argThat(securityToken ->
-                securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) && securityToken.getTokenValue().equals(clientId)
-        ), eq(plan)));
+        return when(
+            getBean(SubscriptionService.class)
+                .getByApiAndSecurityToken(
+                    eq(api),
+                    argThat(securityToken ->
+                        securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) &&
+                        securityToken.getTokenValue().equals(clientId)
+                    ),
+                    eq(plan)
+                )
+        );
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtV4IntegrationTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.jwt;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+public class PlanJwtV4IntegrationTest extends PlanJwtV4EmulationIntegrationTest {
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass)) {
+            final Api definition = (Api) api.getDefinition();
+            try {
+                JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+                configuration.setSignature(HMAC_HS256);
+                configuration.setResolverParameter(JWT_SECRET);
+                configuration.setPublicKeyResolver(GIVEN_KEY);
+
+                Plan plan = Plan.builder()
+                        .id(PLAN_ID)
+                        .name("plan-name")
+                        .security(PlanSecurity.builder()
+                                .type("jwt")
+                                .configuration(new ObjectMapper().writeValueAsString(configuration))
+                                .build())
+                        .status(PlanStatus.PUBLISHED)
+                        .mode(PlanMode.STANDARD)
+                        .build();
+                definition.setPlans(Collections.singletonList(plan));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set JWT policy configuration", e);
+            }
+        }
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v4-proxy-api", true),
+                Arguments.of("v4-message-api", false)
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV3IntegrationTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.keyless;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = V3)
+public class PlanKeylessV3IntegrationTest extends PlanKeylessV4EmulationIntegrationTest {
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV3IntegrationTest.java
@@ -15,17 +15,15 @@
  */
 package io.gravitee.apim.integration.tests.plan.keyless;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static io.gravitee.definition.model.ExecutionMode.V3;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+
 /**
  * @author GraviteeSource Team
  */
 @GatewayTest(v2ExecutionMode = V3)
-public class PlanKeylessV3IntegrationTest extends PlanKeylessV4EmulationIntegrationTest {
-
-}
+public class PlanKeylessV3IntegrationTest extends PlanKeylessV4EmulationIntegrationTest {}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4EmulationIntegrationTest.java
@@ -15,34 +15,31 @@
  */
 package io.gravitee.apim.integration.tests.plan.keyless;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
 import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.Plan;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.keyless.KeylessPolicy;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
-import lombok.NonNull;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
-import static io.vertx.core.http.HttpMethod.GET;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author GraviteeSource Team
@@ -57,12 +54,7 @@ public class PlanKeylessV4EmulationIntegrationTest extends AbstractGatewayTest {
      */
     @Override
     public void configureApi(Api api) {
-        Plan keylessPlan = new Plan();
-        keylessPlan.setId(PLAN_ID);
-        keylessPlan.setApi(api.getId());
-        keylessPlan.setSecurity("KEY_LESS");
-        keylessPlan.setStatus("PUBLISHED");
-        api.setPlans(Collections.singletonList(keylessPlan));
+        configurePlans(api, Set.of("KEY_LESS"));
     }
 
     @Override
@@ -78,23 +70,19 @@ public class PlanKeylessV4EmulationIntegrationTest extends AbstractGatewayTest {
         }
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(HttpClientRequest::rxSend)
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(200);
-                            return response.body();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body.toString()).contains("endpoint response");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
 
         if (requireWiremock) {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
@@ -102,40 +90,39 @@ public class PlanKeylessV4EmulationIntegrationTest extends AbstractGatewayTest {
     }
 
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v2-api", true)
-        );
+        return Stream.of(Arguments.of("v2-api", true));
     }
 
     @ParameterizedTest
     @MethodSource("provideSecurityHeaders")
-    void should_access_api_and_ignore_security(final String apiId, boolean requireWiremock, final String headerName, final String headerValue, HttpClient client) {
-
+    void should_access_api_and_ignore_security(
+        final String apiId,
+        boolean requireWiremock,
+        final String headerName,
+        final String headerValue,
+        HttpClient client
+    ) {
         if (requireWiremock) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
         }
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader(headerName, headerValue);
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(200);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body.toString()).contains("endpoint response");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader(headerName, headerValue);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
 
         if (requireWiremock) {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
@@ -143,13 +130,19 @@ public class PlanKeylessV4EmulationIntegrationTest extends AbstractGatewayTest {
     }
 
     protected Stream<Arguments> provideSecurityHeaders() {
-        return provideApis().flatMap(arguments -> {
-            String path = (String) arguments.get()[0];
-            boolean requireWiremock = (boolean) arguments.get()[1];
-            return Stream.of(
+        return provideApis()
+            .flatMap(arguments -> {
+                String path = (String) arguments.get()[0];
+                boolean requireWiremock = (boolean) arguments.get()[1];
+                return Stream.of(
                     Arguments.of(path, requireWiremock, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(path, requireWiremock, "X-Gravitee-Api-Key", ""),
+                    Arguments.of(path, requireWiremock, "Authorization", ""),
+                    Arguments.of(path, requireWiremock, "Authorization", "Basic 1231456789"),
+                    Arguments.of(path, requireWiremock, "Authorization", "Bearer"),
+                    Arguments.of(path, requireWiremock, "Authorization", "Bearer "),
                     Arguments.of(path, requireWiremock, "Authorization", "Bearer a-jwt-token")
-            );
-        });
+                );
+            });
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4EmulationIntegrationTest.java
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.keyless;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.keyless.KeylessPolicy;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import lombok.NonNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/plan/v2-api.json")
+public class PlanKeylessV4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    /**
+     * Override api plans to have a published KEY_LESS one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        Plan keylessPlan = new Plan();
+        keylessPlan.setId(PLAN_ID);
+        keylessPlan.setApi(api.getId());
+        keylessPlan.setSecurity("KEY_LESS");
+        keylessPlan.setStatus("PUBLISHED");
+        api.setPlans(Collections.singletonList(keylessPlan));
+    }
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_200_success_without_any_security(String apiId, boolean requireWiremock, HttpClient client) {
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(200);
+                            return response.body();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body.toString()).contains("endpoint response");
+                            return true;
+                        }
+                );
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v2-api", true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSecurityHeaders")
+    void should_access_api_and_ignore_security(final String apiId, boolean requireWiremock, final String headerName, final String headerValue, HttpClient client) {
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader(headerName, headerValue);
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(200);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body.toString()).contains("endpoint response");
+                            return true;
+                        }
+                );
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    protected Stream<Arguments> provideSecurityHeaders() {
+        return provideApis().flatMap(arguments -> {
+            String path = (String) arguments.get()[0];
+            boolean requireWiremock = (boolean) arguments.get()[1];
+            return Stream.of(
+                    Arguments.of(path, requireWiremock, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(path, requireWiremock, "Authorization", "Bearer a-jwt-token")
+            );
+        });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4IntegrationTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.integration.tests.plan.keyless;
 
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_KEYLESS_ID;
+
 import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
 import com.graviteesource.reactor.message.MessageApiReactorFactory;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
@@ -34,33 +36,31 @@ import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
-import org.junit.jupiter.params.provider.Arguments;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * @author GraviteeSource Team
  */
-@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+@DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
 public class PlanKeylessV4IntegrationTest extends PlanKeylessV4EmulationIntegrationTest {
 
     @Override
     public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
         if (isV4Api(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            Plan keylessPlan = Plan.builder()
-                    .id("plan-id")
-                    .name("plan-name")
-                    .security(PlanSecurity.builder()
-                            .type("key-less")
-                            .build())
-                    .status(PlanStatus.PUBLISHED)
-                    .mode(PlanMode.STANDARD)
-                    .build();
-            definition.setPlans(Collections.singletonList(keylessPlan));
+            final Api apiDefinition = (Api) api.getDefinition();
+            Plan keylessPlan = Plan
+                .builder()
+                .id(PLAN_KEYLESS_ID)
+                .name("plan-name")
+                .security(PlanSecurity.builder().type("key-less").build())
+                .status(PlanStatus.PUBLISHED)
+                .mode(PlanMode.STANDARD)
+                .build();
+            apiDefinition.setPlans(Collections.singletonList(keylessPlan));
         }
     }
 
@@ -83,10 +83,6 @@ public class PlanKeylessV4IntegrationTest extends PlanKeylessV4EmulationIntegrat
 
     @Override
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v4-proxy-api", true),
-                Arguments.of("v4-message-api", false)
-        );
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
     }
-
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/keyless/PlanKeylessV4IntegrationTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.keyless;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+public class PlanKeylessV4IntegrationTest extends PlanKeylessV4EmulationIntegrationTest {
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass)) {
+            final Api definition = (Api) api.getDefinition();
+            Plan keylessPlan = Plan.builder()
+                    .id("plan-id")
+                    .name("plan-name")
+                    .security(PlanSecurity.builder()
+                            .type("key-less")
+                            .build())
+                    .status(PlanStatus.PUBLISHED)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+            definition.setPlans(Collections.singletonList(keylessPlan));
+        }
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v4-proxy-api", true),
+                Arguments.of("v4-message-api", false)
+        );
+    }
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V3IntegrationTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.mockito.stubbing.OngoingStubbing;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtOAuth2V3IntegrationTest {
+
+    @GatewayTest(v2ExecutionMode = V3)
+    @Nested
+    public class SelectApiKeyTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectApiKeyTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectKeylessTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectKeylessTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectJwtTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        /**
+         * This overrides subscription search :
+         * - in jupiter its searched with getByApiAndSecurityToken
+         * - in V3 its searches with api/clientId/plan
+         */
+        @Override
+        protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+            return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.apim.integration.tests.plan.apikey.PlanApiKeyV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.jwt.PlanJwtV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.keyless.PlanKeylessV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.keyless.KeylessPolicy;
+import io.gravitee.policy.oauth2.Oauth2Policy;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest {
+
+    public static void configureApi(Api api) {
+        configurePlans(api, Set.of("KEY_LESS", "API_KEY", "JWT", "OAUTH2"));
+    }
+
+    public static void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
+        policies.put("api-key", PolicyBuilder.build("api-key", ApiKeyPolicy.class, null, ApiKeyPolicyInitializer.class));
+        policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+        policies.put("oauth2", PolicyBuilder.build("oauth2", Oauth2Policy.class, OAuth2PolicyConfiguration.class));
+    }
+
+    public static void configureResources(Map<String, ResourcePlugin> resources) {
+        resources.put("mock-oauth2-resource", ResourceBuilder.build("mock-oauth2-resource", MockOAuth2Resource.class));
+    }
+
+    public static class AbstractSelectKeylessTest extends PlanKeylessV4EmulationIntegrationTest {
+
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureResources(resources);
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        @Disabled
+        void should_access_api_and_ignore_security(
+            final String apiId,
+            boolean requireWiremock,
+            final String headerName,
+            final String headerValue,
+            HttpClient client
+        ) {
+            // This is disabled as all security type are defined on the api
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectKeylessTest extends AbstractSelectKeylessTest {}
+
+    public static class AbstractSelectApiKeyTest extends PlanApiKeyV4EmulationIntegrationTest {
+
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureResources(resources);
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return super
+                .provideWrongSecurityHeaders()
+                .filter(arguments -> arguments.get()[1] != null && arguments.get()[2] != null && arguments.get()[2] != "");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectApiKeyTest extends AbstractSelectApiKeyTest {}
+
+    public static class AbstractSelectJwtTest extends PlanJwtV4EmulationIntegrationTest {
+
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureResources(resources);
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String apiId = (String) arguments.get()[0];
+                    return Stream.of(
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", ""),
+                        Arguments.of(apiId, "Authorization", "Bearer"),
+                        Arguments.of(apiId, "Authorization", "Bearer "),
+                        Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectJwtTest extends AbstractSelectJwtTest {}
+
+    public static class AbstractSelectOAuth2Test extends PlanJwtV4EmulationIntegrationTest {
+
+        @Override
+        public void configureResources(Map<String, ResourcePlugin> resources) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureResources(resources);
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String apiId = (String) arguments.get()[0];
+                    return Stream.of(
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                        Arguments.of(apiId, "Authorization", "Bearer"),
+                        Arguments.of(apiId, "Authorization", "Bearer "),
+                        Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectOauth2Test extends AbstractSelectOAuth2Test {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtOAuth2V4IntegrationTest {
+
+    public static void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Api apiDefinition = (Api) api.getDefinition();
+        configurePlans(apiDefinition, Set.of("key-less", "api-key", "jwt", "oauth2"));
+    }
+
+    public static void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    public static void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    public static void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    public static Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectKeylessTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectKeylessTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectApiKeyTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectApiKeyTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectJwtTest extends PlanKeylessApiKeyJwtOAuth2V4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtOAuth2V4IntegrationTest.provideApis();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV3IntegrationTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.mockito.stubbing.OngoingStubbing;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtV3IntegrationTest {
+
+    @GatewayTest(v2ExecutionMode = V3)
+    @Nested
+    public class SelectApiKeyTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectApiKeyTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectKeylessTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectKeylessTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectJwtTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        /**
+         * This overrides subscription search :
+         * - in jupiter its searched with getByApiAndSecurityToken
+         * - in V3 its searches with api/clientId/plan
+         */
+        @Override
+        protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+            return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV4EmulationIntegrationTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.plan.apikey.PlanApiKeyV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.jwt.PlanJwtV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.keyless.PlanKeylessV4EmulationIntegrationTest;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.keyless.KeylessPolicy;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtV4EmulationIntegrationTest {
+
+    public static void configureApi(Api api) {
+        configurePlans(api, Set.of("KEY_LESS", "API_KEY", "JWT"));
+    }
+
+    public static void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
+        policies.put("api-key", PolicyBuilder.build("api-key", ApiKeyPolicy.class, null, ApiKeyPolicyInitializer.class));
+        policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+    }
+
+    public static class AbstractSelectKeylessTest extends PlanKeylessV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        @Disabled
+        void should_access_api_and_ignore_security(
+            final String apiId,
+            boolean requireWiremock,
+            final String headerName,
+            final String headerValue,
+            HttpClient client
+        ) {
+            // This is disabled as all security type are defined on the api
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectKeylessTest extends AbstractSelectKeylessTest {}
+
+    public static class AbstractSelectApiKeyTest extends PlanApiKeyV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return super
+                .provideWrongSecurityHeaders()
+                .filter(arguments -> arguments.get()[1] != null && arguments.get()[2] != null && arguments.get()[2] != "");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectApiKeyTest extends AbstractSelectApiKeyTest {}
+
+    public static class AbstractSelectJwtTest extends PlanJwtV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyJwtV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String apiId = (String) arguments.get()[0];
+                    return Stream.of(
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", ""),
+                        Arguments.of(apiId, "Authorization", "Bearer"),
+                        Arguments.of(apiId, "Authorization", "Bearer "),
+                        Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectJwtTest extends AbstractSelectJwtTest {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyJwtV4IntegrationTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyJwtV4IntegrationTest {
+
+    public static void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Api apiDefinition = (Api) api.getDefinition();
+        configurePlans(apiDefinition, Set.of("key-less", "api-key", "jwt"));
+    }
+
+    public static void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    public static void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    public static void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    public static Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectKeylessTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectKeylessTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtV4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectApiKeyTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectApiKeyTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtV4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectJwtTest extends PlanKeylessApiKeyJwtV4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyJwtV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyJwtV4IntegrationTest.provideApis();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV3IntegrationTest.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.integration.tests.plan.apikey;
+package io.gravitee.apim.integration.tests.plan.multiple;
 
 import static io.gravitee.definition.model.ExecutionMode.V3;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import org.junit.jupiter.api.Nested;
 
 /**
  * @author GraviteeSource Team
  */
-@GatewayTest(v2ExecutionMode = V3)
-public class PlanApiKeyV3IntegrationTest extends PlanApiKeyV4EmulationIntegrationTest {}
+public class PlanKeylessApiKeyV3IntegrationTest extends PlanKeylessApiKeyV4EmulationIntegrationTest {
+
+    @GatewayTest(v2ExecutionMode = V3)
+    @Nested
+    public class SelectApiKeyTest extends AbstractSelectApiKeyTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectKeylessTest extends AbstractSelectKeylessTest {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV4EmulationIntegrationTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.plan.apikey.PlanApiKeyV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.keyless.PlanKeylessV4EmulationIntegrationTest;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.keyless.KeylessPolicy;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyV4EmulationIntegrationTest {
+
+    public static void configureApi(Api api) {
+        configurePlans(api, Set.of("KEY_LESS", "API_KEY"));
+    }
+
+    public static void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
+        policies.put("api-key", PolicyBuilder.build("api-key", ApiKeyPolicy.class, null, ApiKeyPolicyInitializer.class));
+    }
+
+    public static class AbstractSelectApiKeyTest extends PlanApiKeyV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String apiId = (String) arguments.get()[0];
+                    return Stream.of(
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                        Arguments.of(apiId, "X-Gravitee-Api-Key", "")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectApiKeyTest extends AbstractSelectApiKeyTest {}
+
+    public static class AbstractSelectKeylessTest extends PlanKeylessV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessApiKeyV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessApiKeyV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String path = (String) arguments.get()[0];
+                    boolean requireWiremock = (boolean) arguments.get()[1];
+                    return Stream.of(
+                        Arguments.of(path, requireWiremock, "Authorization", ""),
+                        Arguments.of(path, requireWiremock, "Authorization", "Basic 1231456789"),
+                        Arguments.of(path, requireWiremock, "Authorization", "Bearer"),
+                        Arguments.of(path, requireWiremock, "Authorization", "Bearer "),
+                        Arguments.of(path, requireWiremock, "Authorization", "Bearer a-jwt-token")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectKeylessTest extends AbstractSelectKeylessTest {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessApiKeyV4IntegrationTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessApiKeyV4IntegrationTest {
+
+    public static void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Api apiDefinition = (Api) api.getDefinition();
+        configurePlans(apiDefinition, Set.of("key-less", "api-key"));
+    }
+
+    public static void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    public static void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    public static void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    public static Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectApiKeyTest extends PlanKeylessApiKeyV4EmulationIntegrationTest.AbstractSelectApiKeyTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyV4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectKeylessTest extends PlanKeylessApiKeyV4EmulationIntegrationTest.AbstractSelectKeylessTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessApiKeyV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessApiKeyV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessApiKeyV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessApiKeyV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessApiKeyV4IntegrationTest.provideApis();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV3IntegrationTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.integration.tests.plan.oauth2;
+package io.gravitee.apim.integration.tests.plan.multiple;
 
 import static io.gravitee.definition.model.ExecutionMode.V3;
 import static org.mockito.Mockito.when;
@@ -22,21 +22,30 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import java.util.Optional;
+import org.junit.jupiter.api.Nested;
 import org.mockito.stubbing.OngoingStubbing;
 
 /**
  * @author GraviteeSource Team
  */
-@GatewayTest(v2ExecutionMode = V3)
-public class PlanOAuth2V3IntegrationTest extends PlanOAuth2V4EmulationIntegrationTest {
+public class PlanKeylessJwtV3IntegrationTest {
 
-    /**
-     * This overrides subscription search :
-     * - in jupiter its searched with getByApiAndSecurityToken
-     * - in V3 its searches with api/clientId/plan
-     */
-    @Override
-    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectKeylessTest extends PlanKeylessJwtV4EmulationIntegrationTest.AbstractSelectKeylessTest {}
+
+    @Nested
+    @GatewayTest(v2ExecutionMode = V3)
+    public class SelectJwtTest extends PlanKeylessJwtV4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        /**
+         * This overrides subscription search :
+         * - in jupiter its searched with getByApiAndSecurityToken
+         * - in V3 its searches with api/clientId/plan
+         */
+        @Override
+        protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+            return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+        }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV4EmulationIntegrationTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.plan.jwt.PlanJwtV4EmulationIntegrationTest;
+import io.gravitee.apim.integration.tests.plan.keyless.PlanKeylessV4EmulationIntegrationTest;
+import io.gravitee.definition.model.Api;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.keyless.KeylessPolicy;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessJwtV4EmulationIntegrationTest {
+
+    public static void configureApi(Api api) {
+        configurePlans(api, Set.of("KEY_LESS", "JWT"));
+    }
+
+    public static void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("key-less", PolicyBuilder.build("key-less", KeylessPolicy.class));
+        policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+    }
+
+    public static class AbstractSelectJwtTest extends PlanJwtV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessJwtV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessJwtV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideWrongSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String apiId = (String) arguments.get()[0];
+                    return Stream.of(
+                        Arguments.of(apiId, "Authorization", "Bearer"),
+                        Arguments.of(apiId, "Authorization", "Bearer "),
+                        Arguments.of(apiId, "Authorization", "Bearer a-jwt-token")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectJwtTest extends AbstractSelectJwtTest {}
+
+    public static class AbstractSelectKeylessTest extends PlanKeylessV4EmulationIntegrationTest {
+
+        @Override
+        public void configureApi(Api api) {
+            PlanKeylessJwtV4EmulationIntegrationTest.configureApi(api);
+        }
+
+        @Override
+        public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+            PlanKeylessJwtV4EmulationIntegrationTest.configurePolicies(policies);
+        }
+
+        protected Stream<Arguments> provideSecurityHeaders() {
+            return provideApis()
+                .flatMap(arguments -> {
+                    String path = (String) arguments.get()[0];
+                    boolean requireWiremock = (boolean) arguments.get()[1];
+                    return Stream.of(
+                        Arguments.of(path, requireWiremock, "X-Gravitee-Api-Key", "an-api-key"),
+                        Arguments.of(path, requireWiremock, "Authorization", ""),
+                        Arguments.of(path, requireWiremock, "Authorization", "Basic 123456789")
+                    );
+                });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/plan/v2-api.json")
+    public class SelectKeylessTest extends AbstractSelectKeylessTest {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/multiple/PlanKeylessJwtV4IntegrationTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.multiple;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PlanKeylessJwtV4IntegrationTest {
+
+    public static void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Api apiDefinition = (Api) api.getDefinition();
+        configurePlans(apiDefinition, Set.of("key-less", "jwt"));
+    }
+
+    public static void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    public static void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    public static void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    public static Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectJwtTest extends PlanKeylessJwtV4EmulationIntegrationTest.AbstractSelectJwtTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessJwtV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessJwtV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessJwtV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessJwtV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessJwtV4IntegrationTest.provideApis();
+        }
+    }
+
+    @Nested
+    @DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+    public class SelectKeylessTest extends PlanKeylessJwtV4EmulationIntegrationTest.AbstractSelectKeylessTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            PlanKeylessJwtV4IntegrationTest.configureApi(api, definitionClass);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            PlanKeylessJwtV4IntegrationTest.configureEntrypoints(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            PlanKeylessJwtV4IntegrationTest.configureEndpoints(endpoints);
+        }
+
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            PlanKeylessJwtV4IntegrationTest.configureReactors(reactors);
+        }
+
+        @Override
+        protected Stream<Arguments> provideApis() {
+            return PlanKeylessJwtV4IntegrationTest.provideApis();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/MockOAuth2Resource.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/MockOAuth2Resource.java
@@ -16,17 +16,17 @@
 
 package io.gravitee.apim.integration.tests.plan.oauth2;
 
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_SUCCESS_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_WITH_INVALID_PAYLOAD;
+
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.resource.api.ResourceConfiguration;
 import io.gravitee.resource.oauth2.api.OAuth2Resource;
 import io.gravitee.resource.oauth2.api.OAuth2Response;
 import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
-
-import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.CLIENT_ID;
-import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.SUCCESS_TOKEN;
-import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_TOKEN;
-import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID;
-import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_WITH_INVALID_PAYLOAD;
 
 /**
  * @author GraviteeSource Team
@@ -39,13 +39,13 @@ public class MockOAuth2Resource extends OAuth2Resource<MockOAuth2Resource.MockOA
     public void introspect(String accessToken, Handler<OAuth2Response> responseHandler) {
         OAuth2Response response = null;
 
-        if (SUCCESS_TOKEN.equals(accessToken)) {
-            response = new OAuth2Response(true, "{ \"client_id\": \"" + CLIENT_ID + "\"}");
-        } else if (UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID.equals(accessToken)) {
+        if (OAUTH2_SUCCESS_TOKEN.equals(accessToken)) {
+            response = new OAuth2Response(true, "{ \"client_id\": \"" + OAUTH2_CLIENT_ID + "\"}");
+        } else if (OAUTH2_UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID.equals(accessToken)) {
             response = new OAuth2Response(true, "{}");
-        } else if (UNAUTHORIZED_WITH_INVALID_PAYLOAD.equals(accessToken)) {
+        } else if (OAUTH2_UNAUTHORIZED_WITH_INVALID_PAYLOAD.equals(accessToken)) {
             response = new OAuth2Response(true, "{this _is _invalid json");
-        } else if (UNAUTHORIZED_TOKEN.equals(accessToken)) {
+        } else if (OAUTH2_UNAUTHORIZED_TOKEN.equals(accessToken)) {
             response = new OAuth2Response(false, null);
         } else {
             response = new OAuth2Response(false, null);
@@ -55,9 +55,7 @@ public class MockOAuth2Resource extends OAuth2Resource<MockOAuth2Resource.MockOA
     }
 
     @Override
-    public void userInfo(String accessToken, Handler<UserInfoResponse> responseHandler) {
-    }
+    public void userInfo(String accessToken, Handler<UserInfoResponse> responseHandler) {}
 
-    public class MockOAuth2ResourceConfiguration implements ResourceConfiguration {
-    }
+    public class MockOAuth2ResourceConfiguration implements ResourceConfiguration {}
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/MockOAuth2Resource.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/MockOAuth2Resource.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.apim.integration.tests.plan.oauth2;
+
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.resource.api.ResourceConfiguration;
+import io.gravitee.resource.oauth2.api.OAuth2Resource;
+import io.gravitee.resource.oauth2.api.OAuth2Response;
+import io.gravitee.resource.oauth2.api.openid.UserInfoResponse;
+
+import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.SUCCESS_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.oauth2.PlanOAuth2V4EmulationIntegrationTest.UNAUTHORIZED_WITH_INVALID_PAYLOAD;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class MockOAuth2Resource extends OAuth2Resource<MockOAuth2Resource.MockOAuth2ResourceConfiguration> {
+
+    public static String RESOURCE_ID = "mock-oauth2-resource";
+
+    @Override
+    public void introspect(String accessToken, Handler<OAuth2Response> responseHandler) {
+        OAuth2Response response = null;
+
+        if (SUCCESS_TOKEN.equals(accessToken)) {
+            response = new OAuth2Response(true, "{ \"client_id\": \"" + CLIENT_ID + "\"}");
+        } else if (UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID.equals(accessToken)) {
+            response = new OAuth2Response(true, "{}");
+        } else if (UNAUTHORIZED_WITH_INVALID_PAYLOAD.equals(accessToken)) {
+            response = new OAuth2Response(true, "{this _is _invalid json");
+        } else if (UNAUTHORIZED_TOKEN.equals(accessToken)) {
+            response = new OAuth2Response(false, null);
+        } else {
+            response = new OAuth2Response(false, null);
+        }
+
+        responseHandler.handle(response);
+    }
+
+    @Override
+    public void userInfo(String accessToken, Handler<UserInfoResponse> responseHandler) {
+    }
+
+    public class MockOAuth2ResourceConfiguration implements ResourceConfiguration {
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V3IntegrationTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.oauth2;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.util.Optional;
+
+import static io.gravitee.definition.model.ExecutionMode.V3;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = V3)
+public class PlanOAuth2V3IntegrationTest extends PlanOAuth2V4EmulationIntegrationTest {
+    /**
+     * This overrides subscription search :
+     * - in jupiter its searched with getByApiAndSecurityToken
+     * - in V3 its searches with api/clientId/plan
+     */
+    @Override
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+        return when(getBean(SubscriptionService.class).getByApiAndClientIdAndPlan(api, clientId, plan));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4EmulationIntegrationTest.java
@@ -15,6 +15,26 @@
  */
 package io.gravitee.apim.integration.tests.plan.oauth2;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_SUCCESS_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_TOKEN;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.OAUTH2_UNAUTHORIZED_WITH_INVALID_PAYLOAD;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_OAUTH2_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
@@ -33,31 +53,16 @@ import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.policy.oauth2.Oauth2Policy;
 import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.stubbing.OngoingStubbing;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
-import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
-import static io.vertx.core.http.HttpMethod.GET;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 /**
  * @author GraviteeSource Team
@@ -65,12 +70,6 @@ import static org.mockito.Mockito.when;
 @GatewayTest
 @DeployApi("/apis/plan/v2-api.json")
 public class PlanOAuth2V4EmulationIntegrationTest extends AbstractGatewayTest {
-
-    public static String CLIENT_ID = "my-client-id";
-    public static String SUCCESS_TOKEN = "success-token";
-    public static String UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID = "unauthorized-token-without-client-id";
-    public static String UNAUTHORIZED_WITH_INVALID_PAYLOAD = "unauthorized-token-with-invalid-payload";
-    public static String UNAUTHORIZED_TOKEN = "unauthorized-token";
 
     @Override
     public void configureResources(Map<String, ResourcePlugin> resources) {
@@ -83,25 +82,7 @@ public class PlanOAuth2V4EmulationIntegrationTest extends AbstractGatewayTest {
      */
     @Override
     public void configureApi(Api api) {
-
-        Resource resource = new Resource(RESOURCE_ID, RESOURCE_ID, new ObjectMapper().createObjectNode());
-        api.getResources().add(resource);
-
-        Plan plan = new Plan();
-        plan.setId(PLAN_ID);
-        plan.setApi(api.getId());
-        plan.setSecurity("OAUTH2");
-        plan.setStatus("PUBLISHED");
-
-        OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
-        configuration.setOauthResource(RESOURCE_ID);
-        try {
-            plan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
-        }
-
-        api.setPlans(Collections.singletonList(plan));
+        configurePlans(api, Set.of("OAUTH2"));
     }
 
     @Override
@@ -110,54 +91,58 @@ public class PlanOAuth2V4EmulationIntegrationTest extends AbstractGatewayTest {
     }
 
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v2-api", true)
-        );
+        return Stream.of(Arguments.of("v2-api", true));
     }
 
     protected Stream<Arguments> provideWrongSecurityHeaders() {
-        return provideApis().flatMap(arguments -> {
-            String apiId = (String) arguments.get()[0];
-            return Stream.of(
+        return provideApis()
+            .flatMap(arguments -> {
+                String apiId = (String) arguments.get()[0];
+                return Stream.of(
                     Arguments.of(apiId, null, null),
                     Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "Authorization", ""),
+                    Arguments.of(apiId, "Authorization", "Bearer"),
+                    Arguments.of(apiId, "Authorization", "Bearer "),
                     Arguments.of(apiId, "Authorization", "Bearer a-jwt-token"),
-                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID),
-                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_WITH_INVALID_PAYLOAD),
-                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_TOKEN)
-            );
-        });
+                    Arguments.of(apiId, "Authorization", "Bearer " + OAUTH2_UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID),
+                    Arguments.of(apiId, "Authorization", "Bearer " + OAUTH2_UNAUTHORIZED_WITH_INVALID_PAYLOAD),
+                    Arguments.of(apiId, "Authorization", "Bearer " + OAUTH2_UNAUTHORIZED_TOKEN)
+                );
+            });
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_200_success_with_valid_oauth2_token_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
-        whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+    void should_return_200_success_with_valid_oauth2_token_and_subscription_on_the_api(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) throws Exception {
+        whenSearchingSubscription(apiId, OAUTH2_CLIENT_ID, PLAN_OAUTH2_ID)
+            .thenReturn(Optional.of(createSubscription(apiId, PLAN_OAUTH2_ID, false)));
 
         if (requireWiremock) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
         }
 
-        client.rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("Authorization", "Bearer " + SUCCESS_TOKEN);
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(200);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(60, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body.toString()).contains("endpoint response");
-                            return true;
-                        }
-                );
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + OAUTH2_SUCCESS_TOKEN);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
 
         if (requireWiremock) {
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
@@ -166,75 +151,83 @@ public class PlanOAuth2V4EmulationIntegrationTest extends AbstractGatewayTest {
 
     @ParameterizedTest
     @MethodSource("provideWrongSecurityHeaders")
-    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+    void should_return_401_unauthorized_with_wrong_security(
+        final String apiId,
+        final String headerName,
+        final String headerValue,
+        final HttpClient client
+    ) {
         wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    if (headerName != null && headerValue != null) {
-                        request.putHeader(headerName, headerValue);
-                    }
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                if (headerName != null && headerValue != null) {
+                    request.putHeader(headerName, headerValue);
+                }
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
     }
 
     @ParameterizedTest
     @MethodSource("provideApis")
-    void should_return_401_unauthorized_with_valid_oauth2_token_but_no_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
+    void should_return_401_unauthorized_with_valid_oauth2_token_but_no_subscription_on_the_api(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client
+    ) throws Exception {
         if (requireWiremock) {
             wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
         }
 
-        whenSearchingSubscription(apiId,CLIENT_ID,PLAN_ID).thenReturn(Optional.empty());
+        whenSearchingSubscription(apiId, OAUTH2_CLIENT_ID, PLAN_OAUTH2_ID).thenReturn(Optional.empty());
 
         client
-                .rxRequest(GET, getApiPath(apiId))
-                .flatMap(request -> {
-                    request.putHeader("Authorization", "Bearer " + SUCCESS_TOKEN);
-                    return request.rxSend();
-                })
-                .flatMap(
-                        response -> {
-                            assertThat(response.statusCode()).isEqualTo(401);
-                            return response.rxBody();
-                        }
-                )
-                .test()
-                .awaitDone(10, TimeUnit.SECONDS)
-                .assertComplete()
-                .assertValue(
-                        body -> {
-                            assertThat(body).hasToString("Unauthorized");
-                            return true;
-                        }
-                );
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + OAUTH2_SUCCESS_TOKEN);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
         if (requireWiremock) {
             wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
         }
     }
 
-
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
-        return when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(api), argThat(securityToken ->
-                securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) && securityToken.getTokenValue().equals(clientId)
-        ), eq(plan)));
+        return when(
+            getBean(SubscriptionService.class)
+                .getByApiAndSecurityToken(
+                    eq(api),
+                    argThat(securityToken ->
+                        securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) &&
+                        securityToken.getTokenValue().equals(clientId)
+                    ),
+                    eq(plan)
+                )
+        );
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4EmulationIntegrationTest.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.resource.ResourceBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.policy.oauth2.Oauth2Policy;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/plan/v2-api.json")
+public class PlanOAuth2V4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    public static String CLIENT_ID = "my-client-id";
+    public static String SUCCESS_TOKEN = "success-token";
+    public static String UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID = "unauthorized-token-without-client-id";
+    public static String UNAUTHORIZED_WITH_INVALID_PAYLOAD = "unauthorized-token-with-invalid-payload";
+    public static String UNAUTHORIZED_TOKEN = "unauthorized-token";
+
+    @Override
+    public void configureResources(Map<String, ResourcePlugin> resources) {
+        resources.put("mock-oauth2-resource", ResourceBuilder.build("mock-oauth2-resource", MockOAuth2Resource.class));
+    }
+
+    /**
+     * Override api plans to have a published KEY_LESS one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+
+        Resource resource = new Resource(RESOURCE_ID, RESOURCE_ID, new ObjectMapper().createObjectNode());
+        api.getResources().add(resource);
+
+        Plan plan = new Plan();
+        plan.setId(PLAN_ID);
+        plan.setApi(api.getId());
+        plan.setSecurity("OAUTH2");
+        plan.setStatus("PUBLISHED");
+
+        OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
+        configuration.setOauthResource(RESOURCE_ID);
+        try {
+            plan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
+        }
+
+        api.setPlans(Collections.singletonList(plan));
+    }
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("oauth2", PolicyBuilder.build("oauth2", Oauth2Policy.class, OAuth2PolicyConfiguration.class));
+    }
+
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v2-api", true)
+        );
+    }
+
+    protected Stream<Arguments> provideWrongSecurityHeaders() {
+        return provideApis().flatMap(arguments -> {
+            String apiId = (String) arguments.get()[0];
+            return Stream.of(
+                    Arguments.of(apiId, null, null),
+                    Arguments.of(apiId, "X-Gravitee-Api-Key", "an-api-key"),
+                    Arguments.of(apiId, "Authorization", "Bearer a-jwt-token"),
+                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_TOKEN_WITHOUT_CLIENT_ID),
+                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_WITH_INVALID_PAYLOAD),
+                    Arguments.of(apiId, "Authorization", "Bearer " + UNAUTHORIZED_TOKEN)
+            );
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_200_success_with_valid_oauth2_token_and_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
+        whenSearchingSubscription(apiId, CLIENT_ID, PLAN_ID).thenReturn(Optional.of(createSubscription(apiId, false)));
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client.rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("Authorization", "Bearer " + SUCCESS_TOKEN);
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(200);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(60, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body.toString()).contains("endpoint response");
+                            return true;
+                        }
+                );
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideWrongSecurityHeaders")
+    void should_return_401_unauthorized_with_wrong_security(final String apiId, final String headerName, final String headerValue, final HttpClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    if (headerName != null && headerValue != null) {
+                        request.putHeader(headerName, headerValue);
+                    }
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    void should_return_401_unauthorized_with_valid_oauth2_token_but_no_subscription_on_the_api(final String apiId, final boolean requireWiremock, final HttpClient client) throws Exception {
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("data")));
+        }
+
+        whenSearchingSubscription(apiId,CLIENT_ID,PLAN_ID).thenReturn(Optional.empty());
+
+        client
+                .rxRequest(GET, getApiPath(apiId))
+                .flatMap(request -> {
+                    request.putHeader("Authorization", "Bearer " + SUCCESS_TOKEN);
+                    return request.rxSend();
+                })
+                .flatMap(
+                        response -> {
+                            assertThat(response.statusCode()).isEqualTo(401);
+                            return response.rxBody();
+                        }
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(
+                        body -> {
+                            assertThat(body).hasToString("Unauthorized");
+                            return true;
+                        }
+                );
+        if (requireWiremock) {
+            wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+        return when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(api), argThat(securityToken ->
+                securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) && securityToken.getTokenValue().equals(clientId)
+        ), eq(plan)));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4IntegrationTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.oauth2;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.resource.Resource;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
+import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+public class PlanOAuth2V4IntegrationTest extends PlanOAuth2V4EmulationIntegrationTest {
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass)) {
+            final Api definition = (Api) api.getDefinition();
+            List<Resource> resources = new ArrayList<>();
+            resources.add(Resource.builder()
+                    .name(RESOURCE_ID)
+                    .type(RESOURCE_ID)
+                    .build());
+            ((Api) api.getDefinition()).setResources(resources);
+            try {
+                OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
+                configuration.setOauthResource(RESOURCE_ID);
+                Plan plan = Plan.builder()
+                        .id(PLAN_ID)
+                        .name("plan-name")
+                        .security(PlanSecurity.builder()
+                                .type("oauth2")
+                                .configuration(new ObjectMapper().writeValueAsString(configuration))
+                                .build())
+                        .status(PlanStatus.PUBLISHED)
+                        .mode(PlanMode.STANDARD)
+                        .build();
+                definition.setPlans(Collections.singletonList(plan));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
+            }
+        }
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(
+                Arguments.of("v4-proxy-api", true),
+                Arguments.of("v4-message-api", false)
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/oauth2/PlanOAuth2V4IntegrationTest.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.apim.integration.tests.plan.oauth2;
 
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_OAUTH2_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
@@ -24,12 +28,12 @@ import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
 import io.gravitee.apim.plugin.reactor.ReactorPlugin;
-import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
@@ -37,55 +41,26 @@ import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
-import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
 import io.gravitee.policy.oauth2.configuration.OAuth2PolicyConfiguration;
-import org.junit.jupiter.params.provider.Arguments;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_ID;
-import static io.gravitee.apim.integration.tests.plan.oauth2.MockOAuth2Resource.RESOURCE_ID;
-import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
-import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * @author GraviteeSource Team
  */
-@DeployApi(value = {"/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json"})
+@DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
 public class PlanOAuth2V4IntegrationTest extends PlanOAuth2V4EmulationIntegrationTest {
 
     @Override
     public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
         if (isV4Api(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            List<Resource> resources = new ArrayList<>();
-            resources.add(Resource.builder()
-                    .name(RESOURCE_ID)
-                    .type(RESOURCE_ID)
-                    .build());
-            ((Api) api.getDefinition()).setResources(resources);
-            try {
-                OAuth2PolicyConfiguration configuration = new OAuth2PolicyConfiguration();
-                configuration.setOauthResource(RESOURCE_ID);
-                Plan plan = Plan.builder()
-                        .id(PLAN_ID)
-                        .name("plan-name")
-                        .security(PlanSecurity.builder()
-                                .type("oauth2")
-                                .configuration(new ObjectMapper().writeValueAsString(configuration))
-                                .build())
-                        .status(PlanStatus.PUBLISHED)
-                        .mode(PlanMode.STANDARD)
-                        .build();
-                definition.setPlans(Collections.singletonList(plan));
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException("Failed to set OAuth2 policy configuration", e);
-            }
+            final Api apiDefinition = (Api) api.getDefinition();
+            configurePlans(apiDefinition, Set.of("oauth2"));
         }
     }
 
@@ -108,9 +83,6 @@ public class PlanOAuth2V4IntegrationTest extends PlanOAuth2V4EmulationIntegratio
 
     @Override
     protected Stream<Arguments> provideApis() {
-        return Stream.of(
-                Arguments.of("v4-proxy-api", true),
-                Arguments.of("v4-message-api", false)
-        );
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
     }
 }

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v2-api-selection-rule.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v2-api-selection-rule.json
@@ -1,0 +1,20 @@
+{
+  "id": "v2-api-selection-rule",
+  "name": "v2-api-selection-rule",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/v2-api-selection-rule",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v2-api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v2-api.json
@@ -1,0 +1,20 @@
+{
+  "id": "v2-api",
+  "name": "v2-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/v2-api",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-message-api-selection-rule.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-message-api-selection-rule.json
@@ -1,0 +1,49 @@
+{
+  "id": "v4-message-api-selection-rule",
+  "name": "v4-message-api-selection-rule",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/v4-message-api-selection-rule"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  1,
+            "messagesLimitDurationMs": 500
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "endpoint response",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled" : false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-message-api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-message-api.json
@@ -1,0 +1,49 @@
+{
+  "id": "v4-message-api",
+  "name": "v4-message-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/v4-message-api"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  1,
+            "messagesLimitDurationMs": 500
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "endpoint response",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled" : false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-proxy-api-selection-rule.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-proxy-api-selection-rule.json
@@ -1,0 +1,48 @@
+{
+  "id": "v4-proxy-api-selection-rule",
+  "name": "v4-proxy-api-selection-rule",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/v4-proxy-api-selection-rule"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-proxy-api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/plan/v4-proxy-api.json
@@ -1,0 +1,48 @@
+{
+  "id": "v4-proxy-api",
+  "name": "v4-proxy-api",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/v4-proxy-api"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.8</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.9</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>4.0.0-alpha.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
@@ -161,7 +161,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>3.0.1</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>4.0.0-alpha.2</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>4.0.0-alpha.3</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.0-alpha.4</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.0-alpha.3</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>2.0.0-alpha.3</gravitee-policy-cache.version>
@@ -178,13 +178,13 @@
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.0-alpha.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.4.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>4.0.0-alpha.2</gravitee-policy-jwt.version>
-        <gravitee-policy-keyless.version>3.0.0-alpha.1</gravitee-policy-keyless.version>
+        <gravitee-policy-jwt.version>4.0.0-alpha.3</gravitee-policy-jwt.version>
+        <gravitee-policy-keyless.version>3.0.0-alpha.2</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.0-alpha.4</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-message-filtering.version>1.1.1</gravitee-policy-message-filtering.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>3.0.0-alpha.2</gravitee-policy-oauth2.version>
+        <gravitee-policy-oauth2.version>3.0.0-alpha.3</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.6.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.1.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>3.0.1</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>3.2.1</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>4.0.0-alpha.2</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.0-alpha.4</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.0-alpha.3</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>2.0.0-alpha.3</gravitee-policy-cache.version>
@@ -178,13 +178,13 @@
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.0-alpha.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.4.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>3.2.0</gravitee-policy-jwt.version>
-        <gravitee-policy-keyless.version>2.2.0</gravitee-policy-keyless.version>
+        <gravitee-policy-jwt.version>4.0.0-alpha.2</gravitee-policy-jwt.version>
+        <gravitee-policy-keyless.version>3.0.0-alpha.1</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.0-alpha.4</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-message-filtering.version>1.1.1</gravitee-policy-message-filtering.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>2.3.2</gravitee-policy-oauth2.version>
+        <gravitee-policy-oauth2.version>3.0.0-alpha.2</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.6.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.1.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
Reopen a PR for https://github.com/gravitee-io/gravitee-api-management/pull/4545

## Description

Add integration tests for plan selection :

- Only keyless
- Only  api-key
- Only jwt
- Only oauth2
- keyless + api-key
- keyless + api-key + jwt
- keyless + api-key + jwt + oauth2 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lljctguexo.chromatic.com)
<!-- Storybook placeholder end -->
