### PR TITLE
feat: open documentation link in a new tab

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-confirmation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-confirmation.component.html
@@ -54,7 +54,7 @@
           <h4>Documentation</h4>
           <div class="action__text__subtitle">Find everything you need to know about how to use Gravitee</div>
         </div>
-        <a mat-stroked-button href="https://documentation.gravitee.io/apim/overview/readme">Open documentation</a>
+        <a mat-stroked-button href="https://documentation.gravitee.io/apim/overview/readme" target="_blank">Open documentation</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

After creating a v4 API, APIM provides an option to open the documentation as shown below. This PR opens documentation in a new tab to avoid taking the user out of APIM


![Screenshot 2023-07-27 at 1 06 19 PM](https://github.com/gravitee-io/gravitee-api-management/assets/81941044/1e29162a-d8a3-4e73-b76d-5df64e28fb2f)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-msxvoyckgh.chromatic.com)
<!-- Storybook placeholder end -->
