### PR TITLE
Test retry flaky tests

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
@@ -61,10 +61,5 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,8 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -87,39 +86,39 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("http://localhost:1234", endpoint.getTarget());
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_noProxyPart() throws Exception {
-        Api api = load("/io/gravitee/definition/jackson/api-noproxy-part.json", Api.class);
+        assertThrows(JsonMappingException.class, () -> load("/io/gravitee/definition/jackson/api-noproxy-part.json", Api.class));
     }
 
     @Test
     public void definition_noPath() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-nopath.json", Api.class);
 
-        Assert.assertNull(api.getPaths());
+        assertNull(api.getPaths());
     }
 
     @Test
     public void definition_reformatContextPath() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-reformat-contextpath.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getVirtualHosts());
-        Assert.assertFalse(api.getProxy().getVirtualHosts().isEmpty());
+        assertNotNull(api.getProxy().getVirtualHosts());
+        assertFalse(api.getProxy().getVirtualHosts().isEmpty());
         assertEquals("/my-api/team", api.getProxy().getVirtualHosts().iterator().next().getPath());
-        Assert.assertNull(api.getProxy().getVirtualHosts().iterator().next().getHost());
-        Assert.assertFalse(api.getProxy().getVirtualHosts().iterator().next().isOverrideEntrypoint());
+        assertNull(api.getProxy().getVirtualHosts().iterator().next().getHost());
+        assertFalse(api.getProxy().getVirtualHosts().iterator().next().isOverrideEntrypoint());
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_contextPathExpected() throws Exception {
-        load("/io/gravitee/definition/jackson/api-no-contextpath.json", Api.class);
+        assertThrows(JsonMappingException.class, () -> load("/io/gravitee/definition/jackson/api-no-contextpath.json", Api.class));
     }
 
     @Test
     public void definition_defaultPath() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-defaultpath.json", Api.class);
 
-        Assert.assertNotNull(api.getPaths());
+        assertNotNull(api.getPaths());
         assertEquals(1, api.getPaths().size());
 
         Map<String, List<Rule>> paths = api.getPaths();
@@ -133,7 +132,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_multiplePath() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-multiplepath.json", Api.class);
 
-        Assert.assertNotNull(api.getPaths());
+        assertNotNull(api.getPaths());
         assertEquals(2, api.getPaths().size());
     }
 
@@ -141,7 +140,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_pathwithmethods() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-defaultpath.json", Api.class);
 
-        Assert.assertNotNull(api.getPaths());
+        assertNotNull(api.getPaths());
         assertEquals(1, api.getPaths().size());
 
         Map<String, List<Rule>> paths = api.getPaths();
@@ -157,7 +156,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_pathwithoutmethods() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-path-nohttpmethod.json", Api.class);
 
-        Assert.assertNotNull(api.getPaths());
+        assertNotNull(api.getPaths());
         assertEquals(1, api.getPaths().size());
 
         Map<String, List<Rule>> paths = api.getPaths();
@@ -176,7 +175,7 @@ public class ApiDeserializerTest extends AbstractTest {
         List<Rule> rules = paths.get("/*");
 
         Policy policy = rules.iterator().next().getPolicy();
-        Assert.assertNotNull(policy);
+        assertNotNull(policy);
         assertEquals("access-control", policy.getName());
     }
 
@@ -188,13 +187,13 @@ public class ApiDeserializerTest extends AbstractTest {
 
         Rule accessControlRule = rules.get(0);
         Policy policy = accessControlRule.getPolicy();
-        Assert.assertNotNull(policy);
+        assertNotNull(policy);
         assertEquals("access-control", policy.getName());
-        Assert.assertFalse(accessControlRule.isEnabled());
+        assertFalse(accessControlRule.isEnabled());
 
         Rule corsRule = rules.get(1);
         policy = corsRule.getPolicy();
-        Assert.assertNotNull(policy);
+        assertNotNull(policy);
         assertEquals("cors", policy.getName());
         assertTrue(corsRule.isEnabled());
     }
@@ -213,7 +212,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withoutproperties.json", Api.class);
         Properties properties = api.getProperties();
 
-        Assert.assertNull(properties);
+        assertNull(properties);
     }
 
     @Test
@@ -221,7 +220,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withemptyproperties.json", Api.class);
         Properties properties = api.getProperties();
 
-        Assert.assertNotNull(properties);
+        assertNotNull(properties);
         assertTrue(properties.getValues().isEmpty());
     }
 
@@ -230,7 +229,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withproperties.json", Api.class);
         Properties properties = api.getProperties();
 
-        Assert.assertNotNull(properties);
+        assertNotNull(properties);
         assertEquals(4, properties.getValues().size());
         assertEquals("true", properties.getValues().get("my_property"));
         assertEquals("123", properties.getValues().get("my_property2"));
@@ -238,22 +237,22 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("text", properties.getValues().get("my_property4"));
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_withoutID() throws Exception {
-        load("/io/gravitee/definition/jackson/api-withoutid.json", Api.class);
+        assertThrows(JsonMappingException.class, () -> load("/io/gravitee/definition/jackson/api-withoutid.json", Api.class));
     }
 
     @Test
     public void definition_withoutTags() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withouttags.json", Api.class);
-        Assert.assertNotNull(api.getTags());
+        assertNotNull(api.getTags());
         assertEquals(0, api.getTags().size());
     }
 
     @Test
     public void definition_withTags() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withtags.json", Api.class);
-        Assert.assertNotNull(api.getTags());
+        assertNotNull(api.getTags());
         assertEquals(2, api.getTags().size());
         assertEquals("tag1", api.getTags().iterator().next());
     }
@@ -268,7 +267,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_singleEndpoint_backup() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-singleendpoint.json", Api.class);
         assertEquals(1, api.getProxy().getGroups().iterator().next().getEndpoints().size());
-        Assert.assertFalse(api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().isBackup());
+        assertFalse(api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().isBackup());
     }
 
     @Test
@@ -287,7 +286,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_singleEndpoint_inArray_backup() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-singleendpoint-inarray.json", Api.class);
         assertEquals(1, api.getProxy().getGroups().iterator().next().getEndpoints().size());
-        Assert.assertFalse(api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().isBackup());
+        assertFalse(api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().isBackup());
     }
 
     @Test
@@ -301,7 +300,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_defaultLoadBalancer_roundRobin() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-defaulthttpconfig.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getGroups().iterator().next().getLoadBalancer());
+        assertNotNull(api.getProxy().getGroups().iterator().next().getLoadBalancer());
         assertEquals(LoadBalancerType.ROUND_ROBIN, api.getProxy().getGroups().iterator().next().getLoadBalancer().getType());
     }
 
@@ -309,15 +308,15 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_no_failover() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-defaulthttpconfig.json", Api.class);
 
-        Assert.assertNull(api.getProxy().getFailover());
-        Assert.assertFalse(api.getProxy().failoverEnabled());
+        assertNull(api.getProxy().getFailover());
+        assertFalse(api.getProxy().failoverEnabled());
     }
 
     @Test
     public void definition_default_failover() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-default-failover.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getFailover());
+        assertNotNull(api.getProxy().getFailover());
         assertTrue(api.getProxy().failoverEnabled());
 
         assertEquals(Failover.DEFAULT_MAX_ATTEMPTS, api.getProxy().getFailover().getMaxAttempts());
@@ -329,23 +328,23 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_override_failover() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-override-failover.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getFailover());
+        assertNotNull(api.getProxy().getFailover());
         assertTrue(api.getProxy().failoverEnabled());
 
         assertEquals(3, api.getProxy().getFailover().getMaxAttempts());
         assertEquals(3000, api.getProxy().getFailover().getRetryTimeout());
-        assertEquals(Failover.DEFAULT_FAILOVER_CASES, api.getProxy().getFailover().getCases());
+        assertArrayEquals(Failover.DEFAULT_FAILOVER_CASES, api.getProxy().getFailover().getCases());
     }
 
     @Test
     public void definition_failover_singlecase() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-failover-singlecase.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getFailover());
+        assertNotNull(api.getProxy().getFailover());
         assertTrue(api.getProxy().failoverEnabled());
 
         assertEquals(3, api.getProxy().getFailover().getMaxAttempts());
-        assertEquals(Failover.DEFAULT_FAILOVER_CASES, api.getProxy().getFailover().getCases());
+        assertArrayEquals(Failover.DEFAULT_FAILOVER_CASES, api.getProxy().getFailover().getCases());
     }
 
     @Test
@@ -360,7 +359,7 @@ public class ApiDeserializerTest extends AbstractTest {
             .getEndpoints()
             .forEach(endpoint -> {
                 if ("endpoint_0".equals(endpoint.getName())) {
-                    Assert.assertFalse(endpoint.isBackup());
+                    assertFalse(endpoint.isBackup());
                 } else {
                     assertTrue(endpoint.isBackup());
                 }
@@ -383,28 +382,44 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("asie", tenants.get(1));
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void shouldFailWithSameEndpointNames() throws Exception {
-        load("/io/gravitee/definition/jackson/api-multiplesameendpoints.json", Api.class);
-        Assert.fail("should throw deser exception");
+        try {
+            load("/io/gravitee/definition/jackson/api-multiplesameendpoints.json", Api.class);
+            fail("should throw deser exception");
+        } catch (JsonMappingException e) {
+            assertNotNull(e);
+        }
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void shouldFailWithSameEndpointNamesInDifferentGroup() throws Exception {
-        load("/io/gravitee/definition/jackson/api-multiplesameendpointsindifferentgroups.json", Api.class);
-        Assert.fail("should throw deser exception");
+        try {
+            load("/io/gravitee/definition/jackson/api-multiplesameendpointsindifferentgroups.json", Api.class);
+            fail("should throw deser exception");
+        } catch (JsonMappingException e) {
+            assertNotNull(e);
+        }
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void shouldFailWithSameGroupEndpointNames() throws Exception {
-        load("/io/gravitee/definition/jackson/api-multiplesamegroupendpoints.json", Api.class);
-        Assert.fail("should throw deser exception");
+        try {
+            load("/io/gravitee/definition/jackson/api-multiplesamegroupendpoints.json", Api.class);
+            fail("should throw deser exception");
+        } catch (JsonMappingException e) {
+            assertNotNull(e);
+        }
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void shouldFailWithSameGroupEndpointNamesAndEndpointNames() throws Exception {
-        load("/io/gravitee/definition/jackson/api-multiplesamegroupendpointsandendpoints.json", Api.class);
-        Assert.fail("should throw deser exception");
+        try {
+            load("/io/gravitee/definition/jackson/api-multiplesamegroupendpointsandendpoints.json", Api.class);
+            fail("should throw deser exception");
+        } catch (JsonMappingException e) {
+            assertNotNull(e);
+        }
     }
 
     @Test
@@ -412,7 +427,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-hostHeader.json", Api.class);
 
         Cors cors = api.getProxy().getCors();
-        Assert.assertNull(cors);
+        assertNull(cors);
     }
 
     @Test
@@ -434,17 +449,17 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-cors-disabled.json", Api.class);
 
         Cors cors = api.getProxy().getCors();
-        Assert.assertNotNull(cors);
-        Assert.assertFalse(cors.isEnabled());
-        Assert.assertFalse(cors.isAccessControlAllowCredentials());
-        Assert.assertFalse(cors.isRunPolicies());
+        assertNotNull(cors);
+        assertFalse(cors.isEnabled());
+        assertFalse(cors.isAccessControlAllowCredentials());
+        assertFalse(cors.isRunPolicies());
         assertEquals(-1, cors.getAccessControlMaxAge());
         assertEquals(HttpStatusCode.BAD_REQUEST_400, cors.getErrorStatusCode());
-        Assert.assertNull(cors.getAccessControlAllowOrigin());
-        Assert.assertNull(cors.getAccessControlAllowOriginRegex());
-        Assert.assertNull(cors.getAccessControlAllowHeaders());
-        Assert.assertNull(cors.getAccessControlAllowMethods());
-        Assert.assertNull(cors.getAccessControlExposeHeaders());
+        assertNull(cors.getAccessControlAllowOrigin());
+        assertNull(cors.getAccessControlAllowOriginRegex());
+        assertNull(cors.getAccessControlAllowHeaders());
+        assertNull(cors.getAccessControlAllowMethods());
+        assertNull(cors.getAccessControlExposeHeaders());
     }
 
     @Test
@@ -452,17 +467,17 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-cors.json", Api.class);
 
         Cors cors = api.getProxy().getCors();
-        Assert.assertNotNull(cors);
+        assertNotNull(cors);
         assertTrue(cors.isEnabled());
-        Assert.assertFalse(cors.isAccessControlAllowCredentials());
-        Assert.assertFalse(cors.isRunPolicies());
+        assertFalse(cors.isAccessControlAllowCredentials());
+        assertFalse(cors.isRunPolicies());
         assertEquals(-1, cors.getAccessControlMaxAge());
         assertEquals(HttpStatusCode.BAD_REQUEST_400, cors.getErrorStatusCode());
-        Assert.assertNotNull(cors.getAccessControlAllowOrigin());
-        Assert.assertNotNull(cors.getAccessControlAllowOriginRegex());
-        Assert.assertNotNull(cors.getAccessControlAllowHeaders());
-        Assert.assertNotNull(cors.getAccessControlAllowMethods());
-        Assert.assertNotNull(cors.getAccessControlExposeHeaders());
+        assertNotNull(cors.getAccessControlAllowOrigin());
+        assertNotNull(cors.getAccessControlAllowOriginRegex());
+        assertNotNull(cors.getAccessControlAllowHeaders());
+        assertNotNull(cors.getAccessControlAllowMethods());
+        assertNotNull(cors.getAccessControlExposeHeaders());
     }
 
     @Test
@@ -470,7 +485,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-logging.json", Api.class);
 
         Logging logging = api.getProxy().getLogging();
-        Assert.assertNotNull(logging);
+        assertNotNull(logging);
         assertEquals(LoggingMode.NONE, logging.getMode());
         assertEquals(LoggingScope.NONE, logging.getScope());
         assertEquals(LoggingContent.NONE, logging.getContent());
@@ -482,7 +497,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-logging-client.json", Api.class);
 
         Logging logging = api.getProxy().getLogging();
-        Assert.assertNotNull(logging);
+        assertNotNull(logging);
         assertEquals(LoggingMode.CLIENT_PROXY, logging.getMode());
         assertEquals(LoggingScope.REQUEST, logging.getScope());
         assertEquals(LoggingContent.HEADERS, logging.getContent());
@@ -494,7 +509,7 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-endpointgroup-discovery.json", Api.class);
 
         EndpointGroup group = api.getProxy().getGroups().iterator().next();
-        Assert.assertNotNull(group);
+        assertNotNull(group);
     }
 
     @Test
@@ -502,10 +517,10 @@ public class ApiDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-response-templates.json", Api.class);
 
         Map<String, Map<String, ResponseTemplate>> responseTemplates = api.getResponseTemplates();
-        Assert.assertNotNull(responseTemplates);
+        assertNotNull(responseTemplates);
 
         Map<String, ResponseTemplate> apiKeyResponseTemplates = responseTemplates.get("API_KEY_INVALID");
-        Assert.assertNotNull(apiKeyResponseTemplates);
+        assertNotNull(apiKeyResponseTemplates);
 
         assertEquals(3, apiKeyResponseTemplates.size());
         Iterator<String> responseTemplateIterator = apiKeyResponseTemplates.keySet().iterator();
@@ -525,7 +540,7 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_virtualhosts() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-virtualhosts.json", Api.class);
 
-        Assert.assertNotNull(api.getProxy().getVirtualHosts());
+        assertNotNull(api.getProxy().getVirtualHosts());
         assertEquals(2, api.getProxy().getVirtualHosts().size());
 
         VirtualHost host1 = api.getProxy().getVirtualHosts().get(0);
@@ -535,9 +550,9 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals("/my-api", host1.getPath());
         assertTrue(host1.isOverrideEntrypoint());
 
-        Assert.assertNull(host2.getHost());
+        assertNull(host2.getHost());
         assertEquals("/my-api2", host2.getPath());
-        Assert.assertFalse(host2.isOverrideEntrypoint());
+        assertFalse(host2.isOverrideEntrypoint());
     }
 
     @Test
@@ -569,12 +584,12 @@ public class ApiDeserializerTest extends AbstractTest {
 
     @Test
     public void definition_defaultFlow() throws Exception {
-        Assert.assertNotNull(DefinitionVersion.valueOfLabel("2.0.0"));
+        assertNotNull(DefinitionVersion.valueOfLabel("2.0.0"));
         Api api = load("/io/gravitee/definition/jackson/api-defaultflow.json", Api.class);
 
-        Assert.assertNotNull(api.getDefinitionVersion());
+        assertNotNull(api.getDefinitionVersion());
         assertEquals(DefinitionVersion.V2, api.getDefinitionVersion());
-        Assert.assertNotNull(api.getFlows());
+        assertNotNull(api.getFlows());
         List<Flow> flows = api.getFlows();
         assertEquals(1, flows.size());
         Flow flow = flows.get(0);
@@ -583,46 +598,46 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals(3, flow.getMethods().size());
         assertTrue(flow.getMethods().containsAll(Arrays.asList(HttpMethod.POST, HttpMethod.PUT, HttpMethod.GET)));
         assertEquals("/", flow.getPath());
-        Assert.assertNotNull(flow.getConsumers());
+        assertNotNull(flow.getConsumers());
         assertEquals(2, flow.getConsumers().size());
         final Consumer consumer = flow.getConsumers().get(0);
-        Assert.assertNotNull(consumer);
+        assertNotNull(consumer);
         assertEquals("PUBLIC", consumer.getConsumerId());
         assertEquals(ConsumerType.TAG, consumer.getConsumerType());
         final Consumer consumer2 = flow.getConsumers().get(1);
-        Assert.assertNotNull(consumer2);
+        assertNotNull(consumer2);
         assertEquals("PRIVATE", consumer2.getConsumerId());
         assertEquals(ConsumerType.TAG, consumer2.getConsumerType());
         assertEquals(FlowStage.API, flow.getStage());
 
         Step rule = flow.getPre().get(0);
-        Assert.assertNotNull(rule);
+        assertNotNull(rule);
         assertEquals("Rate Limit", rule.getName());
         assertEquals("rate-limit", rule.getPolicy());
-        Assert.assertNotNull(rule.getConfiguration());
+        assertNotNull(rule.getConfiguration());
         assertTrue(rule.isEnabled());
         assertNull(rule.getCondition());
 
         Step ruleApiKey = flow.getPre().get(1);
-        Assert.assertNotNull(ruleApiKey);
+        assertNotNull(ruleApiKey);
         assertEquals("Check API Key", ruleApiKey.getName());
         assertEquals("api-key", ruleApiKey.getPolicy());
-        Assert.assertNotNull(ruleApiKey.getConfiguration());
+        assertNotNull(ruleApiKey.getConfiguration());
         assertTrue(ruleApiKey.isEnabled());
         assertNull(ruleApiKey.getCondition());
 
         Step ruleTransformHeaders = flow.getPre().get(2);
-        Assert.assertNotNull(ruleTransformHeaders);
+        assertNotNull(ruleTransformHeaders);
         assertEquals("Add HTTP headers", ruleTransformHeaders.getName());
         assertEquals("transform-headers", ruleTransformHeaders.getPolicy());
-        Assert.assertNotNull(ruleTransformHeaders.getConfiguration());
+        assertNotNull(ruleTransformHeaders.getConfiguration());
         assertTrue(ruleTransformHeaders.isEnabled());
         assertEquals("a non empty condition", ruleTransformHeaders.getCondition());
 
         Collection<Plan> plans = api.getPlans();
-        Assert.assertNotNull(plans);
+        assertNotNull(plans);
         assertEquals(2, plans.size());
-        Assert.assertNotNull(api.getPlan("plan-1"));
+        assertNotNull(api.getPlan("plan-1"));
         assertEquals(2, api.getPlan("plan-1").getFlows().size());
         assertEquals("#context.attributes['jwt'].claims['iss'] == 'toto'", api.getPlan("plan-1").getSelectionRule());
         assertEquals("OAUTH2", api.getPlan("plan-1").getSecurity());
@@ -633,14 +648,14 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals(FlowMode.DEFAULT, api.getFlowMode());
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_v2_withPath() throws Exception {
-        load("/io/gravitee/definition/jackson/api-v2-withpath.json", Api.class);
+        assertThrows(JsonMappingException.class, () -> load("/io/gravitee/definition/jackson/api-v2-withpath.json", Api.class));
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_v1_withFlow() throws Exception {
-        load("/io/gravitee/definition/jackson/api-v1-withflow.json", Api.class);
+        assertThrows(JsonMappingException.class, () -> load("/io/gravitee/definition/jackson/api-v1-withflow.json", Api.class));
     }
 
     @Test

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/DebugApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/DebugApiDeserializerTest.java
@@ -15,7 +15,8 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.gravitee.definition.jackson.AbstractTest;
@@ -25,7 +26,7 @@ import io.gravitee.definition.model.debug.DebugStep;
 import io.gravitee.definition.model.debug.DebugStepStatus;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DebugApiDeserializerTest extends AbstractTest {
 
@@ -139,8 +140,11 @@ public class DebugApiDeserializerTest extends AbstractTest {
         assertEquals(debugApi.getBackendResponse().getHeaders().get("content-length"), List.of("42"));
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void debugApi_withoutRequest() throws Exception {
-        load("/io/gravitee/definition/jackson/debug/debug-api-without-request.json", DebugApi.class);
+        assertThrows(
+            JsonMappingException.class,
+            () -> load("/io/gravitee/definition/jackson/debug/debug-api-without-request.json", DebugApi.class)
+        );
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/DebugApiSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/DebugApiSerializerTest.java
@@ -15,16 +15,11 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.AbstractTest;
-import io.gravitee.definition.model.debug.DebugApi;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpRequestDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpRequestDeserializerTest.java
@@ -15,13 +15,12 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.HttpRequest;
-import io.gravitee.definition.model.HttpResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpRequestSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpRequestSerializerTest.java
@@ -15,15 +15,12 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.HttpRequest;
-import io.gravitee.definition.model.HttpResponse;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -41,7 +38,7 @@ public class HttpRequestSerializerTest extends AbstractTest {
 
         assertNotNull(generatedJsonDefinition);
 
-        Assert.assertEquals(
+        assertEquals(
             objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
             objectMapper().readTree(generatedJsonDefinition.getBytes())
         );
@@ -58,7 +55,7 @@ public class HttpRequestSerializerTest extends AbstractTest {
         assertNotNull(generatedJsonDefinition);
         assertTrue(generatedJsonDefinition.contains("[ \"deflate\", \"gzip\", \"compress\" ]"));
 
-        Assert.assertEquals(
+        assertEquals(
             objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
             objectMapper().readTree(generatedJsonDefinition.getBytes())
         );

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpResponseDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpResponseDeserializerTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.HttpResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpResponseSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/HttpResponseSerializerTest.java
@@ -15,14 +15,12 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.HttpResponse;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -40,7 +38,7 @@ public class HttpResponseSerializerTest extends AbstractTest {
 
         assertNotNull(generatedJsonDefinition);
 
-        Assert.assertEquals(
+        assertEquals(
             objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
             objectMapper().readTree(generatedJsonDefinition.getBytes())
         );
@@ -57,7 +55,7 @@ public class HttpResponseSerializerTest extends AbstractTest {
         assertNotNull(generatedJsonDefinition);
         assertTrue(generatedJsonDefinition.contains("[ \"deflate\", \"gzip\", \"compress\" ]"));
 
-        Assert.assertEquals(
+        assertEquals(
             objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
             objectMapper().readTree(generatedJsonDefinition.getBytes())
         );

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertyDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertyDeserializerTest.java
@@ -15,11 +15,11 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Property;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author GraviteeSource Team

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertySerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertySerializerTest.java
@@ -17,7 +17,7 @@ package io.gravitee.definition.jackson.api;
 
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Property;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/VirtualHostDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/VirtualHostDeserializerTest.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.definition.jackson.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.*;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,8 +34,8 @@ public class VirtualHostDeserializerTest extends AbstractTest {
 
         VirtualHost vHost = objectMapper().readValue(virtualHost, VirtualHost.class);
 
-        Assert.assertNull(vHost.getHost());
-        Assert.assertEquals("/", vHost.getPath());
+        assertNull(vHost.getHost());
+        assertEquals("/", vHost.getPath());
     }
 
     @Test
@@ -42,7 +44,7 @@ public class VirtualHostDeserializerTest extends AbstractTest {
 
         VirtualHost vHost = objectMapper().readValue(virtualHost, VirtualHost.class);
 
-        Assert.assertNull(vHost.getHost());
-        Assert.assertEquals("/randomPath", vHost.getPath());
+        assertNull(vHost.getHost());
+        assertEquals("/randomPath", vHost.getPath());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/plugins/resources/ResourceDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/plugins/resources/ResourceDeserializerTest.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.definition.jackson.plugins.resources;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -29,24 +31,24 @@ public class ResourceDeserializerTest extends AbstractTest {
     @Test
     public void emptyResource() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-defaultpath.json", Api.class);
-        Assert.assertTrue(api.getResources().isEmpty());
+        assertTrue(api.getResources().isEmpty());
     }
 
     @Test
     public void withResource() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withresource.json", Api.class);
-        Assert.assertEquals(1, api.getResources().size());
+        assertEquals(1, api.getResources().size());
     }
 
     @Test
     public void withMultipleResources() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withresources.json", Api.class);
-        Assert.assertEquals(2, api.getResources().size());
+        assertEquals(2, api.getResources().size());
     }
 
     @Test
     public void withDuplicatedResources() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-withduplicatedresources.json", Api.class);
-        Assert.assertEquals(2, api.getResources().size());
+        assertEquals(2, api.getResources().size());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/plugins/resources/ResourceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/plugins/resources/ResourceSerializerTest.java
@@ -15,10 +15,11 @@
  */
 package io.gravitee.definition.jackson.plugins.resources;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -31,7 +32,7 @@ public class ResourceSerializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-defaultpath.json", Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
     }
 
     @Test
@@ -39,7 +40,7 @@ public class ResourceSerializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withresource.json", Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
     }
 
     @Test
@@ -47,7 +48,7 @@ public class ResourceSerializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withresources.json", Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
     }
 
     @Test
@@ -55,6 +56,6 @@ public class ResourceSerializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/api-withduplicatedresources.json", Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesDeserializerTest.java
@@ -15,10 +15,11 @@
  */
 package io.gravitee.definition.jackson.services;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -30,8 +31,8 @@ public class ServicesDeserializerTest extends AbstractTest {
     public void definition_withServices() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/api-withservices.json", Api.class);
 
-        Assert.assertNotNull(api);
-        Assert.assertFalse(api.getServices().isEmpty());
-        Assert.assertEquals(2, api.getServices().getAll().size());
+        assertNotNull(api);
+        assertFalse(api.getServices().isEmpty());
+        assertEquals(2, api.getServices().getAll().size());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesSerializerTest.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.definition.jackson.services;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
@@ -35,7 +36,7 @@ public class ServicesSerializerTest extends AbstractTest {
         Api api = load(oldDefinition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -48,7 +49,7 @@ public class ServicesSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -61,7 +62,7 @@ public class ServicesSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/core/ScheduledServiceDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/core/ScheduledServiceDeserializerTest.java
@@ -15,34 +15,35 @@
  */
 package io.gravitee.definition.jackson.services.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.gravitee.definition.jackson.datatype.services.core.deser.ScheduledServiceDeserializer;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ScheduledServiceDeserializerTest {
 
     @Test
     public void shouldConvertCronForEvery10Seconds() {
         final String every10SecondsCRON = ScheduledServiceDeserializer.convertToCron(10L, TimeUnit.SECONDS);
-        Assert.assertEquals("*/10 * * * * *", every10SecondsCRON);
+        assertEquals("*/10 * * * * *", every10SecondsCRON);
     }
 
     @Test
     public void shouldConvertCronForEvery5Minutes() {
         final String every5MinutesCRON = ScheduledServiceDeserializer.convertToCron(5L, TimeUnit.MINUTES);
-        Assert.assertEquals("0 */5 * * * *", every5MinutesCRON);
+        assertEquals("0 */5 * * * *", every5MinutesCRON);
     }
 
     @Test
     public void shouldConvertCronForEvery2Hours() {
         final String every2HoursCRON = ScheduledServiceDeserializer.convertToCron(2L, TimeUnit.HOURS);
-        Assert.assertEquals("0 0 */2 * * *", every2HoursCRON);
+        assertEquals("0 0 */2 * * *", every2HoursCRON);
     }
 
     @Test
     public void shouldConvertCronForEveryDay() {
         final String everyDayCRON = ScheduledServiceDeserializer.convertToCron(1L, TimeUnit.DAYS);
-        Assert.assertEquals("0 0 0 */1 * *", everyDayCRON);
+        assertEquals("0 0 0 */1 * *", everyDayCRON);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceDeserializerTest.java
@@ -15,12 +15,13 @@
  */
 package io.gravitee.definition.jackson.services.discovery;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -33,7 +34,7 @@ public class EndpointDiscoveryServiceDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/services/discovery/api-withoutservice.json", Api.class);
 
         EndpointDiscoveryService endpointDiscoveryService = api.getService(EndpointDiscoveryService.class);
-        Assert.assertNull(endpointDiscoveryService);
+        assertNull(endpointDiscoveryService);
     }
 
     @Test
@@ -47,15 +48,15 @@ public class EndpointDiscoveryServiceDeserializerTest extends AbstractTest {
             .next()
             .getServices()
             .get(EndpointDiscoveryService.class);
-        Assert.assertNotNull(endpointDiscoveryService);
-        Assert.assertNotNull(endpointDiscoveryService.getConfiguration());
+        assertNotNull(endpointDiscoveryService);
+        assertNotNull(endpointDiscoveryService.getConfiguration());
 
-        Assert.assertEquals("consul-service-discovery", endpointDiscoveryService.getProvider());
-        Assert.assertNotNull(endpointDiscoveryService.getConfiguration());
+        assertEquals("consul-service-discovery", endpointDiscoveryService.getProvider());
+        assertNotNull(endpointDiscoveryService.getConfiguration());
 
         JsonNode configNode = objectMapper().readTree(endpointDiscoveryService.getConfiguration());
-        Assert.assertEquals("my-service", configNode.path("service").asText());
-        Assert.assertEquals("acl", configNode.path("acl").asText());
-        Assert.assertEquals("dc", configNode.path("dc").asText());
+        assertEquals("my-service", configNode.path("service").asText());
+        assertEquals("acl", configNode.path("acl").asText());
+        assertEquals("dc", configNode.path("dc").asText());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceSerializerTest.java
@@ -15,13 +15,15 @@
  */
 package io.gravitee.definition.jackson.services.discovery;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
@@ -37,17 +39,17 @@ public class EndpointDiscoveryServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
 
         EndpointDiscoveryService endpointDiscoveryService = api.getService(EndpointDiscoveryService.class);
-        Assert.assertNull(endpointDiscoveryService);
+        assertNull(endpointDiscoveryService);
     }
 
     @Test
-    @Ignore("Service discovery service has been moved from API to group")
+    @Disabled("Service discovery service has been moved from API to group")
     public void definition_withEndpointDiscovery_consul() throws Exception {
         String definition = "/io/gravitee/definition/jackson/services/discovery/api-withservice-consul.json";
         String expectedDefinition = "/io/gravitee/definition/jackson/services/discovery/api-withservice-consul-expected.json";
@@ -55,7 +57,7 @@ public class EndpointDiscoveryServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceDeserializerTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.definition.jackson.services.dynamicproperty;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.AbstractTest;
@@ -22,8 +24,7 @@ import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyProviderConfiguration;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -36,44 +37,46 @@ public class DynamicPropertyServiceDeserializerTest extends AbstractTest {
         Api api = load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty.json", Api.class);
         DynamicPropertyService dynamicPropertyService = api.getService(DynamicPropertyService.class);
 
-        Assert.assertNotNull(dynamicPropertyService);
+        assertNotNull(dynamicPropertyService);
 
         // Check service configuration
-        Assert.assertTrue(dynamicPropertyService.isEnabled());
+        assertTrue(dynamicPropertyService.isEnabled());
 
         // Check scheduling configuration
-        Assert.assertEquals("*/60 * * * * *", dynamicPropertyService.getSchedule());
+        assertEquals("*/60 * * * * *", dynamicPropertyService.getSchedule());
 
         // Check provider
-        Assert.assertNotNull(dynamicPropertyService.getProvider());
+        assertNotNull(dynamicPropertyService.getProvider());
 
         // Check configuration
         DynamicPropertyProviderConfiguration configuration = dynamicPropertyService.getConfiguration();
-        Assert.assertNotNull(configuration);
+        assertNotNull(configuration);
 
-        Assert.assertEquals("http://my_configuration_url", ((HttpDynamicPropertyProviderConfiguration) configuration).getUrl());
-        Assert.assertEquals("{}", ((HttpDynamicPropertyProviderConfiguration) configuration).getSpecification());
-        Assert.assertEquals(HttpMethod.POST, ((HttpDynamicPropertyProviderConfiguration) configuration).getMethod());
-        Assert.assertEquals(1, ((HttpDynamicPropertyProviderConfiguration) configuration).getHeaders().size());
-        Assert.assertTrue(
+        assertEquals("http://my_configuration_url", ((HttpDynamicPropertyProviderConfiguration) configuration).getUrl());
+        assertEquals("{}", ((HttpDynamicPropertyProviderConfiguration) configuration).getSpecification());
+        assertEquals(HttpMethod.POST, ((HttpDynamicPropertyProviderConfiguration) configuration).getMethod());
+        assertEquals(1, ((HttpDynamicPropertyProviderConfiguration) configuration).getHeaders().size());
+        assertTrue(
             ((HttpDynamicPropertyProviderConfiguration) configuration).getHeaders()
                 .stream()
                 .allMatch(header -> header.getName().equals("Content-type"))
         );
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_withDynamicProperty_badUnit() throws Exception {
-        Api api = load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-badUnit.json", Api.class);
-
-        Assert.assertNotNull(api);
+        assertThrows(
+            JsonMappingException.class,
+            () -> load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-badUnit.json", Api.class)
+        );
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_withDynamicProperty_noProvider() throws Exception {
-        Api api = load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-badUnit.json", Api.class);
-
-        Assert.assertNotNull(api);
+        assertThrows(
+            JsonMappingException.class,
+            () -> load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-badUnit.json", Api.class)
+        );
     }
 
     @Test
@@ -83,23 +86,28 @@ public class DynamicPropertyServiceDeserializerTest extends AbstractTest {
             Api.class
         );
         DynamicPropertyService dynamicPropertyService = api.getService(DynamicPropertyService.class);
-        Assert.assertNotNull(dynamicPropertyService);
-        Assert.assertTrue(dynamicPropertyService.isEnabled());
-        Assert.assertEquals("*/60 * * * * *", dynamicPropertyService.getSchedule());
+        assertNotNull(dynamicPropertyService);
+        assertTrue(dynamicPropertyService.isEnabled());
+        assertEquals("*/60 * * * * *", dynamicPropertyService.getSchedule());
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_withDynamicProperty_httpProvider_noUrl() throws Exception {
-        Api api = load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-noUrl.json", Api.class);
-        api.getServices().get(DynamicPropertyService.class);
+        assertThrows(
+            JsonMappingException.class,
+            () -> load("/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-noUrl.json", Api.class)
+        );
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void definition_withDynamicProperty_httpProvider_noSpecification() throws Exception {
-        Api api = load(
-            "/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-noSpecification.json",
-            Api.class
+        assertThrows(
+            JsonMappingException.class,
+            () ->
+                load(
+                    "/io/gravitee/definition/jackson/services/dynamicproperty/api-withservice-dynamicproperty-noSpecification.json",
+                    Api.class
+                )
         );
-        api.getServices().get(DynamicPropertyService.class);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceSerializerTest.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.definition.jackson.services.dynamicproperty;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
@@ -36,7 +37,7 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Api api = load(oldDefinition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -50,7 +51,7 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -64,7 +65,7 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceDeserializerTest.java
@@ -15,12 +15,13 @@
  */
 package io.gravitee.definition.jackson.services.healthcheck;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,11 +33,11 @@ public class HealthCheckServiceDeserializerTest extends AbstractTest {
     public void healthcheck_withoutservice() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withoutservice-healthcheck.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNull(healthCheckService);
+        assertNull(healthCheckService);
         /*
         This test is to ensure that we remove the boolean "healthcheck" in the root of the definition as it was done before the SME
          */
-        Assert.assertFalse(
+        assertFalse(
             api
                 .getProxy()
                 .getGroups()
@@ -54,75 +55,76 @@ public class HealthCheckServiceDeserializerTest extends AbstractTest {
     public void healthcheck() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
-        Assert.assertTrue(healthCheckService.isEnabled());
-        Assert.assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
+        assertNotNull(healthCheckService);
+        assertTrue(healthCheckService.isEnabled());
+        assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
 
         // Check step
-        Assert.assertFalse(healthCheckService.getSteps().isEmpty());
+        assertFalse(healthCheckService.getSteps().isEmpty());
 
         // Check request
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest());
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
 
         // Check expectations
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getResponse());
+        assertNotNull(healthCheckService.getSteps().get(0).getResponse());
     }
 
     @Test
     public void healthcheck_v2() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-v2.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
-        Assert.assertTrue(healthCheckService.isEnabled());
-        Assert.assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
+        assertNotNull(healthCheckService);
+        assertTrue(healthCheckService.isEnabled());
+        assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
 
         // Check step
-        Assert.assertFalse(healthCheckService.getSteps().isEmpty());
+        assertFalse(healthCheckService.getSteps().isEmpty());
 
         // Check request
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest());
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
-        Assert.assertFalse(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
+        assertFalse(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
 
         // Check expectations
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getResponse());
+        assertNotNull(healthCheckService.getSteps().get(0).getResponse());
     }
 
     @Test
     public void healthcheck_v3() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-v3.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
-        Assert.assertTrue(healthCheckService.isEnabled());
-        Assert.assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
+        assertNotNull(healthCheckService);
+        assertTrue(healthCheckService.isEnabled());
+        assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
 
         // Check step
-        Assert.assertFalse(healthCheckService.getSteps().isEmpty());
+        assertFalse(healthCheckService.getSteps().isEmpty());
 
         // Check request
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest());
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
-        Assert.assertFalse(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest());
+        assertNotNull(healthCheckService.getSteps().get(0).getRequest().getPath());
+        assertFalse(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
 
         // Check expectations
-        Assert.assertNotNull(healthCheckService.getSteps().get(0).getResponse());
+        assertNotNull(healthCheckService.getSteps().get(0).getResponse());
     }
 
-    @Test(expected = JsonMappingException.class)
+    @Test
     public void healthcheck_badUnit() throws Exception {
-        Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-badUnit.json", Api.class);
-
-        Assert.assertNotNull(api);
+        assertThrows(
+            JsonMappingException.class,
+            () -> load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-badUnit.json", Api.class)
+        );
     }
 
     @Test
     public void healthcheck_unitInLowerCase() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-unitInLowerCase.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
-        Assert.assertTrue(healthCheckService.isEnabled());
-        Assert.assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
+        assertNotNull(healthCheckService);
+        assertTrue(healthCheckService.isEnabled());
+        assertEquals("*/60 * * * * *", healthCheckService.getSchedule());
     }
 
     @Test
@@ -131,29 +133,29 @@ public class HealthCheckServiceDeserializerTest extends AbstractTest {
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
 
         // Check step
-        Assert.assertFalse(healthCheckService.getSteps().isEmpty());
+        assertFalse(healthCheckService.getSteps().isEmpty());
 
-        Assert.assertFalse(healthCheckService.getSteps().get(0).getResponse().getAssertions().isEmpty());
+        assertFalse(healthCheckService.getSteps().get(0).getResponse().getAssertions().isEmpty());
     }
 
     @Test
     public void healthcheck_v2_fromRoot() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-v2-fromroot.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
+        assertNotNull(healthCheckService);
 
         // Check step
-        Assert.assertFalse(healthCheckService.getSteps().isEmpty());
+        assertFalse(healthCheckService.getSteps().isEmpty());
 
         // Check request
-        Assert.assertTrue(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
+        assertTrue(healthCheckService.getSteps().get(0).getRequest().isFromRoot());
     }
 
     @Test
     public void healthcheck_disabled() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/services/healthcheck/api-withservice-healthcheck-disabled.json", Api.class);
         HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-        Assert.assertNotNull(healthCheckService);
-        Assert.assertNull(healthCheckService.getSchedule());
+        assertNotNull(healthCheckService);
+        assertNull(healthCheckService.getSchedule());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceSerializerTest.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.definition.jackson.services.healthcheck;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
@@ -35,7 +36,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(oldDefinition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -48,7 +49,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -61,7 +62,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -75,7 +76,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -89,7 +90,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
@@ -102,7 +103,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Api api = load(definition, Api.class);
 
         String generatedJsonDefinition = objectMapper().writeValueAsString(api);
-        Assert.assertNotNull(generatedJsonDefinition);
+        assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
         JSONAssert.assertEquals(expected, generatedJsonDefinition, false);

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.definition.model;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.endpoint.EndpointStatusListener;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EndpointTest {
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/PropertiesTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/PropertiesTest.java
@@ -15,11 +15,11 @@
  */
 package io.gravitee.definition.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -32,14 +32,15 @@ public class PropertiesTest {
         Properties props = new Properties();
         props.setProperties(Arrays.asList(new Property("key1", "value1"), new Property("key2", "value2")));
 
-        assertEquals("not enough properties", 2, props.getProperties().size());
+        assertEquals(2, props.getProperties().size());
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void shouldNotSetDuplicateProperties() {
         Properties props = new Properties();
-        props.setProperties(Arrays.asList(new Property("key1", "value1"), new Property("key1", "value2")));
-
-        fail("must not allow duplicate keys !");
+        assertThrows(
+            RuntimeException.class,
+            () -> props.setProperties(Arrays.asList(new Property("key1", "value1"), new Property("key1", "value2")))
+        );
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/PropertyTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/PropertyTest.java
@@ -15,10 +15,9 @@
  */
 package io.gravitee.definition.model;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author GraviteeSource Team
@@ -30,7 +29,7 @@ public class PropertyTest {
         Property property1 = new Property("key", "value", true);
         Property property2 = new Property("key", "value", true);
 
-        assertTrue(property1.equals(property2));
+        assertEquals(property1, property2);
     }
 
     @Test
@@ -38,21 +37,21 @@ public class PropertyTest {
         Property property1 = new Property("key", "value", true);
         Property property2 = new Property("key", "value", false);
 
-        assertFalse(property1.equals(property2));
+        assertNotEquals(property1, property2);
     }
 
     @Test
     public void equals_should_return_false_cause_parameter_is_null() {
         Property property1 = new Property("key", "value", true);
 
-        assertFalse(property1.equals(null));
+        assertNotEquals(null, property1);
     }
 
     @Test
     public void equals_should_return_false_cause_parameter_is_not_a_property() {
         Property property1 = new Property("key", "value", true);
 
-        assertFalse(property1.equals("a string"));
+        assertNotEquals("a string", property1);
     }
 
     @Test

--- a/gravitee-apim-definition/pom.xml
+++ b/gravitee-apim-definition/pom.xml
@@ -51,8 +51,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gravitee-apim-definition/pom.xml
+++ b/gravitee-apim-definition/pom.xml
@@ -50,9 +50,17 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <!-- Junit dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Do not remove junit-platform-launcher as it's necessary to run the tests with Junit 5 and Junit Pioneer.  -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.RetryingTest;
 import org.mockito.Mock;
 import org.springframework.core.env.Environment;
 
@@ -182,7 +183,7 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
         assertTrue(context.completed());
     }
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     void shouldValidateFromRoot(Vertx vertx, VertxTestContext context) throws Throwable {
         // Prepare HTTP endpoint
         wm.stubFor(get(urlEqualTo("/")).willReturn(ok()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketAcceptTest.java
@@ -23,13 +23,13 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.http.WebSocket;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketAcceptTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_accepted_request(VertxTestContext testContext) throws Throwable {
         httpServer
             .webSocketHandler(serverWebSocket -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketBidirectionalTest.java
@@ -24,12 +24,13 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.http.WebSocket;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketBidirectionalTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_bidirectional_request(VertxTestContext testContext) throws Throwable {
         httpServer
             .webSocketHandler(serverWebSocket -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketCloseTest.java
@@ -22,12 +22,13 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.http.WebSocket;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketCloseTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_closed_request(VertxTestContext testContext) throws Throwable {
         httpServer
             .webSocketHandler(serverWebSocket -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketHeadersTest.java
@@ -26,12 +26,13 @@ import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.http.WebSocket;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketHeadersTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_header_request(VertxTestContext testContext) throws Throwable {
         final String customHeaderName = "Custom-Header";
         final String customHeaderValue = "My-Custom-Header-Value";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketPingFrameTest.java
@@ -25,12 +25,13 @@ import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.WebSocket;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketPingFrameTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_ping_request(VertxTestContext testContext) throws Throwable {
         httpServer
             .webSocketHandler(serverWebSocket -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/WebsocketRejectTest.java
@@ -25,12 +25,13 @@ import io.vertx.core.http.UpgradeRejectedException;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketRejectTest extends AbstractWebsocketGatewayTest {
 
-    @Test
+    @RetryingTest(maxAttempts = 3)
     public void websocket_rejected_request(VertxTestContext testContext) throws Throwable {
         httpServer
             .webSocketHandler(webSocket -> webSocket.reject(UNAUTHORIZED_401))

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -127,6 +127,12 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>${junit-pioneer.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-plugin/pom.xml
+++ b/gravitee-apim-plugin/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Do not remove junit-platform-launcher as it's necessary to run the tests with Junit 5 and Junit Pioneer.  -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
         <json-path.version>2.6.0</json-path.version>
         <json-smart.version>2.4.11</json-smart.version>
         <jsoup.version>1.15.3</jsoup.version>
+        <junit-pioneer.version>2.0.1</junit-pioneer.version>
         <lucene.version>7.7.3</lucene.version>
         <!-- mockito version to remove when https://github.com/gravitee-io/issues/issues/8257 will be completed -->
         <mockito-inline.version>3.11.2</mockito-inline.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- Add junit-pioneer extension to Junit 5. It will allow us to retry our flaky tests.
   See - [circle ci](https://app.circleci.com/insights/github/gravitee-io/gravitee-api-management/workflows/pull_requests/tests?branch=3.19.x) to get the flaky tests list.
- migrate all gravitee-apim-definition tests to use Junit 5.
- Add junit platform launcher in the gravitee-apim-definition and gravitee-apim-plugin modules to avoid `java.lang.NoClassDefFoundError: org/junit/platform/launcher/core/LauncherFactory` exception.

This is not a fix. This annotation is just a way to highlight that a test need to be reworked.
 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lenbctqowb.chromatic.com)
<!-- Storybook placeholder end -->
