### PR TITLE
fix: restore api key mode choice on subscription creation

### DIFF
--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
@@ -39,3 +39,19 @@ export interface Subscription {
   client_id?: string;
   security?: string;
 }
+
+export interface ApplicationSubscription {
+  id?: string;
+  api?: string;
+  plan?: string;
+  application?: string;
+  status?: SubscriptionStatus;
+  security?: string;
+  consumerStatus?: string;
+  processed_at?: Date;
+  processed_by?: string;
+  subscribed_by?: User;
+  starting_at?: Date;
+  created_at?: Date;
+  updated_at?: Date;
+}

--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
@@ -37,4 +37,5 @@ export interface Subscription {
   closed_at?: Date;
   paused_at?: Date;
   client_id?: string;
+  security?: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/api-portal-subscriptions.module.ts
@@ -39,6 +39,7 @@ import {
 } from '@gravitee/ui-particles-angular';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 
 import { ApiPortalSubscriptionCreationDialogComponent } from './components/dialogs/creation/api-portal-subscription-creation-dialog.component';
 import { ApiPortalSubscriptionTransferDialogComponent } from './components/dialogs/transfer/api-portal-subscription-transfer-dialog.component';
@@ -98,6 +99,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioLoaderModule,
     GioPermissionModule,
     GioTableWrapperModule,
+    MatButtonToggleModule,
   ],
   providers: [DatePipe, { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],
 })

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
@@ -61,20 +61,36 @@
         formControlName="selectedPlan"
         arial-label="Select an plan"
         class="subscription-creation__content__plans"
+        [disabled]="!form.get('selectedApplication').value"
       >
         <mat-radio-button *ngFor="let plan of plans" [value]="plan" [disabled]="!!plan.generalConditions">
           {{ plan.name }}
         </mat-radio-button>
       </mat-radio-group>
 
-      <ng-container
-        *ngIf="
-          canUseCustomApiKey &&
-          form.get('selectedPlan').value?.security?.type === 'API_KEY' &&
-          form.get('selectedPlan').value?.apiId &&
-          form.get('selectedApplication').value?.id
-        "
-      >
+      <ng-container *ngIf="form.get('apiKeyMode')">
+        <div class="mat-body-1">
+          <p>You have to choose between two modes for your application :</p>
+          <ul>
+            <li><b>API Key</b> - a new API Key will be generated for each subscription</li>
+            <li><b>Shared API Key</b> - each subscription will use the same API Key</li>
+          </ul>
+        </div>
+        <div class="subscription-creation__content__keymode__warning">
+          <p>Please note that this choice is permanent.</p>
+        </div>
+        <mat-radio-group
+          aria-labelledby="radio-group-label"
+          formControlName="apiKeyMode"
+          arial-label="API Key Mode"
+          class="subscription-creation__content__keymode"
+        >
+          <mat-radio-button value="EXCLUSIVE">API Key</mat-radio-button>
+          <mat-radio-button value="SHARED">Shared API Key</mat-radio-button>
+        </mat-radio-group>
+      </ng-container>
+
+      <ng-container *ngIf="form.get('customApiKey')">
         <div class="mat-body-1">
           You can provide a custom API Key if you already have one. <br />
           Leave it blank to get a generated API Key.

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
@@ -61,9 +61,13 @@
         formControlName="selectedPlan"
         arial-label="Select an plan"
         class="subscription-creation__content__plans"
-        [disabled]="!form.get('selectedApplication').value"
+        [disabled]="!form.get('selectedApplication').value?.id"
       >
-        <mat-radio-button *ngFor="let plan of plans" [value]="plan" [disabled]="!!plan.generalConditions">
+        <mat-radio-button
+          *ngFor="let plan of plans"
+          [value]="plan"
+          [disabled]="!!plan.generalConditions || isPlanSubscribedBySelectedApp(plan)"
+        >
           {{ plan.name }}
         </mat-radio-button>
       </mat-radio-group>

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.scss
@@ -1,3 +1,7 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
 .subscription-creation {
   &__content {
     display: flex;
@@ -11,6 +15,17 @@
       margin-bottom: 12px;
       align-items: flex-start;
       gap: 8px;
+    }
+
+    &__keymode {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-around;
+      margin-bottom: 12px;
+
+      &__warning {
+        color: mat.get-color-from-palette(gio.$mat-warning-palette, default);
+      }
     }
 
     &__applications__option {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -46,9 +46,11 @@ import {
   Plan,
   VerifySubscription,
 } from '../../../../../../../entities/management-api-v2';
-import { Application } from '../../../../../../../entities/application/application';
+import { ApiKeyMode, Application } from '../../../../../../../entities/application/application';
 import { PagedResult } from '../../../../../../../entities/pagedResult';
 import { fakeApplication } from '../../../../../../../entities/application/Application.fixture';
+import { SubscriptionService } from '../../../../../../../services-ngx/subscription.service';
+import { PlanSecurityType } from '../../../../../../../entities/plan';
 
 @Component({
   selector: 'gio-dialog-test',
@@ -90,7 +92,7 @@ describe('Subscription creation dialog', () => {
   let httpTestingController: HttpTestingController;
 
   describe('Test customApiKey input', () => {
-    describe('With custom apiKey enabled', () => {
+    describe('With custom API Key enabled and shared API Key disabled', () => {
       beforeEach(() => {
         TestBed.configureTestingModule({
           declarations: [TestComponent],
@@ -109,6 +111,7 @@ describe('Subscription creation dialog', () => {
                 const constants = CONSTANTS_TESTING;
                 set(constants, 'env.settings.plan.security', {
                   customApiKey: { enabled: true },
+                  sharedApiKey: { enabled: false },
                 });
                 return constants;
               },
@@ -140,8 +143,7 @@ describe('Subscription creation dialog', () => {
 
         const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
-
-        await harness.choosePlan(planV4.name);
+        expect(await harness.isPlanRadioGroupEnabled()).toBeFalsy();
 
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
 
@@ -149,7 +151,11 @@ describe('Subscription creation dialog', () => {
         expectApplicationsSearch('withClientId', [applicationWithClientId]);
         await harness.selectApplication(applicationWithClientId.name);
 
+        expect(await harness.isPlanRadioGroupEnabled()).toBeTruthy();
+        await harness.choosePlan(planV4.name);
+
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeFalsy();
 
         await harness.addCustomKey('12345678');
         const req = httpTestingController.expectOne({
@@ -207,7 +213,187 @@ describe('Subscription creation dialog', () => {
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
       });
     });
-    describe('With custom apiKey disabled', () => {
+    describe('With custom API Key enabled and shared apiKey enabled', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestComponent],
+          imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
+          providers: [
+            { provide: SubscriptionService },
+            {
+              provide: InteractivityChecker,
+              useValue: {
+                isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+                isTabbable: () => true, // This traps tabbable checks and so avoid warnings when dealing with
+              },
+            },
+            {
+              provide: 'Constants',
+              useFactory: () => {
+                const constants = CONSTANTS_TESTING;
+                set(constants, 'env.settings.plan.security', {
+                  customApiKey: { enabled: true },
+                  sharedApiKey: { enabled: true },
+                });
+                return constants;
+              },
+            },
+          ],
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        httpTestingController = TestBed.inject(HttpTestingController);
+        fixture.detectChanges();
+        component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+      });
+
+      afterEach(() => {
+        jest.clearAllMocks();
+        httpTestingController.verify();
+      });
+
+      it('should be able to select API Key mode EXCLUSIVE and custom API Key', async () => {
+        const applicationWithClientId = fakeApplication({
+          id: 'my-app',
+          name: 'withClientId',
+          settings: { app: { client_id: 'clientId' } },
+          api_key_mode: ApiKeyMode.UNSPECIFIED,
+        });
+        const planV4 = fakePlanV4({ apiId: 'my-api', mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+        component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
+
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isPlanRadioGroupEnabled()).toBeFalsy();
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeFalsy();
+
+        await harness.searchApplication('withClientId');
+        expectApplicationsSearch('withClientId', [applicationWithClientId]);
+        await harness.selectApplication(applicationWithClientId.name);
+
+        expect(await harness.isPlanRadioGroupEnabled()).toBeTruthy();
+        await harness.choosePlan(planV4.name);
+
+        expectSubscriptionsForApplication(applicationWithClientId.id, [
+          {
+            security: PlanSecurityType.API_KEY,
+            api: {
+              id: 'another-plan-id',
+            },
+          },
+        ]);
+
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeTruthy();
+
+        await harness.chooseApiKeyMode('API Key');
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
+
+        await harness.addCustomKey('12345678');
+        const req = httpTestingController.expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/my-api/subscriptions/_verify`,
+          method: 'POST',
+        });
+        const verifySubscription: VerifySubscription = {
+          applicationId: 'my-app',
+          apiKey: '12345678',
+        };
+        expect(req.request.body).toEqual(verifySubscription);
+        req.flush({ ok: true });
+      });
+      it('should not be able to select API Key mode when no subscription and custom API Key', async () => {
+        const applicationWithClientId = fakeApplication({
+          id: 'my-app',
+          name: 'withClientId',
+          settings: { app: { client_id: 'clientId' } },
+          api_key_mode: ApiKeyMode.UNSPECIFIED,
+        });
+        const planV4 = fakePlanV4({ apiId: 'my-api', mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+        component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
+
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+        expect(await harness.isPlanRadioGroupEnabled()).toBeFalsy();
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeFalsy();
+
+        await harness.searchApplication('withClientId');
+        expectApplicationsSearch('withClientId', [applicationWithClientId]);
+        await harness.selectApplication(applicationWithClientId.name);
+
+        expect(await harness.isPlanRadioGroupEnabled()).toBeTruthy();
+        await harness.choosePlan(planV4.name);
+
+        expectSubscriptionsForApplication(applicationWithClientId.id, []);
+
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeFalsy();
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeTruthy();
+
+        await harness.addCustomKey('12345678');
+        const req = httpTestingController.expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/my-api/subscriptions/_verify`,
+          method: 'POST',
+        });
+        const verifySubscription: VerifySubscription = {
+          applicationId: 'my-app',
+          apiKey: '12345678',
+        };
+        expect(req.request.body).toEqual(verifySubscription);
+        req.flush({ ok: true });
+      });
+      it('should be able to select API Key mode SHARED and not custom API Key', async () => {
+        const applicationWithClientId = fakeApplication({
+          id: 'my-app',
+          name: 'withClientId',
+          settings: { app: { client_id: 'clientId' } },
+          api_key_mode: ApiKeyMode.UNSPECIFIED,
+        });
+        const planV4 = fakePlanV4({ apiId: 'my-api', mode: 'STANDARD', security: { type: 'API_KEY' }, generalConditions: undefined });
+        component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
+
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+        expect(await harness.isPlanRadioGroupEnabled()).toBeFalsy();
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeFalsy();
+
+        await harness.searchApplication('withClientId');
+        expectApplicationsSearch('withClientId', [applicationWithClientId]);
+        await harness.selectApplication(applicationWithClientId.name);
+
+        expect(await harness.isPlanRadioGroupEnabled()).toBeTruthy();
+        await harness.choosePlan(planV4.name);
+
+        expectSubscriptionsForApplication(applicationWithClientId.id, [
+          {
+            security: PlanSecurityType.API_KEY,
+            api: {
+              id: 'another-plan-id',
+            },
+          },
+        ]);
+
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeTruthy();
+
+        await harness.chooseApiKeyMode('Shared API Key');
+
+        expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      });
+    });
+    describe('With custom API Key disabled', () => {
       beforeEach(() => {
         TestBed.configureTestingModule({
           declarations: [TestComponent],
@@ -261,6 +447,12 @@ describe('Subscription creation dialog', () => {
   });
 
   describe('Test Push plan form', () => {
+    const applicationWithClientId = fakeApplication({
+      id: 'my-app',
+      name: 'withClientId',
+      settings: { app: { client_id: 'clientId' } },
+    });
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TestComponent],
@@ -288,7 +480,7 @@ describe('Subscription creation dialog', () => {
     });
 
     it('should have Push Plan configuration form', async () => {
-      const planV4 = fakePlanV4({ mode: 'PUSH', generalConditions: undefined });
+      const planV4 = fakePlanV4({ mode: 'PUSH', generalConditions: undefined, security: undefined });
       const apiV4 = fakeApiV4({ listeners: [{ type: 'SUBSCRIPTION', entrypoints: [{ type: 'webhook' }] }] });
       component.plans = [planV4];
       component.availableSubscriptionEntrypoints = apiV4.listeners[0].entrypoints;
@@ -299,6 +491,10 @@ describe('Subscription creation dialog', () => {
       expect(await harness.isChannelInputDisplayed()).toBeFalsy();
       expect(await harness.isEntrypointSelectDisplayed()).toBeFalsy();
       expect(await harness.isEntrypointConfigurationFormDisplayed()).toBeFalsy();
+
+      await harness.searchApplication('withClientId');
+      expectApplicationsSearch('withClientId', [applicationWithClientId]);
+      await harness.selectApplication(applicationWithClientId.name);
 
       await harness.choosePlan(planV4.name);
 
@@ -315,7 +511,7 @@ describe('Subscription creation dialog', () => {
     });
 
     it('should remove Push Plan configuration form when select another plan', async () => {
-      const pushPlanV4 = fakePlanV4({ name: 'push plan', mode: 'PUSH', generalConditions: undefined });
+      const pushPlanV4 = fakePlanV4({ name: 'push plan', mode: 'PUSH', generalConditions: undefined, security: undefined });
       const jwtPlanV4 = fakePlanV4({ name: 'JWT plan', mode: 'STANDARD', security: { type: 'JWT' }, generalConditions: undefined });
       const apiV4 = fakeApiV4({ listeners: [{ type: 'SUBSCRIPTION', entrypoints: [{ type: 'webhook' }] }] });
       component.plans = [pushPlanV4, jwtPlanV4];
@@ -324,6 +520,10 @@ describe('Subscription creation dialog', () => {
       expectListEntrypoints(entrypointsGetResponse);
 
       const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+      await harness.searchApplication('withClientId');
+      expectApplicationsSearch('withClientId', [applicationWithClientId]);
+      await harness.selectApplication(applicationWithClientId.name);
+
       await harness.choosePlan(pushPlanV4.name);
       await harness.selectEntrypoint('Webhook');
       expectEntrypointSubscriptionSchema('webhook');
@@ -424,6 +624,18 @@ describe('Subscription creation dialog', () => {
         method: 'GET',
       })
       .flush(entrypoints);
+    fixture.detectChanges();
+  }
+
+  function expectSubscriptionsForApplication(applicationId: string, subscriptions: Partial<any>[]) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/${applicationId}/subscriptions?expand=security`,
+        method: 'GET',
+      })
+      .flush(<PagedResult>{
+        data: [...subscriptions],
+      });
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -16,7 +16,7 @@
 
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { Observable, of, Subject } from 'rxjs';
+import { EMPTY, Observable, of, Subject } from 'rxjs';
 import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { debounceTime, distinctUntilChanged, filter, map, share, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { GioJsonSchema } from '@gravitee/ui-particles-angular';
@@ -24,11 +24,13 @@ import { has } from 'lodash';
 
 import { CreateSubscription, Entrypoint, Plan } from '../../../../../../../entities/management-api-v2';
 import { ApplicationService } from '../../../../../../../services-ngx/application.service';
-import { Application } from '../../../../../../../entities/application/application';
+import { ApiKeyMode, Application } from '../../../../../../../entities/application/application';
 import { PagedResult } from '../../../../../../../entities/pagedResult';
 import { Constants } from '../../../../../../../entities/Constants';
 import { ConnectorPluginsV2Service } from '../../../../../../../services-ngx/connector-plugins-v2.service';
 import { IconService } from '../../../../../../../services-ngx/icon.service';
+import { PlanSecurityType } from '../../../../../../../entities/plan';
+import { SubscriptionService } from '../../../../../../../services-ngx/subscription.service';
 
 export type ApiPortalSubscriptionCreationDialogData = {
   availableSubscriptionEntrypoints?: Entrypoint[];
@@ -36,6 +38,8 @@ export type ApiPortalSubscriptionCreationDialogData = {
 };
 
 export type ApiPortalSubscriptionCreationDialogResult = {
+  application: Application;
+  apiKeyMode?: ApiKeyMode;
   subscriptionToCreate: CreateSubscription;
 };
 
@@ -51,6 +55,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   public selectedSchema: GioJsonSchema;
   public showGeneralConditionsMsg: boolean;
   public canUseCustomApiKey: boolean;
+  public canUseSharedApiKeys: boolean;
 
   public form: FormGroup = new FormGroup({
     selectedPlan: new FormControl(undefined, [Validators.required]),
@@ -64,102 +69,37 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
     @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionCreationDialogData,
     @Inject('Constants') private readonly constants: Constants,
     private readonly applicationService: ApplicationService,
+    private readonly subscriptionService: SubscriptionService,
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
     private readonly iconService: IconService,
   ) {
     this.plans = dialogData.plans.filter((plan) => plan.security?.type !== 'KEY_LESS');
     this.availableSubscriptionEntrypoints = dialogData.availableSubscriptionEntrypoints.map((entrypoint) => ({ type: entrypoint.type }));
     this.canUseCustomApiKey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
+    this.canUseSharedApiKeys = this.constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 
   ngOnInit(): void {
     this.showGeneralConditionsMsg = this.plans.some((plan) => plan.generalConditions);
 
-    if (this.availableSubscriptionEntrypoints.length > 0) {
-      this.connectorPluginsV2Service
-        .listEntrypointPlugins()
-        .pipe(
-          tap((entrypointPlugins) =>
-            this.availableSubscriptionEntrypoints.forEach((entrypoint) => {
-              const connectorPlugin = entrypointPlugins.find((e) => e.id === entrypoint.type);
-              if (connectorPlugin) {
-                entrypoint.name = connectorPlugin.name;
-                entrypoint.icon = this.iconService.registerSvg(connectorPlugin.id, connectorPlugin.icon);
-              }
-            }),
-          ),
-        )
-        .subscribe();
-    }
+    this.prepareSubscriptionEntrypoints();
 
-    this.applications$ = this.form.get('selectedApplication').valueChanges.pipe(
-      distinctUntilChanged(),
-      debounceTime(100),
-      switchMap((term) =>
-        term.length > 0 ? this.applicationService.list('ACTIVE', term, 'name', 1, 20) : of(new PagedResult<Application>()),
-      ),
-      map((applicationsPage) => applicationsPage.data),
-      tap((_) => {
-        this.form.get('customApiKey')?.reset();
-      }),
-      share(),
-      takeUntil(this.unsubscribe$),
-    );
+    this.applications$ = this.onApplicationChange();
 
-    // If we select a PUSH Plan
-    this.form
-      .get('selectedPlan')
-      .valueChanges.pipe(
-        distinctUntilChanged(),
-        filter((plan) => plan.mode === 'PUSH'),
-        tap(() => {
-          this.form.removeControl('customApiKey');
-          this.form.addControl('selectedEntrypoint', new FormControl({}, Validators.required));
-          this.form.addControl('channel', new FormControl(undefined, []));
-        }),
-        switchMap(() => this.form.get('selectedEntrypoint').valueChanges),
-        switchMap((entrypointId) => this.connectorPluginsV2Service.getEntrypointPluginSubscriptionSchema(entrypointId)),
-        tap((subscriptionSchema) => {
-          this.selectedSchema = subscriptionSchema;
-          this.form.addControl('entrypointConfiguration', new FormControl({}, Validators.required));
-        }),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe();
-
-    // If we select an API Key Plan
-    this.form
-      .get('selectedPlan')
-      .valueChanges.pipe(
-        distinctUntilChanged(),
-        filter((plan) => plan.security?.type === 'API_KEY' && this.canUseCustomApiKey),
-        tap(() => {
-          this.form.addControl('customApiKey', new FormControl('', []));
-          this.form.removeControl('selectedEntrypoint');
-          this.form.removeControl('channel');
-          this.form.removeControl('entrypointConfiguration');
-        }),
-      )
-      .subscribe();
-
-    // If we select an OAuth2 or JWT Plan
-    this.form
-      .get('selectedPlan')
-      .valueChanges.pipe(
-        distinctUntilChanged(),
-        filter((plan) => plan.security?.type === 'OAUTH2' || plan.security?.type === 'JWT'),
-        tap(() => {
-          this.form.removeControl('customApiKey');
-          this.form.removeControl('selectedEntrypoint');
-          this.form.removeControl('channel');
-          this.form.removeControl('entrypointConfiguration');
-        }),
-      )
-      .subscribe();
+    this.onPushPlanChange();
+    this.onApiKeyPlanChange();
+    this.onApiKeyModeChange();
+    this.onJwtOrOauth2PlanChange();
   }
 
   onCreate() {
     const dialogResult = {
+      application: this.form.getRawValue().selectedApplication,
+      ...(this.form.getRawValue().apiKeyMode && this.form.getRawValue().apiKeyMode !== ''
+        ? {
+            apiKeyMode: this.form.getRawValue().apiKeyMode,
+          }
+        : {}),
       subscriptionToCreate: {
         planId: this.form.getRawValue().selectedPlan.id,
         applicationId: this.form.getRawValue().selectedApplication.id,
@@ -189,6 +129,143 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
 
   displayApplication(application: Application): string {
     return application?.name;
+  }
+
+  private prepareSubscriptionEntrypoints() {
+    if (this.availableSubscriptionEntrypoints.length > 0) {
+      this.connectorPluginsV2Service
+        .listEntrypointPlugins()
+        .pipe(
+          tap((entrypointPlugins) =>
+            this.availableSubscriptionEntrypoints.forEach((entrypoint) => {
+              const connectorPlugin = entrypointPlugins.find((e) => e.id === entrypoint.type);
+              if (connectorPlugin) {
+                entrypoint.name = connectorPlugin.name;
+                entrypoint.icon = this.iconService.registerSvg(connectorPlugin.id, connectorPlugin.icon);
+              }
+            }),
+          ),
+        )
+        .subscribe();
+    }
+  }
+
+  private onApplicationChange() {
+    return this.form.get('selectedApplication').valueChanges.pipe(
+      distinctUntilChanged(),
+      debounceTime(100),
+      switchMap((term) =>
+        term.length > 0 ? this.applicationService.list('ACTIVE', term, 'name', 1, 20) : of(new PagedResult<Application>()),
+      ),
+      map((applicationsPage) => applicationsPage.data),
+      tap((_) => {
+        this.form.get('selectedPlan')?.reset();
+        this.form.get('customApiKey')?.reset();
+        this.form.removeControl('apiKeyMode');
+        this.form.removeControl('customApiKey');
+      }),
+      share(),
+      takeUntil(this.unsubscribe$),
+    );
+  }
+
+  private onPushPlanChange() {
+    this.form
+      .get('selectedPlan')
+      .valueChanges.pipe(
+        distinctUntilChanged(),
+        filter((plan) => plan?.mode === 'PUSH'),
+        tap(() => {
+          this.form.removeControl('apiKeyMode');
+          this.form.removeControl('customApiKey');
+          this.form.addControl('selectedEntrypoint', new FormControl({}, Validators.required));
+          this.form.addControl('channel', new FormControl(undefined, []));
+        }),
+        switchMap(() => this.form.get('selectedEntrypoint').valueChanges),
+        switchMap((entrypointId) => this.connectorPluginsV2Service.getEntrypointPluginSubscriptionSchema(entrypointId)),
+        tap((subscriptionSchema) => {
+          this.selectedSchema = subscriptionSchema;
+          this.form.addControl('entrypointConfiguration', new FormControl({}, Validators.required));
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  private onApiKeyPlanChange() {
+    this.form
+      .get('selectedPlan')
+      .valueChanges.pipe(
+        distinctUntilChanged(),
+        filter((plan) => plan?.security?.type === 'API_KEY'),
+        switchMap((plan) => {
+          if (this.canUseSharedApiKeys && this.form.get('selectedApplication').value.api_key_mode === ApiKeyMode.UNSPECIFIED) {
+            return this.subscriptionService.getApplicationSubscriptions(this.form.get('selectedApplication').value.id).pipe(
+              map((subscriptions) => {
+                return (
+                  subscriptions.data.filter(
+                    (subscription) => subscription?.security === PlanSecurityType.API_KEY && subscription?.api?.id !== plan?.apiId,
+                  ).length >= 1
+                );
+              }),
+            );
+          }
+          return of(false);
+        }),
+        tap((shouldDisplayKeyModeChoice) => {
+          if (shouldDisplayKeyModeChoice) {
+            this.form.addControl('apiKeyMode', new FormControl('', [Validators.required]));
+          }
+          if (this.canUseCustomApiKey && !shouldDisplayKeyModeChoice) {
+            this.form.addControl('customApiKey', new FormControl('', []));
+          }
+          this.form.removeControl('selectedEntrypoint');
+          this.form.removeControl('channel');
+          this.form.removeControl('entrypointConfiguration');
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  private onApiKeyModeChange() {
+    this.form.valueChanges
+      .pipe(
+        switchMap(() => {
+          if (this.form.get('apiKeyMode')) {
+            return this.form.get('apiKeyMode').valueChanges;
+          }
+          return EMPTY;
+        }),
+        distinctUntilChanged(),
+        tap((value) => {
+          if (this.canUseCustomApiKey && value === ApiKeyMode.EXCLUSIVE) {
+            this.form.addControl('customApiKey', new FormControl('', []));
+          } else {
+            this.form.removeControl('customApiKey');
+          }
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  private onJwtOrOauth2PlanChange() {
+    this.form
+      .get('selectedPlan')
+      .valueChanges.pipe(
+        distinctUntilChanged(),
+        filter((plan) => plan?.security?.type === 'OAUTH2' || plan?.security?.type === 'JWT'),
+        tap(() => {
+          this.form.removeControl('apiKeyMode');
+          this.form.removeControl('customApiKey');
+          this.form.removeControl('selectedEntrypoint');
+          this.form.removeControl('channel');
+          this.form.removeControl('entrypointConfiguration');
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
@@ -32,6 +32,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
     MatFormFieldHarness.with({ selector: '.subscription-creation__content__applications' }),
   );
   protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
+  protected getApiKeyModeRadioGroup = this.locatorForOptional(MatRadioGroupHarness.with({ selector: '[formControlName="apiKeyMode"]' }));
   protected getCustomApiKeyInput = this.locatorForOptional(ApiKeyValidationHarness);
   protected getSelectEntrypointSelect = this.locatorForOptional(
     MatSelectHarness.with({ selector: '[formControlName="selectedEntrypoint"]' }),
@@ -72,15 +73,31 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
     return await matRadioGroupHarness.checkRadioButton({ label: planName });
   }
 
+  public async isPlanRadioGroupEnabled() {
+    const matRadioGroupHarness = await this.getPlansRadioGroup();
+    const group = await matRadioGroupHarness.host();
+    return (await group.getAttribute('ng-reflect-disabled')) !== 'true';
+  }
+
   // Custom API Key
   public async isCustomApiKeyInputDisplayed() {
     const matInputHarness = await this.getCustomApiKeyInput();
     return matInputHarness !== null;
   }
 
-  public async addCustomKey(customApiKey: string) {
+  public async isApiKeyModeRadioGroupDisplayed() {
+    const matRadioGroupHarness = await this.getApiKeyModeRadioGroup();
+    return matRadioGroupHarness !== null;
+  }
+
+  public async chooseApiKeyMode(label: string) {
+    const matRadioGroupHarness = await this.getApiKeyModeRadioGroup();
+    return await matRadioGroupHarness.checkRadioButton({ label });
+  }
+
+  public async addCustomKey(customApikey: string) {
     const matInputHarness = await this.getCustomApiKeyInput();
-    return await matInputHarness.setInputValue(customApiKey);
+    return await matInputHarness.setInputValue(customApikey);
   }
 
   // PUSH Plan

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
@@ -16,7 +16,7 @@
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
-import { MatRadioGroupHarness } from '@angular/material/radio/testing';
+import { MatRadioGroupHarness, RadioButtonHarnessFilters } from '@angular/material/radio/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
@@ -31,7 +31,7 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
   public getSelectedApplicationFormField = this.locatorFor(
     MatFormFieldHarness.with({ selector: '.subscription-creation__content__applications' }),
   );
-  protected getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
+  public getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
   protected getApiKeyModeRadioGroup = this.locatorForOptional(MatRadioGroupHarness.with({ selector: '[formControlName="apiKeyMode"]' }));
   protected getCustomApiKeyInput = this.locatorForOptional(ApiKeyValidationHarness);
   protected getSelectEntrypointSelect = this.locatorForOptional(
@@ -64,8 +64,8 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
   }
 
   // Plans
-  public async getRadioButtons() {
-    return (await this.getPlansRadioGroup()).getRadioButtons();
+  public async getRadioButtons(filter?: RadioButtonHarnessFilters) {
+    return (await this.getPlansRadioGroup()).getRadioButtons(filter);
   }
 
   public async choosePlan(planName: string) {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.spec.ts
@@ -53,6 +53,7 @@ import { ApiKeyMode, Application } from '../../../../../entities/application/app
 import { fakeApplication } from '../../../../../entities/application/Application.fixture';
 import { ApiPortalSubscriptionCreationDialogHarness } from '../components/dialogs/creation/api-portal-subscription-creation-dialog.harness';
 import { PlanSecurityType } from '../../../../../entities/plan';
+import { ApplicationSubscription } from '../../../../../entities/subscription/subscription';
 
 @Component({
   template: ` <api-portal-subscription-list #apiPortalSubscriptionList></api-portal-subscription-list> `,
@@ -404,16 +405,14 @@ describe('ApiPortalSubscriptionListComponent', () => {
       tick(400);
       expectApplicationsSearch('application', [application]);
       await creationDialogHarness.selectApplication('application');
-      await creationDialogHarness.choosePlan(planV4.name);
-
+      tick(400);
       expectSubscriptionsForApplication(application.id, [
         {
           security: PlanSecurityType.API_KEY,
-          api: {
-            id: 'another-plan-id',
-          },
+          api: 'another-plan-id',
         },
       ]);
+      await creationDialogHarness.choosePlan(planV4.name);
 
       expect(await creationDialogHarness.isCustomApiKeyInputDisplayed()).toBeFalsy();
 
@@ -461,16 +460,15 @@ describe('ApiPortalSubscriptionListComponent', () => {
       tick(400);
       expectApplicationsSearch('application', [application]);
       await creationDialogHarness.selectApplication('application');
-      await creationDialogHarness.choosePlan(planV4.name);
-
+      tick(400);
       expectSubscriptionsForApplication(application.id, [
         {
           security: PlanSecurityType.API_KEY,
-          api: {
-            id: 'another-plan-id',
-          },
+          api: 'another-plan-id',
         },
       ]);
+
+      await creationDialogHarness.choosePlan(planV4.name);
 
       expect(await creationDialogHarness.isCustomApiKeyInputDisplayed()).toBeFalsy();
 
@@ -845,7 +843,7 @@ describe('ApiPortalSubscriptionListComponent', () => {
     }
   }
 
-  function expectSubscriptionsForApplication(applicationId: string, subscriptions: Partial<any>[]) {
+  function expectSubscriptionsForApplication(applicationId: string, subscriptions: Partial<ApplicationSubscription>[]) {
     httpTestingController
       .expectOne({
         url: `${CONSTANTS_TESTING.env.baseURL}/applications/${applicationId}/subscriptions?expand=security`,

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
@@ -125,4 +125,32 @@ describe('ApplicationService', () => {
       req.flush(mockApplication);
     });
   });
+  describe('update', () => {
+    it('should call the API', (done) => {
+      const mockApplication = fakeApplication({ id: 'my-app-id' });
+
+      applicationService.update(mockApplication).subscribe((response) => {
+        expect(response).toMatchObject(mockApplication);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/my-app-id`,
+      });
+
+      expect(req.request.body).toEqual({
+        name: mockApplication.name,
+        description: mockApplication.description,
+        domain: mockApplication.domain,
+        groups: mockApplication.groups,
+        settings: mockApplication.settings,
+        picture_url: mockApplication.picture_url,
+        disable_membership_notifications: mockApplication.disable_membership_notifications,
+        api_key_mode: mockApplication.api_key_mode,
+      });
+
+      req.flush(mockApplication);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -74,4 +74,17 @@ export class ApplicationService {
   getById(applicationId: string): Observable<Application> {
     return this.http.get<Application>(`${this.constants.env.baseURL}/applications/${applicationId}`);
   }
+
+  update(application: Application): Observable<Application> {
+    return this.http.put<Application>(`${this.constants.env.baseURL}/applications/${application.id}`, {
+      name: application.name,
+      description: application.description,
+      domain: application.domain,
+      groups: application.groups,
+      settings: application.settings,
+      picture_url: application.picture_url,
+      disable_membership_notifications: application.disable_membership_notifications,
+      api_key_mode: application.api_key_mode,
+    });
+  }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/subscription.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription.service.spec.ts
@@ -22,6 +22,7 @@ import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
 import { fakeApi } from '../entities/api/Api.fixture';
 import { fakeSubscription } from '../entities/subscription/subscription.fixture';
 import { fakePlan } from '../entities/plan/plan.fixture';
+import { fakeApplication } from '../entities/application/Application.fixture';
 
 describe('SubscriptionService', () => {
   let httpTestingController: HttpTestingController;
@@ -56,6 +57,26 @@ describe('SubscriptionService', () => {
       const req = httpTestingController.expectOne({
         method: 'GET',
         url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/subscriptions?plan=${planId}&status=accepted,pending,rejected,closed,paused`,
+      });
+
+      req.flush([mockSubscription]);
+    });
+  });
+
+  describe('getApplicationSubscriptions', () => {
+    it('should get the application subscriptions', (done) => {
+      const app = fakeApplication({ id: 'API#1' });
+      const plan = fakePlan({ id: 'PLAN#1' });
+      const mockSubscription = fakeSubscription({ plan });
+
+      subscriptionService.getApplicationSubscriptions(app.id).subscribe((response) => {
+        expect(response).toMatchObject([mockSubscription]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/${app.id}/subscriptions?expand=security`,
       });
 
       req.flush([mockSubscription]);

--- a/gravitee-apim-console-webui/src/services-ngx/subscription.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription.service.ts
@@ -20,7 +20,7 @@ import { IScope } from 'angular';
 
 import { Constants } from '../entities/Constants';
 import { AjsRootScope } from '../ajs-upgraded-providers';
-import { Subscription } from '../entities/subscription/subscription';
+import { ApplicationSubscription, Subscription } from '../entities/subscription/subscription';
 import { PagedResult } from '../entities/pagedResult';
 
 @Injectable({
@@ -39,7 +39,9 @@ export class SubscriptionService {
     );
   }
 
-  public getApplicationSubscriptions(appId: string): Observable<PagedResult<Subscription>> {
-    return this.http.get<PagedResult<Subscription>>(`${this.constants.env.baseURL}/applications/${appId}/subscriptions?expand=security`);
+  public getApplicationSubscriptions(appId: string): Observable<PagedResult<ApplicationSubscription>> {
+    return this.http.get<PagedResult<ApplicationSubscription>>(
+      `${this.constants.env.baseURL}/applications/${appId}/subscriptions?expand=security`,
+    );
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/subscription.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/subscription.service.ts
@@ -38,4 +38,8 @@ export class SubscriptionService {
       `${this.constants.env.baseURL}/apis/${apiId}/subscriptions?plan=${planId}&status=accepted,pending,rejected,closed,paused`,
     );
   }
+
+  public getApplicationSubscriptions(appId: string): Observable<PagedResult<Subscription>> {
+    return this.http.get<PagedResult<Subscription>>(`${this.constants.env.baseURL}/applications/${appId}/subscriptions?expand=security`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2167

## Description

fix: restore api key mode choice on subscription creation
- disable plan selection till application is not selected

![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/3e4697de-f807-4770-9565-7c7fea60ec40)

- add api key mode choice if setting is enabled and chain it with custom api key selection if enabled
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/29aed0ec-794d-4006-900a-01d13d156592)

- update application with api_key_mode

fix: disable plan already subscribed by current app

![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/27ada89b-caf9-45de-ab39-3242e82737b3)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fymcohetvh.chromatic.com)
<!-- Storybook placeholder end -->
