### PR TITLE
Test/2022+2075 api general and plans pages

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -18,7 +18,7 @@
 <ng-container *ngIf="generalForm" [formGroup]="generalForm">
   <mat-form-field class="name-field">
     <mat-label>Name</mat-label>
-    <input matInput formControlName="name" required />
+    <input matInput data-testid="api_planName" formControlName="name" required />
     <mat-error *ngIf="generalForm.get('name').hasError('required')">Name is required.</mat-error>
     <mat-error *ngIf="generalForm.get('name').hasError('maxlength')">The name has to be less than 50 characters long.</mat-error>
     <mat-hint align="end">{{ generalForm.get('name').value?.length || 0 }}/50</mat-hint>
@@ -26,7 +26,7 @@
 
   <mat-form-field class="description-field">
     <mat-label>Description</mat-label>
-    <textarea matInput formControlName="description"></textarea>
+    <textarea matInput data-testid="api_planDescription" formControlName="description"></textarea>
   </mat-form-field>
 
   <mat-form-field class="characteristics-field">

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
@@ -55,13 +55,13 @@
         <div class="details-card__header__info-inputs__first-row">
           <mat-form-field class="details-card__header__info-inputs__first-row__name-field">
             <mat-label>Name</mat-label>
-            <input #apiName matInput formControlName="name" required />
+            <input #apiName matInput formControlName="name" data-testid="generalName" required />
             <mat-error *ngIf="apiDetailsForm.controls.name.hasError('required')">Name is required.</mat-error>
           </mat-form-field>
 
           <mat-form-field class="details-card__header__info-inputs__first-row__version-field">
             <mat-label>Version</mat-label>
-            <input matInput formControlName="version" required maxlength="32" />
+            <input matInput formControlName="version" data-testid="generalVersion" required maxlength="32" />
             <mat-error *ngIf="apiDetailsForm.controls.version.hasError('required')">Version is required.</mat-error>
             <mat-error *ngIf="apiDetailsForm.controls.version.hasError('version')">{{
               apiDetailsForm.controls.version.getError('version')
@@ -71,13 +71,14 @@
         <div class="details-card__header__info-inputs__second-row">
           <mat-form-field class="details-card__header__info-inputs__second-row__description-field">
             <mat-label>Description</mat-label>
-            <textarea matInput formControlName="description"></textarea>
+            <textarea matInput formControlName="description" data-testid="generalDescription"></textarea>
           </mat-form-field>
 
           <mat-form-field class="etails-card__header__info-inputs__second-row__labels-field">
             <mat-label>Labels</mat-label>
             <gio-form-tags-input
               formControlName="labels"
+              data-testid="generalLabels"
               [addOnBlur]="false"
               [autocompleteOptions]="labelsAutocompleteOptions"
             ></gio-form-tags-input>
@@ -85,9 +86,9 @@
 
           <mat-form-field class="etails-card__header__info-inputs__second-row__categories-field">
             <mat-label>Categories</mat-label>
-            <mat-select formControlName="categories" multiple>
-              <mat-option *ngIf="apiCategories.length === 0" disabled>No categories available</mat-option>
-              <mat-option *ngFor="let category of apiCategories" [value]="category.key"
+            <mat-select formControlName="categories" data-testid="generalCategories" multiple>
+              <mat-option data-testid="categoryList" *ngIf="apiCategories.length === 0" disabled>No categories available</mat-option>
+              <mat-option *ngFor="let category of apiCategories" [value]="category.key" data-testid="categoryList"
                 >{{ category.name }} <em *ngIf="category.description"> - {{ category.description }}</em></mat-option
               >
             </mat-select>
@@ -184,5 +185,5 @@
 
   <api-portal-details-danger-zone class="danger-zone" [api]="api" (reloadDetails)="ngOnInit()"></api-portal-details-danger-zone>
 
-  <gio-save-bar [form]="parentForm" [formInitialValues]="initialApiDetailsFormValue" (submitted)="onSubmit()"></gio-save-bar>
+  <gio-save-bar [form]="parentForm" data-testid="apiGeneralSaveBar" [formInitialValues]="initialApiDetailsFormValue" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
@@ -31,6 +31,7 @@
     [creationMode]="mode === 'create'"
     [form]="planForm"
     [formInitialValues]="initialPlanFormValue"
+    data-testid="planCreate"
     [hideSubmitButton]="mode === 'create' && apiPlanForm.hasNextStep() === true"
   >
     <button
@@ -49,6 +50,7 @@
       gioFormFocusInvalid
       color="primary"
       type="button"
+      data-testid="planNext"
       (click)="apiPlanForm.nextStep()"
     >
       Next

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
@@ -23,6 +23,7 @@
       type="button"
       color="primary"
       aria-label="Add new plan"
+      data-testid="api_addPlan_button"
       [matMenuTriggerFor]="menu"
     >
       <mat-icon svgIcon="gio:plus"></mat-icon>Add new plan
@@ -152,6 +153,7 @@
               mat-icon-button
               aria-label="Close the plan"
               matTooltip="Close the plan"
+              data-testid="apiPlanClosePlan"
               (click)="closePlan(element)"
             >
               <mat-icon svgIcon="gio:cancel"></mat-icon>

--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -16,5 +16,5 @@ SIMPLE_USERNAME=user
 SIMPLE_PASSWORD=password
 
 # docker image registry and version
-APIM_REGISTRY=graviteeio
-APIM_TAG=3
+APIM_REGISTRY=graviteeio.azurecr.io
+APIM_TAG=master-latest

--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -16,5 +16,5 @@ SIMPLE_USERNAME=user
 SIMPLE_PASSWORD=password
 
 # docker image registry and version
-APIM_REGISTRY=graviteeio.azurecr.io
-APIM_TAG=master-latest
+APIM_REGISTRY=graviteeio
+APIM_TAG=3

--- a/gravitee-apim-e2e/tsconfig.json
+++ b/gravitee-apim-e2e/tsconfig.json
@@ -13,7 +13,8 @@
       "@model/*": ["ui-test/model/*"],
       "@commands/*": ["ui-test/commands/*"],
       "@api-test-resources/*": ["<rootDir>/api-test/resources/$1"],
-      "@lib/jest-utils": ["lib/jest-utils"]
+      "@lib/jest-utils": ["lib/jest-utils"],
+      "@pageobjects/*": ["ui-test/support/PageObjects/*"]
     }
   },
   "include": ["**/*.ts"]

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
@@ -25,60 +25,57 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.wait(1000)
             cy.contains('Home board').should('be.visible');
         });
-
-        // it('Navigate to Test (1) API', () => {
-        //     cy.visit('/')
-        //     HomePage.apis().click();
-        //     ApiHome.searchApi().click().type("Test");
-        //     cy.get('input').type('{enter}')
-        //     ApiHome.testApi().click().click();
-        //     cy.contains('Test (1)').should('be.visible');
-        //     ApiDetails.design().should('be.visible');
-        //     ApiDetails.general().should('be.visible');
-        //     ApiDetails.plans().should('be.visible');
-        // });
         
         it('Verify General Page Elements', () => {
             cy.visit('/#!/environments/default/apis/');
-            ApiHome.searchApi().click().type("Test");
+            cy.getByDataTestId('search').click().type("Test")
             cy.get('input').type('{enter}')
-            ApiHome.testApi().click().click();
-            cy.contains('Test (1)').should('be.visible');
-            ApiDetails.design().should('be.visible');
-            ApiDetails.general().should('be.visible');
-            ApiDetails.plans().should('be.visible');
-            ApiDetails.general().click();
-            ApiDetails.generalName().should('be.visible');
-            ApiDetails.generalVersion().should('be.visible');
-            ApiDetails.generalDescription().should('be.visible');
-            ApiDetails.generalLabels().should('be.visible');
-            ApiDetails.generalCategories().should('be.visible');
-            ApiDetails.generalCategories().click();
-            ApiDetails.categories().should('be.visible');
+            cy.wait(1000)
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            // cy.contains('Test (1)').should('be.visible');
+            cy.contains('Design').should('be.visible');
+            cy.contains('General').should('be.visible');
+            cy.contains('Plans').should('be.visible');
+            // ApiDetails.general().click();
+            // ^ I cannot pinpoint the html element for this button.
+            cy.getByDataTestId('generalName').should('be.visible');
+            cy.getByDataTestId('generalVersion').should('be.visible');
+            cy.getByDataTestId('generalDescription').should('be.visible');
+            cy.getByDataTestId('generalLabels').should('be.visible');
+            cy.getByDataTestId('generalCategories').should('be.visible');
+            cy.getByDataTestId('generalCategories').click();
+            cy.getByDataTestId('categoryList').should('be.visible');
         })
 
         it('Edit General Page and Verify changes', () => {
             cy.visit('/#!/environments/default/apis/');
-            ApiHome.searchApi().click().type("Test");
+            cy.getByDataTestId('search').click().type("Test");
             cy.get('input').type('{enter}')
-            ApiHome.testApi().click().click();
-            ApiDetails.general().click();
-            ApiDetails.generalName().should('be.visible');
-            ApiDetails.generalName().type(' EDIT');
             cy.wait(1000)
-            ApiDetails.saveDetails().click();
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            // ApiDetails.general().click();
+            // ^ I cannot pinpoint the html element for this button.
+            cy.getByDataTestId('generalName').should('be.visible');
+            cy.getByDataTestId('generalName').type(' EDIT');
+            cy.getByDataTestId('generalVersion').clear().type('1');
+            cy.wait(1000)
+            // // ApiDetails.saveDetails().click();
+            cy.getByDataTestId('apiGeneralSaveBar').contains('Save').click();
             cy.contains('Configuration successfully saved!').should('be.visible');
-            HomePage.apis().click();
-            ApiHome.searchApi().click().type("Test");
+            cy.visit('/#!/environments/default/apis/');
+            cy.getByDataTestId('search').click().type("EDIT");
             cy.get('input').type('{enter}');
-            cy.contains('Test EDIT (1)').should('be.visible');
-            cy.get('[href]').contains('Test EDIT (1)').click().click();
-            // cy.contains('Test EDIT (1)').click().click();
-            ApiDetails.generalName().should('be.visible');
-            ApiDetails.generalName().clear().type('Test')
-            cy.wait(1000)
-            ApiDetails.saveDetails().click();
-            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.contains('EDIT (1)').should('be.visible');
+            // ^ for now, test stops here to verify edited api until i figure out faker to generate a random api name
+
+            // cy.get('[href]').contains('EDIT (1)').click().click();
+            // cy.getByDataTestId('generalName').should('be.visible');
+            // cy.getByDataTestId('generalName').clear().type('Test');
+            // // ^ Could probably do with faker here to generate random name so this test is able to execute over and over.
+            // cy.wait(1000)
+            // // ApiDetails.saveDetails().click();
+            // cy.getByDataTestId('apiGeneralSaveDetails').click();
+            // cy.contains('Configuration successfully saved!').should('be.visible');
             })
 
     });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
@@ -53,18 +53,18 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.get('input').type('{enter}')
             cy.wait(1000)
             cy.getByDataTestId('api_list_edit_button').first().click();
-            // ApiDetails.general().click();
-            // ^ I cannot pinpoint the html element for this button.
+            ApiDetails.general().click();
+            // ^ I cannot pinpoint the html element for this button. 
+            // // ^ Page dynamically generated, therefore, use page object. 
             cy.getByDataTestId('generalName').should('be.visible');
             cy.getByDataTestId('generalName').type(' EDIT');
             cy.getByDataTestId('generalVersion').clear().type('1');
-            cy.wait(1000)
-            // // ApiDetails.saveDetails().click();
+            cy.wait(500)
+            // ^ ideally need to waitFor apiGeneralSaveBar, need to figure out correct command. 
             cy.getByDataTestId('apiGeneralSaveBar').contains('Save').click();
             cy.contains('Configuration successfully saved!').should('be.visible');
             cy.visit('/#!/environments/default/apis/');
-            cy.getByDataTestId('search').click().type("EDIT");
-            cy.get('input').type('{enter}');
+            cy.getByDataTestId('search').type("EDIT");
             cy.contains('EDIT (1)').should('be.visible');
             // ^ for now, test stops here to verify edited api until i figure out faker to generate a random api name
 

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
@@ -1,0 +1,84 @@
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { ApiEntity, PlanStatus } from '../../../../../lib/management-webclient-sdk/src/lib/models';
+import faker from '@faker-js/faker';
+
+import homePage from "@pageobjects/HomePage/HomePage"
+import apiHome from "@pageobjects/Apis/ApiHome"
+import apiDetails from '@pageobjects/Apis/ApiDetails';
+
+// This is purely for PageObject example and on hold for now until policy studio changes are completed.
+
+
+    describe('API General Page', () => {
+        beforeEach(() => {
+          cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
+        });
+
+        const HomePage = new homePage()
+        const ApiHome = new apiHome()
+        const ApiDetails = new apiDetails()
+
+        it('Verify Home Page', () => {
+            cy.visit('/')
+            cy.wait(1000)
+            cy.contains('Home board').should('be.visible');
+        });
+
+        // it('Navigate to Test (1) API', () => {
+        //     cy.visit('/')
+        //     HomePage.apis().click();
+        //     ApiHome.searchApi().click().type("Test");
+        //     cy.get('input').type('{enter}')
+        //     ApiHome.testApi().click().click();
+        //     cy.contains('Test (1)').should('be.visible');
+        //     ApiDetails.design().should('be.visible');
+        //     ApiDetails.general().should('be.visible');
+        //     ApiDetails.plans().should('be.visible');
+        // });
+        
+        it('Verify General Page Elements', () => {
+            cy.visit('/#!/environments/default/apis/');
+            ApiHome.searchApi().click().type("Test");
+            cy.get('input').type('{enter}')
+            ApiHome.testApi().click().click();
+            cy.contains('Test (1)').should('be.visible');
+            ApiDetails.design().should('be.visible');
+            ApiDetails.general().should('be.visible');
+            ApiDetails.plans().should('be.visible');
+            ApiDetails.general().click();
+            ApiDetails.generalName().should('be.visible');
+            ApiDetails.generalVersion().should('be.visible');
+            ApiDetails.generalDescription().should('be.visible');
+            ApiDetails.generalLabels().should('be.visible');
+            ApiDetails.generalCategories().should('be.visible');
+            ApiDetails.generalCategories().click();
+            ApiDetails.categories().should('be.visible');
+        })
+
+        it('Edit General Page and Verify changes', () => {
+            cy.visit('/#!/environments/default/apis/');
+            ApiHome.searchApi().click().type("Test");
+            cy.get('input').type('{enter}')
+            ApiHome.testApi().click().click();
+            ApiDetails.general().click();
+            ApiDetails.generalName().should('be.visible');
+            ApiDetails.generalName().type(' EDIT');
+            cy.wait(1000)
+            ApiDetails.saveDetails().click();
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            HomePage.apis().click();
+            ApiHome.searchApi().click().type("Test");
+            cy.get('input').type('{enter}');
+            cy.contains('Test EDIT (1)').should('be.visible');
+            cy.get('[href]').contains('Test EDIT (1)').click().click();
+            // cy.contains('Test EDIT (1)').click().click();
+            ApiDetails.generalName().should('be.visible');
+            ApiDetails.generalName().clear().type('Test')
+            cy.wait(1000)
+            ApiDetails.saveDetails().click();
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            })
+
+    });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -1,0 +1,49 @@
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { ApiEntity, PlanStatus } from '../../../../../lib/management-webclient-sdk/src/lib/models';
+import faker from '@faker-js/faker';
+
+import homePage from "@pageobjects/HomePage/HomePage"
+import apiHome from "@pageobjects/Apis/ApiHome"
+import apiDetails from '@pageobjects/Apis/ApiDetails';
+
+// This is purely for PageObject example and on hold for now until policy studio changes are completed.
+
+
+    describe('API Plans Feature', () => {
+        beforeEach(() => {
+          cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
+        });
+
+        const HomePage = new homePage()
+        const ApiHome = new apiHome()
+        const ApiDetails = new apiDetails()
+
+        it('Verify Home Page', () => {
+            cy.visit('/')
+            cy.wait(1000)
+            cy.contains('Home board').should('be.visible');
+        });
+
+        it('Navigate to Test (1) API', () => {
+        cy.visit('/')
+        HomePage.apis().click();
+        ApiHome.searchApi().click().type("Test");
+        ApiHome.testApi().click().click();
+        cy.contains('Test (1)').should('be.visible');
+        ApiDetails.design().should('be.visible');
+        ApiDetails.general().should('be.visible');
+        ApiDetails.plans().should('be.visible');
+        });
+        
+        it('Verify Existing Plan', () => {
+        cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+        ApiHome.testApi().click().click();
+        ApiDetails.plans().click();
+        cy.contains('STAGING').should('be.visible');
+        cy.contains('PUBLISHED').should('be.visible');
+        cy.contains('DEPRECATED').should('be.visible');
+        cy.contains('CLOSED').should('be.visible');
+        })
+    });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -27,10 +27,9 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
         });
         
         it('Verify Existing Plan', () => {
-            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
-            cy.getByDataTestId('search').click().type("Test");
-            cy.get('input').type('{enter}')
-            cy.wait(1000)
+            cy.visit('/#!/environments/default/apis/?page=1&size=10');
+            cy.getByDataTestId('search').type("Test");
+            cy.wait(500)
             cy.getByDataTestId('api_list_edit_button').first().click();
             cy.contains('Design').should('be.visible');
             cy.contains('General').should('be.visible');
@@ -41,7 +40,6 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.contains('DEPRECATED').should('be.visible');
             cy.contains('CLOSED').should('be.visible');
             cy.contains('Default Keyless').should('be.visible')
-            // I don't know if this is liable to change ... I am assuming we set up and look for / use same API every time.
         })
 
         it('Create a generic New Plan (API Key), verify and delete', () => {
@@ -52,13 +50,13 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.contains('PUBLISHED').should('be.visible');
             cy.contains('DEPRECATED').should('be.visible');
             cy.contains('CLOSED').should('be.visible');
-
             cy.getByDataTestId('api_addPlan_button').click();
             cy.contains('API Key').click();
 
             cy.getByDataTestId('api_planName').type('TestApiKey')
             cy.getByDataTestId('api_planDescription').type('Testy Test McTest')
             // ^ ^ Could probably do with being faker'd
+
             cy.getByDataTestId('planNext').click()
             cy.contains('selection rule').should('be.visible')
             cy.getByDataTestId('planNext').click()
@@ -71,9 +69,8 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.contains('TestApiKey').should('be.visible')
             // ^ would need readjusting after faker
             cy.getByDataTestId('apiPlanClosePlan').first().click()
-            cy.wait(1000)
             cy.get('[placeholder="TestApiKey"]').type('TestApiKey')
-            cy.contains('Yes, delete this plan').as('btn').click()
+            cy.contains('Yes, delete this plan').click()
             cy.contains('The plan TestApiKey has been closed with success.').should('be.visible')
             cy.wait(500)
             cy.contains('TestApiKey').should('not.exist')
@@ -109,7 +106,6 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.contains('TestOAuth2').should('be.visible')
             // ^ would need readjusting after faker
             cy.getByDataTestId('apiPlanClosePlan').first().click()
-            cy.wait(1000)
             cy.get('[placeholder="TestOAuth2"]').type('TestOAuth2')
             cy.contains('Yes, close this plan').as('btn').click()
             cy.contains('The plan TestOAuth2 has been closed with success.').should('be.visible')

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -25,18 +25,6 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.wait(1000)
             cy.contains('Home board').should('be.visible');
         });
-
-        // it('Navigate to Test API', () => {
-        //     cy.visit('/')
-        //     HomePage.apis().click();
-        //     cy.getByDataTestId('search').click().type("Test");
-        //     cy.get('input').type('{enter}')
-        //     cy.wait(1000)
-        //     cy.getByDataTestId('api_list_edit_button').first().click();
-        //     ApiDetails.design().should('be.visible');
-        //     ApiDetails.general().should('be.visible');
-        //     ApiDetails.plans().should('be.visible');
-        // });
         
         it('Verify Existing Plan', () => {
             cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -26,24 +26,174 @@ import apiDetails from '@pageobjects/Apis/ApiDetails';
             cy.contains('Home board').should('be.visible');
         });
 
-        it('Navigate to Test (1) API', () => {
-        cy.visit('/')
-        HomePage.apis().click();
-        ApiHome.searchApi().click().type("Test");
-        ApiHome.testApi().click().click();
-        cy.contains('Test (1)').should('be.visible');
-        ApiDetails.design().should('be.visible');
-        ApiDetails.general().should('be.visible');
-        ApiDetails.plans().should('be.visible');
-        });
+        // it('Navigate to Test API', () => {
+        //     cy.visit('/')
+        //     HomePage.apis().click();
+        //     cy.getByDataTestId('search').click().type("Test");
+        //     cy.get('input').type('{enter}')
+        //     cy.wait(1000)
+        //     cy.getByDataTestId('api_list_edit_button').first().click();
+        //     ApiDetails.design().should('be.visible');
+        //     ApiDetails.general().should('be.visible');
+        //     ApiDetails.plans().should('be.visible');
+        // });
         
         it('Verify Existing Plan', () => {
-        cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
-        ApiHome.testApi().click().click();
-        ApiDetails.plans().click();
-        cy.contains('STAGING').should('be.visible');
-        cy.contains('PUBLISHED').should('be.visible');
-        cy.contains('DEPRECATED').should('be.visible');
-        cy.contains('CLOSED').should('be.visible');
+            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+            cy.getByDataTestId('search').click().type("Test");
+            cy.get('input').type('{enter}')
+            cy.wait(1000)
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            cy.contains('Design').should('be.visible');
+            cy.contains('General').should('be.visible');
+            cy.contains('Plans').should('be.visible');
+            ApiDetails.plans().click();
+            cy.contains('STAGING').should('be.visible');
+            cy.contains('PUBLISHED').should('be.visible');
+            cy.contains('DEPRECATED').should('be.visible');
+            cy.contains('CLOSED').should('be.visible');
+            cy.contains('Default Keyless').should('be.visible')
+            // I don't know if this is liable to change ... I am assuming we set up and look for / use same API every time.
+        })
+
+        it('Create a generic New Plan (API Key), verify and delete', () => {
+            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            ApiDetails.plans().click();
+            cy.contains('STAGING').should('be.visible');
+            cy.contains('PUBLISHED').should('be.visible');
+            cy.contains('DEPRECATED').should('be.visible');
+            cy.contains('CLOSED').should('be.visible');
+
+            cy.getByDataTestId('api_addPlan_button').click();
+            cy.contains('API Key').click();
+
+            cy.getByDataTestId('api_planName').type('TestApiKey')
+            cy.getByDataTestId('api_planDescription').type('Testy Test McTest')
+            // ^ ^ Could probably do with being faker'd
+            cy.getByDataTestId('planNext').click()
+            cy.contains('selection rule').should('be.visible')
+            cy.getByDataTestId('planNext').click()
+            cy.contains('Rate Limiting').should('be.visible')
+            cy.contains('Quota').should('be.visible')
+            cy.contains('Resource Filtering').should('be.visible')
+            cy.contains('Create').as('btn').click()
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.contains('STAGING').as('btn').click()
+            cy.contains('TestApiKey').should('be.visible')
+            // ^ would need readjusting after faker
+            cy.getByDataTestId('apiPlanClosePlan').first().click()
+            cy.wait(1000)
+            cy.get('[placeholder="TestApiKey"]').type('TestApiKey')
+            cy.contains('Yes, delete this plan').as('btn').click()
+            cy.contains('The plan TestApiKey has been closed with success.').should('be.visible')
+            cy.wait(500)
+            cy.contains('TestApiKey').should('not.exist')
+        }),
+
+        it('Create a generic New Plan (OAuth2), verify and delete', () => {
+            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            ApiDetails.plans().click();
+            cy.contains('STAGING').should('be.visible');
+            cy.contains('PUBLISHED').should('be.visible');
+            cy.contains('DEPRECATED').should('be.visible');
+            cy.contains('CLOSED').should('be.visible');
+
+            cy.getByDataTestId('api_addPlan_button').click();
+            cy.contains('OAuth2').click();
+
+            cy.getByDataTestId('api_planName').type('TestOAuth2')
+            cy.getByDataTestId('api_planDescription').type('Testy Test McTest')
+            // ^ ^ Could probably do with being faker'd
+            cy.getByDataTestId('planNext').click()
+            // cy.get('[role="combobox"]').contains('OAuth2 resource').type('Test')
+            cy.get('#mat-input-7').type('Test')
+            // ^ I can't find html element for this, this doesn't feel good but was best I could do as OAuth2 Resource a mandatory field 
+            cy.contains('selection rule').should('be.visible')
+            cy.getByDataTestId('planNext').click()
+            cy.contains('Rate Limiting').should('be.visible')
+            cy.contains('Quota').should('be.visible')
+            cy.contains('Resource Filtering').should('be.visible')
+            cy.contains('Create').as('btn').click()
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.contains('STAGING').as('btn').click()
+            cy.contains('TestOAuth2').should('be.visible')
+            // ^ would need readjusting after faker
+            cy.getByDataTestId('apiPlanClosePlan').first().click()
+            cy.wait(1000)
+            cy.get('[placeholder="TestOAuth2"]').type('TestOAuth2')
+            cy.contains('Yes, close this plan').as('btn').click()
+            cy.contains('The plan TestOAuth2 has been closed with success.').should('be.visible')
+            cy.wait(500)
+            cy.contains('TestOAuth2').should('not.exist')
+        }),
+
+        it('Create a generic New Plan (JWT), verify and delete', () => {
+            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            ApiDetails.plans().click();
+            cy.contains('STAGING').should('be.visible');
+            cy.contains('PUBLISHED').should('be.visible');
+            cy.contains('DEPRECATED').should('be.visible');
+            cy.contains('CLOSED').should('be.visible');
+
+            cy.getByDataTestId('api_addPlan_button').click();
+            cy.contains('JWT').click();
+
+            cy.getByDataTestId('api_planName').type('TestJWT')
+            cy.getByDataTestId('api_planDescription').type('Testy Test McTest')
+            // ^ ^ Could probably do with being faker'd
+            cy.getByDataTestId('planNext').click()
+            cy.contains('selection rule').should('be.visible')
+            cy.getByDataTestId('planNext').click()
+            cy.contains('Rate Limiting').should('be.visible')
+            cy.contains('Quota').should('be.visible')
+            cy.contains('Resource Filtering').should('be.visible')
+            cy.contains('Create').as('btn').click()
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.contains('STAGING').as('btn').click()
+            cy.contains('TestJWT').should('be.visible')
+            // ^ would need readjusting after faker
+            cy.getByDataTestId('apiPlanClosePlan').first().click()
+            cy.wait(1000)
+            cy.get('[placeholder="TestJWT"]').type('TestJWT')
+            cy.contains('Yes, close this plan').as('btn').click()
+            cy.contains('The plan TestJWT has been closed with success.').should('be.visible')
+            cy.wait(500)
+            cy.contains('TestJWT').should('not.exist')
+        }),
+
+        it('Create a generic New Plan (Keyless), verify and delete', () => {
+            cy.visit('/#!/environments/default/apis/?q=Test&page=1&size=10');
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            ApiDetails.plans().click();
+            cy.contains('STAGING').should('be.visible');
+            cy.contains('PUBLISHED').should('be.visible');
+            cy.contains('DEPRECATED').should('be.visible');
+            cy.contains('CLOSED').should('be.visible');
+
+            cy.getByDataTestId('api_addPlan_button').click();
+            cy.contains('Keyless (public)').click();
+
+            cy.getByDataTestId('api_planName').type('TestKeyless')
+            cy.getByDataTestId('api_planDescription').type('Testy Test McTest')
+            // ^ ^ Could probably do with being faker'd
+            cy.getByDataTestId('planNext').click()
+            cy.contains('Rate Limiting').should('be.visible')
+            cy.contains('Quota').should('be.visible')
+            cy.contains('Resource Filtering').should('be.visible')
+            cy.contains('Create').as('btn').click()
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.contains('STAGING').as('btn').click()
+            cy.contains('TestKeyless').should('be.visible')
+            // ^ would need readjusting after faker
+            cy.getByDataTestId('apiPlanClosePlan').first().click()
+            cy.wait(1000)
+            cy.get('[placeholder="TestKeyless"]').type('TestKeyless')
+            cy.contains('Yes, close this plan').as('btn').click()
+            cy.contains('The plan TestKeyless has been closed with success.').should('be.visible')
+            cy.wait(500)
+            cy.contains('TestKeyless').should('not.exist')
         })
     });

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
@@ -1,0 +1,33 @@
+// gio-submenu-item__title and gio-submenu-item for Design
+
+class apiDetails {
+
+    design(){return cy.get('.gio-submenu-item').contains('Design')}
+
+    general(){return cy.get('.gio-submenu-item__title').contains('General')}
+
+    plans(){return cy.get('.gio-submenu-item__title').contains('Plans')}
+
+    // General
+
+    generalName(){return cy.get('[formcontrolname="name"]')}
+
+    generalVersion(){return cy.get('[formcontrolname="version"]')}
+    
+    generalDescription(){return cy.get('[formcontrolname="description"]')}
+
+    generalLabels(){return cy.get('[formcontrolname="labels"]')}
+
+    generalCategories(){return cy.get('[formcontrolname="categories"]')}
+
+    categories(){return cy.get('.mat-option-text')} 
+    // above Step Def would write as ApiDetails.categories().contains('[CATEGORY]').click()
+
+    saveDetails(){return cy.get('[type="submit"]').contains('Save')}
+
+
+    // Plans
+
+}
+
+export default apiDetails;

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
@@ -28,6 +28,20 @@ class apiDetails {
 
     // Plans
 
+    addPlan(){return cy.get('[type="button"]').contains('Add new plan')}
+
+    planOauth2(){return cy.get('[role="menuitem"]').contains('OAuth2')}
+    
+    planJwt(){return cy.get('[role="menuitem"]').contains('JWT')}
+
+    planApiKey(){return cy.get('[role="menuitem"]').contains('API Key')}
+
+    planName(){return cy.get('[formcontrolname="name"]')}
+
+    planDescription(){return cy.get('[formcontrolname="description"]')}
+
+    // planName(){return cy.get('[formcontrolname="name"]')}
+
 }
 
 export default apiDetails;

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiHome.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiHome.ts
@@ -1,0 +1,11 @@
+class apiHome {
+
+    addApi(){return cy.get('.mat-button-wrapper').contains('Add API')}
+
+    searchApi(){return cy.get('[data-testid="search"]')}
+
+    testApi(){return cy.get('[href]').contains('Test (1)')}
+
+}
+
+export default apiHome;

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiHome.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiHome.ts
@@ -4,7 +4,7 @@ class apiHome {
 
     searchApi(){return cy.get('[data-testid="search"]')}
 
-    testApi(){return cy.get('[href]').contains('Test (1)')}
+    testApi(){return cy.get('[data-layer="Content"]').first()}
 
 }
 

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/HomePage/DashBoard.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/HomePage/DashBoard.ts
@@ -1,0 +1,7 @@
+class dashBoard {
+
+    noOfApis(){return cy.get('.ng-binding').contains('Number of APIs')}
+
+}
+
+export default dashBoard;

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/HomePage/HomePage.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/HomePage/HomePage.ts
@@ -1,0 +1,31 @@
+class homePage {
+
+    dashboard(){return cy.get('.gio-menu-item__title').contains('Dashboard')}
+
+    apis(){return cy.get('.gio-menu-item__title').contains('APIs')}
+
+    applications(){return cy.get('.gio-menu-item__title').contains('Applications')}
+
+    gateways(){return cy.get('.gio-menu-item__title').contains('Gateways')}
+
+    audit(){return cy.get('.gio-menu-item__title').contains('Audit')}
+
+    messages(){return cy.get('.gio-menu-item__title').contains('Messages')}
+
+    analytics(){return cy.get('.gio-menu-item__title').contains('Analytics')}
+
+    alerts(){return cy.get('.gio-menu-item__title').contains('Alerts')}
+
+    settings(){return cy.get('.gio-menu-item__title').contains('Settings')}
+
+    help(){return cy.get('.btn').contains('Display contextual documentation')}
+
+    notifications(){return cy.get('.btn').contains('Open notifications')}
+
+    // vvv Not sure about this one, but you get the idea... 
+    userMenu(){return cy.get('.btn').contains('gio-user-menu')}
+    // class = .gio-user-menu__button-avatar mat-icon-button mat-button-base ???
+
+}
+
+export default homePage;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2075 

https://gravitee.atlassian.net/browse/APIM-2022

## Description

General and Plan pages for APIs in APIM. 

Off the back of former `kyle-apiplans` branch; fixed comments regarding as() command and other unnecessary steps. Next step is to merge, pull/rebase with master and work on faker steps for plan and general pages, generate api at start of test and in doing so will remove wait times etc. See other code comments. 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vaptsfdzfq.chromatic.com)
<!-- Storybook placeholder end -->
