### PR TITLE
fix(service): allow active subscriptions to be updated with valid clientIds

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -122,13 +122,7 @@ import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -689,7 +683,11 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 .findById(updateSubscription.getId())
                 .orElseThrow(() -> new SubscriptionNotFoundException(updateSubscription.getId()));
 
-            if (subscription.getStatus() == Subscription.Status.ACCEPTED) {
+            if (
+                subscription.getStatus() == Subscription.Status.ACCEPTED ||
+                subscription.getStatus() == PENDING ||
+                subscription.getStatus() == Subscription.Status.PAUSED
+            ) {
                 final GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
 
                 subscriptionValidationService.validateAndSanitize(genericPlanEntity, updateSubscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -793,7 +793,7 @@ public class SubscriptionServiceTest {
         UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
         updatedSubscription.setId(SUBSCRIPTION_ID);
 
-        Subscription subscription = buildTestSubscription(PENDING);
+        Subscription subscription = buildTestSubscription(REJECTED);
 
         // Stub
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
@@ -867,6 +867,44 @@ public class SubscriptionServiceTest {
 
         // Verify
         verify(subscriptionRepository, times(1)).update(argThat(s -> "my-client-id".equals(s.getClientId())));
+    }
+
+    @Test
+    public void shouldUpdateSubscriptionWithPendingStatus() throws Exception {
+        UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
+        updatedSubscription.setId(SUBSCRIPTION_ID);
+
+        Subscription subscription = buildTestSubscription(PENDING);
+
+        // Stub
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
+
+        // Run
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updatedSubscription, null);
+
+        // Verify
+        verify(subscriptionRepository, times(1)).update(any());
+    }
+
+    @Test
+    public void shouldUpdateSubscriptionWithPausedStatus() throws Exception {
+        UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
+        updatedSubscription.setId(SUBSCRIPTION_ID);
+
+        Subscription subscription = buildTestSubscription(PAUSED);
+
+        // Stub
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
+
+        // Run
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updatedSubscription, null);
+
+        // Verify
+        verify(subscriptionRepository, times(1)).update(any());
     }
 
     @Test(expected = SubscriptionNotFoundException.class)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1130

## Description

Subscriptions with accepted, pending or paused statuses are updated with clientIds (if clientId is not null and subscription already has a non-null clientId)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-polpbzrgph.chromatic.com)
<!-- Storybook placeholder end -->
