### PR TITLE
map overrideAccess on API update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PathValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PathValidationServiceImpl.java
@@ -75,7 +75,7 @@ public class PathValidationServiceImpl implements PathValidationService {
         }
         List<Path> sanitizedPaths = paths
             .stream()
-            .map(path -> new Path(path.getHost(), sanitizePath(path.getPath())))
+            .map(path -> new Path(path.getHost(), sanitizePath(path.getPath()), path.isOverrideAccess()))
             .collect(Collectors.toList());
 
         final EnvironmentEntity currentEnv = environmentService.findById(executionContext.getEnvironmentId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PathValidationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PathValidationServiceTest.java
@@ -121,6 +121,28 @@ public class PathValidationServiceTest {
         assertEquals(new Path(null, "/context/", false), paths.get(0));
     }
 
+    @Test
+    public void shouldSucceed_create_withOverrideAccess() {
+        Api api1 = createMock("mock1", "/existing");
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
+
+        List<Path> paths = pathValidationService.validateAndSanitizePaths(
+            GraviteeContext.getExecutionContext(),
+            null,
+            Collections.singletonList(new Path("host", "path", true))
+        );
+
+        assertEquals(1, paths.size());
+        assertEquals(new Path("host", "/path/", true), paths.get(0));
+    }
+
     @Test(expected = PathAlreadyExistsException.class)
     public void shouldFail_create_existingPath() {
         Api api1 = createMock("mock1", "/context");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2062

## Description

Currently we lose the overrideAccess attribute in entrypoint paths when we update an API

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xemtvoflss.chromatic.com)
<!-- Storybook placeholder end -->
