### PR TITLE
fix(rest-api): map null to empty string for flow step serialization

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/FlowDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/FlowDeserializer.java
@@ -48,11 +48,15 @@ public class FlowDeserializer extends StdScalarDeserializer<Flow> {
 
         JsonNode jsonId = node.path("id");
 
-        if (jsonId != null && !jsonId.asText().isEmpty()) {
+        if (!jsonId.isNull() && !jsonId.asText().isEmpty()) {
             flow.setId(jsonId.asText());
         }
 
-        flow.setName(node.path("name").asText());
+        JsonNode name = node.path("name");
+        if (!name.isNull() && !name.isMissingNode()) {
+            flow.setName(name.asText());
+        }
+
         flow.setEnabled(node.path("enabled").asBoolean(true));
 
         JsonNode jsonPathOperator = node.get("path-operator");
@@ -61,7 +65,10 @@ public class FlowDeserializer extends StdScalarDeserializer<Flow> {
             flow.setPathOperator(jsonPathOperator.traverse(jp.getCodec()).readValueAs(PathOperator.class));
         }
 
-        flow.setCondition(node.path("condition").asText());
+        JsonNode condition = node.path("condition");
+        if (!condition.isNull() && !condition.isMissingNode()) {
+            flow.setCondition(condition.asText());
+        }
 
         JsonNode consumersNode = node.get("consumers");
         if (consumersNode != null && consumersNode.isArray()) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/StepDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/StepDeserializer.java
@@ -39,10 +39,14 @@ public class StepDeserializer extends StdScalarDeserializer<Step> {
 
         Step step = new Step();
         step.setName(node.path("name").asText());
-        step.setDescription(node.path("description").asText());
+
+        JsonNode description = node.path("description");
+        if (!description.isMissingNode() && !description.isNull()) {
+            step.setDescription(description.asText());
+        }
         step.setPolicy(node.get("policy").asText());
         final JsonNode condition = node.get("condition");
-        if (condition != null && !condition.isNull()) {
+        if (condition != null && !condition.isMissingNode() && !condition.isNull()) {
             final String conditionStr = condition.asText();
             if (!conditionStr.isBlank()) {
                 step.setCondition(conditionStr);

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/FlowSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/FlowSerializer.java
@@ -44,14 +44,18 @@ public class FlowSerializer extends StdScalarSerializer<Flow> {
         jgen.writeStartObject();
 
         jgen.writeStringField("id", flow.getId());
-        jgen.writeStringField("name", flow.getName());
+        if (flow.getName() != null) {
+            jgen.writeStringField("name", flow.getName());
+        }
 
         final PathOperator pathOperator = flow.getPathOperator();
         if (pathOperator != null) {
             jgen.writeObjectField("path-operator", pathOperator);
         }
 
-        jgen.writeStringField("condition", flow.getCondition());
+        if (flow.getCondition() != null) {
+            jgen.writeStringField("condition", flow.getCondition());
+        }
 
         jgen.writeArrayFieldStart("consumers");
         if (flow.getConsumers() != null) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/StepSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/StepSerializer.java
@@ -36,7 +36,9 @@ public class StepSerializer extends StdScalarSerializer<Step> {
     public void serialize(Step step, JsonGenerator jgen, SerializerProvider provider) throws IOException {
         jgen.writeStartObject();
         jgen.writeStringField("name", step.getName());
-        jgen.writeStringField("description", step.getDescription());
+        if (step.getDescription() != null) {
+            jgen.writeStringField("description", step.getDescription());
+        }
         jgen.writeBooleanField("enabled", step.isEnabled());
         jgen.writeStringField("policy", step.getPolicy());
         if (step.getCondition() != null && !step.getCondition().isBlank()) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
@@ -16,12 +16,17 @@
 package io.gravitee.definition.jackson.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.flow.Flow;
+
+import java.io.IOException;
 import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,5 +46,25 @@ public class FlowSerializerTest extends AbstractTest {
         String flow2json = objectMapper().writeValueAsString(flow2);
 
         assertEquals(flow1json, flow2json);
+    }
+
+    @Test
+    public void should_handle_null_values() throws IOException {
+        final String rawDefinitionToSerialize = IOUtils.toString(read("/io/gravitee/definition/jackson/flow-nullvalue.json"));
+
+        final Flow flow = objectMapper().readValue(rawDefinitionToSerialize, Flow.class);
+        assertNull(flow.getName());
+        assertNull(flow.getCondition());
+        assertNull(flow.getPre().get(0).getDescription());
+    }
+
+    @Test
+    public void should_map_missing_fields_to_null() throws IOException {
+        final String rawDefinitionToSerialize = IOUtils.toString(read("/io/gravitee/definition/jackson/flow-missingfields.json"));
+
+        final Flow flow = objectMapper().readValue(rawDefinitionToSerialize, Flow.class);
+        assertNull(flow.getName());
+        assertNull(flow.getCondition());
+        assertNull(flow.getPre().get(0).getDescription());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/flow-missingfields.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/flow-missingfields.json
@@ -1,0 +1,58 @@
+{
+  "id": "52f1a803-729e-4870-b1a8-03729ee8706f",
+  "path-operator": {
+    "path": "/",
+    "operator": "STARTS_WITH"
+  },
+  "consumers": [],
+  "methods": [],
+  "pre": [
+    {
+      "name": "Rate Limiting",
+      "enabled": true,
+      "policy": "rate-limit",
+      "configuration": {
+        "async": false,
+        "addHeaders": false,
+        "rate": {
+          "periodTime": 1,
+          "limit": 4,
+          "periodTimeUnit": "SECONDS",
+          "key": ""
+        }
+      }
+    },
+    {
+      "name": "Quota",
+      "enabled": true,
+      "policy": "quota",
+      "configuration": {
+        "async": false,
+        "addHeaders": true,
+        "quota": {
+          "periodTime": 4,
+          "periodTimeUnit": "MONTHS",
+          "key": ""
+        }
+      }
+    },
+    {
+      "name": "Resource Filtering",
+      "enabled": true,
+      "policy": "resource-filtering",
+      "configuration": {
+        "blacklist": [],
+        "whitelist": [
+          {
+            "methods": [
+              "HEAD"
+            ],
+            "pattern": "/failnot"
+          }
+        ]
+      }
+    }
+  ],
+  "post": [],
+  "enabled": true
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/flow-nullvalue.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/flow-nullvalue.json
@@ -1,0 +1,63 @@
+{
+  "id": "52f1a803-729e-4870-b1a8-03729ee8706f",
+  "name": null,
+  "path-operator": {
+    "path": "/",
+    "operator": "STARTS_WITH"
+  },
+  "condition": null,
+  "consumers": [],
+  "methods": [],
+  "pre": [
+    {
+      "name": "Rate Limiting",
+      "description": null,
+      "enabled": true,
+      "policy": "rate-limit",
+      "configuration": {
+        "async": false,
+        "addHeaders": false,
+        "rate": {
+          "periodTime": 1,
+          "limit": 4,
+          "periodTimeUnit": "SECONDS",
+          "key": ""
+        }
+      }
+    },
+    {
+      "name": "Quota",
+      "description": null,
+      "enabled": true,
+      "policy": "quota",
+      "configuration": {
+        "async": false,
+        "addHeaders": true,
+        "quota": {
+          "periodTime": 4,
+          "periodTimeUnit": "MONTHS",
+          "key": ""
+        }
+      }
+    },
+    {
+      "name": "Resource Filtering",
+      "description": null,
+      "enabled": true,
+      "policy": "resource-filtering",
+      "configuration": {
+        "blacklist": [],
+        "whitelist": [
+          {
+            "methods": [
+              "HEAD"
+            ],
+            "pattern": "/failnot"
+          }
+        ]
+      }
+    }
+  ],
+  "post": [],
+  "enabled": true
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/FlowStepSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/FlowStepSerializer.java
@@ -31,7 +31,9 @@ public class FlowStepSerializer extends StdScalarSerializer<FlowStep> {
     public void serialize(FlowStep step, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
         jsonGenerator.writeStartObject();
         jsonGenerator.writeStringField("name", step.getName());
-        jsonGenerator.writeStringField("description", step.getDescription());
+        if (step.getDescription() != null) {
+            jsonGenerator.writeStringField("description", step.getDescription());
+        }
         jsonGenerator.writeBooleanField("enabled", step.isEnabled());
         jsonGenerator.writeStringField("policy", step.getPolicy());
         jsonGenerator.writeNumberField("order", step.getOrder());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/FlowConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/FlowConverterTest.java
@@ -76,7 +76,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toModelShouldInitializeNonNullableFields() {
+    public void to_model_should_initialize_non_nullable_fields() {
         Flow flowDefinition = new Flow();
         flowDefinition.setName("platform");
         flowDefinition.setPathOperator(pathOperator());
@@ -100,7 +100,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toModelShouldKeepTheStepOrder() {
+    public void to_model_should_keep_the_step_order() {
         Flow flowDefinition = new Flow();
         flowDefinition.setPre(pre());
 
@@ -114,7 +114,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toDefinitionShouldSetPathOperatorFromPathAndOperatorValues() {
+    public void to_definition_should_set_path_operator_from_path_and_operator_values() {
         final PathOperator expectedOperator = pathOperator();
 
         var flow = new io.gravitee.repository.management.model.flow.Flow();
@@ -130,7 +130,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toDefinitionStepShouldMapAllStepData() {
+    public void to_definition_step_should_map_all_stepData() {
         FlowStep flowStep = new FlowStep();
         flowStep.setPolicy("test-policy");
         flowStep.setDescription("test-description");
@@ -150,7 +150,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toDefinitionStepShouldMapConfiguration() {
+    public void to_definition_step_should_map_configuration() {
         FlowStep flowStep = new FlowStep();
         flowStep.setPolicy("test-policy");
         flowStep.setConfiguration("{\"key\": \"value\"}");
@@ -160,7 +160,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toDefinitionStepShouldMapConfigurationWithEscapedValues() {
+    public void to_definition_step_should_map_configuration_with_escaped_values() {
         FlowStep flowStep = new FlowStep();
         flowStep.setPolicy("test-policy");
         flowStep.setConfiguration("{\"key\": \"<\\/value\\nvalue>\"}");
@@ -170,7 +170,7 @@ public class FlowConverterTest {
     }
 
     @Test
-    public void toDefinitionShouldKeepTheStepOrder() {
+    public void to_definition_should_keep_the_step_order() {
         final PathOperator expectedOperator = pathOperator();
 
         var flow = new io.gravitee.repository.management.model.flow.Flow();
@@ -184,6 +184,30 @@ public class FlowConverterTest {
         assertEquals(2, flowDefinition.getPre().size());
         assertEquals("IPFiltering", flowDefinition.getPre().get(0).getName());
         assertEquals("HTTP Callout", flowDefinition.getPre().get(1).getName());
+    }
+
+    @Test
+    public void to_definition_should_not_stringify_null_values() {
+        FlowStep flowStep = new FlowStep();
+        flowStep.setEnabled(true);
+        flowStep.setName("IPFiltering");
+        flowStep.setPolicy("ip-filtering");
+        flowStep.setConfiguration("{\"whitelistIps\":[\"0.0.0.0/0\"]}");
+        flowStep.setOrder(0);
+        flowStep.setDescription(null);
+
+        var flow = new io.gravitee.repository.management.model.flow.Flow();
+        flow.setPath("/");
+        flow.setName(null);
+        flow.setCondition(null);
+        flow.setOperator(FlowOperator.STARTS_WITH);
+        flow.setConsumers(List.of());
+        flow.setPre(List.of(flowStep));
+
+        Flow convertedFlow = converter.toDefinition(flow);
+        assertNull(convertedFlow.getName());
+        assertNull(convertedFlow.getCondition());
+        assertNull(convertedFlow.getPre().get(0).getDescription());
     }
 
     private static List<FlowStep> definitionPre() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2392

## Description

Map null or missing attributes of Flow or Step to a true null value (not stringified `"null"`)
When value in DB is null, omit field from DTO



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-olljrgexvm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4849.team-apim.gravitee.dev/console](https://4849.team-apim.gravitee.dev/console)
      Portal: [https://4849.team-apim.gravitee.dev/portal](https://4849.team-apim.gravitee.dev/portal)
      Management-api: [https://4849.team-apim.gravitee.dev/api/management](https://4849.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4849.team-apim.gravitee.dev](https://4849.team-apim.gravitee.dev)
      Gateway v3: [https://4849.gateway-v3.team-apim.gravitee.dev](https://4849.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
