### PR TITLE
fix: use ApiSearchService generic API in portal metrics resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.analytics.query.StatsQuery;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.model.ApiMetrics;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.service.AnalyticsService;
@@ -66,7 +67,7 @@ public class ApiMetricsResource extends AbstractResource {
     @Produces({ MediaType.APPLICATION_JSON })
     @RequirePortalAuth
     public Response getApiMetricsByApiId(@Context Request request, @PathParam("apiId") String apiId) {
-        ApiEntity api = apiSearchService.findById(GraviteeContext.getExecutionContext(), apiId);
+        GenericApiEntity api = apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), apiId);
 
         if (api.getLifecycleState() != ApiLifecycleState.PUBLISHED) {
             throw new ApiNotFoundException(apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
@@ -60,13 +60,13 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
         ApiEntity mockApi = new ApiEntity();
         mockApi.setId(API);
         mockApi.setLifecycleState(ApiLifecycleState.PUBLISHED);
-        when(apiSearchService.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(mockApi);
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API)).thenReturn(mockApi);
         when(accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API)).thenReturn(true);
     }
 
     @Test
     public void shouldNotFoundApiWhileGettingApiMetrics() {
-        when(apiSearchService.findById(GraviteeContext.getExecutionContext(), API)).thenThrow(new ApiNotFoundException(API));
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API)).thenThrow(new ApiNotFoundException(API));
 
         final Response response = target(API).path("metrics").request().get();
         assertEquals(NOT_FOUND_404, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
@@ -73,7 +73,7 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotFoundApiWhileGettingApiSubscribers() {
         // init
-        when(apiSearchService.findById(GraviteeContext.getExecutionContext(), API))
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API))
             .thenReturn(new io.gravitee.rest.api.model.v4.api.ApiEntity());
         // test
         final Response response = target(API).path("metrics").request().get();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2001

## Description

Use generic API to be able to call metrics with V2 and V4 APIs

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ffwtrtxpyk.chromatic.com)
<!-- Storybook placeholder end -->
