### PR TITLE
feat(helm): add auto basic header

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -27,3 +27,4 @@ annotations:
     - Change readinessProbe for the gateway to sync-process
     - Update Elasticsearch version
     - Allow plugin override via {api|gatewaye}.additionalPlugins property
+    - Add auto generate Authorization header on gateway probes when authentication basic is set. 

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -162,17 +162,57 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .Values.gateway.deployment.livenessProbe.enabled }}
-          livenessProbe: {{- omit .Values.gateway.deployment.livenessProbe "enabled" | toYaml | nindent 12 }}
+          livenessProbe:
+            periodSeconds: 15
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /_node/health?probes=http-server
+              scheme: HTTP
+              port: 18082
+              {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
+              httpHeaders:
+                - name: Authorization
+                  value: {{ print "Basic " }}{{print "admin:" .Values.gateway.services.core.http.authentication.password | b64enc }}
+              {{- end }}
           {{- else if .Values.gateway.deployment.customLivenessProbe }}
           livenessProbe: {{ toYaml .Values.gateway.deployment.customLivenessProbe | nindent 12 }}
           {{- end }}
           {{- if .Values.gateway.deployment.readinessProbe.enabled }}
-          readinessProbe: {{- omit .Values.gateway.deployment.readinessProbe "enabled" | toYaml | nindent 12 }}
+          readinessProbe:
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 2
+            httpGet:
+              path: /_node/health?probes=sync-process
+              scheme: HTTP
+              port: 18082
+              {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
+              httpHeaders:
+                - name: Authorization
+                  value: {{ print "Basic " }}{{print "admin:" .Values.gateway.services.core.http.authentication.password | b64enc }}
+              {{- end }}
           {{- else if .Values.gateway.deployment.customReadinessProbe }}
           readinessProbe: {{ toYaml .Values.gateway.deployment.customReadinessProbe | nindent 12 }}
           {{- end }}
           {{- if and (.Values.gateway.deployment.startupProbe.enabled) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-          startupProbe: {{- omit .Values.gateway.deployment.startupProbe "enabled" | toYaml | nindent 12 }}
+          startupProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 29
+            httpGet:
+              path: /_node/health?probes=http-server
+              scheme: HTTP
+              port: 18082
+              {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
+              httpHeaders:
+                - name: Authorization
+                  value: {{ print "Basic " }}{{print "admin:" .Values.gateway.services.core.http.authentication.password | b64enc }}
+              {{- end }}
           {{- else if and (.Values.gateway.deployment.customStartupProbe) (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
           startupProbe: {{ toYaml .Values.gateway.deployment.customStartupProbe | nindent 12 }}
           {{- end }}

--- a/helm/tests/gateway/deployment_probes_test.yaml
+++ b/helm/tests/gateway/deployment_probes_test.yaml
@@ -9,8 +9,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /_node/health?probes=sync-process
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders[0].value
+          value: Basic YWRtaW46YWRtaW5hZG1pbg==
       - isEmpty:
           path: spec.template.spec.containers[0].readinessProbe.tcpSocket
+
+  - it: Check default readinessProbe without security
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              authentication:
+                type: none
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /_node/health?probes=sync-process
+      - isEmpty:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders
 
   - it: Check default livenessProbe
     template: gateway/gateway-deployment.yaml
@@ -18,8 +37,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /_node/health?probes=http-server
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders[0].value
+          value: Basic YWRtaW46YWRtaW5hZG1pbg==
       - isEmpty:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket
+
+  - it: Check default livenessProbe without security
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              authentication:
+                type: none
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /_node/health?probes=http-server
+      - isEmpty:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders
 
   - it: Check default startupProbe
     template: gateway/gateway-deployment.yaml
@@ -27,8 +65,27 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
           value: /_node/health?probes=http-server
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders[0].value
+          value: Basic YWRtaW46YWRtaW5hZG1pbg==
       - isEmpty:
           path: spec.template.spec.containers[0].startupProbe.tcpSocket
+
+  - it: Check default startupProbe without security
+    template: gateway/gateway-deployment.yaml
+    set:
+      gateway:
+        services:
+          core:
+            http:
+              authentication:
+                type: none
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /_node/health?probes=http-server
+      - isEmpty:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders
 
   - it: Check custom readinessProbe
     template: gateway/gateway-deployment.yaml

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -743,18 +743,6 @@ gateway:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      timeoutSeconds: 1
-      successThreshold: 1
-      failureThreshold: 29
-      httpGet:
-        path: /_node/health?probes=http-server
-        scheme: HTTP
-        port: 18082
-        httpHeaders:
-        - name: Authorization
-          value: Basic YWRtaW46YWRtaW5hZG1pbg==
 
     # set startupProbe.enabled: false to define your own StartupProbe
     customStartupProbe: {}
@@ -765,17 +753,6 @@ gateway:
 
     livenessProbe:
       enabled: true
-      periodSeconds: 15
-      timeoutSeconds: 2
-      successThreshold: 1
-      failureThreshold: 3
-      httpGet:
-        path: /_node/health?probes=http-server
-        scheme: HTTP
-        port: 18082
-        httpHeaders:
-        - name: Authorization
-          value: Basic YWRtaW46YWRtaW5hZG1pbg==
 
     # set livenessProbe.enabled: false to define your own livenessProbe
     customLivenessProbe: {}
@@ -787,17 +764,6 @@ gateway:
 
     readinessProbe:
       enabled: true
-      periodSeconds: 10
-      timeoutSeconds: 2
-      successThreshold: 1
-      failureThreshold: 2
-      httpGet:
-        path: /_node/health?probes=sync-process
-        scheme: HTTP
-        port: 18082
-        httpHeaders:
-        - name: Authorization
-          value: Basic YWRtaW46YWRtaW5hZG1pbg==
 
     # set readinessProbe.enabled: false to define your own readinessProbe
     customReadinessProbe: {}


### PR DESCRIPTION
Helm: Auto generate Authorization header on gateway probes when authentication basic is set.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qevcuwabcb.chromatic.com)
<!-- Storybook placeholder end -->
