### PR TITLE
chore: log message when error occurs during request/message processing

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
@@ -30,12 +30,14 @@ import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public abstract class AbstractFailureProcessor implements Processor {
 
     public static final String ID = "processor-simple-failure";
@@ -79,8 +81,21 @@ public abstract class AbstractFailureProcessor implements Processor {
         response.status(executionFailure.statusCode());
         response.reason(HttpResponseStatus.valueOf(executionFailure.statusCode()).reasonPhrase());
         // In case of client error we don't want to force close the connection
-        if (response.status() / 100 != 4) {
+        if (executionFailure.statusCode() / 100 != 4) {
             response.headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+        }
+
+        if (executionFailure.parameters() != null && log.isDebugEnabled()) {
+            var exception = (Throwable) executionFailure.parameters().get("exception");
+
+            if (exception != null) {
+                log.debug(
+                    "An error occurred while executing request [requestId={}]: {}",
+                    request.id(),
+                    executionFailure.message(),
+                    exception
+                );
+            }
         }
 
         if (executionFailure.message() != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/appender/MemoryAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/appender/MemoryAppender.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package appender;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.Collections;
+import java.util.List;
+
+public class MemoryAppender extends ListAppender<ILoggingEvent> {
+
+    public void reset() {
+        this.list.clear();
+    }
+
+    public List<ILoggingEvent> getLoggedEvents() {
+        return Collections.unmodifiableList(this.list);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
@@ -16,10 +16,15 @@
 package io.gravitee.gateway.reactive.handlers.api.processor.error;
 
 import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCEPT;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import appender.MemoryAppender;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.HttpHeadersValues;
@@ -31,16 +36,18 @@ import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.handler.codec.http.HttpStatusClass;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -50,6 +57,8 @@ class SimpleFailureProcessorTest extends AbstractProcessorTest {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    private final MemoryAppender memoryAppender = new MemoryAppender();
+
     @Captor
     ArgumentCaptor<Flowable<Buffer>> bufferCaptor;
 
@@ -58,127 +67,165 @@ class SimpleFailureProcessorTest extends AbstractProcessorTest {
     @BeforeEach
     public void beforeEach() {
         simpleFailureProcessor = SimpleFailureProcessor.instance();
+        memoryAppender.reset();
     }
 
     @Test
-    void shouldCompleteWith500StatusWithoutExecutionFailure() {
+    void should_set_default_application_when_no_application_associated_to_the_request() {
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
         assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
+    }
+
+    @Test
+    void should_not_set_default_application_when_an_application_is_associated_to_the_request() {
+        spyCtx.metrics().setApplicationId("my-application");
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("my-application");
+    }
+
+    @Test
+    void should_build_500_response_when_no_execution_failure() {
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
         verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
         verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
-        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
     }
 
     @Test
-    void shouldCompleteWithChangingResponseBodyWithoutProcessorFailureMessage() {
-        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+    void should_build_response_based_on_the_execution_failure_without_message() {
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.SERVICE_UNAVAILABLE.code());
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
-        verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
-        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
+
+        verify(mockResponse).status(eq(HttpResponseStatus.SERVICE_UNAVAILABLE.code()));
+        verify(mockResponse).reason(eq(HttpResponseStatus.SERVICE_UNAVAILABLE.reasonPhrase()));
     }
 
     @Test
-    void shouldCompleteWithJsonErrorAndAcceptHeaderJson() throws JsonProcessingException {
+    void should_build_a_json_response_when_json_accept_header() throws JsonProcessingException {
         ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).message("error");
-        String contentAsJson = mapper.writeValueAsString(new ExecutionFailureAsJson(executionFailure));
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
         spyRequestHeaders.add(ACCEPT, List.of("application/json"));
+
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
-        verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
+
         assertThat(spyResponseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)).isTrue();
         assertThat(spyResponseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("application/json");
-        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
-        verify(mockResponse).chunks(bufferCaptor.capture());
 
-        assertThat(bufferCaptor.getValue().blockingFirst().toString()).isEqualTo(contentAsJson);
+        String expectedJson = mapper.writeValueAsString(new ExecutionFailureAsJson(executionFailure));
+        verify(mockResponse).chunks(bufferCaptor.capture());
+        assertThat(bufferCaptor.getValue().blockingFirst()).hasToString(expectedJson);
     }
 
     @Test
-    void shouldCompleteWithJsonErrorAndAcceptHeaderWildCard() throws JsonProcessingException {
+    void should_build_a_json_response_when_wildcard_accept_header() throws JsonProcessingException {
         ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).message("error");
-        String contentAsJson = mapper.writeValueAsString(new ExecutionFailureAsJson(executionFailure));
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
         spyRequestHeaders.add(ACCEPT, List.of(MediaType.WILDCARD));
+
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
-        verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
+
         assertThat(spyResponseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)).isTrue();
         assertThat(spyResponseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("application/json");
-        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
+
+        String contentAsJson = mapper.writeValueAsString(new ExecutionFailureAsJson(executionFailure));
         verify(mockResponse).chunks(bufferCaptor.capture());
-        assertThat(bufferCaptor.getValue().blockingFirst().toString()).isEqualTo(contentAsJson);
+        assertThat(bufferCaptor.getValue().blockingFirst()).hasToString(contentAsJson);
     }
 
     @Test
-    public void shouldCompleteWithJsonErrorAndAcceptHeaderJsonAndContentTypeJson() {
+    public void should_build_a_json_response_when_json_accept_header_and_json_content_type() {
         String contentAsJson = "{\"text\": \"error\"}";
         ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
             .message(contentAsJson)
             .contentType("application/json");
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
         spyRequestHeaders.add(ACCEPT, List.of("application/json"));
+
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
-        verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
+
         assertThat(spyResponseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)).isTrue();
         assertThat(spyResponseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("application/json");
-        assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
-        verify(mockResponse).chunks(bufferCaptor.capture());
 
-        assertThat(bufferCaptor.getValue().blockingFirst().toString()).isEqualTo(contentAsJson);
+        verify(mockResponse).chunks(bufferCaptor.capture());
+        assertThat(bufferCaptor.getValue().blockingFirst()).hasToString(contentAsJson);
     }
 
     @Test
-    void shouldCompleteWithTxtErrorAndNoAcceptHeader() {
+    void should_build_a_text_response_when_no_accept_header() {
         String contentAsText = "error";
         ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()).message(contentAsText);
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        verify(mockResponse).status(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.code()));
-        verify(mockResponse).reason(eq(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase()));
+
         assertThat(spyResponseHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)).isTrue();
         assertThat(spyResponseHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo("text/plain");
         assertThat(spyResponseHeaders.get(HttpHeaderNames.CONNECTION)).isEqualTo(HttpHeadersValues.CONNECTION_CLOSE);
+
         verify(mockResponse).chunks(bufferCaptor.capture());
+        assertThat(bufferCaptor.getValue().blockingFirst()).hasToString(contentAsText);
     }
 
-    @ParameterizedTest(name = "''Connection: close'' header should be added only if status is not in CLIENT_ERROR family ")
+    @ParameterizedTest(name = "response status ''{0}''")
     @ValueSource(
         ints = {
-            0,
-            HttpStatusCode.CONTINUE_100,
-            HttpStatusCode.NO_CONTENT_204,
-            HttpStatusCode.NOT_MODIFIED_304,
-            HttpStatusCode.CONFLICT_409,
-            HttpStatusCode.BAD_GATEWAY_502,
+            0, HttpStatusCode.CONTINUE_100, HttpStatusCode.NO_CONTENT_204, HttpStatusCode.NOT_MODIFIED_304, HttpStatusCode.BAD_GATEWAY_502,
         }
     )
-    void shouldAddConnectionCloseHeaderWhenNotAClientError(Integer responseStatus) {
+    void should_add_connection_close_header_when_error_status_is_not_a_client_error_family(Integer responseStatus) {
         ExecutionFailure executionFailure = new ExecutionFailure(responseStatus);
-
-        lenient().when(mockResponse.status()).thenReturn(responseStatus);
-
         spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
 
         simpleFailureProcessor.execute(spyCtx).test().assertResult();
 
-        verify(mockResponse, times(1)).status(responseStatus);
+        Assertions
+            .assertThat(mockResponse.headers().getAll(HttpHeaderNames.CONNECTION))
+            .hasSize(1)
+            .containsExactly(HttpHeadersValues.CONNECTION_CLOSE);
+    }
 
-        if (HttpStatusClass.CLIENT_ERROR.contains(responseStatus)) {
-            Assertions.assertThat(mockResponse.headers().contains(HttpHeaderNames.CONNECTION)).isFalse();
-        } else {
-            Assertions
-                .assertThat(mockResponse.headers().getAll(HttpHeaderNames.CONNECTION))
-                .hasSize(1)
-                .containsExactly(HttpHeadersValues.CONNECTION_CLOSE);
-        }
+    @ParameterizedTest(name = "response status ''{0}''")
+    @ValueSource(ints = { 400, 404, 499 })
+    void should_not_add_connection_close_header_when_error_status_is_a_client_error_family(Integer responseStatus) {
+        ExecutionFailure executionFailure = new ExecutionFailure(responseStatus);
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        Assertions.assertThat(mockResponse.headers().contains(HttpHeaderNames.CONNECTION)).isFalse();
+    }
+
+    @Test
+    void should_log_message_when_failure_has_exception_parameter() {
+        configureMemoryAppender();
+
+        when(mockRequest.id()).thenReturn("request-id");
+        ExecutionFailure executionFailure = new ExecutionFailure(HttpResponseStatus.INTERNAL_SERVER_ERROR.code())
+            .message("message error")
+            .parameters(Map.of("exception", new RuntimeException("root exception")));
+        spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, executionFailure);
+
+        simpleFailureProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        SoftAssertions.assertSoftly(soft -> {
+            var event = memoryAppender.getLoggedEvents().get(0);
+            soft.assertThat(event.getMessage()).contains("An error occurred while executing request");
+            soft.assertThat(event.getArgumentArray()).contains("request-id", "message error");
+            soft.assertThat(event.getThrowableProxy().getMessage()).isEqualTo("root exception");
+        });
+    }
+
+    private void configureMemoryAppender() {
+        Logger logger = (Logger) LoggerFactory.getLogger(AbstractFailureProcessor.class);
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.DEBUG);
+        logger.addAppender(memoryAppender);
+        memoryAppender.start();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <gravitee-endpoint-rabbitmq.version>1.0.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.0.1</gravitee-endpoint-solace.version>
         <gravitee-resource-schema-registry-confluent.version>2.0.0</gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>1.0.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.2</gravitee-reactor-message.version>
         <gravitee-repository-bridge.version>4.0.0</gravitee-repository-bridge.version>
     </properties>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2388

## Description

Logs a message in DEBUG when error occurs during request/message processing displaying the original exception


## Additional context

Require https://github.com/gravitee-io/gravitee-reactor-message/pull/23

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4842.team-apim.gravitee.dev/console](https://4842.team-apim.gravitee.dev/console)
      Portal: [https://4842.team-apim.gravitee.dev/portal](https://4842.team-apim.gravitee.dev/portal)
      Management-api: [https://4842.team-apim.gravitee.dev/api/management](https://4842.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4842.team-apim.gravitee.dev](https://4842.team-apim.gravitee.dev)
      Gateway v3: [https://4842.gateway-v3.team-apim.gravitee.dev](https://4842.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yqulnwlvcz.chromatic.com)
<!-- Storybook placeholder end -->
