### PR TITLE
fix: add in-memory cache with ttl to reduce hash time computation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -182,6 +182,12 @@
             <artifactId>gravitee-node-container</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-cache-plugin-standalone</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -52,6 +52,7 @@ import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
@@ -133,8 +134,8 @@ public class ApiHandlerConfiguration {
     }
 
     @Bean
-    public ApiProcessorChainFactory apiProcessorChainFactory() {
-        return new ApiProcessorChainFactory(configuration, node);
+    public ApiProcessorChainFactory apiProcessorChainFactory(final CacheManager cacheManager) {
+        return new ApiProcessorChainFactory(configuration, node, cacheManager);
     }
 
     @Bean
@@ -187,9 +188,15 @@ public class ApiHandlerConfiguration {
 
     @Bean
     public io.gravitee.gateway.reactive.handlers.api.v4.processor.ApiProcessorChainFactory v4ApiProcessorChainFactory(
-        final ReporterService reporterService
+        final ReporterService reporterService,
+        final CacheManager cacheManager
     ) {
-        return new io.gravitee.gateway.reactive.handlers.api.v4.processor.ApiProcessorChainFactory(configuration, node, reporterService);
+        return new io.gravitee.gateway.reactive.handlers.api.v4.processor.ApiProcessorChainFactory(
+            configuration,
+            node,
+            reporterService,
+            cacheManager
+        );
     }
 
     @Bean
@@ -202,7 +209,8 @@ public class ApiHandlerConfiguration {
         OrganizationManager organizationManager,
         io.gravitee.gateway.reactive.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
-        ReporterService reporterService
+        ReporterService reporterService,
+        CacheManager cacheManager
     ) {
         return new DefaultApiReactorFactory(
             applicationContext,
@@ -216,7 +224,8 @@ public class ApiHandlerConfiguration {
             organizationManager,
             flowResolverFactory,
             requestTimeoutConfiguration,
-            reporterService
+            reporterService,
+            cacheManager
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -57,6 +57,7 @@ import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.gateway.resource.internal.ResourceConfigurationFactoryImpl;
 import io.gravitee.gateway.resource.internal.v4.DefaultResourceManager;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
@@ -110,7 +111,8 @@ public class DefaultApiReactorFactory implements ReactorFactory<Api> {
         final OrganizationManager organizationManager,
         final io.gravitee.gateway.reactive.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory,
         final RequestTimeoutConfiguration requestTimeoutConfiguration,
-        final ReporterService reporterService
+        final ReporterService reporterService,
+        final CacheManager cacheManager
     ) {
         this.applicationContext = applicationContext;
         this.configuration = configuration;
@@ -121,7 +123,7 @@ public class DefaultApiReactorFactory implements ReactorFactory<Api> {
         this.apiServicePluginManager = apiServicePluginManager;
         this.organizationPolicyChainFactoryManager = organizationPolicyChainFactoryManager;
         this.organizationManager = organizationManager;
-        this.apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
+        this.apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService, cacheManager);
         this.flowResolverFactory = flowResolverFactory;
         this.v4FlowResolverFactory = flowResolverFactory();
         this.requestTimeoutConfiguration = requestTimeoutConfiguration;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -44,6 +44,7 @@ import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRespons
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.pathparameters.PathParametersExtractor;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.configuration.Configuration;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,15 +63,22 @@ public class ApiProcessorChainFactory {
     private final Node node;
     private final Configuration configuration;
     protected final ReporterService reporterService;
+    private final CacheManager cacheManager;
     private final List<ProcessorHook> processorHooks = new ArrayList<>();
 
-    public ApiProcessorChainFactory(final Configuration configuration, final Node node, final ReporterService reporterService) {
+    public ApiProcessorChainFactory(
+        final Configuration configuration,
+        final Node node,
+        final ReporterService reporterService,
+        final CacheManager cacheManager
+    ) {
         this.configuration = configuration;
         this.overrideXForwardedPrefix = configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false);
         this.clientIdentifierHeader =
             configuration.getProperty("handlers.request.client.header", String.class, DEFAULT_CLIENT_IDENTIFIER_HEADER);
         this.node = node;
         this.reporterService = reporterService;
+        this.cacheManager = cacheManager;
 
         boolean tracing = configuration.getProperty("services.tracing.enabled", Boolean.class, false);
         if (tracing) {
@@ -140,7 +148,7 @@ public class ApiProcessorChainFactory {
                 processors.add(new PathParametersProcessor(extractor));
             }
 
-            processors.add(SubscriptionProcessor.instance(clientIdentifierHeader));
+            processors.add(SubscriptionProcessor.instance(clientIdentifierHeader, cacheManager));
         }
 
         return new ProcessorChain("processor-chain-before-api-execution", processors, processorHooks);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
@@ -42,7 +42,9 @@ import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitPro
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
 import java.util.Map;
@@ -68,14 +70,16 @@ class ApiProcessorChainFactoryTest {
     private Node node;
 
     private ApiProcessorChainFactory apiProcessorChainFactory;
+    private CacheManager standaloneCacheManager;
 
     @BeforeEach
     public void beforeEach() {
+        standaloneCacheManager = new StandaloneCacheManager();
         when(configuration.getProperty("services.tracing.enabled", Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty("handlers.request.client.header", String.class, DEFAULT_CLIENT_IDENTIFIER_HEADER))
             .thenReturn(DEFAULT_CLIENT_IDENTIFIER_HEADER);
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, standaloneCacheManager);
     }
 
     @Test
@@ -159,7 +163,7 @@ class ApiProcessorChainFactoryTest {
     @Test
     void shouldReturnXForwardedBeforeApiExecutionWithOverrideXForwarded() {
         when(configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false)).thenReturn(true);
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, standaloneCacheManager);
 
         io.gravitee.definition.model.Api apiModel = new io.gravitee.definition.model.Api();
         final Proxy proxy = new Proxy();
@@ -179,7 +183,7 @@ class ApiProcessorChainFactoryTest {
 
     @Test
     void shouldReturnPathParamProcessorBeforeApiExecution() {
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, standaloneCacheManager);
 
         io.gravitee.definition.model.Api apiModel = new io.gravitee.definition.model.Api();
         final Proxy proxy = new Proxy();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorBenchmark.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.processor.subscription;
+
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_APPLICATION;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_PLAN;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_SUBSCRIPTION_ID;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.REMOTE_ADDRESS_HASHES_CACHE;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessorTest.APPLICATION_ID;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessorTest.PLAN_ID;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessorTest.REMOTE_ADDRESS;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessorTest.TRANSACTION_ID;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
+import io.gravitee.gateway.reactive.core.context.MutableResponse;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.vertx.core.MultiMap;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 2)
+public class SubscriptionProcessorBenchmark {
+
+    private static SubscriptionProcessor cut;
+    private static StandaloneCacheManager cacheManager;
+    private DefaultExecutionContext executionContext;
+
+    // used to run benchmark directly from IDE
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(SubscriptionProcessor.class.getSimpleName()).forks(1).build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        MutableRequest mockRequest = mock(MutableRequest.class);
+        MutableResponse mockResponse = mock(MutableResponse.class);
+        lenient().when(mockRequest.headers()).thenReturn(requestHeaders);
+        lenient().when(mockResponse.headers()).thenReturn(responseHeaders);
+        lenient().when(mockRequest.remoteAddress()).thenReturn(REMOTE_ADDRESS);
+        lenient().when(mockRequest.transactionId()).thenReturn(TRANSACTION_ID);
+
+        VertxHttpHeaders requestParams = new VertxHttpHeaders(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(mockRequest.parameters()).thenReturn(requestParams);
+
+        executionContext = new DefaultExecutionContext(mockRequest, mockResponse);
+        executionContext.setAttribute(ATTR_PLAN, PLAN_ID);
+        executionContext.setAttribute(ATTR_APPLICATION, APPLICATION_ID);
+        executionContext.setAttribute(ATTR_SUBSCRIPTION_ID, REMOTE_ADDRESS);
+        executionContext.metrics(Metrics.builder().timestamp(System.currentTimeMillis()).build());
+
+        cacheManager = new StandaloneCacheManager();
+        cut = SubscriptionProcessor.instance(null, cacheManager);
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDown() {
+        cacheManager.destroy(REMOTE_ADDRESS_HASHES_CACHE);
+    }
+
+    @Benchmark
+    public void bench_hash_computation() {
+        try {
+            cut.execute(executionContext).blockingAwait();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -49,6 +49,7 @@ import io.gravitee.gateway.resource.internal.v4.DefaultResourceManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
@@ -141,7 +142,8 @@ public class DefaultApiReactorFactoryTest {
                 organizationManager,
                 flowResolverFactory,
                 requestTimeoutConfiguration,
-                reporterService
+                reporterService,
+                new StandaloneCacheManager()
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -45,7 +45,9 @@ import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequest
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
 import java.util.Set;
@@ -73,14 +75,16 @@ class ApiProcessorChainFactoryTest {
     private ReporterService reporterService;
 
     private ApiProcessorChainFactory apiProcessorChainFactory;
+    private CacheManager standaloneCacheManager;
 
     @BeforeEach
     public void beforeEach() {
+        standaloneCacheManager = new StandaloneCacheManager();
         when(configuration.getProperty("services.tracing.enabled", Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty("handlers.request.client.header", String.class, DEFAULT_CLIENT_IDENTIFIER_HEADER))
             .thenReturn(DEFAULT_CLIENT_IDENTIFIER_HEADER);
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService, standaloneCacheManager);
     }
 
     @Test
@@ -173,7 +177,7 @@ class ApiProcessorChainFactoryTest {
     @Test
     void shouldReturnXForwardedBeforeApiExecutionChainWithHttpListenerAndOverrideXForwarded() {
         when(configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false)).thenReturn(true);
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService, standaloneCacheManager);
 
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
         HttpListener httpListener = new HttpListener();
@@ -192,7 +196,7 @@ class ApiProcessorChainFactoryTest {
 
     @Test
     void shouldReturnPathParamProcessorBeforeApiExecution() {
-        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
+        apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService, standaloneCacheManager);
 
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
         HttpListener httpListener = new HttpListener();

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <!-- Version properties -->
         <revision>4.2.0</revision>
         <sha1/>
-        <changelist>-SNAPSHOT</changelist>
+        <changelist>-optimize-client-identifier-computation-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
         <vertx.version>4.4.6</vertx.version>
@@ -271,7 +271,7 @@
         <gravitee-endpoint-rabbitmq.version>1.3.0</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.1.0</gravitee-endpoint-solace.version>
         <gravitee-resource-schema-registry-confluent.version>2.0.0</gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>2.0.0-alpha.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>2.0.0-optimize-client-identifier-computation-SNAPSHOT</gravitee-reactor-message.version>
         <gravitee-repository-bridge.version>4.0.1</gravitee-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>1.0.0-alpha.3</gravitee-secretprovider-hc-vault.version>
 


### PR DESCRIPTION
## Description

When using a keyless plan, the remote address is used as a client identifier. To avoid divulging sensitive data, we hash it before. However, that is CPU consuming and so the idea here is to add a in-memory cache with short ttl to deal with a burst of requests.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-powzsiohaa.chromatic.com)
<!-- Storybook placeholder end -->
