### PR TITLE
Do some house keeping on the repository tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1601,6 +1601,48 @@ jobs:
                             name: Version not set - nothing to run
                             command: exit 0
 
+    job-redis-repository-test-container:
+        parameters:
+            version:
+                type: string
+                description: version of Redis to run the test against
+                default: ""
+        executor:
+            name: ubuntu
+        steps:
+            - when:
+                  condition: << parameters.version >>
+                  steps:
+                      - install-jdk-17-for-machine
+                      - checkout
+                      - attach_workspace:
+                            at: .
+                      - cmd-restore-maven-job-cache:
+                            jobName: job-redis-test-container
+                      - run:
+                            name: Run Redis repository tests with version << parameters.version >>
+                            command: |
+                                cd gravitee-apim-repository
+                                mvn -pl 'gravitee-apim-repository-redis' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DredisVersion=<< parameters.version >>
+                      - run:
+                            name: Save test results
+                            command: |
+                                mkdir -p ~/test-results/junit/
+                                find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+                            when: always
+                      - cmd-save-maven-job-cache:
+                            jobName: job-redis-test-container
+                      - store_test_results:
+                            path: ~/test-results
+                      - cmd-notify-on-failure
+            - when:
+                  condition:
+                      not: << parameters.version >>
+                  steps:
+                      - run:
+                            name: Version not set - nothing to run
+                            command: exit 0
+
     job-e2e-test:
         executor:
             name: ubuntu
@@ -2520,6 +2562,14 @@ workflows:
                       parameters:
                           engineType: ["opensearch"]
                           version: ["1", "2"]
+            - job-redis-repository-test-container:
+                  name: Rate Limit repository tests - Redis << matrix.version >>
+                  context: cicd-orchestrator
+                  requires:
+                      - Build
+                  matrix:
+                      parameters:
+                          version: ["6.2.6-v9", "7.0.6-RC9"]
 
     release_notes_apim:
         when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,6 +374,7 @@ parameters:
                 bridge_e2e,
                 publish_docker_images,
                 release_helm,
+                repositories_tests,
             ]
         default: pull_requests
     dry_run:
@@ -1296,7 +1297,7 @@ jobs:
 
                       # Helm chart
                       sed "0,/version.*/s/version.*/version: ${GRAVITEEIO_VERSION_WITH_QUALIFIER}/" -i helm/Chart.yaml
-                    
+
                       git add --update
                       git commit -m "${GRAVITEEIO_VERSION_WITH_QUALIFIER}"
                       git tag ${GRAVITEEIO_VERSION_WITH_QUALIFIER}
@@ -2493,23 +2494,17 @@ workflows:
                       - Nexus staging
 
     db_repositories_test_container:
-        triggers:
-            - schedule:
-                  cron: "0 12 * * *"
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
+        when:
+            equal: [repositories_tests, << pipeline.parameters.gio_action >>]
         jobs:
             - job-setup:
                   name: Setup
                   context: cicd-orchestrator
             - job-build:
-                name: Build
-                context: cicd-orchestrator
-                requires:
-                  - Setup
+                  name: Build
+                  context: cicd-orchestrator
+                  requires:
+                      - Setup
             - job-jdbc-test-container:
                   name: Management repository tests - JDBC - << matrix.version >>
                   context: cicd-orchestrator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1555,7 +1555,7 @@ jobs:
                             name: Version not set - nothing to run
                             command: exit 0
 
-    elastic-test-container:
+    job-elastic-test-container:
         parameters:
             version:
                 type: string
@@ -1576,7 +1576,7 @@ jobs:
                       - attach_workspace:
                             at: .
                       - cmd-restore-maven-job-cache:
-                            jobName: elastic-test-container
+                            jobName: job-elastic-test-container
                       - run:
                             name: Run Elasticsearch repository tests with version << parameters.version >>
                             command: |
@@ -1589,7 +1589,7 @@ jobs:
                                 find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
                             when: always
                       - cmd-save-maven-job-cache:
-                            jobName: elastic-test-container
+                            jobName: job-elastic-test-container
                       - store_test_results:
                             path: ~/test-results
                       - cmd-notify-on-failure
@@ -2463,54 +2463,63 @@ workflows:
             - job-setup:
                   name: Setup
                   context: cicd-orchestrator
+            - job-build:
+                name: Build
+                context: cicd-orchestrator
+                requires:
+                  - Setup
             - job-jdbc-test-container:
-                  name: JDBC Test container
+                  name: Management repository tests - JDBC - << matrix.version >>
                   context: cicd-orchestrator
                   requires:
-                      - Setup
+                      - Build
                   matrix:
                       parameters:
                           version:
                               [
-                                  "postgresql~9.6.24",
-                                  "postgresql~10.20",
-                                  "postgresql~11.15",
-                                  "postgresql~12.10",
-                                  "postgresql~13.6",
-                                  "mariadb~10.1.48",
-                                  "mariadb~10.2.43",
-                                  "mariadb~10.3.34",
-                                  "mariadb~10.4.24",
-                                  "mysql~5.7.37",
-                                  "mysql~8.0.28",
-                                  "sqlserver~2017-CU12",
+                                  "postgresql~11",
+                                  "postgresql~12",
+                                  "postgresql~13",
+                                  "postgresql~14",
+                                  "postgresql~15",
+                                  "mariadb~10.4",
+                                  "mariadb~10.5",
+                                  "mariadb~10.6",
+                                  "mariadb~10.10",
+                                  "mariadb~10.11",
+                                  "mariadb~11",
+                                  "mysql~5.7",
+                                  "mysql~8.0",
+                                  "sqlserver~2017-latest",
+                                  "sqlserver~2019-latest",
+                                  "sqlserver~2022-latest",
                               ]
             - job-mongo-test-container:
-                  name: Mongo Test container
+                  name: Management repository tests - Mongo << matrix.version >>
                   context: cicd-orchestrator
                   requires:
-                      - Setup
+                      - Build
                   matrix:
                       parameters:
-                          version: ["4", "5", "6.0"]
-            - elastic-test-container:
-                  name: Run ElasticSearch repositories tests << matrix.version >>
+                          version: ["4.4", "5.0", "6.0"]
+            - job-elastic-test-container:
+                  name: Analytics repository tests - ElasticSearch << matrix.version >>
                   context: cicd-orchestrator
                   requires:
-                      - Setup
+                      - Build
                   matrix:
                       parameters:
                           engineType: ["elasticsearch"]
-                          version: ["5.6.16", "6.8.23", "7.17.8", "8.7.0"]
-            - elastic-test-container:
-                  name: Run Opensearch repositories tests << matrix.version >>
+                          version: ["7.17.10", "8.8.1"]
+            - job-elastic-test-container:
+                  name: Analytics repository tests - OpenSearch << matrix.version >>
                   context: cicd-orchestrator
                   requires:
-                      - Setup
+                      - Build
                   matrix:
                       parameters:
                           engineType: ["opensearch"]
-                          version: ["2.6.0", "1.3.9"]
+                          version: ["1", "2"]
 
     release_notes_apim:
         when:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -37,7 +37,7 @@
         <liquibase-slf4j.version>4.0.0</liquibase-slf4j.version>
         <mariaDB.version>2.5.3</mariaDB.version>
         <mssql-jdbc.version>9.4.1.jre8</mssql-jdbc.version>
-        <mysql-connector-java.version>8.0.31</mysql-connector-java.version>
+        <mysql-connector-j.version>8.0.31</mysql-connector-j.version>
         <postgresql.version>42.4.1</postgresql.version>
 
         <!-- Plugin configuration -->
@@ -134,9 +134,9 @@
             https://github.com/mysql/mysql-connector-j/blob/release/8.0/LICENSE
         -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql-connector-java.version}</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql-connector-j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
@@ -86,6 +86,9 @@ public class JdbcTestRepositoryConfiguration {
                 break;
             case SQLSERVER:
                 containerBean = new MSSQLServerContainer<>(dockerImageName);
+                // ACCEPT_EULA confirms your acceptance of the End-User Licensing Agreement.
+                // For details see: https://hub.docker.com/_/microsoft-mssql-server#environment-variables
+                containerBean.withEnv("ACCEPT_EULA", "Y");
                 break;
             case POSTGRESQL:
             default:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/resources/container-license-acceptance.txt
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,0 @@
-mcr.microsoft.com/mssql/server:2017-CU12

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
@@ -223,8 +223,8 @@ ratelimit:
 
 == Testing
 
-By default, unit tests are run with a TestContainer version of Redis 7.0.10, but sometimes it can be useful to run them against other version of Redis.
+By default, unit tests are run with a TestContainer version of Redis Stack `6.2.6-v9`, but sometimes it can be useful to run them against other version of Redis.
 
-You can use the version of Redis you want to test by using the docker image tag in the `-DredisVersion` parameter.
+You can use the version of Redis you want to test by using the docker image tag in the `-DredisStackVersion` parameter.
 
-For example, for Redis 5.0, you will use `mvn -DredisVersion=5.0 test` .
+For example, for Redis 7.0.x, you will use `mvn -DredisStackVersion=7.0.6-RC9 test` .

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
@@ -44,7 +44,7 @@ public class RedisTestRepositoryConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisTestRepositoryConfiguration.class);
 
-    @Value("${redisStackVersion:6.2.6-v7}")
+    @Value("${redisStackVersion:6.2.6-v9}")
     private String redisStackVersion;
 
     @Bean(destroyMethod = "stop")

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -218,7 +218,6 @@ const gatewayDependenciesExclusion = [
   'gravitee-apim-repository-elasticsearch',
   'gravitee-apim-repository-hazelcast',
   'gravitee-apim-repository-noop',
-  'gravitee-apim-repository-redis',
 ];
 
 console.log(chalk.blue(`Add plugins to Gateway`));


### PR DESCRIPTION
## Issue

NA

## Description

- Use environment variable instead of file to accept SQLServer licence in JDBC repository tests
- Move from `mysql-connector-java` to `mysql-connector-j`
- Add Redis repository in default bundle
- Add a scheduled job to run redis repository tests against multiple versions of Redis
- Rename the ci job running repository tests

## CI in Action

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/39b64b8c-b0b7-4bf3-9803-8a6ed64dcda3)


<!-- Storybook placeholder -->


---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xcjveeszrn.chromatic.com)
<!-- Storybook placeholder end -->
