### PR TITLE
Use a tooltip when no plan type available

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-list.component.html
@@ -18,12 +18,17 @@
 <div class="step-4-security-1-plans-list__header">
   <div class="step-4-security-1-plans-list__header__title">Your API plans</div>
 
-  <button mat-stroked-button type="button" aria-label="Add new plan" [matMenuTriggerFor]="menu">
-    <mat-icon svgIcon="gio:plus"></mat-icon>Add plan
-  </button>
-  <mat-menu #menu="matMenu">
-    <button mat-menu-item *ngFor="let planMenuItem of planMenuItems" (click)="addPlan(planMenuItem)">{{ planMenuItem.name }}</button>
-  </mat-menu>
+  <div
+    [matTooltip]="'No compatible plan type enabled for entrypoints. This is configured under Settings > Portal > Settings > Console.'"
+    [matTooltipDisabled]="planMenuItems?.length > 0"
+  >
+    <button mat-stroked-button type="button" aria-label="Add new plan" [matMenuTriggerFor]="menu" [disabled]="planMenuItems?.length === 0">
+      <mat-icon svgIcon="gio:plus"></mat-icon>Add plan
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item *ngFor="let planMenuItem of planMenuItems" (click)="addPlan(planMenuItem)">{{ planMenuItem.name }}</button>
+    </mat-menu>
+  </div>
 </div>
 <form [formGroup]="form" (ngSubmit)="save()">
   <table mat-table class="step-4-security-1-plans-list__table" [dataSource]="plans" aria-label="security plans">

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -18,7 +18,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { ApiType, CreatePlanV4 } from '../../../../../entities/management-api-v2';
-import { AVAILABLE_PLANS_FOR_MENU, PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
+import { AVAILABLE_PLANS_FOR_MENU, ConstantsService, PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
 import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 
 @Component({
@@ -36,7 +36,7 @@ export class Step4Security1PlansComponent implements OnInit {
   selectedPlanMenuItem: PlanMenuItemVM;
   public apiType: ApiType;
 
-  constructor(private readonly stepService: ApiCreationStepService) {}
+  constructor(private readonly stepService: ApiCreationStepService, private readonly constantsService: ConstantsService) {}
 
   ngOnInit(): void {
     const currentStepPayload = this.stepService.payload;
@@ -52,8 +52,9 @@ export class Step4Security1PlansComponent implements OnInit {
   }
 
   private computeDefaultApiPlans(currentStepPayload: ApiCreationPayload) {
+    const availablePlanMenuItems = this.constantsService.getEnabledPlanMenuItems();
     const entrypoint = currentStepPayload.selectedEntrypoints.find((e) => e.supportedListenerType !== 'SUBSCRIPTION');
-    if (entrypoint) {
+    if (entrypoint && availablePlanMenuItems.some((p) => p.planFormType === 'KEY_LESS')) {
       this.plans.push({
         definitionVersion: 'V4',
         name: 'Default Keyless (UNSECURED)',
@@ -68,8 +69,7 @@ export class Step4Security1PlansComponent implements OnInit {
     }
 
     const subscriptionEntrypoint = currentStepPayload.selectedEntrypoints.find((e) => e.supportedListenerType === 'SUBSCRIPTION');
-    if (subscriptionEntrypoint) {
-      // If yes, add a plan with a default security type
+    if (subscriptionEntrypoint && availablePlanMenuItems.some((p) => p.planFormType === 'PUSH')) {
       this.plans.push({
         definitionVersion: 'V4',
         name: 'Default PUSH plan',

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
@@ -16,8 +16,19 @@
 
 -->
 <div class="plans__header">
-  <div *ngIf="!isReadOnly && plansTableDS && !isLoadingData">
-    <button mat-raised-button type="button" color="primary" aria-label="Add new plan" [matMenuTriggerFor]="menu">
+  <div
+    *ngIf="!isReadOnly && plansTableDS && !isLoadingData"
+    [matTooltip]="'No compatible plan type enabled for entrypoints. This is configured under Settings > Portal > Settings > Console.'"
+    [matTooltipDisabled]="planMenuItems?.length > 0"
+  >
+    <button
+      mat-raised-button
+      type="button"
+      color="primary"
+      aria-label="Add new plan"
+      [matMenuTriggerFor]="menu"
+      [disabled]="planMenuItems?.length === 0"
+    >
       <mat-icon svgIcon="gio:plus"></mat-icon>Add new plan
     </button>
     <mat-menu #menu="matMenu">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1995

## Description

- Use a tooltip when no plan type is available.
- Create a default plan in API Creation Workflow only if its plan type is available

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/c82f0cda-ec91-4a04-b2e8-afac514986b1)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xwkdkycyww.chromatic.com)
<!-- Storybook placeholder end -->
