### PR TITLE
Configurable gateway http max sizes

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,18 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.1
+
+- Define gateway http max sizes
+
+### 3.20.15
+
+- Define gateway http max sizes
+
+### 3.19.20
+
+- Define gateway http max sizes
+
 ### 4.0.0
 
 - Remove old and unused `cache.type` from gateway config map

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -19,12 +19,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
-    - Change the versioning
-    - Remove duplicate annotation in ui deployment
-    - Add support for managed Service Account for each product
-    - Remove old and unused `cache.type` from gateway config map
-    - Fix resources missing in ui-deployment.yaml
-    - Change readinessProbe for the gateway to sync-process
-    - Update Elasticsearch version
-    - Allow plugin override via {api|gatewaye}.additionalPlugins property
-    - Add auto generate Authorization header on gateway probes when authentication basic is set. 
+    - Define gateway http max sizes

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -35,6 +35,10 @@ data:
     #  tcpKeepAlive: true
     #  compressionSupported: false
     #  instances: 0
+      maxHeaderSize: {{ .Values.gateway.http.maxHeaderSize }}
+      maxChunkSize: {{ .Values.gateway.http.maxChunkSize }}
+      maxInitialLineLength: {{ .Values.gateway.http.maxInitialLineLength }}
+      maxFormAttributeSize: {{ .Values.gateway.http.maxFormAttributeSize }}
       alpn: true
       {{- if .Values.gateway.ssl.enabled }}
       secured: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -695,6 +695,11 @@ gateway:
   ingressController: false
   type: Deployment
   name: gateway
+  http:
+    maxHeaderSize: 8192
+    maxChunkSize: 8192
+    maxInitialLineLength: 4096
+    maxFormAttributeSize: 2048
   logging:
     debug: false
     stdout:


### PR DESCRIPTION
based on am chart: (main HEAD commit at the time):
- https://github.com/gravitee-io/helm-charts/blob/2b98b7f7dafbd897d77404e9a5c970ea36e7bd53/am/templates/gateway/gateway-configmap.yaml#L50-L53
- https://github.com/gravitee-io/helm-charts/blob/2b98b7f7dafbd897d77404e9a5c970ea36e7bd53/am/values.yaml#L468-L471

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Configurable maxInitialLineLength and related.
I am currently using this fix in production on https://github.com/lucasfcnunes/gravitee-api-management/tree/3.20.13-lucasfcnunes (using helmfile [helm git]).

## Additional context

Long URL throws HTTP ERROR 414. Increasing maxInitialLineLength solves it.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

