### PR TITLE
fix: allow to update application that has push plans subscriptions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -654,6 +655,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 Set<GenericPlanEntity> plans =
                     this.planSearchService.findByIdIn(executionContext, planIds)
                         .stream()
+                        .filter(planEntity -> PlanMode.STANDARD.equals(planEntity.getPlanMode()))
                         .filter(planEntity -> {
                             PlanSecurityType security = PlanSecurityType.valueOfLabel(planEntity.getPlanSecurity().getType());
                             return security == PlanSecurityType.JWT || security == PlanSecurityType.OAUTH2;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2262

## Description

ApplicationService was not taking account of the refactor regarding PlanMode.
For PUSH plans, there is no `PlanSecurity` object, and the service was relying on its existence. 
Solution is to add a filter to apply client id check on STANDARD plans
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xqcqgjgsbg.chromatic.com)
<!-- Storybook placeholder end -->
