### PR TITLE
fix: clean any security token if selection rule doesn't match

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandler.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.handlers.api.security;
 
+import static io.gravitee.gateway.security.core.AuthenticationContext.ATTR_INTERNAL_TOKEN_IDENTIFIED;
+
 import io.gravitee.definition.model.Plan;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.el.EvaluableRequest;
@@ -87,7 +89,12 @@ public abstract class PlanBasedAuthenticationHandler implements AuthenticationHa
                 evaluation.setVariable("request", new EvaluableRequest(authenticationContext.request()));
                 evaluation.setVariable("context", new EvaluableAuthenticationContext(authenticationContext));
 
-                return expression.getValue(evaluation, Boolean.class);
+                Boolean value = expression.getValue(evaluation, Boolean.class);
+                // Remove any security  token as the selection rule don't match
+                if (Boolean.FALSE.equals(value)) {
+                    authenticationContext.setInternalAttribute(ATTR_INTERNAL_TOKEN_IDENTIFIED, false);
+                }
+                return Boolean.TRUE.equals(value);
             } catch (ParseException | EvaluationException e) {
                 LOGGER.error("Plan selection rule execution failed", e);
                 return false;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
@@ -83,10 +83,12 @@ public class SecurityPlan {
             .flatMap(securityToken ->
                 matchSelectionRule(ctx)
                     .flatMap(matches -> {
-                        if (!matches) {
-                            return FALSE;
+                        if (matches) {
+                            return validateSubscription(ctx, securityToken);
                         }
-                        return validateSubscription(ctx, securityToken);
+                        // Remove any security  token as the selection rule don't match
+                        ctx.removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
+                        return FALSE;
                     })
             )
             .defaultIfEmpty(false)


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/9127
https://gravitee.atlassian.net/browse/APIM-2190

## Description

Fix an issue where a selection rule that doesn't match didn't clean the context and so keyless won't be applied.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vvadbnlywj.chromatic.com)
<!-- Storybook placeholder end -->
