### PR TITLE
Apim 2126 bug delete entrypoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -104,10 +104,17 @@
                 <button
                   mat-icon-button
                   aria-label="Delete endpoint"
-                  matTooltip="Delete endpoint"
                   (click)="deleteEndpoint(group.name, element.name)"
+                  [disabled]="groupsTableData?.length === 1 && group.endpoints.length === 1"
                 >
-                  <mat-icon svgIcon="gio:trash"></mat-icon>
+                  <mat-icon
+                    [matTooltip]="
+                      groupsTableData?.length === 1 && group.endpoints.length === 1
+                        ? 'At least one endpoint is required'
+                        : 'Delete endpoint'
+                    "
+                    svgIcon="gio:trash"
+                  ></mat-icon>
                 </button>
               </div>
             </td>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.scss
@@ -65,10 +65,6 @@
     &__actions {
       display: flex;
       justify-content: center;
-
-      mat-icon {
-        color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter50');
-      }
     }
   }
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
@@ -148,6 +148,15 @@ describe('ApiEndpointsGroupsComponent', () => {
       });
       expectEndpointsGetRequest();
     });
+
+    it('should not be able to delete last endpoint', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [group2],
+      });
+      await initComponent(apiV4);
+      expect(await componentHarness.isEndpointDeleteDisabled(0)).toEqual(true);
+    });
   });
 
   describe('deleteGroup', () => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
@@ -49,6 +49,10 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
       .then((element) => element.click());
   }
 
+  public async isEndpointDeleteDisabled(index: number) {
+    return this.getDeleteEndpointButtons().then((buttons) => buttons[index].isDisabled());
+  }
+
   public async clickAddEndpoint(index: number) {
     const button = (await this.getAddEndpointButtons())[index];
     return button.click();

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -15,42 +15,48 @@
     limitations under the License.
 
 -->
-<mat-card class="entrypoints">
-  <h3>Entrypoints</h3>
+<div class="entrypoints">
   <form [formGroup]="formGroup" *ngIf="formGroup" (ngSubmit)="onSaveChanges()">
-    <div class="entrypoints__context-path" *ngIf="pathsFormControl">
-      <div class="entrypoints__context-path__title">
-        <span class="mat-body-strong">Entrypoints context-paths</span>
+    <mat-card *ngIf="apiExistingPaths?.length > 0">
+      <div class="entrypoints__context-path">
+        <div class="entrypoints__context-path__title">
+          <span class="mat-body-strong">Entrypoint context-paths</span>
 
-        <button id="switchListenerType" mat-button type="button" (click)="switchEntrypointsMode()">
-          <ng-container *ngIf="!this.enableVirtualHost"> <mat-icon svgIcon="gio:check"></mat-icon> Enable virtual hosts </ng-container>
-          <ng-container *ngIf="this.enableVirtualHost"> <mat-icon svgIcon="gio:cancel"></mat-icon> Disable virtual hosts </ng-container>
-        </button>
+          <button id="switchListenerType" mat-button type="button" (click)="switchEntrypointsMode()">
+            <ng-container *ngIf="!this.enableVirtualHost"> <mat-icon svgIcon="gio:check"></mat-icon> Enable virtual hosts </ng-container>
+            <ng-container *ngIf="this.enableVirtualHost"> <mat-icon svgIcon="gio:cancel"></mat-icon> Disable virtual hosts </ng-container>
+          </button>
+        </div>
+        <gio-form-listeners-context-path
+          *ngIf="!this.enableVirtualHost"
+          [formControl]="pathsFormControl"
+          [pathsToIgnore]="apiExistingPaths"
+        ></gio-form-listeners-context-path>
+
+        <gio-form-listeners-virtual-host
+          *ngIf="this.enableVirtualHost"
+          [formControl]="pathsFormControl"
+          [pathsToIgnore]="apiExistingPaths"
+          [domainRestrictions]="domainRestrictions"
+        ></gio-form-listeners-virtual-host>
       </div>
-      <gio-form-listeners-context-path
-        *ngIf="!this.enableVirtualHost"
-        [formControl]="pathsFormControl"
-        [pathsToIgnore]="apiExistingPaths"
-      ></gio-form-listeners-context-path>
-
-      <gio-form-listeners-virtual-host
-        *ngIf="this.enableVirtualHost"
-        [formControl]="pathsFormControl"
-        [pathsToIgnore]="apiExistingPaths"
-        [domainRestrictions]="domainRestrictions"
-      ></gio-form-listeners-virtual-host>
-    </div>
-
+      <div class="entrypoints__footer">
+        <button
+          mat-flat-button
+          color="primary"
+          type="submit"
+          [disabled]="formGroup.pristine || formGroup.invalid || dataSource.length === 0"
+        >
+          Save changes
+        </button>
+        <button mat-stroked-button type="button" (click)="onReset()" [disabled]="!formGroup.dirty">Reset</button>
+      </div>
+    </mat-card>
+  </form>
+  <mat-card *ngIf="api?.type === 'MESSAGE'">
     <div class="entrypoints__type">
-      <span class="mat-body-strong">Entrypoints types</span>
-
-      <table
-        mat-table
-        [dataSource]="dataSource"
-        class="entrypoints__type__table gio-table-light"
-        aria-label="entrypoints"
-        *ngIf="api?.type === 'MESSAGE'"
-      >
+      <span class="mat-body-strong">Entrypoint types</span>
+      <table mat-table [dataSource]="dataSource" class="entrypoints__type__table gio-table-light" aria-label="entrypoints">
         <ng-container matColumnDef="type">
           <th mat-header-cell *matHeaderCellDef>Entrypoint type</th>
           <td mat-cell *matCellDef="let element">
@@ -61,10 +67,13 @@
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let element" class="entrypoints__type__table__actions">
             <button type="button" mat-icon-button aria-label="Edit" (click)="onEdit(element)">
-              <mat-icon svgIcon="gio:edit-pencil"> </mat-icon>
+              <mat-icon svgIcon="gio:edit-pencil" matTooltip="Edit"> </mat-icon>
             </button>
-            <button type="button" [disabled]="dataSource.length === 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
-              <mat-icon svgIcon="gio:trash"></mat-icon>
+            <button type="button" [disabled]="dataSource.length <= 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
+              <mat-icon
+                svgIcon="gio:trash"
+                [matTooltip]="dataSource.length <= 1 ? 'At least one entrypoint is required' : 'Delete'"
+              ></mat-icon>
             </button>
           </td>
         </ng-container>
@@ -72,21 +81,9 @@
         <tr mat-header-row *matHeaderRowDef="displayedColumns" class="entrypoints__type__table__header"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
       </table>
-      <button
-        mat-stroked-button
-        type="button"
-        *ngIf="api?.type === 'MESSAGE'"
-        [disabled]="entrypointAvailableForAdd.length < 1"
-        (click)="addNewEntrypoint()"
-      >
+      <button mat-stroked-button type="button" [disabled]="entrypointAvailableForAdd.length < 1" (click)="addNewEntrypoint()">
         Add an entrypoint
       </button>
     </div>
-
-    <div class="entrypoints__footer">
-      <button mat-flat-button color="primary" type="submit" [disabled]="formGroup.pristine || formGroup.invalid || dataSource.length === 0">
-        Save changes
-      </button>
-    </div>
-  </form>
-</mat-card>
+  </mat-card>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -63,7 +63,7 @@
             <button type="button" mat-icon-button aria-label="Edit" (click)="onEdit(element)">
               <mat-icon svgIcon="gio:edit-pencil"> </mat-icon>
             </button>
-            <button type="button" mat-icon-button aria-label="Edit" (click)="onDelete(element)">
+            <button type="button" [disabled]="dataSource.length === 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
               <mat-icon svgIcon="gio:trash"></mat-icon>
             </button>
           </td>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.scss
@@ -9,6 +9,10 @@
 }
 
 .entrypoints {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
   &__context-path {
     &__title {
       display: flex;

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -429,6 +429,32 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       expect(saveReq.request.body).toEqual(expectedUpdateApi);
       saveReq.flush(API);
     });
+
+    it('should only be not be able to delete last entrypoint', async () => {
+      const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiEntrypointsV4GeneralHarness);
+      const tableRows = await harness.getEntrypointsTableRows();
+
+      // Find row to delete
+      const allEntrypointsType = await Promise.all(
+        tableRows.map(async (row) => row.getCells({ columnName: 'type' }).then((cells) => cells[0].getText())),
+      );
+      expect(allEntrypointsType).toEqual(['HTTP GET', 'HTTP POST', 'Webhook']);
+
+      // Delete
+      const saveButton = await loader.getHarness(MatButtonHarness.with({ text: 'Save changes' }));
+      expect(await saveButton.isDisabled()).toEqual(true);
+
+      expect(await harness.getDeleteBtnByRowIndex(2).then((btn) => btn.isDisabled())).toEqual(false);
+      await harness.deleteRowByIndex(2);
+      expect(await saveButton.isDisabled()).toEqual(false);
+
+      expect(await harness.getDeleteBtnByRowIndex(1).then((btn) => btn.isDisabled())).toEqual(false);
+      await harness.deleteRowByIndex(1);
+      expect(await saveButton.isDisabled()).toEqual(false);
+
+      expect(await harness.getDeleteBtnByRowIndex(0).then((btn) => btn.isDisabled())).toEqual(true);
+      expect(await saveButton.isDisabled()).toEqual(false);
+    });
   });
 
   describe('When deleting the only entrypoint for HTTP listener', () => {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
@@ -18,7 +18,7 @@ import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing'
 import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class ApiEntrypointsV4GeneralHarness extends ComponentHarness {
-  public static hostSelector = 'api-entrypoints-v4-general';
+  public static hostSelector = '.entrypoints';
 
   private tableLocator = this.locatorFor(MatTableHarness);
 
@@ -37,7 +37,7 @@ export class ApiEntrypointsV4GeneralHarness extends ComponentHarness {
       .then((actionCell) => actionCell[0].getAllHarnesses(MatButtonHarness))
       .then((actionButtons) => actionButtons[1]);
   }
-  async deleteRowByIndex(index: number): Promise<void> {
+  async deleteEntrypointByIndex(index: number): Promise<void> {
     return this.getDeleteBtnByRowIndex(index).then((btn) => btn.click());
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
-import { MatTableHarness } from '@angular/material/table/testing';
+import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class ApiEntrypointsV4GeneralHarness extends ComponentHarness {
   public static hostSelector = 'api-entrypoints-v4-general';
@@ -26,7 +27,17 @@ export class ApiEntrypointsV4GeneralHarness extends ComponentHarness {
       .then((_) => true)
       .catch((_) => false);
   }
-  async getEntrypointsTableRows() {
+  async getEntrypointsTableRows(): Promise<MatRowHarness[]> {
     return this.tableLocator().then((table) => table.getRows());
+  }
+
+  async getDeleteBtnByRowIndex(index: number): Promise<MatButtonHarness> {
+    return this.getEntrypointsTableRows()
+      .then((rows) => rows[index].getCells({ columnName: 'actions' }))
+      .then((actionCell) => actionCell[0].getAllHarnesses(MatButtonHarness))
+      .then((actionButtons) => actionButtons[1]);
+  }
+  async deleteRowByIndex(index: number): Promise<void> {
+    return this.getDeleteBtnByRowIndex(index).then((btn) => btn.click());
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
@@ -23,6 +23,7 @@ import { GioFormJsonSchemaModule, GioIconsModule, GioLoaderModule } from '@gravi
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { ApiEntrypointsV4GeneralComponent } from './api-entrypoints-v4-general.component';
 import { ApiEntrypointsV4EditComponent } from './edit/api-entrypoints-v4-edit.component';
@@ -38,20 +39,21 @@ import { GioEntrypointsSelectionListModule } from '../component/gio-entrypoints-
     CommonModule,
     ReactiveFormsModule,
 
+    GioEntrypointsSelectionListModule,
+    GioFormJsonSchemaModule,
     GioFormListenersContextPathModule,
     GioFormListenersVirtualHostModule,
-    GioEntrypointsSelectionListModule,
-
-    MatCardModule,
-    MatTableModule,
-    MatButtonModule,
-    MatSnackBarModule,
-    MatIconModule,
-    GioIconsModule,
-    MatDialogModule,
-    GioFormJsonSchemaModule,
     GioGoBackButtonModule,
+    GioIconsModule,
     GioLoaderModule,
+
+    MatButtonModule,
+    MatCardModule,
+    MatDialogModule,
+    MatIconModule,
+    MatSnackBarModule,
+    MatTableModule,
+    MatTooltipModule,
   ],
   declarations: [ApiEntrypointsV4GeneralComponent, ApiEntrypointsV4EditComponent, ApiEntrypointsV4AddDialogComponent],
 })

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-add-dialog.component.html
@@ -17,7 +17,7 @@
 -->
 <ng-container *ngIf="!showContextPathForm; else contextPathForm">
   <div class="header">
-    <div class="header__title">Select your Event-Native API entrypoints</div>
+    <div class="header__title">Add your API entrypoints</div>
     <p class="header__subtitle">Choose how your users will consume your API</p>
   </div>
 
@@ -25,7 +25,7 @@
     <gio-entrypoints-selection-list formControlName="selectedEntrypointsIds" [entrypoints]="entrypoints"></gio-entrypoints-selection-list>
     <mat-dialog-actions class="actions">
       <button mat-stroked-button type="button" (click)="cancel()">Cancel</button>
-      <button mat-flat-button color="primary" type="submit" [disabled]="formGroup.invalid">Select my entrypoints</button>
+      <button mat-flat-button color="primary" type="submit" [disabled]="formGroup.invalid">Add API entrypoints</button>
     </mat-dialog-actions>
   </form>
 </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-add-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-add-dialog.harness.ts
@@ -24,7 +24,7 @@ export class ApiEntrypointsV4AddDialogHarness extends ComponentHarness {
 
   private entrypointListLocator = this.locatorFor(GioEntrypointsSelectionListHarness);
   private contextPathFormLocator = this.locatorFor(GioFormListenersContextPathHarness);
-  private saveButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Select my entrypoints' }));
+  private saveButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add API entrypoints' }));
   private saveWithContextPathButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Validate my entrypoints' }));
   private cancelButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
   public getEntrypointSelectionList() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2126

## Description

- Make at least one entrypoint mandatory for entrypoints page
- Restructure entrypoints page to have two sections: context-path form + entrypoints
- Synchronize entrypoint add + delete
- Add "Are you sure you want to delete?" dialog for deleting entrypoints
- Add Reset button for context-paths
- Fix tests
- Disable delete for last endpoint

New Layout: 

![Screen Shot 2023-07-07 at 16 54 38](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/26e3bb03-1de3-4dbb-b6e1-7d1f6488ab42)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lvdfmhdfdo.chromatic.com)
<!-- Storybook placeholder end -->
