### PR TITLE
Use migrated components to display subscriptions of V1 and V2 APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
@@ -151,8 +151,8 @@ export class ApiNavigationComponent implements OnInit, OnDestroy {
     if (this.permissionService.hasAnyMatching(['api-subscription-r'])) {
       plansMenuItem.tabs.push({
         displayName: 'Subscriptions',
-        targetRoute: 'management.apis.detail.portal.subscriptions.list',
-        baseRoute: 'management.apis.detail.portal.subscriptions',
+        targetRoute: 'management.apis.detail.portal.subscriptions',
+        baseRoute: ['management.apis.detail.portal.subscriptions', 'management.apis.detail.portal.subscription'],
       });
     }
     if (plansMenuItem.tabs.length > 0) {

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -202,30 +202,6 @@ const states: Ng2StateDeclaration[] = [
     },
   },
   {
-    name: 'management.apis.ng.entrypoints',
-    url: '/entrypoints',
-    component: ApiEntrypointsV4GeneralComponent,
-    data: {
-      useAngularMaterial: true,
-      docs: null,
-      apiPermissions: {
-        only: ['api-definition-r'],
-      },
-    },
-  },
-  {
-    name: 'management.apis.ng.entrypoints-edit',
-    url: '/entrypoints/:entrypointId',
-    component: ApiEntrypointsV4EditComponent,
-    data: {
-      useAngularMaterial: true,
-      docs: null,
-      apiPermissions: {
-        only: ['api-definition-u'],
-      },
-    },
-  },
-  {
     name: 'management.apis.ng.subscription',
     url: '/subscription',
     component: GioEmptyComponent,
@@ -246,6 +222,30 @@ const states: Ng2StateDeclaration[] = [
       docs: null,
       apiPermissions: {
         only: ['api-subscription-u'],
+      },
+    },
+  },
+  {
+    name: 'management.apis.ng.entrypoints',
+    url: '/entrypoints',
+    component: ApiEntrypointsV4GeneralComponent,
+    data: {
+      useAngularMaterial: true,
+      docs: null,
+      apiPermissions: {
+        only: ['api-definition-r'],
+      },
+    },
+  },
+  {
+    name: 'management.apis.ng.entrypoints-edit',
+    url: '/entrypoints/:entrypointId',
+    component: ApiEntrypointsV4EditComponent,
+    data: {
+      useAngularMaterial: true,
+      docs: null,
+      apiPermissions: {
+        only: ['api-definition-u'],
       },
     },
   },

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -163,7 +163,7 @@ const states: Ng2StateDeclaration[] = [
   },
   {
     name: 'management.apis.ng.subscriptions',
-    url: '/subscriptions?page&size&plan&application&status&apikey',
+    url: '/subscriptions?page&size&plan&application&status&apiKey',
     component: ApiPortalSubscriptionListComponent,
     data: {
       useAngularMaterial: true,
@@ -195,7 +195,7 @@ const states: Ng2StateDeclaration[] = [
         value: 10,
         dynamic: true,
       },
-      apikey: {
+      apiKey: {
         type: 'string',
         dynamic: true,
       },

--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
@@ -15,7 +15,6 @@
  */
 import { StateParams } from '@uirouter/core';
 
-import { ApiService } from '../../../services/api.service';
 import CategoryService from '../../../services/category.service';
 import { DocumentationQuery, DocumentationService } from '../../../services/documentation.service';
 import FetcherService from '../../../services/fetcher.service';
@@ -97,47 +96,15 @@ function apisPortalRouterConfig($stateProvider) {
       },
     })
     .state('management.apis.detail.portal.subscriptions', {
-      abstract: true,
-      url: '/subscriptions',
-      template: '<div layout="column"><div ui-view></div></div>',
-      resolve: {
-        api: ($stateParams, ApiService: ApiService) => ApiService.get($stateParams.apiId).then((response) => response.data),
-      },
-    })
-    .state('management.apis.detail.portal.subscriptions.list', {
-      url: '?page&size&:application&:status&:plan&:api_key',
-      component: 'apiSubscriptions',
-      resolve: {
-        subscriptions: ($stateParams, ApiService: ApiService) => {
-          let query = '?page=' + $stateParams.page + '&size=' + $stateParams.size;
-
-          if ($stateParams.status) {
-            query += '&status=' + $stateParams.status;
-          }
-
-          if ($stateParams.application) {
-            query += '&application=' + $stateParams.application;
-          }
-
-          if ($stateParams.plan) {
-            query += '&plan=' + $stateParams.plan;
-          }
-
-          if ($stateParams.api_key) {
-            query += '&api_key=' + $stateParams.api_key;
-          }
-
-          return ApiService.getSubscriptions($stateParams.apiId, query).then((response) => response.data);
-        },
-
-        plans: ($stateParams, ApiService: ApiService) => ApiService.getApiPlans($stateParams.apiId).then((response) => response.data),
-      },
+      url: '/subscriptions?page&size&:application&:status&:plan&:apiKey',
+      component: 'ngApiPortalSubscriptionList',
       data: {
-        perms: {
-          only: ['api-subscription-r'],
-        },
+        useAngularMaterial: true,
         docs: {
           page: 'management-api-subscriptions',
+        },
+        perms: {
+          only: ['api-subscription-r'],
         },
       },
       params: {
@@ -163,53 +130,25 @@ function apisPortalRouterConfig($stateProvider) {
           value: 10,
           dynamic: true,
         },
-        api_key: {
+        apiKey: {
           type: 'string',
           dynamic: true,
         },
       },
     })
-    .state('management.apis.detail.portal.subscriptions.subscription', {
-      url: '/:subscriptionId?:page&:size&:application&:status&:plan&:api_key',
-      component: 'apiSubscription',
-      resolve: {
-        subscription: ($stateParams, ApiService: ApiService) =>
-          ApiService.getSubscription($stateParams.apiId, $stateParams.subscriptionId).then((response) => response.data),
-      },
+    .state('management.apis.detail.portal.subscription', {
+      url: '/subscription',
+    })
+    .state('management.apis.detail.portal.subscription.edit', {
+      url: '/:subscriptionId',
+      component: 'ngApiPortalSubscriptionEdit',
       data: {
-        perms: {
-          only: ['api-subscription-r'],
-        },
+        useAngularMaterial: true,
         docs: {
           page: 'management-api-subscriptions',
         },
-      },
-      params: {
-        status: {
-          type: 'string',
-          dynamic: true,
-        },
-        application: {
-          type: 'string',
-          dynamic: true,
-        },
-        plan: {
-          type: 'string',
-          dynamic: true,
-        },
-        page: {
-          type: 'int',
-          value: 1,
-          dynamic: true,
-        },
-        size: {
-          type: 'int',
-          value: 10,
-          dynamic: true,
-        },
-        api_key: {
-          type: 'string',
-          dynamic: true,
+        perms: {
+          only: ['api-subscription-r'],
         },
       },
     })

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
@@ -69,7 +69,7 @@
 
       <ng-container
         *ngIf="
-          canUseCustomApikey &&
+          canUseCustomApiKey &&
           form.get('selectedPlan').value?.security?.type === 'API_KEY' &&
           form.get('selectedPlan').value?.apiId &&
           form.get('selectedApplication').value?.id

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -89,8 +89,8 @@ describe('Subscription creation dialog', () => {
   let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
-  describe('Test customApikey input', () => {
-    describe('With custom apikey enabled', () => {
+  describe('Test customApiKey input', () => {
+    describe('With custom apiKey enabled', () => {
       beforeEach(() => {
         TestBed.configureTestingModule({
           declarations: [TestComponent],
@@ -207,7 +207,7 @@ describe('Subscription creation dialog', () => {
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
       });
     });
-    describe('With custom apikey disabled', () => {
+    describe('With custom apiKey disabled', () => {
       beforeEach(() => {
         TestBed.configureTestingModule({
           declarations: [TestComponent],

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -50,7 +50,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   public applications$: Observable<Application[]> = new Observable<Application[]>();
   public selectedSchema: GioJsonSchema;
   public showGeneralConditionsMsg: boolean;
-  public canUseCustomApikey: boolean;
+  public canUseCustomApiKey: boolean;
 
   public form: FormGroup = new FormGroup({
     selectedPlan: new FormControl(undefined, [Validators.required]),
@@ -69,7 +69,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   ) {
     this.plans = dialogData.plans.filter((plan) => plan.security?.type !== 'KEY_LESS');
     this.availableSubscriptionEntrypoints = dialogData.availableSubscriptionEntrypoints.map((entrypoint) => ({ type: entrypoint.type }));
-    this.canUseCustomApikey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
+    this.canUseCustomApiKey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
   }
 
   ngOnInit(): void {
@@ -132,7 +132,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
       .get('selectedPlan')
       .valueChanges.pipe(
         distinctUntilChanged(),
-        filter((plan) => plan.security?.type === 'API_KEY' && this.canUseCustomApikey),
+        filter((plan) => plan.security?.type === 'API_KEY' && this.canUseCustomApiKey),
         tap(() => {
           this.form.addControl('customApiKey', new FormControl('', []));
           this.form.removeControl('selectedEntrypoint');

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
@@ -32,7 +32,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
     MatFormFieldHarness.with({ selector: '.subscription-creation__content__applications' }),
   );
   protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
-  protected getCustomApikeyInput = this.locatorForOptional(ApiKeyValidationHarness);
+  protected getCustomApiKeyInput = this.locatorForOptional(ApiKeyValidationHarness);
   protected getSelectEntrypointSelect = this.locatorForOptional(
     MatSelectHarness.with({ selector: '[formControlName="selectedEntrypoint"]' }),
   );
@@ -74,13 +74,13 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
 
   // Custom API Key
   public async isCustomApiKeyInputDisplayed() {
-    const matInputHarness = await this.getCustomApikeyInput();
+    const matInputHarness = await this.getCustomApiKeyInput();
     return matInputHarness !== null;
   }
 
-  public async addCustomKey(customApikey: string) {
-    const matInputHarness = await this.getCustomApikeyInput();
-    return await matInputHarness.setInputValue(customApikey);
+  public async addCustomKey(customApiKey: string) {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return await matInputHarness.setInputValue(customApiKey);
   }
 
   // PUSH Plan

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
@@ -72,7 +72,7 @@
 
     <mat-form-field class="subscriptions__filters__inputs__field">
       <mat-label>API key</mat-label>
-      <input matInput formControlName="apikey" />
+      <input matInput formControlName="apiKey" />
     </mat-form-field>
   </div>
   <div class="subscriptions__filters__buttons">

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.spec.ts
@@ -132,9 +132,9 @@ describe('ApiPortalSubscriptionListComponent', () => {
       expect(await statusSelectInput.isDisabled()).toEqual(false);
       expect(await statusSelectInput.getValueText()).toEqual('Accepted, Paused, Pending');
 
-      const apikeyInput = await harness.getApiKeyInput();
-      expect(await apikeyInput.isDisabled()).toEqual(false);
-      expect(await apikeyInput.getValue()).toEqual('');
+      const apiKeyInput = await harness.getApiKeyInput();
+      expect(await apiKeyInput.isDisabled()).toEqual(false);
+      expect(await apiKeyInput.getValue()).toEqual('');
     }));
 
     it('should init filters from params', fakeAsync(async () => {
@@ -142,7 +142,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
         plan: PLAN_ID,
         application: APPLICATION_ID,
         status: 'CLOSED,REJECTED',
-        apikey: 'apikey_1',
+        apiKey: 'apiKey_1',
       });
       const harness = await loader.getHarness(ApiPortalSubscriptionListHarness);
 
@@ -158,9 +158,9 @@ describe('ApiPortalSubscriptionListComponent', () => {
       expect(await statusSelectInput.isDisabled()).toEqual(false);
       expect(await statusSelectInput.getValueText()).toEqual('Closed, Rejected');
 
-      const apikeyInput = await harness.getApiKeyInput();
-      expect(await apikeyInput.isDisabled()).toEqual(false);
-      expect(await apikeyInput.getValue()).toEqual('apikey_1');
+      const apiKeyInput = await harness.getApiKeyInput();
+      expect(await apiKeyInput.isDisabled()).toEqual(false);
+      expect(await apiKeyInput.getValue()).toEqual('apiKey_1');
     }));
 
     it('should reset filters from params', fakeAsync(async () => {
@@ -168,7 +168,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
         plan: null,
         application: null,
         status: 'CLOSED,REJECTED',
-        apikey: 'apikey_1',
+        apiKey: 'apiKey_1',
       });
       const harness = await loader.getHarness(ApiPortalSubscriptionListHarness);
 
@@ -188,9 +188,9 @@ describe('ApiPortalSubscriptionListComponent', () => {
       expect(await statusSelectInput.isDisabled()).toEqual(false);
       expect(await statusSelectInput.getValueText()).toEqual('Accepted, Paused, Pending');
 
-      const apikeyInput = await harness.getApiKeyInput();
-      expect(await apikeyInput.isDisabled()).toEqual(false);
-      expect(await apikeyInput.getValue()).toEqual('');
+      const apiKeyInput = await harness.getApiKeyInput();
+      expect(await apiKeyInput.isDisabled()).toEqual(false);
+      expect(await apiKeyInput.getValue()).toEqual('');
     }));
   });
 
@@ -414,7 +414,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
         plan: aPlan.id,
         application: aBaseApplication.id,
         status: 'ACCEPTED,CLOSED,RESUMED',
-        apikey: '12345678',
+        apiKey: '12345678',
       });
 
       const harness = await loader.getHarness(ApiPortalSubscriptionListHarness);
@@ -434,7 +434,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
     plans: Plan[] = [aPlan],
     subscribers: BaseApplication[] = [aBaseApplication],
     applications?: Application[],
-    params?: { plan?: string; application?: string; status?: string; apikey?: string },
+    params?: { plan?: string; application?: string; status?: string; apiKey?: string },
   ) {
     await TestBed.overrideProvider(UIRouterStateParams, { useValue: { apiId: api.id, ...(params ? params : {}) } }).compileComponents();
     fixture = TestBed.createComponent(TestComponent);
@@ -458,7 +458,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
       params?.status?.split(','),
       params?.application?.split(','),
       params?.plan?.split(','),
-      params?.apikey,
+      params?.apiKey,
     );
     loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.detectChanges();
@@ -540,7 +540,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
     statuses?: string[],
     applicationIds?: string[],
     planIds?: string[],
-    apikey?: string,
+    apiKey?: string,
   ) {
     const response: ApiSubscriptionsResponse = {
       data: subscriptions,
@@ -554,7 +554,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions?page=1&perPage=10${
           statuses ? `&statuses=${statuses.join(',')}` : '&statuses=ACCEPTED,PAUSED,PENDING'
         }${applicationIds ? `&applicationIds=${applicationIds.join(',')}` : ''}${planIds ? `&planIds=${planIds.join(',')}` : ''}${
-          apikey ? `&apikey=${apikey}` : ''
+          apiKey ? `&apiKey=${apiKey}` : ''
         }&expands=application,plan`,
         method: 'GET',
       })
@@ -618,14 +618,14 @@ describe('ApiPortalSubscriptionListComponent', () => {
     statuses?: string[],
     applicationIds?: string[],
     planIds?: string[],
-    apikey?: string,
+    apiKey?: string,
   ) {
     httpTestingController
       .expectOne({
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/_export?page=1&perPage=${subscriptions.length}${
           statuses ? `&statuses=${statuses.join(',')}` : '&statuses=ACCEPTED,PAUSED,PENDING'
         }${applicationIds ? `&applicationIds=${applicationIds.join(',')}` : ''}${planIds ? `&planIds=${planIds.join(',')}` : ''}${
-          apikey ? `&apikey=${apikey}` : ''
+          apiKey ? `&apiKey=${apiKey}` : ''
         }`,
         method: 'GET',
       })

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.ts
@@ -64,7 +64,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
     planIds: new FormControl(),
     applicationIds: new FormControl(),
     statuses: new FormControl(),
-    apikey: new FormControl(),
+    apiKey: new FormControl(),
   });
 
   public plans: Plan[] = [];
@@ -86,7 +86,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
       planIds?: string[];
       applicationIds?: string[];
       statuses?: SubscriptionStatus[];
-      apikey?: string;
+      apiKey?: string;
     };
   }>({
     tableWrapper: {
@@ -97,7 +97,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
       planIds: null,
       applicationIds: null,
       statuses: ['ACCEPTED', 'PAUSED', 'PENDING'],
-      apikey: undefined,
+      apiKey: undefined,
     },
   });
 
@@ -126,7 +126,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
 
     this.filtersForm.valueChanges
       .pipe(distinctUntilChanged(isEqual), takeUntil(this.unsubscribe$))
-      .subscribe(({ planIds, applicationIds, statuses, apikey }) =>
+      .subscribe(({ planIds, applicationIds, statuses, apiKey }) =>
         this.filtersStream.next({
           tableWrapper: {
             ...this.filtersStream.value.tableWrapper,
@@ -138,7 +138,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
             planIds,
             applicationIds,
             statuses,
-            apikey,
+            apiKey,
           },
         }),
       );
@@ -176,7 +176,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
               status: subscriptionsFilters.statuses?.join(','),
               plan: subscriptionsFilters.planIds?.join(','),
               application: subscriptionsFilters.applicationIds?.join(','),
-              apikey: subscriptionsFilters.apikey,
+              apiKey: subscriptionsFilters.apiKey,
             },
             { notify: false },
           );
@@ -185,7 +185,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
           this.filtersForm.get('planIds').setValue(subscriptionsFilters.planIds);
           this.filtersForm.get('applicationIds').setValue(subscriptionsFilters.applicationIds);
           this.filtersForm.get('statuses').setValue(subscriptionsFilters.statuses);
-          this.filtersForm.get('apikey').setValue(subscriptionsFilters.apikey);
+          this.filtersForm.get('apiKey').setValue(subscriptionsFilters.apiKey);
         }),
         switchMap(({ subscriptionsFilters, tableWrapper }) =>
           this.apiSubscriptionService
@@ -196,7 +196,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
               subscriptionsFilters.statuses,
               subscriptionsFilters.applicationIds,
               subscriptionsFilters.planIds,
-              subscriptionsFilters.apikey,
+              subscriptionsFilters.apiKey,
               ['application', 'plan'],
             )
             .pipe(
@@ -240,10 +240,10 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
     const planIds: string[] = this.filtersStream.value.subscriptionsFilters.statuses;
     const applicationIds = this.filtersStream.value.subscriptionsFilters.applicationIds;
     const statuses = this.filtersStream.value.subscriptionsFilters.planIds;
-    const apikey = this.filtersStream.value.subscriptionsFilters.apikey;
+    const apiKey = this.filtersStream.value.subscriptionsFilters.apiKey;
 
     this.apiSubscriptionService
-      .exportAsCSV(apiId, page, perPage, planIds, applicationIds, statuses, apikey)
+      .exportAsCSV(apiId, page, perPage, planIds, applicationIds, statuses, apiKey)
       .pipe(
         tap((blob) => {
           let fileName = `subscriptions-${this.api.name}-${this.api.apiVersion}-${_.now()}.csv`;
@@ -303,7 +303,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
     const initialPlanIds: string[] = this.ajsStateParams.plan ? this.ajsStateParams.plan.split(',') : null;
     const initialApplicationIds = this.ajsStateParams.application ? this.ajsStateParams.application.split(',') : null;
     const initialStatuses = this.ajsStateParams.status ? this.ajsStateParams.status.split(',') : ['ACCEPTED', 'PAUSED', 'PENDING'];
-    const initialApikey = this.ajsStateParams.apikey ? this.ajsStateParams.apikey : undefined;
+    const initialApiKey = this.ajsStateParams.apiKey ? this.ajsStateParams.apiKey : undefined;
 
     this.filtersStream.next({
       tableWrapper: {
@@ -314,7 +314,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
         planIds: initialPlanIds,
         applicationIds: initialApplicationIds,
         statuses: initialStatuses,
-        apikey: initialApikey,
+        apiKey: initialApiKey,
       },
     });
   }
@@ -329,7 +329,7 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
         planIds: null,
         applicationIds: null,
         statuses: ['ACCEPTED', 'PAUSED', 'PENDING'],
-        apikey: undefined,
+        apiKey: undefined,
       },
     });
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
@@ -25,7 +25,7 @@ export class ApiPortalSubscriptionListHarness extends ComponentHarness {
   public getPlanSelectInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="planIds"]' }));
   public getApplicationSelectInput = this.locatorFor(GioFormTagsInputHarness);
   public getStatusSelectInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="statuses"]' }));
-  public getApiKeyInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="apikey"]' }));
+  public getApiKeyInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="apiKey"]' }));
   public getCreateSubscriptionButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Create a subscription"]' }));
   public getResetFilterButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Reset filters"]' }));
   public getExportButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Export subscriptions list"]' }));

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -513,6 +513,8 @@ import { ApiBackendServicesComponent } from './api/endpoints-v4/backend-services
 import { OrgNavigationComponent } from '../organization/configuration/navigation/org-navigation.component';
 import { ClientRegistrationProviderComponent } from './configuration/client-registration-providers/client-registration-provider/client-registration-provider.component';
 import { GioPermissionService } from '../shared/components/gio-permission/gio-permission.service';
+import { ApiPortalSubscriptionListComponent } from './api/portal/ng-subscriptions/list/api-portal-subscription-list.component';
+import { ApiPortalSubscriptionEditComponent } from './api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -671,6 +673,8 @@ graviteeManagementModule.controller('ApisStatusDashboardController', ApisStatusD
 graviteeManagementModule.controller('ApiAdminController', ApiAdminController);
 graviteeManagementModule.directive('ngApiPortalDetails', downgradeComponent({ component: ApiPortalDetailsComponent }));
 graviteeManagementModule.directive('ngApiPortalPlanList', downgradeComponent({ component: ApiPortalPlanListComponent }));
+graviteeManagementModule.directive('ngApiPortalSubscriptionList', downgradeComponent({ component: ApiPortalSubscriptionListComponent }));
+graviteeManagementModule.directive('ngApiPortalSubscriptionEdit', downgradeComponent({ component: ApiPortalSubscriptionEditComponent }));
 graviteeManagementModule.directive(
   'ngApiPortalDocumentationMetadata',
   downgradeComponent({ component: ApiPortalDocumentationMetadataComponent }),

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -74,14 +74,14 @@ describe('ApiSubscriptionV2Service', () => {
       };
 
       apiSubscriptionV2Service
-        .list(API_ID, '1', '10', ['ACCEPTED', 'CLOSED'], ['app1', 'app2'], ['plan1', 'plan2'], 'apikey', ['plan', 'application'])
+        .list(API_ID, '1', '10', ['ACCEPTED', 'CLOSED'], ['app1', 'app2'], ['plan1', 'plan2'], 'apiKey', ['plan', 'application'])
         .subscribe((apiSubscriptionsResponse) => {
           expect(apiSubscriptionsResponse.data).toEqual([fakeSubscription()]);
           done();
         });
 
       const req = httpTestingController.expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions?page=1&perPage=10&statuses=ACCEPTED,CLOSED&applicationIds=app1,app2&planIds=plan1,plan2&apikey=apikey&expands=plan,application`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions?page=1&perPage=10&statuses=ACCEPTED,CLOSED&applicationIds=app1,app2&planIds=plan1,plan2&apiKey=apiKey&expands=plan,application`,
         method: 'GET',
       });
 
@@ -105,13 +105,13 @@ describe('ApiSubscriptionV2Service', () => {
 
     it('should export with all query params', (done) => {
       apiSubscriptionV2Service
-        .exportAsCSV(API_ID, '1', '10', ['ACCEPTED', 'CLOSED'], ['app1', 'app2'], ['plan1', 'plan2'], 'apikey')
+        .exportAsCSV(API_ID, '1', '10', ['ACCEPTED', 'CLOSED'], ['app1', 'app2'], ['plan1', 'plan2'], 'apiKey')
         .subscribe(() => {
           done();
         });
 
       const req = httpTestingController.expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/_export?page=1&perPage=10&statuses=ACCEPTED,CLOSED&applicationIds=app1,app2&planIds=plan1,plan2&apikey=apikey`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/_export?page=1&perPage=10&statuses=ACCEPTED,CLOSED&applicationIds=app1,app2&planIds=plan1,plan2&apiKey=apiKey`,
         method: 'GET',
       });
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -42,7 +42,7 @@ export class ApiSubscriptionV2Service {
     statuses?: string[],
     applicationIds?: string[],
     planIds?: string[],
-    apikey?: string,
+    apiKey?: string,
     expands?: ('plan' | 'application')[],
   ): Observable<ApiSubscriptionsResponse> {
     return this.http.get<ApiSubscriptionsResponse>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions`, {
@@ -52,7 +52,7 @@ export class ApiSubscriptionV2Service {
         ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
         ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
         ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
-        ...(apikey ? { apikey: apikey } : {}),
+        ...(apiKey ? { apiKey: apiKey } : {}),
         ...(expands ? { expands: expands.join(',') } : {}),
       },
     });
@@ -65,7 +65,7 @@ export class ApiSubscriptionV2Service {
     statuses?: string[],
     applicationIds?: string[],
     planIds?: string[],
-    apikey?: string,
+    apiKey?: string,
   ): Observable<Blob> {
     return this.http.get(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/_export`, {
       responseType: 'blob',
@@ -75,7 +75,7 @@ export class ApiSubscriptionV2Service {
         ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
         ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
         ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
-        ...(apikey ? { apikey: apikey } : {}),
+        ...(apiKey ? { apiKey: apiKey } : {}),
       },
     });
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2182

## Description

- Refactor the word `apikey` in `apiKey`, to follow the openapi spec for the MAPI v2 (see https://github.com/gravitee-io/gravitee-api-management/blob/4.0.x/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml#L982)
- Change the angularJS router to use the Angular components developed for V4 APIs.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hftkiglamc.chromatic.com)
<!-- Storybook placeholder end -->
