### PR TITLE
Improve sanitization of log values when exporting as CSV

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CsvUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CsvUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+public class CsvUtils {
+
+    /**
+     * The delimiter used in the CSV file: comma, semicolon, etc.
+     */
+    private final char delimiter;
+
+    public CsvUtils(char delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    /**
+     * Sanitize a value to be used in a CSV file. It follows the OWASP best practices described in: https://owasp.org/www-community/attacks/CSV_Injection
+     * @param value the value to sanitize
+     * @return the sanitized value, an empty string if the value is null
+     */
+    public String sanitize(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        // If value starts with equal, plus or minus, the equal sign character is prepended.
+        if (value.startsWith("=") || value.startsWith("+") || value.startsWith("-")) {
+            value = "'" + value;
+        }
+
+        // If the value contains double quotation marks, the quotation mark character is repeated twice.
+        value = value.replace("\"", "\"\"");
+
+        // If the value contains the delimiter, the single-quote character, the newline character, or the carriage-return character, then the value is enclosed in double quotation marks.
+        if (value.contains(String.valueOf(delimiter)) || value.contains("'") || value.contains("\n") || value.contains("\r")) {
+            return "\"" + value + "\"";
+        }
+
+        return value;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -48,13 +48,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
-import io.gravitee.rest.api.service.ApiKeyService;
-import io.gravitee.rest.api.service.ApplicationService;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.InstanceService;
-import io.gravitee.rest.api.service.LogsService;
-import io.gravitee.rest.api.service.ParameterService;
-import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.ApiKeyNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
@@ -104,6 +98,7 @@ public class LogsServiceImpl implements LogsService {
     private static final String RFC_3339_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
     private static final FastDateFormat dateFormatter = FastDateFormat.getInstance(RFC_3339_DATE_FORMAT);
     private static final char separator = ';';
+    private static final CsvUtils csvUtils = new CsvUtils(separator);
     private final Logger logger = LoggerFactory.getLogger(LogsServiceImpl.class);
 
     @Lazy
@@ -547,7 +542,7 @@ public class LogsServiceImpl implements LogsService {
                     apiLog.getUser()
                 );
                 final Object application = searchLogResponse.getMetadata().get(apiLog.getApplication());
-                sb.append(getName(application));
+                sb.append(csvUtils.sanitize(getName(application)));
                 sb.append(lineSeparator());
             }
         } else if (searchLogResponse.getLogs().get(0) instanceof ApplicationRequestItem) {
@@ -571,7 +566,7 @@ public class LogsServiceImpl implements LogsService {
                     applicationLog.getUser()
                 );
                 final Object api = searchLogResponse.getMetadata().get(applicationLog.getApi());
-                sb.append(getName(api));
+                sb.append(csvUtils.sanitize(getName(api)));
                 sb.append(lineSeparator());
             }
         } else if (searchLogResponse.getLogs().get(0) instanceof PlatformRequestItem) {
@@ -601,10 +596,10 @@ public class LogsServiceImpl implements LogsService {
                     platformLog.getUser()
                 );
                 final Object api = searchLogResponse.getMetadata().get(platformLog.getApi());
-                sb.append(getName(api));
+                sb.append(csvUtils.sanitize(getName(api)));
                 sb.append(separator);
                 final Object application = searchLogResponse.getMetadata().get(platformLog.getApplication());
-                sb.append(getName(application));
+                sb.append(csvUtils.sanitize(getName(application)));
                 sb.append(lineSeparator());
             }
         }
@@ -627,22 +622,22 @@ public class LogsServiceImpl implements LogsService {
     ) {
         sb.append(dateFormatter.format(timestamp));
         sb.append(separator);
-        sb.append(id);
+        sb.append(csvUtils.sanitize(id));
         sb.append(separator);
-        sb.append(transactionId);
+        sb.append(csvUtils.sanitize(transactionId));
         sb.append(separator);
         sb.append(method);
         sb.append(separator);
-        sb.append(path);
+        sb.append(csvUtils.sanitize(path));
         sb.append(separator);
         sb.append(status);
         sb.append(separator);
         sb.append(responseTime);
         sb.append(separator);
-        sb.append(getName(searchLogResponse.getMetadata().get(plan)));
+        sb.append(csvUtils.sanitize(getName(searchLogResponse.getMetadata().get(plan))));
         sb.append(separator);
         if (userEnabled) {
-            sb.append(user);
+            sb.append(csvUtils.sanitize(user));
             sb.append(separator);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CsvUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CsvUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CsvUtilsTest {
+
+    CsvUtils csvUtils = new CsvUtils(';');
+
+    @ParameterizedTest
+    @MethodSource({"csvInputs"})
+    void sanitize(String input, String expected) {
+        assertThat(csvUtils.sanitize(input)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> csvInputs() {
+        return Stream.of(
+            Arguments.of(null, ""),
+            Arguments.of("", ""),
+            Arguments.of("a", "a"),
+            Arguments.of("a;b", "\"a;b\""),
+            Arguments.of("a\"b", "a\"\"b"),
+            Arguments.of("a\"\"\"\"b", "a\"\"\"\"\"\"\"\"b"),
+            Arguments.of("=1+2\";=1+2", "\"'=1+2\"\";=1+2\""),
+            Arguments.of("=1+2'\" ;,=1+2", "\"'=1+2'\"\" ;,=1+2\""),
+            Arguments.of("=1+2", "\"'=1+2\"")
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/LogsServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/LogsServiceTest.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.rest.api.model.PlanSecurityType.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpHeaders;
@@ -44,18 +44,14 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Set;
-import junit.framework.TestCase;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-/**
- * @author GraviteeSource Team
- */
-@RunWith(MockitoJUnitRunner.class)
-public class LogsServiceITest extends TestCase {
+@ExtendWith(MockitoExtension.class)
+class LogsServiceTest {
 
     private static final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
     private static final String LOG_ID = "2560f540-c0f1-4c12-a76e-0da89ace6911";
@@ -92,24 +88,24 @@ public class LogsServiceITest extends TestCase {
     @InjectMocks
     private final LogsService logService = new LogsServiceImpl();
 
-    @Test(expected = TechnicalManagementException.class)
-    public void findApiLogShouldThrowException() throws Exception {
+    @Test
+    void findApiLogShouldThrowException() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenThrow(new AnalyticsException());
 
-        logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP);
+        assertThrows(TechnicalManagementException.class, () -> logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP));
     }
 
     @Test
-    public void findApiLogShouldReturnNull() throws Exception {
+    void findApiLogShouldReturnNull() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(null);
 
         ApiRequest result = logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP);
-        assertNull(result);
-        verify(logRepository, times(1)).findById(eq(LOG_ID), eq(LOG_TIMESTAMP));
+        assertThat(result).isNull();
+        verify(logRepository, times(1)).findById(LOG_ID, LOG_TIMESTAMP);
     }
 
     @Test
-    public void findApiLogShouldFindWithKeyLessPlan() throws Exception {
+    void findApiLogShouldFindWithKeyLessPlan() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(KEY_LESS));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(KEY_LESS));
@@ -124,7 +120,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldFindWithApiKeyPlan() throws Exception {
+    void findApiLogShouldFindWithApiKeyPlan() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(API_KEY));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(API_KEY));
@@ -141,7 +137,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldFindWithJwtPlan() throws Exception {
+    void findApiLogShouldFindWithJwtPlan() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(JWT));
@@ -159,7 +155,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldHaveEmptySubscriptionWithNoSecurity() throws Exception {
+    void findApiLogShouldHaveEmptySubscriptionWithNoSecurity() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(null));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(null));
@@ -175,7 +171,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldHaveEmptySubscriptionWithNoSecurityInV4Plan() throws Exception {
+    void findApiLogShouldHaveEmptySubscriptionWithNoSecurityInV4Plan() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(null));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlanV4(null));
@@ -191,7 +187,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldNotFailOnApiKeyNotFoundException() throws Exception {
+    void findApiLogShouldNotFailOnApiKeyNotFoundException() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(API_KEY));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(API_KEY));
@@ -208,7 +204,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldNotFailOnPlanNotFoundException() throws Exception {
+    void findApiLogShouldNotFailOnPlanNotFoundException() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenThrow(new PlanNotFoundException(LOG_PLAN_ID));
@@ -223,7 +219,7 @@ public class LogsServiceITest extends TestCase {
     }
 
     @Test
-    public void findApiLogShouldNotFailOnDuplicatedSubscription() throws Exception {
+    void findApiLogShouldNotFailOnDuplicatedSubscription() throws Exception {
         when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(JWT));
@@ -240,26 +236,28 @@ public class LogsServiceITest extends TestCase {
         assertThat(apiLog.getSubscription()).isNull();
     }
 
-    @Test(expected = TechnicalManagementException.class)
-    public void findLogByApiShouldThrowException() throws Exception {
+    @Test
+    void findLogByApiShouldThrowException() throws Exception {
         when(logRepository.query(any())).thenThrow(new AnalyticsException());
 
-        logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
+        LogQuery query = new LogQuery();
+
+        assertThrows(TechnicalManagementException.class, () -> logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, query));
     }
 
     @Test
-    public void findLogByApiShouldReturnEmptyResult() throws Exception {
+    void findLogByApiShouldReturnEmptyResult() throws Exception {
         when(logRepository.query(any())).thenReturn(null);
 
         SearchLogResponse<ApiRequestItem> result = logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
-        assertNotNull(result);
-        assertNull(result.getLogs());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isNull();
         verify(logRepository, times(1)).query(any());
     }
 
     @Test
-    public void findLogByApiShouldReturnSearchLogResponse() throws Exception {
+    void findLogByApiShouldReturnSearchLogResponse() throws Exception {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
@@ -267,32 +265,32 @@ public class LogsServiceITest extends TestCase {
 
         SearchLogResponse<ApiRequestItem> result = logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
-        assertNotNull(result);
-        assertNotNull(result.getLogs());
-        assertTrue(result.getLogs().isEmpty());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isEmpty();
         verify(logRepository, times(1)).query(any());
     }
 
-    @Test(expected = TechnicalManagementException.class)
-    public void findLogByApplicationShouldThrowException() throws Exception {
+    @Test
+    void findLogByApplicationShouldThrowException() throws Exception {
         when(logRepository.query(any())).thenThrow(new AnalyticsException());
+        LogQuery query = new LogQuery();
 
-        logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
+        assertThrows(TechnicalManagementException.class, () -> logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, query));
     }
 
     @Test
-    public void findLogByApplicationShouldReturnEmptyResult() throws Exception {
+    void findLogByApplicationShouldReturnEmptyResult() throws Exception {
         when(logRepository.query(any())).thenReturn(null);
 
         SearchLogResponse<ApplicationRequestItem> result = logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
-        assertNotNull(result);
-        assertNull(result.getLogs());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isNull();
         verify(logRepository, times(1)).query(any());
     }
 
     @Test
-    public void findLogByApplicationShouldReturnSearchLogResponse() throws Exception {
+    void findLogByApplicationShouldReturnSearchLogResponse() throws Exception {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
@@ -300,32 +298,33 @@ public class LogsServiceITest extends TestCase {
 
         SearchLogResponse<ApplicationRequestItem> result = logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
-        assertNotNull(result);
-        assertNotNull(result.getLogs());
-        assertTrue(result.getLogs().isEmpty());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isEmpty();
         verify(logRepository, times(1)).query(any());
     }
 
-    @Test(expected = TechnicalManagementException.class)
-    public void findLogByPlatformShouldThrowException() throws Exception {
+    @Test
+    void findLogByPlatformShouldThrowException() throws Exception {
         when(logRepository.query(any())).thenThrow(new AnalyticsException());
 
-        logService.findPlatform(EXECUTION_CONTEXT, new LogQuery());
+        LogQuery query = new LogQuery();
+
+        assertThrows(TechnicalManagementException.class, () -> logService.findPlatform(EXECUTION_CONTEXT, query));
     }
 
     @Test
-    public void findLogByPlatformShouldReturnEmptyResult() throws Exception {
+    void findLogByPlatformShouldReturnEmptyResult() throws Exception {
         when(logRepository.query(any())).thenReturn(null);
 
         SearchLogResponse<PlatformRequestItem> result = logService.findPlatform(EXECUTION_CONTEXT, new LogQuery());
 
-        assertNotNull(result);
-        assertNull(result.getLogs());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isNull();
         verify(logRepository, times(1)).query(any());
     }
 
     @Test
-    public void findLogByPlatformShouldReturnSearchLogResponse() throws Exception {
+    void findLogByPlatformShouldReturnSearchLogResponse() throws Exception {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
@@ -333,31 +332,31 @@ public class LogsServiceITest extends TestCase {
 
         SearchLogResponse<PlatformRequestItem> result = logService.findPlatform(EXECUTION_CONTEXT, new LogQuery());
 
-        assertNotNull(result);
-        assertNotNull(result.getLogs());
-        assertTrue(result.getLogs().isEmpty());
+        assertThat(result).isNotNull();
+        assertThat(result.getLogs()).isEmpty();
         verify(logRepository, times(1)).query(any());
     }
 
-    @Test(expected = TechnicalManagementException.class)
-    public void findApplicationLogShouldThrowException() throws Exception {
+    @Test
+    void findApplicationLogShouldThrowException() throws Exception {
         when(logRepository.findById(eq(LOG_ID), anyLong())).thenThrow(new AnalyticsException("test_error"));
+        long timestamp = Instant.now().toEpochMilli();
 
-        logService.findApplicationLog(EXECUTION_CONTEXT, LOG_ID, Instant.now().toEpochMilli());
+        assertThrows(TechnicalManagementException.class, () -> logService.findApplicationLog(EXECUTION_CONTEXT, LOG_ID, timestamp));
     }
 
     @Test
-    public void findApplicationLogShouldReturnNull() throws Exception {
+    void findApplicationLogShouldReturnNull() throws Exception {
         when(logRepository.findById(eq(LOG_ID), anyLong())).thenReturn(null);
 
         ApplicationRequest result = logService.findApplicationLog(EXECUTION_CONTEXT, LOG_ID, Instant.now().toEpochMilli());
 
-        assertNull(result);
+        assertThat(result).isNull();
         verify(logRepository, times(1)).findById(eq(LOG_ID), anyLong());
     }
 
     @Test
-    public void findApplicationLogShouldReturnSearchLogResponse() throws Exception {
+    void findApplicationLogShouldReturnSearchLogResponse() throws Exception {
         ExtendedLog log = newLog(JWT);
         log.setClientRequest(newRequest());
         log.setClientResponse(newResponse());
@@ -367,7 +366,7 @@ public class LogsServiceITest extends TestCase {
 
         ApplicationRequest result = logService.findApplicationLog(EXECUTION_CONTEXT, LOG_ID, Instant.now().toEpochMilli());
 
-        assertNotNull(result);
+        assertThat(result).isNotNull();
         verify(logRepository, times(1)).findById(eq(LOG_ID), anyLong());
         verify(apiSearchService, times(1)).findGenericById(any(), anyString());
         verify(planSearchService, times(1)).findById(any(), anyString());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2158

## Description

 - Migrate LogsServiceTest to JUnit5 and AssertJ
 - Improve sanitization of log values when exporting as CSV


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qacwmwtbcu.chromatic.com)
<!-- Storybook placeholder end -->
