### PR TITLE
fix(console): change api permission resolution priority

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -75,7 +75,7 @@ function apiPermissionHook($transitions: TransitionService, gioPermissionService
         )
         .toPromise();
     },
-    { priority: 11 },
+    { priority: 9 },
   );
 }
 graviteeManagementModule.run(apiPermissionHook);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2189

## Description

The API Permission resolution has been moved to a dedicated transition hook.
The priority was too high making the environment id was not resolved, causing problem in a multi-environment use case.
Lower the priority fixes the order of transitions.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-beawknweop.chromatic.com)
<!-- Storybook placeholder end -->
