### PR TITLE
fix: redeploy message shown incorrectly when exporting api after creation

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Properties.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Properties.java
@@ -30,33 +30,30 @@ import java.util.stream.Collectors;
 public class Properties implements Serializable {
 
     @JsonProperty("properties")
-    private List<Property> properties;
+    private List<Property> propertiesList = List.of();
 
     @JsonIgnore
-    private Map<String, String> entries;
+    private Map<String, String> entries = Map.of();
 
     public void setProperties(List<Property> properties) {
-        this.properties = properties;
+        this.propertiesList = properties == null ? List.of() : properties;
 
-        if (properties != null) {
-            this.entries =
-                properties
-                    .stream()
-                    .collect(
-                        Collectors.toMap(
-                            Property::getKey,
-                            Property::getValue,
-                            (v1, v2) -> {
-                                throw new RuntimeException(String.format("Duplicate key for values %s and %s", v1, v2));
-                            },
-                            TemplatedValueHashMap::new
-                        )
-                    );
-        }
+        this.entries =
+            this.propertiesList.stream()
+                .collect(
+                    Collectors.toMap(
+                        Property::getKey,
+                        Property::getValue,
+                        (v1, v2) -> {
+                            throw new RuntimeException(String.format("Duplicate key for values %s and %s", v1, v2));
+                        },
+                        TemplatedValueHashMap::new
+                    )
+                );
     }
 
     public List<Property> getProperties() {
-        return properties;
+        return propertiesList;
     }
 
     @JsonIgnore

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/processor/SynchronizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/processor/SynchronizationService.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.model.DeploymentRequired;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -40,32 +41,82 @@ public class SynchronizationService {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Check synchronization between two entities by only comparing the required fields necessary for comparision
+     *
+     * @param entityClass    entity class type
+     * @param deployedEntity currently deployed entity state
+     * @param entityToDeploy proposed entity state to be deployed
+     * @return the synchronization status
+     */
     public <T> boolean checkSynchronization(final Class<T> entityClass, final T deployedEntity, final T entityToDeploy) {
-        List<Object> requiredFieldsDeployedApi = new ArrayList<Object>();
-        List<Object> requiredFieldsApiToDeploy = new ArrayList<Object>();
-        for (Field f : entityClass.getDeclaredFields()) {
-            if (f.getAnnotation(DeploymentRequired.class) != null) {
-                boolean previousAccessibleState = f.isAccessible();
-                f.setAccessible(true);
-                try {
-                    requiredFieldsDeployedApi.add(f.get(deployedEntity));
-                    requiredFieldsApiToDeploy.add(f.get(entityToDeploy));
-                } catch (Exception e) {
-                    LOGGER.error("Error access entity required deployment fields", e);
-                } finally {
-                    f.setAccessible(previousAccessibleState);
-                }
-            }
-        }
-
         try {
-            String requiredFieldsDeployedApiDefinition = objectMapper.writeValueAsString(requiredFieldsDeployedApi);
-            String requiredFieldsApiToDeployDefinition = objectMapper.writeValueAsString(requiredFieldsApiToDeploy);
+            String requiredFieldsDeployedApiDefinition = objectMapper.writeValueAsString(
+                getRequiredFieldsForComparison(entityClass, deployedEntity)
+            );
+            String requiredFieldsApiToDeployDefinition = objectMapper.writeValueAsString(
+                getRequiredFieldsForComparison(entityClass, entityToDeploy)
+            );
 
-            return requiredFieldsDeployedApiDefinition.equals(requiredFieldsApiToDeployDefinition);
+            return objectMapper
+                .readTree(requiredFieldsDeployedApiDefinition)
+                .equals(objectMapper.readTree(requiredFieldsApiToDeployDefinition));
         } catch (Exception e) {
             LOGGER.error("Unexpected error while generating API deployment required fields definition", e);
             return false;
         }
+    }
+
+    /**
+     * Get required entity fields for synchronization checks
+     *
+     * @param entityClass entity class type
+     * @param entity      an entity object
+     * @return the list of required entity fields
+     */
+    public <T> List<Object> getRequiredFieldsForComparison(final Class<T> entityClass, final T entity) {
+        List<Object> requiredEntityFields = new ArrayList<>();
+
+        if (Objects.nonNull(entityClass)) {
+            for (Field entityField : entityClass.getDeclaredFields()) {
+                addRequiredEntityFieldToList(entityField, entity, requiredEntityFields);
+            }
+        }
+
+        return requiredEntityFields;
+    }
+
+    /**
+     * Add an entity field from the supplied entity to the given list
+     * if the entity field is a required field
+     *
+     * @param entityField the field within a given entity
+     * @param entity the entity object
+     * @param requiredEntityFields a list of required fields
+     */
+    public <T> void addRequiredEntityFieldToList(Field entityField, final T entity, List<Object> requiredEntityFields) {
+        if (isFieldRequiredForDeployment(entityField)) {
+            boolean previousAccessibleState = entityField.isAccessible();
+            entityField.setAccessible(true);
+
+            try {
+                requiredEntityFields.add(entityField.get(entity));
+            } catch (Exception e) {
+                LOGGER.error("Error access entity required deployment fields", e);
+            } finally {
+                entityField.setAccessible(previousAccessibleState);
+            }
+        }
+    }
+
+    /**
+     * Check if the field within a class has the DeploymentRequired
+     * annotation
+     *
+     * @param classField The field within a class
+     * @return whether the field is required
+     */
+    public boolean isFieldRequiredForDeployment(Field classField) {
+        return classField.getAnnotation(DeploymentRequired.class) != null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/processor/SynchronizationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/processor/SynchronizationServiceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.processor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doThrow;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import java.util.*;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class SynchronizationServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private ObjectMapper objectMapperMock;
+
+    private final SynchronizationService synchronizationService = new SynchronizationService(objectMapper);
+
+    /**
+     * GIVEN an entity
+     * WHEN the required entity fields are retrieved
+     * THEN only the correct amount of required fields should be returned
+     */
+    @Test
+    public void thenTheRequiredFieldsShouldBeReturned() {
+        ApiEntity entity = new ApiEntity();
+
+        entity.setCrossId("c38d779e-6e7e-472b-8d77-9e6e7e172b08");
+        entity.setUpdatedAt(new Date());
+        entity.setState(Lifecycle.State.INITIALIZED);
+        entity.setPrimaryOwner(new PrimaryOwnerEntity());
+        entity.setProperties(new Properties());
+        entity.setServices(new Services());
+        entity.setEntrypoints(new ArrayList<>());
+
+        int apiEntityRequiredFieldCount = 13;
+
+        List<Object> requiredFields = synchronizationService.getRequiredFieldsForComparison(ApiEntity.class, entity);
+
+        assertThat(requiredFields.size() == apiEntityRequiredFieldCount, is(true));
+    }
+
+    /**
+     * GIVEN two equal entities
+     * WHEN the synchronization check is invoked
+     * THEN the two equal entities should be deemed as in sync
+     */
+    @Test
+    public void thenTwoEqualEntitiesShouldBeSynchronized() {
+        ApiEntity deployedEntity = new ApiEntity();
+
+        deployedEntity.setCrossId("c38d779e-6e7e-472b-8d77-9e6e7e172b08");
+        deployedEntity.setUpdatedAt(new Date());
+        deployedEntity.setState(Lifecycle.State.INITIALIZED);
+        deployedEntity.setPrimaryOwner(new PrimaryOwnerEntity());
+        deployedEntity.setProperties(new Properties());
+        deployedEntity.setServices(new Services());
+        deployedEntity.setEntrypoints(new ArrayList<>());
+
+        ApiEntity entityToDeploy = new ApiEntity();
+
+        entityToDeploy.setCrossId("c38d779e-6e7e-472b-8d77-9e6e7e172b08");
+        entityToDeploy.setUpdatedAt(new Date());
+        entityToDeploy.setState(Lifecycle.State.INITIALIZED);
+        entityToDeploy.setPrimaryOwner(new PrimaryOwnerEntity());
+        entityToDeploy.setProperties(new Properties());
+        entityToDeploy.setServices(new Services());
+        entityToDeploy.setEntrypoints(new ArrayList<>());
+
+        boolean isSynchronized = synchronizationService.checkSynchronization(ApiEntity.class, deployedEntity, entityToDeploy);
+
+        assertThat(isSynchronized, is(true));
+    }
+
+    /**
+     * GIVEN two unequal entities
+     * WHEN the synchronization check is invoked
+     * THEN the two unequal entities should be out of sync
+     */
+    @Test
+    public void thenTwoUnequalEntitiesShouldNotBeSynchronized() {
+        ApiEntity deployedEntity = new ApiEntity();
+
+        deployedEntity.setCrossId("c38d779e-6e7e-472b-8d77-9e6e7e172b08");
+        deployedEntity.setUpdatedAt(new Date());
+        deployedEntity.setState(Lifecycle.State.INITIALIZED);
+        deployedEntity.setPrimaryOwner(new PrimaryOwnerEntity());
+        deployedEntity.setProperties(new Properties());
+        deployedEntity.setServices(new Services());
+        deployedEntity.setEntrypoints(new ArrayList<>());
+        deployedEntity.setId("1");
+
+        ApiEntity entityToDeploy = new ApiEntity();
+
+        entityToDeploy.setCrossId(null);
+        entityToDeploy.setUpdatedAt(null);
+        entityToDeploy.setState(null);
+        entityToDeploy.setPrimaryOwner(null);
+        entityToDeploy.setProperties(null);
+        entityToDeploy.setServices(null);
+        entityToDeploy.setEntrypoints(null);
+        entityToDeploy.setId("2");
+
+        boolean isSynchronized = synchronizationService.checkSynchronization(ApiEntity.class, deployedEntity, entityToDeploy);
+
+        assertThat(isSynchronized, is(false));
+    }
+
+    /**
+     * GIVEN an invalid field
+     * WHEN we attempt to extract the field from the entity
+     * THEN an error should be thrown regarding access to entity fields
+     */
+    @Test(expected = Exception.class)
+    public void thenAnErrorShouldBeThrownRegardingAccessToEntityFields() {
+        synchronizationService.addRequiredEntityFieldToList(null, null, null);
+
+        fail("should throw Exception regarding access to entity fields");
+    }
+
+    /**
+     * GIVEN an issue has occurred during synchronization checks
+     * WHEN we attempt to check synchronization between two entities
+     * THEN an error is thrown regarding field definition generation
+     */
+    @Test(expected = Exception.class)
+    public void thenAnErrorShouldBeThrownRegardingFieldDefinitionGeneration() throws JsonProcessingException {
+        doThrow(new RuntimeException()).when(objectMapperMock).writeValueAsString(any());
+
+        SynchronizationService synchronizationServiceWithMock = new SynchronizationService(objectMapperMock);
+
+        synchronizationServiceWithMock.checkSynchronization(null, null, null);
+
+        fail("should throw Exception regarding field definition generation");
+    }
+}


### PR DESCRIPTION
## Issue
First API Export Causes API Desynchronization

https://gravitee.atlassian.net/browse/APIM-1701

## Description

Added functionality to ensure when the API is exported (First export) after being created then the banner requesting the end user to redeploy the API is not shown as no changes have been made.

The Issue was that the string comparison made did not account for the Proxy -> Group -> Endpoint string being compared in an incorrect order see **_Figure 1.1_** - Even though the object is in fact equal the string comparison declared it as out of sync due to the order in which the Object attributes where being compared.

<img width="1199" alt="incorrect order compare" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/81c44e42-cfc1-4c60-af33-47e04092abff">
**_Figure 1.1_**


The other issue was the null comparison check between the Properties `io/gravitee/definition/model/Properties.java`& Services `io.gravitee.definition.model.services.Services` - although not exactly the same both the deployed API and the API to be deployed have empty values after export and so we have ignored this difference. see **_Figure 1.2_**

<img width="1199" alt="null compare" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/f7472407-45c6-47d7-9b9f-5f94d3c3dfa4">
**_Figure 1.2_**

 

## Additional context

<!-- Add any other context about the PR here -->
Assumptions made:

- null comparison with an empty array / object  should equate to true for Properties `io/gravitee/definition/model/Properties.java`& Services `io.gravitee.definition.model.services.Services`

- the Endpoint comparison only compares the endpoint name in the equals method `io/gravitee/definition/model/Endpoint.java`

<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
- Create and Deploy a Keyless API
- Export API (select all or no options)
- The banner is then shown to the user to redeploy API see **_Figure 2.1_**

<img width="1179" alt="API banner on first export" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/76285807-4205-4d8d-af11-e7d10f66d5d4">
**_Figure 2.1_**

- The correct result is shown in **_Video 2.1_**

https://github.com/gravitee-io/gravitee-api-management/assets/137767084/c0c21d68-c608-4696-adc0-cef4d799e9b9
_**Video 2.1**_

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mvnrvuuywa.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4726.team-apim.gravitee.dev/console](https://4726.team-apim.gravitee.dev/console)
      Portal: [https://4726.team-apim.gravitee.dev/portal](https://4726.team-apim.gravitee.dev/portal)
      Management-api: [https://4726.team-apim.gravitee.dev/api/management](https://4726.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4726.team-apim.gravitee.dev](https://4726.team-apim.gravitee.dev)
      Gateway v3: [https://4726.gateway-v3.team-apim.gravitee.dev](https://4726.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
