### PR TITLE
fix: create primary keys the same time than the table in 4.0.0 changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ commands:
                   name: Parse Gravitee version
                   command: |
                       # parse graviteeio_version
-                      export GRAVITEEIO_VERSION_WITH_QUALIFIER="<< parameters.graviteeio_version >>"                    # 3.19.0-alpha.1 or 3.19.0
+                      export GRAVITEEIO_VERSION_WITH_QUALIFIER="4.0.0-alpha.2"                    # 3.19.0-alpha.1 or 3.19.0
 
                       export GRAVITEEIO_VERSION=$(echo $GRAVITEEIO_VERSION_WITH_QUALIFIER | awk -F '-' '{print $1}')    # 3.19.0
                       export GRAVITEEIO_VERSION_MAJOR=$(echo $GRAVITEEIO_VERSION | awk -F '.' '{print $1}')             # 3

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
@@ -15,10 +15,11 @@ databaseChangeLog:
               - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest
-            columnNames: id
-            tableName: ${gravitee_prefix}events_latest
+            constraints:
+              - primaryKey:
+                  columnNames: id
+                  constraintName: pk_${gravitee_prefix}events_latest
+
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_type
             columns:
@@ -40,10 +41,11 @@ databaseChangeLog:
               - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: property_value, type: nvarchar(256), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest_properties
-            columnNames: event_id, property_key
-            tableName: ${gravitee_prefix}events_latest_properties
+            constraints:
+              - primaryKey:
+                  columnNames: event_id, property_key
+                  constraintName: pk_${gravitee_prefix}events_latest_properties
+
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_properties_propertykey
             columns:
@@ -57,21 +59,20 @@ databaseChangeLog:
             columns:
               - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest_environments
-            columnNames: event_id, environment_id
-            tableName: ${gravitee_prefix}events_latest_environments
+            constraints:
+              - primaryKey:
+                  columnNames: event_id, environment_id
+                  constraintName: pk_${gravitee_prefix}events_latest_environments
 
         - createTable:
             tableName: ${gravitee_prefix}upgraders
             columns:
               - column: { name: id, type: nvarchar(255), constraints: { nullable: false } }
               - column: { name: applied_at, type: timestamp(6), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}upgraders
-            columnNames: id
-            tableName: ${gravitee_prefix}upgraders
+            constraints:
+              - primaryKey:
+                  columnNames: id
+                  constraintName: pk_${gravitee_prefix}upgraders
 
         - dropColumn:
             columnName: author_picture


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2184

## Description

Here is a PR to not add the primary keys after the create table. We currently have an issue with Mysql about that. Other pull requests are coming 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jvczrwojhp.chromatic.com)
<!-- Storybook placeholder end -->
