### PR TITLE
refactor(console): prepare API menu migration to angular for V1&V2 APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/ApiMenuService.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/ApiMenuService.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MenuGroupItem, MenuItem } from './MenuGroupItem';
+
+export interface ApiMenuService {
+  getMenu(): {
+    subMenuItems: MenuItem[];
+    groupItems: MenuGroupItem[];
+  };
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/MenuGroupItem.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/MenuGroupItem.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface MenuItem {
+  targetRoute?: string;
+  baseRoute?: string | string[];
+  displayName: string;
+  tabs?: MenuItem[];
+}
+
+export interface MenuGroupItem {
+  title: string;
+  items: MenuItem[];
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.ts
@@ -17,8 +17,8 @@ import { Component, Inject, Input } from '@angular/core';
 import { StateService } from '@uirouter/core';
 import { castArray } from 'lodash';
 
-import { MenuItem } from '../api-ng-navigation.component';
 import { UIRouterState } from '../../../../ajs-upgraded-providers';
+import { MenuItem } from '../MenuGroupItem';
 
 @Component({
   selector: 'api-ng-navigation-tabs',

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
@@ -28,24 +28,15 @@ import {
   ApiConfirmDeploymentDialogResult,
 } from './api-confirm-deployment-dialog/api-confirm-deployment-dialog.component';
 import { ApiReviewDialogComponent, ApiReviewDialogData, ApiReviewDialogResult } from './api-review-dialog/api-review-dialog.component';
+import { MenuGroupItem, MenuItem } from './MenuGroupItem';
+import { ApiNgV4MenuService } from './api-ng-v4-menu.service';
+import { ApiNgV1V2MenuService } from './api-ng-v1-v2-menu.service';
 
 import { AjsRootScope, CurrentUserService, UIRouterState, UIRouterStateParams } from '../../../ajs-upgraded-providers';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import UserService from '../../../services/user.service';
 import { Constants } from '../../../entities/Constants';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-
-export interface MenuItem {
-  targetRoute?: string;
-  baseRoute?: string | string[];
-  displayName: string;
-  tabs?: MenuItem[];
-}
-
-interface GroupItem {
-  title: string;
-  items: MenuItem[];
-}
 
 type TopBanner = {
   title: string;
@@ -60,12 +51,13 @@ type TopBanner = {
   selector: 'api-ng-navigation',
   template: require('./api-ng-navigation.component.html'),
   styles: [require('./api-ng-navigation.component.scss')],
+  providers: [ApiNgV1V2MenuService, ApiNgV4MenuService],
 })
 export class ApiNgNavigationComponent implements OnInit, OnDestroy {
   public currentApi$ = this.apiV2Service.getLastApiFetch(this.ajsStateParams.apiId);
 
   public subMenuItems: MenuItem[] = [];
-  public groupItems: GroupItem[] = [];
+  public groupItems: MenuGroupItem[] = [];
   public selectedItemWithTabs: MenuItem = undefined;
   public bannerState: string;
   public hasBreadcrumb = false;
@@ -246,6 +238,8 @@ export class ApiNgNavigationComponent implements OnInit, OnDestroy {
     private readonly gioMenuService: GioMenuService,
     private readonly apiV2Service: ApiV2Service,
     private readonly matDialog: MatDialog,
+    private readonly apiNgV1V2MenuService: ApiNgV1V2MenuService,
+    private readonly apiNgV4MenuService: ApiNgV4MenuService,
   ) {}
 
   ngOnInit() {
@@ -255,16 +249,18 @@ export class ApiNgNavigationComponent implements OnInit, OnDestroy {
 
     this.bannerState = localStorage.getItem('gv-api-navigation-banner');
 
-    this.appendPolicyStudio();
-    this.appendGeneralGroup();
-    this.appendEntrypointsGroup();
-    this.appendEndpointsGroup();
+    this.currentApi$.subscribe((api) => {
+      const { groupItems, subMenuItems } =
+        api.definitionVersion !== 'V4' ? this.apiNgV1V2MenuService.getMenu() : this.apiNgV4MenuService.getMenu();
+      this.groupItems = groupItems;
+      this.subMenuItems = subMenuItems;
 
-    this.selectedItemWithTabs = this.findMenuItemWithTabs();
-    this.breadcrumbItems = this.computeBreadcrumbItems();
-
-    this.ajsRootScope.$on('$locationChangeStart', () => {
       this.selectedItemWithTabs = this.findMenuItemWithTabs();
+      this.breadcrumbItems = this.computeBreadcrumbItems();
+
+      this.ajsRootScope.$on('$locationChangeStart', () => {
+        this.selectedItemWithTabs = this.findMenuItemWithTabs();
+      });
     });
   }
 
@@ -272,102 +268,6 @@ export class ApiNgNavigationComponent implements OnInit, OnDestroy {
     this.unsubscribe$.next(true);
     this.unsubscribe$.unsubscribe();
   }
-
-  private appendPolicyStudio() {
-    this.subMenuItems.push({
-      displayName: 'Policy Studio',
-      targetRoute: 'management.apis.ng.policyStudio',
-      baseRoute: 'management.apis.ng.policyStudio',
-      tabs: undefined,
-    });
-  }
-
-  private appendGeneralGroup() {
-    const generalGroup: GroupItem = {
-      title: 'General',
-      items: [
-        {
-          displayName: 'Info',
-          targetRoute: 'management.apis.ng.general',
-          baseRoute: 'management.apis.ng.general',
-        },
-      ],
-    };
-    // Plans
-    const plansMenuItem: MenuItem = {
-      displayName: 'Plans',
-      tabs: [],
-    };
-
-    if (this.permissionService.hasAnyMatching(['api-plan-r'])) {
-      plansMenuItem.tabs.push({
-        displayName: 'Plans',
-        targetRoute: 'management.apis.ng.plans',
-        baseRoute: ['management.apis.ng.plans', 'management.apis.ng.plan'],
-      });
-    }
-    if (this.permissionService.hasAnyMatching(['api-subscription-r'])) {
-      plansMenuItem.tabs.push({
-        displayName: 'Subscriptions',
-        targetRoute: 'management.apis.ng.subscriptions',
-        baseRoute: ['management.apis.ng.subscriptions', 'management.apis.ng.subscription'],
-      });
-    }
-    if (plansMenuItem.tabs.length > 0) {
-      generalGroup.items.push(plansMenuItem);
-    }
-
-    if (this.permissionService.hasAnyMatching(['api-definition-r'])) {
-      generalGroup.items.push(
-        {
-          displayName: 'Properties',
-          targetRoute: 'management.apis.ng.properties',
-          baseRoute: 'management.apis.ng.properties',
-        },
-        {
-          displayName: 'Resources',
-          targetRoute: 'management.apis.ng.resources',
-          baseRoute: 'management.apis.ng.resources',
-        },
-      );
-    }
-
-    this.groupItems.push(generalGroup);
-  }
-
-  private appendEntrypointsGroup() {
-    if (this.permissionService.hasAnyMatching(['api-definition-r', 'api-health-r'])) {
-      const entrypointsGroup: GroupItem = {
-        title: 'Entrypoints',
-        items: [
-          {
-            displayName: 'General',
-            targetRoute: 'management.apis.ng.entrypoints',
-            baseRoute: 'management.apis.ng.entrypoints',
-          },
-        ],
-      };
-      this.groupItems.push(entrypointsGroup);
-    }
-  }
-
-  private appendEndpointsGroup() {
-    const endpointsGroup: GroupItem = {
-      title: 'Endpoints',
-      items: [],
-    };
-
-    if (this.permissionService.hasAnyMatching(['api-definition-r'])) {
-      endpointsGroup.items.push({
-        displayName: 'Backend services',
-        targetRoute: 'management.apis.ng.endpoints',
-        baseRoute: ['management.apis.ng.endpoints', 'management.apis.ng.endpoint'],
-      });
-    }
-
-    this.groupItems.push(endpointsGroup);
-  }
-
   private findMenuItemWithTabs(): MenuItem {
     let item: MenuItem = this.findActiveMenuItem(this.subMenuItems);
     if (item) {

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v1-v2-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v1-v2-menu.service.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+
+import { MenuGroupItem, MenuItem } from './MenuGroupItem';
+import { ApiMenuService } from './ApiMenuService';
+
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+
+@Injectable()
+export class ApiNgV1V2MenuService implements ApiMenuService {
+  constructor(private readonly permissionService: GioPermissionService) {}
+
+  public getMenu(): {
+    subMenuItems: MenuItem[];
+    groupItems: MenuGroupItem[];
+  } {
+    const subMenuItems: MenuItem[] = [
+      // TODO: To be completed
+    ];
+    const groupItems: MenuGroupItem[] = [
+      // TODO: To be completed
+    ].filter((group) => !!group);
+
+    return { subMenuItems, groupItems };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+
+import { MenuGroupItem, MenuItem } from './MenuGroupItem';
+import { ApiMenuService } from './ApiMenuService';
+
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+
+@Injectable()
+export class ApiNgV4MenuService implements ApiMenuService {
+  constructor(private readonly permissionService: GioPermissionService) {}
+
+  public getMenu(): {
+    subMenuItems: MenuItem[];
+    groupItems: MenuGroupItem[];
+  } {
+    const subMenuItems: MenuItem[] = [
+      {
+        displayName: 'Policy Studio',
+        targetRoute: 'management.apis.ng.policyStudio',
+        baseRoute: 'management.apis.ng.policyStudio',
+        tabs: undefined,
+      },
+    ];
+    const groupItems: MenuGroupItem[] = [this.getGeneralGroup(), this.getEntrypointsGroup(), this.getEndpointsGroup()].filter(
+      (group) => !!group,
+    );
+
+    return { subMenuItems, groupItems };
+  }
+
+  private getGeneralGroup(): MenuGroupItem {
+    const generalGroup: MenuGroupItem = {
+      title: 'General',
+      items: [
+        {
+          displayName: 'Info',
+          targetRoute: 'management.apis.ng.general',
+          baseRoute: 'management.apis.ng.general',
+        },
+      ],
+    };
+    // Plans
+    const plansMenuItem: MenuItem = {
+      displayName: 'Plans',
+      tabs: [],
+    };
+
+    if (this.permissionService.hasAnyMatching(['api-plan-r'])) {
+      plansMenuItem.tabs.push({
+        displayName: 'Plans',
+        targetRoute: 'management.apis.ng.plans',
+        baseRoute: ['management.apis.ng.plans', 'management.apis.ng.plan'],
+      });
+    }
+    if (this.permissionService.hasAnyMatching(['api-subscription-r'])) {
+      plansMenuItem.tabs.push({
+        displayName: 'Subscriptions',
+        targetRoute: 'management.apis.ng.subscriptions',
+        baseRoute: ['management.apis.ng.subscriptions', 'management.apis.ng.subscription'],
+      });
+    }
+    if (plansMenuItem.tabs.length > 0) {
+      generalGroup.items.push(plansMenuItem);
+    }
+
+    if (this.permissionService.hasAnyMatching(['api-definition-r'])) {
+      generalGroup.items.push(
+        {
+          displayName: 'Properties',
+          targetRoute: 'management.apis.ng.properties',
+          baseRoute: 'management.apis.ng.properties',
+        },
+        {
+          displayName: 'Resources',
+          targetRoute: 'management.apis.ng.resources',
+          baseRoute: 'management.apis.ng.resources',
+        },
+      );
+    }
+
+    return generalGroup;
+  }
+
+  private getEntrypointsGroup(): MenuGroupItem {
+    if (this.permissionService.hasAnyMatching(['api-definition-r', 'api-health-r'])) {
+      const entrypointsGroup: MenuGroupItem = {
+        title: 'Entrypoints',
+        items: [
+          {
+            displayName: 'General',
+            targetRoute: 'management.apis.ng.entrypoints',
+            baseRoute: 'management.apis.ng.entrypoints',
+          },
+        ],
+      };
+      return entrypointsGroup;
+    }
+    return undefined;
+  }
+
+  private getEndpointsGroup(): MenuGroupItem {
+    const endpointsGroup: MenuGroupItem = {
+      title: 'Endpoints',
+      items: [],
+    };
+
+    if (this.permissionService.hasAnyMatching(['api-definition-r'])) {
+      endpointsGroup.items.push({
+        displayName: 'Backend services',
+        targetRoute: 'management.apis.ng.endpoints',
+        baseRoute: ['management.apis.ng.endpoints', 'management.apis.ng.endpoint'],
+      });
+    }
+
+    return endpointsGroup;
+  }
+}


### PR DESCRIPTION
## Issue
n/a

## Description

Extract V4 menu in dedicated service. And init v1-v2 one.  
📝  The goal isn't to migrate the v2 menu with V4.0.x but to have the minimum conflit if we fix things here and then mergify to master. 

next PR will be on Master only


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wdsnwqpole.chromatic.com)
<!-- Storybook placeholder end -->
