### PR TITLE
fix: create primary keys the same time than the table in 4.0.0 changelog

### DIFF
--- a/.run/Repository - DistributedSync - Redis.run.xml
+++ b/.run/Repository - DistributedSync - Redis.run.xml
@@ -15,7 +15,7 @@
       </ENTRIES>
     </extension>
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.distributedsync" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - ES.run.xml
+++ b/.run/Repository - ES.run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-elasticsearch" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.elasticsearch" />
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - JDBC (MARIADB).run.xml
+++ b/.run/Repository - JDBC (MARIADB).run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-jdbc" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.management" />
     <option name="MAIN_CLASS_NAME" value="io.gravitee.repository.management.RepositoryTestSuite" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - JDBC (MYSQL).run.xml
+++ b/.run/Repository - JDBC (MYSQL).run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-jdbc" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.management" />
     <option name="MAIN_CLASS_NAME" value="io.gravitee.repository.management.RepositoryTestSuite" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - JDBC (POSTGRES).run.xml
+++ b/.run/Repository - JDBC (POSTGRES).run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-jdbc" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.management" />
     <option name="MAIN_CLASS_NAME" value="io.gravitee.repository.management.RepositoryTestSuite" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - JDBC (SQLSERVER).run.xml
+++ b/.run/Repository - JDBC (SQLSERVER).run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-jdbc" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.management" />
     <option name="MAIN_CLASS_NAME" value="io.gravitee.repository.management.RepositoryTestSuite" />
     <option name="METHOD_NAME" value="" />

--- a/.run/Repository - MongoDB.run.xml
+++ b/.run/Repository - MongoDB.run.xml
@@ -5,7 +5,7 @@
     </classpathModifications>
     <module name="gravitee-apim-repository-mongodb" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
-    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH" value="17" />
     <option name="PACKAGE_NAME" value="io.gravitee.repository.management" />
     <option name="MAIN_CLASS_NAME" value="io.gravitee.repository.management.RepositoryTestSuite" />
     <option name="METHOD_NAME" value="" />

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
@@ -15,10 +15,11 @@ databaseChangeLog:
               - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest
-            columnNames: id
-            tableName: ${gravitee_prefix}events_latest
+            constraints:
+              - primaryKey:
+                  columnNames: id
+                  constraintName: pk_${gravitee_prefix}events_latest
+
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_type
             columns:
@@ -40,10 +41,11 @@ databaseChangeLog:
               - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: property_value, type: nvarchar(256), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest_properties
-            columnNames: event_id, property_key
-            tableName: ${gravitee_prefix}events_latest_properties
+            constraints:
+              - primaryKey:
+                  columnNames: event_id, property_key
+                  constraintName: pk_${gravitee_prefix}events_latest_properties
+
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_properties_propertykey
             columns:
@@ -57,21 +59,20 @@ databaseChangeLog:
             columns:
               - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events_latest_environments
-            columnNames: event_id, environment_id
-            tableName: ${gravitee_prefix}events_latest_environments
+            constraints:
+              - primaryKey:
+                  columnNames: event_id, environment_id
+                  constraintName: pk_${gravitee_prefix}events_latest_environments
 
         - createTable:
             tableName: ${gravitee_prefix}upgraders
             columns:
               - column: { name: id, type: nvarchar(255), constraints: { nullable: false } }
               - column: { name: applied_at, type: timestamp(6), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}upgraders
-            columnNames: id
-            tableName: ${gravitee_prefix}upgraders
+            constraints:
+              - primaryKey:
+                  columnNames: id
+                  constraintName: pk_${gravitee_prefix}upgraders
 
         - dropColumn:
             columnName: author_picture

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_0/schema.yml
@@ -9,16 +9,12 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}events_latest
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_events_latest } }
               - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: payload, type: nclob, constraints: { nullable: true } }
               - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-            constraints:
-              - primaryKey:
-                  columnNames: id
-                  constraintName: pk_${gravitee_prefix}events_latest
 
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_type
@@ -38,13 +34,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}events_latest_properties
             columns:
-              - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_events_latest_properties } }
+              - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_events_latest_properties } }
               - column: {name: property_value, type: nvarchar(256), constraints: { nullable: true } }
-            constraints:
-              - primaryKey:
-                  columnNames: event_id, property_key
-                  constraintName: pk_${gravitee_prefix}events_latest_properties
 
         - createIndex:
             indexName: idx_${gravitee_prefix}events_latest_properties_propertykey
@@ -57,22 +49,14 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}events_latest_environments
             columns:
-              - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
-            constraints:
-              - primaryKey:
-                  columnNames: event_id, environment_id
-                  constraintName: pk_${gravitee_prefix}events_latest_environments
+              - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_events_latest_environments } }
+              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_events_latest_environments } }
 
         - createTable:
             tableName: ${gravitee_prefix}upgraders
             columns:
-              - column: { name: id, type: nvarchar(255), constraints: { nullable: false } }
+              - column: { name: id, type: nvarchar(255), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_upgraders } }
               - column: { name: applied_at, type: timestamp(6), constraints: { nullable: false } }
-            constraints:
-              - primaryKey:
-                  columnNames: id
-                  constraintName: pk_${gravitee_prefix}upgraders
 
         - dropColumn:
             columnName: author_picture


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2184

## Description

Here is a PR to not add the primary keys after the create table. We currently have an issue with Mysql about that. Other pull requests are coming

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wbwqsbhbth.chromatic.com)
<!-- Storybook placeholder end -->
