### PR TITLE
fix(api): Sanitize API's name and description during creation / update / import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -102,7 +102,7 @@ public class NewApiEntity {
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        this.description = HTML_SANITIZER.sanitize(description);
     }
 
     public String getContextPath() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
@@ -33,13 +33,21 @@ import jakarta.validation.constraints.NotNull;
 import java.util.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
- * @author David BRASSELY (brasseld at gmail.com)
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
  */
 @Getter
 @Setter
 public class UpdateApiEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     @Schema(description = "API's crossId. Identifies API across environments.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
     private String crossId;
@@ -173,5 +181,13 @@ public class UpdateApiEntity {
             return properties.getProperties();
         }
         return Collections.emptyList();
+    }
+
+    public void setName(String name) {
+        this.name = HTML_SANITIZER.sanitize(name);
+    }
+
+    public void setDescription(String description) {
+        this.description = HTML_SANITIZER.sanitize(description);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
@@ -104,4 +104,8 @@ public class NewApiEntity {
     public void setName(String name) {
         this.name = HTML_SANITIZER.sanitize(name);
     }
+
+    public void setDescription(String description) {
+        this.description = HTML_SANITIZER.sanitize(description);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
@@ -48,9 +48,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
- * @author David BRASSELY (brasseld at gmail.com)
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
  */
 @NoArgsConstructor
 @Getter
@@ -59,6 +62,11 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Schema(name = "UpdateApiEntityV4")
 public class UpdateApiEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     @Schema(description = "API's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
     private String id;
@@ -181,4 +189,12 @@ public class UpdateApiEntity {
         example = "https://gravitee.mycompany.com/management/apis/6c530064-0b2c-4004-9300-640b2ce0047b/background"
     )
     private String backgroundUrl;
+
+    public void setName(String name) {
+        this.name = HTML_SANITIZER.sanitize(name);
+    }
+
+    public void setDescription(String description) {
+        this.description = HTML_SANITIZER.sanitize(description);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/NewApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/NewApiEntityTest.java
@@ -39,4 +39,23 @@ public class NewApiEntityTest {
         newApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
         assertEquals("A Test API", newApiEntity.getName());
     }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        NewApiEntity newApiEntity = new NewApiEntity();
+        newApiEntity.setDescription("A Test API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A Test <script>alert()</script>API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("<h1>A Test</h1> API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/UpdateApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/UpdateApiEntityTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateApiEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setName("A Test API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A Test <script>alert()</script>API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("<h1>A Test</h1> API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", updateApiEntity.getName());
+    }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setDescription("A Test API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A Test <script>alert()</script>API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("<h1>A Test</h1> API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/NewApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/NewApiEntityTest.java
@@ -39,4 +39,23 @@ public class NewApiEntityTest {
         newApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
         assertEquals("A Test API", newApiEntity.getName());
     }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        NewApiEntity newApiEntity = new NewApiEntity();
+        newApiEntity.setDescription("A Test API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A Test <script>alert()</script>API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("<h1>A Test</h1> API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+
+        newApiEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", newApiEntity.getDescription());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntityTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UpdateApiEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setName("A Test API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A Test <script>alert()</script>API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("<h1>A Test</h1> API");
+        assertEquals("A Test API", updateApiEntity.getName());
+
+        updateApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", updateApiEntity.getName());
+    }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setDescription("A Test API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A Test <script>alert()</script>API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("<h1>A Test</h1> API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+
+        updateApiEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", updateApiEntity.getDescription());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2161

## Description

We already have sanitization during the creation of an API, but we were missing some cases such as the update or the import of a new API.
Previously, only the name was sanitized. I added the sanitization of the description to follow the same as we did for application.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-frzyywghtn.chromatic.com)
<!-- Storybook placeholder end -->
