### PR TITLE
Display doc page with invalid template as it instead of blank

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidTemplateException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidTemplateException.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Collections;
+import java.util.Map;
+
+public class InvalidTemplateException extends AbstractManagementException {
+
+    public InvalidTemplateException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.INTERNAL_SERVER_ERROR_500;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "template.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -94,17 +94,7 @@ import io.gravitee.rest.api.service.SwaggerService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.PageConverter;
-import io.gravitee.rest.api.service.exceptions.InvalidDataException;
-import io.gravitee.rest.api.service.exceptions.NoFetcherDefinedException;
-import io.gravitee.rest.api.service.exceptions.PageActionException;
-import io.gravitee.rest.api.service.exceptions.PageContentUnsafeException;
-import io.gravitee.rest.api.service.exceptions.PageFolderActionException;
-import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
-import io.gravitee.rest.api.service.exceptions.PageUsedAsGeneralConditionsException;
-import io.gravitee.rest.api.service.exceptions.PageUsedByCategoryException;
-import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import io.gravitee.rest.api.service.exceptions.TemplateProcessingException;
+import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
 import io.gravitee.rest.api.service.impl.swagger.transformer.SwaggerTransformer;
 import io.gravitee.rest.api.service.impl.swagger.transformer.entrypoints.EntrypointsOAITransformer;
@@ -821,6 +811,11 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                     pageEntity.setMessages(new ArrayList<>());
                 }
                 pageEntity.getMessages().add("Invalid expression or value is missing for " + e.getBlamedExpressionString());
+            } catch (InvalidTemplateException e) {
+                if (pageEntity.getMessages() == null) {
+                    pageEntity.setMessages(new ArrayList<>());
+                }
+                pageEntity.getMessages().add("Invalid template: " + e.getMessage());
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_TemplateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_TemplateTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import freemarker.template.TemplateException;
+import io.gravitee.rest.api.model.MetadataEntity;
+import io.gravitee.rest.api.model.MetadataFormat;
+import io.gravitee.rest.api.model.PageEntity;
+import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.InvalidTemplateException;
+import io.gravitee.rest.api.service.exceptions.TemplateProcessingException;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PageService_TemplateTest {
+
+    private static final String ORGANIZATION_ID = "ORG_ID";
+    private static final String ENVIRONMENT_ID = "ENV_ID";
+
+    private static final String API_ID = "myAPI";
+    private static final String PAGE_ID = "ba01aef0-e3da-4499-81ae-f0e3daa4995a";
+
+    @InjectMocks
+    private PageServiceImpl pageService = new PageServiceImpl();
+
+    @Mock
+    private MetadataService metadataService;
+
+    @Mock
+    private NotificationTemplateService notificationTemplateService;
+
+    @Test
+    public void shouldSetContentBasedOnTemplate() {
+        MetadataEntity metadata = new MetadataEntity();
+        metadata.setKey("emailSupport");
+        metadata.setName("Email Support");
+        metadata.setFormat(MetadataFormat.MAIL);
+        metadata.setValue("support@gio.com");
+        when(metadataService.findAllDefault()).thenReturn(List.of(metadata));
+
+        PageEntity pageEntity = new PageEntity();
+        pageEntity.setId(PAGE_ID);
+        pageEntity.setContent("# Hello ${metadata.emailSupport}");
+
+        when(
+            notificationTemplateService.resolveInlineTemplateWithParam(
+                eq(ORGANIZATION_ID),
+                eq(pageEntity.getId()),
+                eq(pageEntity.getContent()),
+                anyMap(),
+                eq(false)
+            )
+        )
+            .thenReturn("# Hello support@gio.com");
+
+        pageService.transformWithTemplate(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID), pageEntity, null);
+
+        assertThat(pageEntity.getContent()).isEqualTo("# Hello support@gio.com");
+    }
+
+    @Test
+    public void shouldKeepContentAsIsWhenTemplateIsInvalid() {
+        MetadataEntity metadata = new MetadataEntity();
+        metadata.setKey("emailSupport");
+        metadata.setName("Email Support");
+        metadata.setFormat(MetadataFormat.MAIL);
+        metadata.setValue("support@gio.com");
+        when(metadataService.findAllDefault()).thenReturn(List.of(metadata));
+
+        PageEntity pageEntity = new PageEntity();
+        pageEntity.setId(PAGE_ID);
+        pageEntity.setContent("# Hello ${metadata.['emailSupport']}");
+
+        when(
+            notificationTemplateService.resolveInlineTemplateWithParam(
+                eq(ORGANIZATION_ID),
+                eq(pageEntity.getId()),
+                eq(pageEntity.getContent()),
+                anyMap(),
+                eq(false)
+            )
+        )
+            .thenThrow(new InvalidTemplateException("expecting something else, found ["));
+
+        pageService.transformWithTemplate(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID), pageEntity, null);
+
+        assertThat(pageEntity.getContent()).isEqualTo("# Hello ${metadata.['emailSupport']}");
+        assertThat(pageEntity.getMessages()).isEqualTo(List.of("Invalid template: expecting something else, found ["));
+    }
+
+    @Test
+    public void shouldKeepContentAsIsWhenUsingUnknownProperty() {
+        MetadataEntity metadata = new MetadataEntity();
+        metadata.setKey("emailSupport");
+        metadata.setName("Email Support");
+        metadata.setFormat(MetadataFormat.MAIL);
+        metadata.setValue("support@gio.com");
+        when(metadataService.findAllDefault()).thenReturn(List.of(metadata));
+
+        PageEntity pageEntity = new PageEntity();
+        pageEntity.setId(PAGE_ID);
+        pageEntity.setContent("# Hello ${metadata.wrong}");
+
+        when(
+            notificationTemplateService.resolveInlineTemplateWithParam(
+                eq(ORGANIZATION_ID),
+                eq(pageEntity.getId()),
+                eq(pageEntity.getContent()),
+                anyMap(),
+                eq(false)
+            )
+        )
+            .thenThrow(new TemplateProcessingException(new TemplateException(null)));
+
+        pageService.transformWithTemplate(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID), pageEntity, null);
+
+        assertThat(pageEntity.getContent()).isEqualTo("# Hello ${metadata.wrong}");
+        assertThat(pageEntity.getMessages()).isEqualTo(List.of("Invalid expression or value is missing for null"));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-868
https://github.com/gravitee-io/issues/issues/7230

## Description

Display doc page with invalid template as it instead of blank


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rtrkhkahwf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4624.team-apim.gravitee.dev/console](https://4624.team-apim.gravitee.dev/console)
      Portal: [https://4624.team-apim.gravitee.dev/portal](https://4624.team-apim.gravitee.dev/portal)
      Management-api: [https://4624.team-apim.gravitee.dev/api/management](https://4624.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4624.team-apim.gravitee.dev](https://4624.team-apim.gravitee.dev)
      Gateway v3: [https://4624.gateway-v3.team-apim.gravitee.dev](https://4624.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
