### PR TITLE
perf: refactor portal api page resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageResource.java
@@ -104,7 +104,7 @@ public class ApiPageResource extends AbstractResource {
             pageEntity.setGeneralConditions(pageService.isPageUsedAsGeneralConditions(executionContext, pageEntity, api));
 
             if (portal) {
-                pageService.transformSwagger(executionContext, pageEntity, api);
+                pageService.transformSwagger(executionContext, pageEntity, genericApiEntity);
                 if (!isAuthenticated() && pageEntity.getMetadata() != null) {
                     pageEntity.getMetadata().clear();
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
@@ -18,13 +18,14 @@ package io.gravitee.rest.api.portal.rest.resource;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.mapper.PageMapper;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
-import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
@@ -33,11 +34,13 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class ApiPageResource extends AbstractResource {
 
     private static final String INCLUDE_CONTENT = "content";
@@ -57,24 +60,21 @@ public class ApiPageResource extends AbstractResource {
         @PathParam("pageId") String pageId,
         @QueryParam("include") List<String> include
     ) {
-        if (accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), apiId)) {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiId);
+
+        if (accessControlService.canAccessApiFromPortal(executionContext, genericApiEntity)) {
             final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
-
             PageEntity pageEntity = pageService.findById(pageId, acceptedLocale);
-
-            if (accessControlService.canAccessPageFromPortal(GraviteeContext.getExecutionContext(), apiId, pageEntity)) {
-                pageService.transformSwagger(GraviteeContext.getExecutionContext(), pageEntity, apiId);
-
+            if (accessControlService.canAccessApiPageFromPortal(executionContext, genericApiEntity, pageEntity)) {
+                pageService.transformSwagger(executionContext, pageEntity, genericApiEntity);
                 if (!isAuthenticated() && pageEntity.getMetadata() != null) {
                     pageEntity.getMetadata().clear();
                 }
-
                 Page page = pageMapper.convert(uriInfo.getBaseUriBuilder(), apiId, pageEntity);
-
                 if (include.contains(INCLUDE_CONTENT)) {
                     page.setContent(pageEntity.getContent());
                 }
-
                 page.setLinks(
                     pageMapper.computePageLinks(
                         PortalApiLinkHelper.apiPagesURL(uriInfo.getBaseUriBuilder(), apiId, pageId),
@@ -96,10 +96,11 @@ public class ApiPageResource extends AbstractResource {
     public Response getPageContentByApiIdAndPageId(@PathParam("apiId") String apiId, @PathParam("pageId") String pageId) {
         final ApiQuery apiQuery = new ApiQuery();
         apiQuery.setIds(Collections.singletonList(apiId));
-        if (accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), apiId)) {
+        GenericApiEntity genericApiEntity = apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), apiId);
+        if (accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), genericApiEntity)) {
             PageEntity pageEntity = pageService.findById(pageId, null);
-            if (accessControlService.canAccessPageFromPortal(GraviteeContext.getExecutionContext(), apiId, pageEntity)) {
-                pageService.transformSwagger(GraviteeContext.getExecutionContext(), pageEntity, apiId);
+            if (accessControlService.canAccessApiPageFromPortal(GraviteeContext.getExecutionContext(), genericApiEntity, pageEntity)) {
+                pageService.transformSwagger(GraviteeContext.getExecutionContext(), pageEntity, genericApiEntity);
                 return Response.ok(pageEntity.getContent()).build();
             } else {
                 throw new UnauthorizedAccessException();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
@@ -20,12 +20,12 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
@@ -83,7 +83,16 @@ public class ApiPageResourceNotAuthenticatedTest extends AbstractResourceTest {
 
     @Test
     public void shouldHaveMetadataCleared() {
-        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getExecutionContext()), eq(API), any(PageEntity.class)))
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API)).thenReturn(mock(GenericApiEntity.class));
+        when(accessControlService.canAccessApiFromPortal(eq(GraviteeContext.getExecutionContext()), any(GenericApiEntity.class)))
+            .thenReturn(true);
+        when(
+            accessControlService.canAccessApiPageFromPortal(
+                eq(GraviteeContext.getExecutionContext()),
+                any(GenericApiEntity.class),
+                any(PageEntity.class)
+            )
+        )
             .thenReturn(true);
 
         Response anotherResponse = target(API).path("pages").path(ANOTHER_PAGE).request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
@@ -33,5 +33,7 @@ public interface AccessControlService {
 
     boolean canAccessPageFromPortal(final ExecutionContext executionContext, String apiId, PageEntity pageEntity);
 
+    boolean canAccessApiPageFromPortal(final ExecutionContext executionContext, GenericApiEntity apiEntity, PageEntity pageEntity);
+
     boolean canAccessPageFromConsole(final ExecutionContext executionContext, GenericApiEntity genericApiEntity, PageEntity pageEntity);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.documentation.PageQuery;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,7 @@ public interface PageService {
 
     void transformSwagger(ExecutionContext executionContext, PageEntity pageEntity);
 
-    void transformSwagger(ExecutionContext executionContext, PageEntity pageEntity, String apiId);
+    void transformSwagger(ExecutionContext executionContext, PageEntity pageEntity, GenericApiEntity apiEntity);
 
     PageEntity createPage(ExecutionContext executionContext, String apiId, NewPageEntity page);
 
@@ -86,6 +87,7 @@ public interface PageService {
     Map<SystemFolderType, String> initialize(ExecutionContext executionContext);
 
     PageEntity createAsideFolder(ExecutionContext executionContext, String apiId);
+
     PageEntity createSystemFolder(ExecutionContext executionContext, String apiId, SystemFolderType systemFolderType, int order);
 
     PageEntity createWithDefinition(ExecutionContext executionContext, String apiId, String toString);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AccessControlServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AccessControlServiceImpl.java
@@ -72,12 +72,7 @@ public class AccessControlServiceImpl extends AbstractService implements AccessC
         if (PUBLIC.equals(genericApiEntity.getVisibility())) {
             return true;
         } else if (isAuthenticated()) {
-            Set<String> publishedByUser = apiAuthorizationService.findAccessibleApiIdsForUser(
-                executionContext,
-                getAuthenticatedUser().getUsername(),
-                Set.of(genericApiEntity.getId())
-            );
-            return publishedByUser.contains(genericApiEntity.getId());
+            return apiAuthorizationService.canConsumeApi(executionContext, getAuthenticatedUsername(), genericApiEntity);
         }
         return false;
     }
@@ -146,6 +141,11 @@ public class AccessControlServiceImpl extends AbstractService implements AccessC
             return canAccessPage(executionContext, genericApiEntity, pageEntity);
         }
         return canAccessPage(executionContext, null, pageEntity);
+    }
+
+    @Override
+    public boolean canAccessApiPageFromPortal(ExecutionContext executionContext, GenericApiEntity apiEntity, PageEntity pageEntity) {
+        return canAccessPage(executionContext, apiEntity, pageEntity);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -580,81 +580,89 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
     @Override
     public void transformSwagger(final ExecutionContext executionContext, PageEntity pageEntity) {
-        String apiId = null;
         if (pageEntity instanceof ApiPageEntity) {
-            apiId = ((ApiPageEntity) pageEntity).getApi();
+            ApiPageEntity apiPageEntity = (ApiPageEntity) pageEntity;
+            GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiPageEntity.getApi());
+            transformSwagger(executionContext, pageEntity, genericApiEntity);
+        } else {
+            if (markdownSanitize && PageType.MARKDOWN.name().equalsIgnoreCase(pageEntity.getType())) {
+                sanitizeMarkdown(pageEntity);
+            } else if (PageType.SWAGGER.name().equalsIgnoreCase(pageEntity.getType())) {
+                SwaggerDescriptor<?> descriptor = swaggerService.parse(pageEntity.getContent());
+                Collection<SwaggerTransformer<OAIDescriptor>> transformers = new ArrayList<>();
+                transformers.add(new PageConfigurationOAITransformer(pageEntity));
+                swaggerService.transform((OAIDescriptor) descriptor, transformers);
+                setSwaggerContent(pageEntity, descriptor);
+            }
         }
-        transformSwagger(executionContext, pageEntity, apiId);
     }
 
     @Override
-    public void transformSwagger(final ExecutionContext executionContext, PageEntity pageEntity, String apiId) {
+    public void transformSwagger(final ExecutionContext executionContext, PageEntity pageEntity, GenericApiEntity genericApiEntity) {
         // First apply templating if required
-        if (apiId != null) {
-            transformWithTemplate(executionContext, pageEntity, apiId);
-        }
+        transformWithTemplate(executionContext, pageEntity, genericApiEntity.getId());
 
         if (markdownSanitize && PageType.MARKDOWN.name().equalsIgnoreCase(pageEntity.getType())) {
-            final HtmlSanitizer.SanitizeInfos safe = HtmlSanitizer.isSafe(pageEntity.getContent());
-            if (!safe.isSafe()) {
-                pageEntity.setContent(HtmlSanitizer.sanitize(pageEntity.getContent()));
-            }
+            sanitizeMarkdown(pageEntity);
         } else if (PageType.SWAGGER.name().equalsIgnoreCase(pageEntity.getType())) {
             // If swagger page, let's try to apply transformations
             SwaggerDescriptor<?> descriptor;
+
             try {
                 descriptor = swaggerService.parse(pageEntity.getContent());
             } catch (SwaggerDescriptorException sde) {
-                if (apiId != null) {
-                    logger.error("Parsing error for API id[{}]: {}", apiId, sde.getMessage());
-                }
+                logger.error("Parsing error for API id[{}]: {}", genericApiEntity.getId(), sde.getMessage());
                 throw sde;
             }
 
             Collection<SwaggerTransformer<OAIDescriptor>> transformers = new ArrayList<>();
             transformers.add(new PageConfigurationOAITransformer(pageEntity));
 
-            if (apiId != null) {
-                GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiId);
-                List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(executionContext, genericApiEntity);
-
-                String contextPath = null;
-                if (genericApiEntity.getDefinitionVersion() != DefinitionVersion.V4) {
-                    ApiEntity apiEntity = (ApiEntity) genericApiEntity;
-                    contextPath = apiEntity.getContextPath();
-                } else {
-                    io.gravitee.rest.api.model.v4.api.ApiEntity apiEntity = (io.gravitee.rest.api.model.v4.api.ApiEntity) genericApiEntity;
-                    Optional<String> firstPathOpt = apiEntity
-                        .getListeners()
-                        .stream()
-                        .filter(listener -> listener.getType() == ListenerType.HTTP)
-                        .findFirst()
-                        .map(listener -> {
-                            HttpListener httpListener = (HttpListener) listener;
-                            return httpListener.getPaths().get(0).getPath();
-                        });
-                    if (firstPathOpt.isPresent()) {
-                        contextPath = firstPathOpt.get();
-                    }
-                }
-
-                transformers.add(new EntrypointsOAITransformer(pageEntity, apiEntrypoints, contextPath));
-            }
+            List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(executionContext, genericApiEntity);
+            String contextPath = getContextPath(genericApiEntity);
+            transformers.add(new EntrypointsOAITransformer(pageEntity, apiEntrypoints, contextPath));
 
             swaggerService.transform((OAIDescriptor) descriptor, transformers);
 
+            setSwaggerContent(pageEntity, descriptor);
+        }
+    }
+
+    private void setSwaggerContent(PageEntity pageEntity, SwaggerDescriptor<?> descriptor) {
+        try {
             if (pageEntity.getContentType().equalsIgnoreCase(MediaType.APPLICATION_JSON)) {
-                try {
-                    pageEntity.setContent(descriptor.toJson());
-                } catch (JsonProcessingException e) {
-                    logger.error("Unexpected error", e);
-                }
+                pageEntity.setContent(descriptor.toJson());
             } else {
-                try {
-                    pageEntity.setContent(descriptor.toYaml());
-                } catch (JsonProcessingException e) {
-                    logger.error("Unexpected error", e);
-                }
+                pageEntity.setContent(descriptor.toYaml());
+            }
+            pageEntity.setContent(descriptor.toJson());
+        } catch (JsonProcessingException e) {
+            logger.error("Unexpected error", e);
+        }
+    }
+
+    private String getContextPath(GenericApiEntity genericApiEntity) {
+        if (genericApiEntity.getDefinitionVersion() != DefinitionVersion.V4) {
+            ApiEntity apiEntity = (ApiEntity) genericApiEntity;
+            return apiEntity.getContextPath();
+        } else {
+            io.gravitee.rest.api.model.v4.api.ApiEntity apiEntity = (io.gravitee.rest.api.model.v4.api.ApiEntity) genericApiEntity;
+            return apiEntity
+                .getListeners()
+                .stream()
+                .filter(listener -> listener.getType() == ListenerType.HTTP)
+                .findFirst()
+                .map(HttpListener.class::cast)
+                .map(listener -> listener.getPaths().get(0).getPath())
+                .orElse(null);
+        }
+    }
+
+    private void sanitizeMarkdown(PageEntity pageEntity) {
+        if (markdownSanitize && PageType.MARKDOWN.name().equalsIgnoreCase(pageEntity.getType())) {
+            final HtmlSanitizer.SanitizeInfos safe = HtmlSanitizer.isSafe(pageEntity.getContent());
+            if (!safe.isSafe()) {
+                pageEntity.setContent(HtmlSanitizer.sanitize(pageEntity.getContent()));
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -38,7 +38,7 @@ import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.search.Indexable;
-import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -47,8 +47,10 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.UserConverter;
 import io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
+import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +81,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
 
     private final ApiRepository apiRepository;
 
-    private final ApiService apiService;
+    private final GenericApiMapper genericApiMapper;
 
     private final PageService pageService;
 
@@ -100,7 +102,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     @Autowired
     public SearchIndexUpgrader(
         @Lazy ApiRepository apiRepository,
-        ApiService apiService,
+        GenericApiMapper genericApiMapper,
         PageService pageService,
         @Lazy UserRepository userRepository,
         SearchEngineService searchEngineService,
@@ -111,7 +113,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
         final PrimaryOwnerService primaryOwnerService
     ) {
         this.apiRepository = apiRepository;
-        this.apiService = apiService;
+        this.genericApiMapper = genericApiMapper;
         this.pageService = pageService;
         this.userRepository = userRepository;
         this.searchEngineService = searchEngineService;
@@ -200,12 +202,13 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
         } else {
             indexable = apiConverter.toApiEntity(api, primaryOwner);
         }
-        return runApiIndexationAsync(executionContext, api.getId(), indexable, executorService);
+        return runApiIndexationAsync(executionContext, api, primaryOwner, indexable, executorService);
     }
 
     private CompletableFuture<?> runApiIndexationAsync(
         ExecutionContext executionContext,
-        String apiId,
+        Api api,
+        PrimaryOwnerEntity primaryOwnerEntity,
         Indexable indexable,
         ExecutorService executorService
     ) {
@@ -216,9 +219,10 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
                     searchEngineService.index(executionContext, indexable, true, false);
 
                     // Pages
+                    GenericApiEntity genericApiEntity = genericApiMapper.toGenericApi(api, primaryOwnerEntity);
                     List<PageEntity> apiPages = pageService.search(
                         executionContext.getEnvironmentId(),
-                        new PageQuery.Builder().api(apiId).published(true).build(),
+                        new PageQuery.Builder().api(api.getId()).published(true).build(),
                         true
                     );
                     apiPages.forEach(page -> {
@@ -229,7 +233,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
                                 !PageType.SYSTEM_FOLDER.name().equals(page.getType()) &&
                                 !PageType.LINK.name().equals(page.getType())
                             ) {
-                                pageService.transformSwagger(executionContext, page, apiId);
+                                pageService.transformSwagger(executionContext, page, genericApiEntity);
                                 searchEngineService.index(executionContext, page, true, false);
                             }
                         } catch (Exception ignored) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Set;
@@ -29,6 +30,8 @@ import java.util.Set;
  */
 public interface ApiAuthorizationService {
     boolean canManageApi(RoleEntity role);
+
+    boolean canConsumeApi(ExecutionContext executionContext, String userId, GenericApiEntity apiEntity);
 
     default Set<String> findAccessibleApiIdsForUser(final ExecutionContext executionContext, final String userId) {
         return findAccessibleApiIdsForUser(executionContext, userId, new ApiQuery());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -29,13 +29,10 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.*;
-import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.repository.management.model.Visibility;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.PrimaryOwnerEntity;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -218,6 +215,48 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
         return searchEngineQuery;
     }
 
+    @Override
+    public boolean canConsumeApi(ExecutionContext executionContext, String userId, GenericApiEntity api) {
+        if (io.gravitee.rest.api.model.Visibility.PUBLIC.equals(api.getVisibility())) {
+            return true;
+        }
+
+        boolean isDirectMember = membershipService
+            .getMembershipsByMemberAndReference(MembershipMemberType.USER, userId, MembershipReferenceType.API)
+            .stream()
+            .anyMatch(membership -> membership.getReferenceId().equals(api.getId()));
+
+        if (isDirectMember) {
+            return true;
+        }
+
+        Set<String> apiGroups = api.getGroups();
+
+        if (apiGroups != null && !apiGroups.isEmpty()) {
+            boolean isApiGroupMember = membershipService
+                .getMembershipsByMemberAndReference(MembershipMemberType.USER, userId, MembershipReferenceType.GROUP)
+                .stream()
+                .anyMatch(membership -> apiGroups.contains(membership.getReferenceId()));
+
+            if (isApiGroupMember) {
+                return true;
+            }
+        }
+
+        Set<String> applicationIds = getUserApplicationIds(executionContext, userId);
+
+        if (applicationIds.isEmpty()) {
+            return false;
+        }
+
+        final SubscriptionQuery query = new SubscriptionQuery();
+        query.setApplications(applicationIds);
+        query.setApi(api.getId());
+        query.setStatuses(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.RESUMED));
+
+        return !subscriptionService.search(executionContext, query).isEmpty();
+    }
+
     public List<ApiCriteria> computeApiCriteriaForUser(
         ExecutionContext executionContext,
         String userId,
@@ -265,27 +304,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
 
             // get user subscribed apis, useful when an API becomes private and an app owner is not anymore in members.
             if (!manageOnly) {
-                Set<String> userApplicationIds = membershipService.getReferenceIdsByMemberAndReference(
-                    MembershipMemberType.USER,
-                    userId,
-                    MembershipReferenceType.APPLICATION
-                );
-
-                Set<String> applicationIds = new HashSet<>(userApplicationIds);
-
-                Set<String> userGroupIds = membershipService.getReferenceIdsByMemberAndReference(
-                    MembershipMemberType.USER,
-                    userId,
-                    MembershipReferenceType.GROUP
-                );
-
-                ApplicationQuery appQuery = new ApplicationQuery();
-                appQuery.setGroups(userGroupIds);
-                appQuery.setStatus(ApplicationStatus.ACTIVE.name());
-
-                Set<String> userGroupApplicationIds = applicationService.searchIds(executionContext, appQuery, null);
-
-                applicationIds.addAll(userGroupApplicationIds);
+                Set<String> applicationIds = getUserApplicationIds(executionContext, userId);
 
                 if (!applicationIds.isEmpty()) {
                     final SubscriptionQuery query = new SubscriptionQuery();
@@ -311,6 +330,31 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
             }
         }
         return apiCriteriaList;
+    }
+
+    private Set<String> getUserApplicationIds(ExecutionContext executionContext, String userId) {
+        Set<String> userApplicationIds = membershipService.getReferenceIdsByMemberAndReference(
+            MembershipMemberType.USER,
+            userId,
+            MembershipReferenceType.APPLICATION
+        );
+
+        Set<String> applicationIds = new HashSet<>(userApplicationIds);
+
+        Set<String> userGroupIds = membershipService.getReferenceIdsByMemberAndReference(
+            MembershipMemberType.USER,
+            userId,
+            MembershipReferenceType.GROUP
+        );
+
+        ApplicationQuery appQuery = new ApplicationQuery();
+        appQuery.setGroups(userGroupIds);
+        appQuery.setStatus(ApplicationStatus.ACTIVE.name());
+
+        Set<String> groupApplicationIds = applicationService.searchIds(executionContext, appQuery, null);
+        applicationIds.addAll(groupApplicationIds);
+
+        return applicationIds;
     }
 
     private Set<String> findApiIdsByUserGroups(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AccessControlServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AccessControlServiceTest.java
@@ -39,6 +39,7 @@ import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
@@ -46,9 +47,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
-import io.gravitee.rest.api.service.v4.ApiService;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -197,8 +196,11 @@ public class AccessControlServiceTest {
         apiEntity.setId(API_ID);
         apiEntity.setVisibility(Visibility.PRIVATE);
 
-        when(apiAuthorizationService.findAccessibleApiIdsForUser(eq(GraviteeContext.getExecutionContext()), any(), any(Set.class)))
-            .thenReturn(Collections.singleton(API_ID));
+        when(
+            apiAuthorizationService.canConsumeApi(eq(GraviteeContext.getExecutionContext()), any(String.class), any(GenericApiEntity.class))
+        )
+            .thenReturn(true);
+
         connectUser();
 
         boolean canAccess = accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
@@ -33,7 +33,6 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.search.Indexable;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -41,6 +40,7 @@ import io.gravitee.rest.api.service.converter.UserConverter;
 import io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -62,6 +62,9 @@ public class SearchIndexUpgraderTest {
 
     @Mock
     private ApiRepository apiRepository;
+
+    @Mock
+    private GenericApiMapper genericApiMapper;
 
     @Mock
     private PageService pageService;
@@ -107,7 +110,10 @@ public class SearchIndexUpgraderTest {
         verify(environmentRepository, times(1)).findById("env1");
         verify(environmentRepository, times(1)).findById("env2");
         verify(environmentRepository, times(1)).findById("env3");
+
         verifyNoMoreInteractions(environmentRepository);
+
+        verify(genericApiMapper, times(4)).toGenericApi(any(Api.class), any());
     }
 
     @Test
@@ -148,6 +154,8 @@ public class SearchIndexUpgraderTest {
                 eq(true),
                 eq(false)
             );
+
+        verify(genericApiMapper, times(4)).toGenericApi(any(Api.class), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -23,9 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
 import io.gravitee.common.data.domain.Page;
@@ -35,20 +33,19 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.Visibility;
-import io.gravitee.rest.api.model.MembershipEntity;
-import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.CategoryService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -484,5 +481,59 @@ public class ApiAuthorizationServiceImplTest {
 
         assertThat(result).hasSize(2);
         verify(subscriptionService).search(any(), argThat(argument -> argument.getExcludedApis().contains(apiId)));
+    }
+
+    @Test
+    public void shouldBeAbleToConsumePublicApi() {
+        GenericApiEntity api = mock(GenericApiEntity.class);
+        when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PUBLIC);
+        assertThat(apiAuthorizationService.canConsumeApi(GraviteeContext.getExecutionContext(), USER_NAME, api)).isTrue();
+    }
+
+    @Test
+    public void shouldBeAbleToConsumeApiIfDirectMember() {
+        GenericApiEntity api = mock(GenericApiEntity.class);
+        when(api.getId()).thenReturn("api-id");
+        when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
+        MembershipEntity membership = mock(MembershipEntity.class);
+        when(membership.getReferenceId()).thenReturn("api-id");
+        when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.API))
+            .thenReturn(Collections.singleton(membership));
+        assertThat(apiAuthorizationService.canConsumeApi(GraviteeContext.getExecutionContext(), USER_NAME, api)).isTrue();
+    }
+
+    @Test
+    public void shouldBeAbleToConsumeApiIfMemberFromGroup() {
+        GenericApiEntity api = mock(GenericApiEntity.class);
+        when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
+        when(api.getGroups()).thenReturn(Collections.singleton("group-id"));
+        MembershipEntity membership = mock(MembershipEntity.class);
+        when(membership.getReferenceId()).thenReturn("group-id");
+        when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.GROUP))
+            .thenReturn(Collections.singleton(membership));
+        assertThat(apiAuthorizationService.canConsumeApi(GraviteeContext.getExecutionContext(), USER_NAME, api)).isTrue();
+    }
+
+    @Test
+    public void shouldBeAbleToConsumeApiIfDirectMemberOfSubscribedApplication() {
+        GenericApiEntity api = mock(GenericApiEntity.class);
+        when(api.getId()).thenReturn("api-id");
+        when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
+        when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
+
+        when(
+            membershipService.getReferenceIdsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.APPLICATION)
+        )
+            .thenReturn(Collections.singleton("application-id"));
+
+        final SubscriptionQuery query = new SubscriptionQuery();
+        query.setApplications(Collections.singleton("application-id"));
+        query.setApi(api.getId());
+        query.setStatuses(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.RESUMED));
+
+        when(subscriptionService.search(any(ExecutionContext.class), eq(query)))
+            .thenReturn(Collections.singletonList(new SubscriptionEntity()));
+
+        assertThat(apiAuthorizationService.canConsumeApi(GraviteeContext.getExecutionContext(), USER_NAME, api)).isTrue();
     }
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-2133

Data
--

Data used for testing is available on the document DB instance under the `gravitee_apim_3_20_x_perf` database:

  - 50 apis
  - 4500 applications
  - user is linked to the APIs by subscription attached to an application that he's been granted access to through a group

Average time to get one API page before refactoring is 7s
Average time to get one API page after refactoring is 2s

The refactoring consists in
  - not fetching all APIs in the canAccessApiFrom portal method
  - reduce the number of calls to fetch a generic API entity

Details
--

Fist sample is before refactoring, second is after refactoring the canAccessApiFromPortal method and third is after reducing the calls to apiSearchService.findGenericById

```
 ---------------------------------------------
ns         %     Task name
---------------------------------------------
5272996625  083%  accessControlService.canAccessApiFromPortal
171418583  003%  pageService.findById
374651708  006%  accessControlService.canAccessPageFromPortal
533524917  008%  pageService.transformSwagger
---------------------------------------------
1289978125  049%  accessControlService.canAccessApiFromPortal
204550958  008%  pageService.findById
491606000  019%  accessControlService.canAccessPageFromPortal
658290833  025%  pageService.transformSwagger
---------------------------------------------
1033692500  061%  accessControlService.canAccessApiFromPortal
122929208  007%  pageService.findById
000019292  000%  accessControlService.canAccessPageFromPortal
548748917  032%  pageService.transformSwagger
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jnbcfvwtey.chromatic.com)
<!-- Storybook placeholder end -->
