### PR TITLE
Fix docker default run e2e

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -18,6 +18,7 @@ FROM graviteeio/nginx-noconfd:1.25
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONSOLE_BASE_HREF "/"
+ENV MGMT_API_URL "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT"
 
 COPY ./dist /usr/share/nginx/html/
 

--- a/gravitee-apim-console-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-console-webui/docker/Dockerfile-from-download
@@ -23,6 +23,7 @@ ARG GRAVITEEIO_PACKAGE_NAME=graviteeio-full
 
 ENV WWW_TARGET /usr/share/nginx/html
 ENV CONSOLE_BASE_HREF "/"
+ENV MGMT_API_URL "http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT"
 
 RUN apk update \
   && apk add --update --no-cache zip unzip netcat-openbsd wget \

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -19,6 +19,7 @@ LABEL maintainer="contact@graviteesource.com"
 
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"
 ENV PORTAL_BASE_HREF "/"
+ENV PORTAL_API_URL "http://localhost:8083/portal/environments/DEFAULT"
 
 COPY ./dist /usr/share/nginx/html/
 

--- a/gravitee-apim-portal-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-from-download
@@ -24,6 +24,7 @@ ARG GRAVITEEIO_PACKAGE_NAME=graviteeio-full
 ENV WWW_TARGET /usr/share/nginx/html
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"
 ENV PORTAL_BASE_HREF "/"
+ENV PORTAL_API_URL "http://localhost:8083/portal/environments/DEFAULT"
 
 RUN apk update \
   && apk add --update --no-cache zip unzip netcat-openbsd wget \


### PR DESCRIPTION
Add default values for PORTAL_API_URL and MGMT_API_URL
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zdukqcruge.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4623.team-apim.gravitee.dev/console](https://4623.team-apim.gravitee.dev/console)
      Portal: [https://4623.team-apim.gravitee.dev/portal](https://4623.team-apim.gravitee.dev/portal)
      Management-api: [https://4623.team-apim.gravitee.dev/api/management](https://4623.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4623.team-apim.gravitee.dev](https://4623.team-apim.gravitee.dev)
      Gateway v3: [https://4623.gateway-v3.team-apim.gravitee.dev](https://4623.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
