### PR TITLE
test: added cypress tests for general page including faker

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.html
@@ -55,13 +55,13 @@
         <div class="details-card__header__info-inputs__first-row">
           <mat-form-field class="details-card__header__info-inputs__first-row__name-field">
             <mat-label>Name</mat-label>
-            <input #apiName matInput formControlName="name" required />
+            <input #apiName matInput formControlName="name" data-testid="api_general_namefield" required />
             <mat-error *ngIf="apiDetailsForm.controls.name.hasError('required')">Name is required.</mat-error>
           </mat-form-field>
 
           <mat-form-field class="details-card__header__info-inputs__first-row__version-field">
             <mat-label>Version</mat-label>
-            <input matInput formControlName="version" required maxlength="32" />
+            <input matInput formControlName="version" data-testid="api_general_versionfield" required maxlength="32" />
             <mat-error *ngIf="apiDetailsForm.controls.version.hasError('required')">Version is required.</mat-error>
             <mat-error *ngIf="apiDetailsForm.controls.version.hasError('version')">{{
               apiDetailsForm.controls.version.getError('version')
@@ -71,13 +71,14 @@
         <div class="details-card__header__info-inputs__second-row">
           <mat-form-field class="details-card__header__info-inputs__second-row__description-field">
             <mat-label>Description</mat-label>
-            <textarea matInput formControlName="description"></textarea>
+            <textarea matInput formControlName="description" data-testid="api_general_descriptionfield"></textarea>
           </mat-form-field>
 
           <mat-form-field class="etails-card__header__info-inputs__second-row__labels-field">
             <mat-label>Labels</mat-label>
             <gio-form-tags-input
               formControlName="labels"
+              data-testid="api_general_labelsfield"
               [addOnBlur]="false"
               [autocompleteOptions]="labelsAutocompleteOptions"
             ></gio-form-tags-input>
@@ -85,8 +86,8 @@
 
           <mat-form-field class="etails-card__header__info-inputs__second-row__categories-field">
             <mat-label>Categories</mat-label>
-            <mat-select formControlName="categories" multiple>
-              <mat-option *ngIf="apiCategories.length === 0" disabled>No categories available</mat-option>
+            <mat-select formControlName="categories" data-testid="api_general_categoriesdropdown" multiple>
+              <mat-option data-testid="api_general_categorieslist-unavailable" *ngIf="apiCategories.length === 0" disabled>No categories available</mat-option>
               <mat-option *ngFor="let category of apiCategories" [value]="category.key"
                 >{{ category.name }} <em *ngIf="category.description"> - {{ category.description }}</em></mat-option
               >
@@ -187,5 +188,5 @@
 
   <api-portal-details-danger-zone class="danger-zone" [api]="api" (reloadDetails)="ngOnInit()"></api-portal-details-danger-zone>
 
-  <gio-save-bar [form]="parentForm" [formInitialValues]="initialApiDetailsFormValue" (submitted)="onSubmit()"></gio-save-bar>
+  <gio-save-bar [form]="parentForm" data-testid="api_general_savebar" [formInitialValues]="initialApiDetailsFormValue" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-general.spec.ts
@@ -1,0 +1,98 @@
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { MAPIV2ApisFaker } from '../../../../../lib/fixtures/management/MAPIV2ApisFaker';
+import { ApiV4 } from '../../../../../lib/management-v2-webclient-sdk/src/lib';
+import faker from '@faker-js/faker';
+import apiDetails from '@pageobjects/Apis/ApiDetails';
+
+
+    describe('API General Page functionality', () => {
+        beforeEach(() => {
+          cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
+          cy.visit('/#!/environments/default/apis/');
+          cy.url().should('include', '/apis/');
+        });
+
+        before(() => {
+            v4api = [];
+      
+            Cypress._.times(noOfApis, () => {
+              cy.log('Create v4 API');
+              cy.request({
+                method: 'POST',
+                url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis`,
+                auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
+                body: MAPIV2ApisFaker.newApi({
+                  listeners: [
+                    MAPIV2ApisFaker.newSubscriptionListener({
+                      entrypoints: [
+                        {
+                          type: 'webhook',
+                        },
+                      ],
+                    }),
+                  ],
+                  endpointGroups: [
+                    {
+                      name: 'default-group',
+                      type: 'mock',
+                      endpoints: [
+                        {
+                          name: 'default',
+                          type: 'mock',
+                          configuration: {
+                            messageInterval: 0,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                }),
+              }).then((response) => {
+                expect(response.status).to.eq(201);
+                v4api.push(response.body);
+              });
+            });
+          });
+
+        const ApiDetails = new apiDetails()
+        const apiName = faker.commerce.productName();
+        const apiVersion = faker.datatype.number();
+        const apiDescription = faker.commerce.productDescription();
+        let v4api: ApiV4[];
+        const noOfApis = 1;
+                 
+// Above may not be correct as struggling to resolve import ApiV4 module but it runs perfect with pre-created api through ui
+        
+        it('Verify General Page Elements', () => {
+            cy.getByDataTestId('api_list_edit_button', { timeout: 5000 }).first().click();
+            cy.contains('Policy Studio').should('be.visible');
+            cy.contains('Info').should('be.visible');
+            cy.contains('Plans').should('be.visible');
+            ApiDetails.info().click();
+            cy.getByDataTestId('api_general_namefield').should('be.visible');
+            cy.getByDataTestId('api_general_versionfield').should('be.visible');
+            cy.getByDataTestId('api_general_descriptionfield').should('be.visible');
+            cy.getByDataTestId('api_general_labelsfield').should('be.visible');
+            cy.getByDataTestId('api_general_categoriesdropdown').should('be.visible').click();
+            cy.getByDataTestId('api_general_categorieslist-unavailable').should('be.visible');
+        })
+
+        it('Edit General Page and Verify changes', () => {
+            cy.getByDataTestId('api_list_edit_button').first().click();
+            ApiDetails.info().click();
+        //  ^^ Sidebar dynamically generated, therefore, use page object.
+            cy.getByDataTestId('api_general_namefield').should('be.visible');
+            cy.getByDataTestId('api_general_namefield').clear().type(`${apiName}`);
+            cy.getByDataTestId('api_general_versionfield').clear().type(`${apiVersion}`);
+            cy.getByDataTestId('api_general_descriptionfield').clear().type(`${apiDescription}`);
+
+            cy.getByDataTestId('api_general_savebar', { timeout: 5000 }).should('be.visible').contains('Save').click();
+            cy.contains('Configuration successfully saved!').should('be.visible');
+            cy.visit('/#!/environments/default/apis/');
+            cy.contains(`${apiName}`).should('be.visible');
+            })
+
+        // Could possibly do with danger zone buttons but left out until proper end to end - 
+        // - tests can be completed and I know it is finished and expected consequences 
+
+    });

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/ApiDetails.ts
@@ -1,0 +1,47 @@
+// gio-submenu-item__title and gio-submenu-item for Design
+
+class apiDetails {
+
+    design(){return cy.get('.gio-submenu-item').contains('Design')}
+
+    info(){return cy.get('.gio-submenu-item__title').contains('Info')}
+
+    plans(){return cy.get('.gio-submenu-item__title').contains('Plans')}
+
+    // General
+
+    generalName(){return cy.get('[formcontrolname="name"]')}
+
+    generalVersion(){return cy.get('[formcontrolname="version"]')}
+    
+    generalDescription(){return cy.get('[formcontrolname="description"]')}
+
+    generalLabels(){return cy.get('[formcontrolname="labels"]')}
+
+    generalCategories(){return cy.get('[formcontrolname="categories"]')}
+
+    categories(){return cy.get('.mat-option-text')} 
+    // above Step Def would write as ApiDetails.categories().contains('[CATEGORY]').click()
+
+    saveDetails(){return cy.get('[type="submit"]').contains('Save')}
+
+
+    // Plans
+
+    addPlan(){return cy.get('[type="button"]').contains('Add new plan')}
+
+    planOauth2(){return cy.get('[role="menuitem"]').contains('OAuth2')}
+    
+    planJwt(){return cy.get('[role="menuitem"]').contains('JWT')}
+
+    planApiKey(){return cy.get('[role="menuitem"]').contains('API Key')}
+
+    planName(){return cy.get('[formcontrolname="name"]')}
+
+    planDescription(){return cy.get('[formcontrolname="description"]')}
+
+    // planName(){return cy.get('[formcontrolname="name"]')}
+
+}
+
+export default apiDetails;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2075 

## Description

General page tests for APIs in APIM. 

Splitting out my General and Plan commits, with updated code and faker details. 

I had a problem with importing the module for ApiV4 but I noticed it in .gitignore so have left the api creation step in and pushed to see if it works in pipeline. If it does, then this is done. See other comments (may do danger zone buttons but left for now as I believe this to be out of scope until we do full end to end and I know the consequences) 

(sorry 2nd PR to add -run-e2e suffix)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-anhmjatwvg.chromatic.com)
<!-- Storybook placeholder end -->
