### PR TITLE
Add missing websocket config in gravitee.yml of the gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -52,6 +52,8 @@
 #    subProtocols: v10.stomp, v11.stomp, v12.stomp
 #    perMessageWebSocketCompressionSupported: true
 #    perFrameWebSocketCompressionSupported: true
+#    maxWebSocketFrameSize: 65536
+#    maxWebSocketMessageSize: 262144 # 4 full frames worth of data
 #  haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
 #    proxyProtocol: false
 #    proxyProtocolTimeout: 10000


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/6751
https://gravitee.atlassian.net/browse/APIM-863

## Description

Add missing websocket config in gravitee.yml of the gateway, these parameters are there for a long time but weren't listed anywhere so people were just thinking it was implemented.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kalctqywyx.chromatic.com)
<!-- Storybook placeholder end -->
