### PR TITLE
Apim 2220 permissions 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -221,7 +221,7 @@ const states: Ng2StateDeclaration[] = [
       useAngularMaterial: true,
       docs: null,
       apiPermissions: {
-        only: ['api-subscription-u'],
+        only: ['api-subscription-r', 'api-subscription-u'],
       },
     },
   },

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.html
@@ -53,6 +53,7 @@
           mat-icon-button
           aria-label="Delete"
           [class.gio-form-listeners__table__row__td__button__hide]="listenerFormArray.controls.length <= 1"
+          *ngIf="!isDisabled"
           (click)="onDelete(controlIndex)"
         >
           <mat-icon svgIcon="gio:cancel"></mat-icon>
@@ -62,4 +63,6 @@
   </tbody>
 </table>
 
-<button class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">Add context-path</button>
+<button *ngIf="!isDisabled" class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">
+  Add context-path
+</button>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
@@ -71,6 +71,7 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
     [this.listenersAsyncValidator()],
   );
   public contextPathPrefix: string;
+  public isDisabled = false;
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   public onDelete(pathIndex: number): void {
@@ -145,6 +146,13 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
   // From ControlValueAccessor interface
   public registerOnTouched(fn: () => void): void {
     this._onTouched = fn;
+  }
+
+  // From ControlValueAccessor interface
+  public setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+
+    isDisabled ? this.mainForm?.disable() : this.mainForm?.enable();
   }
 
   public initForm(): void {

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.harness.ts
@@ -80,4 +80,8 @@ export class GioFormListenersContextPathHarness extends ComponentHarness {
 
     await pathInput.setValue(path);
   }
+
+  public async getAddButton(): Promise<MatButtonHarness> {
+    return this.addButton();
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
@@ -243,4 +243,21 @@ describe('GioFormListenersContextPathModule', () => {
     expect(testComponent.formControl.touched).toEqual(true);
     expect(testComponent.formControl.dirty).toEqual(true);
   });
+
+  it('should not show add button or delete button and be unmodifiable when disabled', async () => {
+    testComponent.formControl = new FormControl({ value: LISTENERS, disabled: true });
+
+    const formPaths = await loader.getHarness(GioFormListenersContextPathHarness);
+
+    const contextPathRow = (await formPaths.getListenerRows())[1];
+    expectApiVerify();
+
+    expect(await contextPathRow.pathInput.isDisabled()).toEqual(true);
+    expect(await contextPathRow.removeButton).toBeFalsy();
+
+    await formPaths
+      .getAddButton()
+      .then((_) => fail('The add button should not appear'))
+      .catch((err) => expect(err).toBeTruthy());
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.html
@@ -83,7 +83,7 @@
           <gio-form-label>Enable</gio-form-label>
         </gio-form-slide-toggle>
       </td>
-      <td class="gio-form-listeners__table__row__td">
+      <td class="gio-form-listeners__table__row__td" *ngIf="!isDisabled">
         <button
           mat-icon-button
           type="button"
@@ -99,4 +99,6 @@
   </tbody>
 </table>
 
-<button class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">Add context-path</button>
+<button *ngIf="!isDisabled" class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">
+  Add context-path
+</button>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.module.spec.ts
@@ -206,7 +206,7 @@ describe('GioFormListenersVirtualHostModule', () => {
     expect(initialContextPathRows.length).toEqual(2);
 
     const contextPathRowToRemove = initialContextPathRows[1];
-    await contextPathRowToRemove.removeButton?.click();
+    await contextPathRowToRemove.removeButton.click();
 
     const newContextPathRows = await formContextPaths.getListenerRows();
     expect(newContextPathRows.length).toEqual(1);
@@ -246,5 +246,23 @@ describe('GioFormListenersVirtualHostModule', () => {
 
     expect(testComponent.formControl.touched).toEqual(true);
     expect(testComponent.formControl.dirty).toEqual(true);
+  });
+
+  it('should not show delete or add buttons and the context paths should be unmodifiable when disabled', async () => {
+    testComponent.formControl = new FormControl({ value: LISTENERS, disabled: true });
+
+    const formPaths = await loader.getHarness(GioFormListenersVirtualHostHarness);
+
+    const contextPathRow = (await formPaths.getListenerRows())[1];
+
+    expect(await contextPathRow.pathInput.isDisabled()).toEqual(true);
+    expect(await contextPathRow.removeButton).toBeFalsy();
+    expect(await contextPathRow.hostSubDomainInput.isDisabled()).toEqual(true);
+    expect(await contextPathRow.overrideAccessInput.isDisabled()).toEqual(true);
+
+    await formPaths
+      .getAddButton()
+      .then((_) => fail('The add button should not appear'))
+      .catch((err) => expect(err).toBeTruthy());
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -50,15 +50,17 @@
           >
             <mat-icon svgIcon="gio:arrow-down"></mat-icon>
           </button>
-          <button
-            *ngIf="groupsTableData?.length > 1"
-            mat-stroked-button
-            aria-label="Delete endpoints group"
-            (click)="deleteGroup(group.name)"
-          >
-            <mat-icon svgIcon="gio:trash"></mat-icon>
-            Delete
-          </button>
+          <ng-container *gioPermission="{ anyOf: ['api-definition-u'] }">
+            <button
+              *ngIf="groupsTableData?.length > 1"
+              mat-stroked-button
+              aria-label="Delete endpoints group"
+              (click)="deleteGroup(group.name)"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+              Delete
+            </button>
+          </ng-container>
         </div>
       </div>
       <mat-card-content>
@@ -97,7 +99,7 @@
           <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef id="actions">Actions</th>
             <td mat-cell *matCellDef="let element; let j = index">
-              <div class="endpoints-group-card__table__actions">
+              <div class="endpoints-group-card__table__actions" *gioPermission="{ anyOf: ['api-definition-u'] }">
                 <a mat-icon-button aria-label="Edit endpoint" matTooltip="Edit endpoint" (click)="editEndpoint(i, j)">
                   <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
                 </a>
@@ -128,7 +130,14 @@
             <td class="mat-cell" [attr.colspan]="endpointsDisplayedColumns.length">No Endpoints</td>
           </tr>
         </table>
-        <a mat-stroked-button aria-label="Add endpoint" class="add_endpoint" (click)="addEndpoint(i)">Add endpoint</a>
+        <a
+          *gioPermission="{ anyOf: ['api-definition-u'] }"
+          mat-stroked-button
+          aria-label="Add endpoint"
+          class="add_endpoint"
+          (click)="addEndpoint(i)"
+          >Add endpoint</a
+        >
       </mat-card-content>
     </ng-container>
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
@@ -40,6 +40,10 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
       .then((element) => element.click());
   }
 
+  public async isEndpointGroupDeleteButtonVisible(): Promise<boolean> {
+    return this.getDeleteEndpointGroupButtons().then((buttons) => buttons?.length > 0);
+  }
+
   public async deleteEndpoint(index: number, rootLoader: HarnessLoader) {
     const button = (await this.getDeleteEndpointButtons())[index];
     await button.click();
@@ -53,14 +57,26 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
     return this.getDeleteEndpointButtons().then((buttons) => buttons[index].isDisabled());
   }
 
+  public async isEndpointDeleteButtonVisible(): Promise<boolean> {
+    return this.getDeleteEndpointButtons().then((buttons) => buttons?.length > 0);
+  }
+
   public async clickAddEndpoint(index: number) {
     const button = (await this.getAddEndpointButtons())[index];
     return button.click();
   }
 
+  public async isAddEndpointButtonVisible(): Promise<boolean> {
+    return this.getAddEndpointButtons().then((buttons) => buttons?.length > 0);
+  }
+
   public async clickEditEndpoint(index: number) {
     const button = (await this.getEditEndpointButtons())[index];
     return button.click();
+  }
+
+  public async isEditEndpointButtonVisible(): Promise<boolean> {
+    return this.getEditEndpointButtons().then((buttons) => buttons?.length > 0);
   }
 
   public async moveGroupUp(index: number) {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
@@ -27,6 +27,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { ApiEndpointsGroupsComponent } from './api-endpoints-groups.component';
 
 import { ApiEndpointModule } from '../endpoint/api-endpoint.module';
+import { GioPermissionModule } from '../../../../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
   declarations: [ApiEndpointsGroupsComponent],
@@ -42,6 +43,7 @@ import { ApiEndpointModule } from '../endpoint/api-endpoint.module';
     GioIconsModule,
 
     ApiEndpointModule,
+    GioPermissionModule,
   ],
 })
 export class ApiEndpointsGroupsModule {}

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -22,7 +22,7 @@
         <div class="entrypoints__context-path__title">
           <span class="mat-body-strong">Entrypoint context-paths</span>
 
-          <button id="switchListenerType" mat-button type="button" (click)="switchEntrypointsMode()">
+          <button *ngIf="canUpdate" id="switchListenerType" mat-button type="button" (click)="switchEntrypointsMode()">
             <ng-container *ngIf="!this.enableVirtualHost"> <mat-icon svgIcon="gio:check"></mat-icon> Enable virtual hosts </ng-container>
             <ng-container *ngIf="this.enableVirtualHost"> <mat-icon svgIcon="gio:cancel"></mat-icon> Disable virtual hosts </ng-container>
           </button>
@@ -40,7 +40,7 @@
           [domainRestrictions]="domainRestrictions"
         ></gio-form-listeners-virtual-host>
       </div>
-      <div class="entrypoints__footer">
+      <div class="entrypoints__footer" *ngIf="canUpdate">
         <button
           mat-flat-button
           color="primary"
@@ -66,22 +66,30 @@
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let element" class="entrypoints__type__table__actions">
-            <button type="button" mat-icon-button aria-label="Edit" (click)="onEdit(element)">
-              <mat-icon svgIcon="gio:edit-pencil" matTooltip="Edit"> </mat-icon>
-            </button>
-            <button type="button" [disabled]="dataSource.length <= 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
-              <mat-icon
-                svgIcon="gio:trash"
-                [matTooltip]="dataSource.length <= 1 ? 'At least one entrypoint is required' : 'Delete'"
-              ></mat-icon>
-            </button>
+            <ng-container *ngIf="canUpdate">
+              <button type="button" mat-icon-button aria-label="Edit" (click)="onEdit(element)">
+                <mat-icon svgIcon="gio:edit-pencil" matTooltip="Edit"> </mat-icon>
+              </button>
+              <button type="button" [disabled]="dataSource.length <= 1" mat-icon-button aria-label="Delete" (click)="onDelete(element)">
+                <mat-icon
+                  svgIcon="gio:trash"
+                  [matTooltip]="dataSource.length <= 1 ? 'At least one entrypoint is required' : 'Delete'"
+                ></mat-icon>
+              </button>
+            </ng-container>
           </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns" class="entrypoints__type__table__header"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
       </table>
-      <button mat-stroked-button type="button" [disabled]="entrypointAvailableForAdd.length < 1" (click)="addNewEntrypoint()">
+      <button
+        *ngIf="canUpdate"
+        mat-stroked-button
+        type="button"
+        [disabled]="entrypointAvailableForAdd.length < 1"
+        (click)="addNewEntrypoint()"
+      >
         Add an entrypoint
       </button>
     </div>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
@@ -32,6 +32,7 @@ import { IconService } from '../../../services-ngx/icon.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { EnvironmentService } from '../../../services-ngx/environment.service';
 import { ConnectorVM, fromConnector } from '../creation-v4/models/ConnectorVM';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 type EntrypointVM = {
   id: string;
@@ -56,6 +57,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit {
   public apiExistingPaths: PathV4[] = [];
   public domainRestrictions: string[] = [];
   public entrypointAvailableForAdd: ConnectorVM[] = [];
+  private canUpdate = false;
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
     @Inject(UIRouterState) private readonly ajsState: StateService,
@@ -66,12 +68,15 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit {
     private readonly iconService: IconService,
     private readonly snackBarService: SnackBarService,
     private readonly matDialog: MatDialog,
+    private readonly permissionService: GioPermissionService,
     private readonly changeDetector: ChangeDetectorRef,
   ) {
     this.apiId = this.ajsStateParams.apiId;
   }
 
   ngOnInit(): void {
+    this.canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
+
     forkJoin([
       this.environmentService.getCurrent(),
       this.apiService.get(this.apiId),
@@ -97,7 +102,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit {
       this.apiExistingPaths = httpListeners.flatMap((listener) => {
         return (listener as HttpListener).paths;
       });
-      this.pathsFormControl = this.formBuilder.control(this.apiExistingPaths, Validators.required);
+      this.pathsFormControl = this.formBuilder.control({ value: this.apiExistingPaths, disabled: !this.canUpdate }, Validators.required);
       this.formGroup.addControl('paths', this.pathsFormControl);
       this.enableVirtualHost = this.apiExistingPaths.some((path) => path.host !== undefined);
     } else {

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
@@ -148,12 +148,14 @@
     </div>
 
     <div class="details-card__actions">
-      <button mat-button class="details-card__actions_btn" (click)="exportApi()"><mat-icon svgIcon="gio:upload"></mat-icon> Export</button>
+      <button *gioPermission="{ anyOf: ['api-definition-r'] }" mat-button class="details-card__actions_btn" (click)="exportApi()">
+        <mat-icon svgIcon="gio:upload"></mat-icon> Export
+      </button>
       <button
-        *gioPermission="{ anyOf: ['api-definition-u'] }"
+        *gioPermission="{ anyOf: ['api-definition-c'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="isReadOnly || api.definitionVersion === 'V4'"
+        [disabled]="isKubernetesOrigin || api.definitionVersion === 'V4'"
         (click)="importApi()"
       >
         <mat-icon svgIcon="gio:download"></mat-icon> Import
@@ -162,7 +164,7 @@
         *gioPermission="{ anyOf: ['api-definition-c'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="isReadOnly || api.definitionVersion === 'V4'"
+        [disabled]="isKubernetesOrigin || api.definitionVersion === 'V4'"
         (click)="duplicateApi()"
       >
         <mat-icon svgIcon="gio:copy"></mat-icon> Duplicate
@@ -171,7 +173,7 @@
         *gioPermission="{ anyOf: ['api-definition-u'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="!canPromote || isReadOnly || api.definitionVersion === 'V4'"
+        [disabled]="!canPromote || isKubernetesOrigin || api.definitionVersion === 'V4'"
         (click)="promoteApi()"
       >
         <mat-icon svgIcon="gio:language"></mat-icon> Promote

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.spec.ts
@@ -40,7 +40,7 @@ import { Api, fakeApiV2, fakeApiV4 } from '../../../../entities/management-api-v
 describe('ApiPortalDetailsComponent', () => {
   const API_ID = 'apiId';
   const currentUser = new User();
-  currentUser.userPermissions = ['api-definition-u', 'api-definition-d', 'api-definition-c'];
+  currentUser.userPermissions = ['api-definition-u', 'api-definition-d', 'api-definition-c', 'api-definition-r'];
   const fakeAjsState = {
     go: jest.fn().mockReturnValue({}),
   };

--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.ts
@@ -88,6 +88,7 @@ export class ApiPortalDetailsComponent implements OnInit, OnDestroy {
   public isQualityEnabled = false;
 
   public isReadOnly = false;
+  public isKubernetesOrigin = false;
   public updateState: 'TO_UPDATE' | 'IN_PROGRESS' | 'UPDATED' | undefined;
 
   constructor(
@@ -130,7 +131,8 @@ export class ApiPortalDetailsComponent implements OnInit, OnDestroy {
           ),
         ),
         tap(([api, categories]) => {
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || this.isKubernetesOrigin;
 
           this.apiId = api.id;
           this.api = api;

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
@@ -17,14 +17,7 @@
 -->
 <div class="plans__header">
   <div *ngIf="!isReadOnly && plansTableDS && !isLoadingData">
-    <button
-      *gioPermission="{ anyOf: ['api-plan-u'] }"
-      mat-raised-button
-      type="button"
-      color="primary"
-      aria-label="Add new plan"
-      [matMenuTriggerFor]="menu"
-    >
+    <button mat-raised-button type="button" color="primary" aria-label="Add new plan" [matMenuTriggerFor]="menu">
       <mat-icon svgIcon="gio:plus"></mat-icon>Add new plan
     </button>
     <mat-menu #menu="matMenu">
@@ -103,57 +96,27 @@
       <div class="plans__table__actions">
         <ng-container *ngIf="!isReadOnly; else readOnlyPlanActions">
           <ng-container *ngIf="element.status !== 'CLOSED'">
-            <button
-              *gioPermission="{ anyOf: ['api-plan-u'] }"
-              mat-icon-button
-              aria-label="Edit the plan"
-              matTooltip="Edit the plan"
-              (click)="navigateToPlan(element.id)"
-            >
+            <button mat-icon-button aria-label="Edit the plan" matTooltip="Edit the plan" (click)="navigateToPlan(element.id)">
               <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
             </button>
           </ng-container>
           <ng-container *ngIf="isV2Api && element.status !== 'CLOSED'">
-            <button
-              *gioPermission="{ anyOf: ['api-plan-u'] }"
-              mat-icon-button
-              aria-label="Design the plan"
-              matTooltip="Design the plan"
-              (click)="designPlan(element.id)"
-            >
+            <button mat-icon-button aria-label="Design the plan" matTooltip="Design the plan" (click)="designPlan(element.id)">
               <mat-icon svgIcon="gio:shield-check"></mat-icon>
             </button>
           </ng-container>
           <ng-container *ngIf="element.status === 'STAGING'">
-            <button
-              *gioPermission="{ anyOf: ['api-plan-u'] }"
-              mat-icon-button
-              aria-label="Publish the plan"
-              matTooltip="Publish the plan"
-              (click)="publishPlan(element)"
-            >
+            <button mat-icon-button aria-label="Publish the plan" matTooltip="Publish the plan" (click)="publishPlan(element)">
               <mat-icon svgIcon="gio:upload-cloud"></mat-icon>
             </button>
           </ng-container>
           <ng-container *ngIf="element.status === 'PUBLISHED'">
-            <button
-              *gioPermission="{ anyOf: ['api-plan-u'] }"
-              mat-icon-button
-              aria-label="Deprecate the plan"
-              matTooltip="Deprecate the plan"
-              (click)="deprecatePlan(element)"
-            >
+            <button mat-icon-button aria-label="Deprecate the plan" matTooltip="Deprecate the plan" (click)="deprecatePlan(element)">
               <mat-icon svgIcon="gio:cloud-unpublished"></mat-icon>
             </button>
           </ng-container>
           <ng-container *ngIf="element.status !== 'CLOSED'">
-            <button
-              *gioPermission="{ anyOf: ['api-plan-u'] }"
-              mat-icon-button
-              aria-label="Close the plan"
-              matTooltip="Close the plan"
-              (click)="closePlan(element)"
-            >
+            <button mat-icon-button aria-label="Close the plan" matTooltip="Close the plan" (click)="closePlan(element)">
               <mat-icon svgIcon="gio:cancel"></mat-icon>
             </button>
           </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.html
@@ -20,8 +20,9 @@
     <h2>Manage your subscriptions</h2>
   </div>
 
-  <div *ngIf="!isReadOnly && subscriptionsTableDS && !isLoadingData" class="subscriptions__header__buttons">
+  <div *ngIf="!isKubernetesOrigin && subscriptionsTableDS && !isLoadingData" class="subscriptions__header__buttons">
     <button
+      *gioPermission="{ anyOf: ['api-subscription-r'] }"
       mat-raised-button
       type="button"
       [disabled]="isLoadingData || subscriptionsTableDS.length === 0"
@@ -158,9 +159,8 @@
       <th mat-header-cell *matHeaderCellDef id="actions"></th>
       <td mat-cell *matCellDef="let element">
         <div class="subscriptions__table__actions">
-          <ng-container *ngIf="!isReadOnly; else readOnlyPlanActions">
+          <ng-container *ngIf="canUpdate; else readOnlyPlanActions">
             <button
-              *gioPermission="{ anyOf: ['api-subscription-u'] }"
               mat-icon-button
               aria-label="Edit the subscription"
               matTooltip="Edit the subscription"

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/list/api-portal-subscription-list.component.ts
@@ -104,9 +104,9 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
   private api: Api;
 
   public isLoadingData = true;
-  public isReadOnly = false;
+  public canUpdate = false;
   private routeBase: string;
-
+  private isKubernetesOrigin = false;
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
     @Inject(UIRouterState) private readonly ajsState: StateService,
@@ -148,9 +148,8 @@ export class ApiPortalSubscriptionListComponent implements OnInit, OnDestroy {
       .pipe(
         tap((api) => {
           this.api = api;
-          this.isReadOnly =
-            !this.permissionService.hasAnyMatching(['api-subscription-u', 'api-subscription-c']) ||
-            api.definitionContext?.origin === 'KUBERNETES';
+          this.isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+          this.canUpdate = this.permissionService.hasAnyMatching(['api-subscription-u']) && !this.isKubernetesOrigin;
         }),
         switchMap(() => this.apiPlanService.list(this.ajsStateParams.apiId, null, null, null, 1, 9999)),
         tap((plansResponse) => (this.plans = plansResponse.data)),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2220

## Description

- Clean up permissions for v4 resources
- Hide buttons when user does not have the permissions to access them

Entrypoints page without update permissions / in read-only mode:

<img width="1039" alt="Screen Shot 2023-07-13 at 11 14 33" src="https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1b821693-5746-45ed-9745-ccd1b238c897">
<img width="1030" alt="Screen Shot 2023-07-13 at 11 15 24" src="https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1500e1c1-4edd-4766-ac83-ba778962f256">
<img width="1031" alt="Screen Shot 2023-07-13 at 11 17 22" src="https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1ad90f8a-89f9-4ff8-a5fb-850ea473a39d">



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vxtuekroui.chromatic.com)
<!-- Storybook placeholder end -->
