### PR TITLE
fix: use applicationType from db instead of optional metadata

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -350,7 +350,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             if (!isApplicationTypeAllowed(executionContext, appType, executionContext.getEnvironmentId())) {
                 throw new IllegalStateException("Application type '" + appType + "' is not allowed");
             }
-            checkClientSettings(newApplicationEntity.getSettings().getoAuthClient());
+            checkClientSettings(newApplicationEntity.getSettings().getoAuthClient(), newApplicationEntity.getType());
 
             // Create an OAuth client
             ClientRegistrationResponse registrationResponse = clientRegistrationService.register(executionContext, newApplicationEntity);
@@ -454,15 +454,15 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
     }
 
-    private void checkClientSettings(OAuthClientSettings oAuthClientSettings) {
+    private void checkClientSettings(OAuthClientSettings oAuthClientSettings, String applicationType) {
         if (oAuthClientSettings.getGrantTypes() == null || oAuthClientSettings.getGrantTypes().isEmpty()) {
             throw new ApplicationGrantTypesNotFoundException();
         }
 
-        ApplicationTypeEntity applicationType = applicationTypeService.getApplicationType(oAuthClientSettings.getApplicationType());
+        ApplicationTypeEntity applicationTypeEntity = applicationTypeService.getApplicationType(applicationType);
 
         List<String> targetGrantTypes = oAuthClientSettings.getGrantTypes();
-        List<String> allowedGrantTypes = applicationType
+        List<String> allowedGrantTypes = applicationTypeEntity
             .getAllowed_grant_types()
             .stream()
             .map(ApplicationGrantTypeEntity::getType)
@@ -472,11 +472,11 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
 
         List<String> redirectUris = oAuthClientSettings.getRedirectUris();
-        if (applicationType.getRequires_redirect_uris() && (redirectUris == null || redirectUris.isEmpty())) {
+        if (applicationTypeEntity.getRequires_redirect_uris() && (redirectUris == null || redirectUris.isEmpty())) {
             throw new ApplicationRedirectUrisNotFound();
         }
 
-        List<String> responseTypes = applicationType
+        List<String> responseTypes = applicationTypeEntity
             .getAllowed_grant_types()
             .stream()
             .filter(applicationGrantTypeEntity -> targetGrantTypes.contains(applicationGrantTypeEntity.getType()))
@@ -548,7 +548,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             } else {
                 // Check that client registration is enabled
                 checkClientRegistrationEnabled(executionContext, executionContext.getEnvironmentId());
-                checkClientSettings(updateApplicationEntity.getSettings().getoAuthClient());
+                checkClientSettings(updateApplicationEntity.getSettings().getoAuthClient(), applicationToUpdate.getType().name());
 
                 // Update an OAuth client
                 final String registrationPayload = applicationToUpdate.getMetadata().get(METADATA_REGISTRATION_PAYLOAD);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -326,7 +326,7 @@ public class ApplicationService_CreateTest {
     @Test
     public void shouldCreateOauthApp() throws TechnicalException {
         when(application.getName()).thenReturn(APPLICATION_NAME);
-        when(application.getType()).thenReturn(ApplicationType.SIMPLE);
+        when(application.getType()).thenReturn(ApplicationType.BROWSER);
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
         when(applicationRepository.create(any())).thenReturn(application);
         when(newApplication.getName()).thenReturn(APPLICATION_NAME);
@@ -347,7 +347,7 @@ public class ApplicationService_CreateTest {
         oAuthClientSettings.setApplicationType("BROWSER");
         settings.setoAuthClient(oAuthClientSettings);
         when(newApplication.getSettings()).thenReturn(settings);
-        when(newApplication.getSettings()).thenReturn(settings);
+        when(newApplication.getType()).thenReturn(ApplicationType.BROWSER.name());
 
         // mock application type service
         ApplicationTypeEntity applicationTypeEntity = new ApplicationTypeEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -393,7 +393,7 @@ public class ApplicationService_UpdateTest {
         ApplicationSettings settings = new ApplicationSettings();
         OAuthClientSettings oAuthClientSettings = new OAuthClientSettings();
         oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
-        oAuthClientSettings.setApplicationType("application-type");
+        oAuthClientSettings.setApplicationType(ApplicationType.BROWSER.name());
         settings.setoAuthClient(oAuthClientSettings);
         when(updateApplication.getSettings()).thenReturn(settings);
 
@@ -403,7 +403,7 @@ public class ApplicationService_UpdateTest {
         applicationGrantTypeEntity.setResponse_types(List.of("response-type"));
         applicationTypeEntity.setAllowed_grant_types(List.of(applicationGrantTypeEntity));
         applicationTypeEntity.setRequires_redirect_uris(false);
-        when(applicationTypeService.getApplicationType("application-type")).thenReturn(applicationTypeEntity);
+        when(applicationTypeService.getApplicationType(ApplicationType.BROWSER.name())).thenReturn(applicationTypeEntity);
 
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
@@ -454,7 +454,7 @@ public class ApplicationService_UpdateTest {
         ApplicationSettings settings = new ApplicationSettings();
         OAuthClientSettings oAuthClientSettings = new OAuthClientSettings();
         oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
-        oAuthClientSettings.setApplicationType("application-type");
+        oAuthClientSettings.setApplicationType(ApplicationType.BROWSER.name());
         settings.setoAuthClient(oAuthClientSettings);
         when(updateApplication.getSettings()).thenReturn(settings);
 
@@ -464,7 +464,7 @@ public class ApplicationService_UpdateTest {
         applicationGrantTypeEntity.setResponse_types(List.of("response-type"));
         applicationTypeEntity.setAllowed_grant_types(List.of(applicationGrantTypeEntity));
         applicationTypeEntity.setRequires_redirect_uris(false);
-        when(applicationTypeService.getApplicationType("application-type")).thenReturn(applicationTypeEntity);
+        when(applicationTypeService.getApplicationType(ApplicationType.BROWSER.name())).thenReturn(applicationTypeEntity);
 
         // DCR throws exception
         when(clientRegistrationService.update(any(), any(), same(updateApplication))).thenThrow(RuntimeException.class);


### PR DESCRIPTION
In openId spec, the application_type property is optional (https://openid.net/specs/openid-connect-registration-1_0.html\#ClientMetadata)

## Issue

https://gravitee.atlassian.net/browse/APIM-345


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ajxxxteuyv.chromatic.com)
<!-- Storybook placeholder end -->
