### PR TITLE
Introduce specific profile to build the default bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,7 +552,7 @@ jobs:
             - run:
                   name: "Build project"
                   command: |
-                      mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C -Ddistribution-dev
+                      mvn -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C -Pbundle-default,bundle-dev
                       mkdir -p ./rest-api-docker-context/distribution && cp -r ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution ./rest-api-docker-context/.
                       mkdir -p ./gateway-docker-context/distribution && cp -r ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./gateway-docker-context/.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,7 +23,7 @@ tasks:
   build-quick:
     desc: "Build management-api & gateway quickly without running tests & validations steps"
     cmds:
-      - mvn clean install -DskipTests -Dskip.validation -P distribution-dev -T 1C
+      - mvn clean install -DskipTests -Dskip.validation -Pbundle-default,bundle-dev -T 1C
 
   docker:
     desc: "Build all 🐳 images"

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -748,6 +748,22 @@
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>
+
+                <!-- Repositories -->
+                <dependency>
+                    <groupId>com.graviteesource.apim</groupId>
+                    <artifactId>gravitee-apim-repository-bridge-http-server</artifactId>
+                    <version>${gravitee-repository-bridge.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.apim</groupId>
+                    <artifactId>gravitee-apim-repository-bridge-http-client</artifactId>
+                    <version>${gravitee-repository-bridge.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
             </dependencies>
         </profile>
         <!-- Developer profile, to add all available plugins not already added in default bundle. Useful to deploy on our dev & test environments-->
@@ -883,20 +899,6 @@
                     <groupId>com.graviteesource.resource</groupId>
                     <artifactId>gravitee-resource-schema-registry-confluent</artifactId>
                     <version>${gravitee-resource-schema-registry-confluent.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.apim</groupId>
-                    <artifactId>gravitee-apim-repository-bridge-http-server</artifactId>
-                    <version>${gravitee-repository-bridge.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.apim</groupId>
-                    <artifactId>gravitee-apim-repository-bridge-http-client</artifactId>
-                    <version>${gravitee-repository-bridge.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -529,6 +529,13 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-redis</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+        </dependency>
 
         <!-- Resources -->
         <dependency>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -56,19 +56,19 @@
         <!-- Clusters -->
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
-            <version>${gravitee-node.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <!-- Clusters -->
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cache-plugin-standalone</artifactId>
             <version>${gravitee-node.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-cluster-plugin-standalone</artifactId>
+            <version>${gravitee-node.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
+
         <!-- Connectors -->
         <dependency>
             <groupId>io.gravitee.ae</groupId>
@@ -153,6 +153,7 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+
         <!-- Notifiers -->
         <dependency>
             <groupId>io.gravitee.notifier</groupId>
@@ -175,6 +176,7 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+
         <!-- Policies -->
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -500,6 +502,7 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+
         <!-- Repositories -->
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
@@ -775,7 +778,6 @@
                 </dependency>
 
                 <!-- Policies -->
-
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-transform-avro-json</artifactId>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -32,17 +32,26 @@
 
     <name>Gravitee.io APIM - Distribution</name>
 
+    <!-- INSTRUCTIONS -->
     <!--
-        This pom.xml is used to prepare the full distribution of Management API & Gateway.
-        It defines all dependencies that have to be bundled by default in each component.
-        To add a new plugin in the bundle:
-         1. add the version in the <properties> section.
-            please respect alphabetic order and the separation between Gateway only, Management only and both
-         2. add the plugin in the <dependencies> section with <type>zip</type> and <scope>runtime</scope>.
+        This pom.xml is used to prepare the distribution of Management API & Gateway. It defines all dependencies that have to be bundled by default those components.
 
-        To add plugins only for the dev environment, follow the same steps in the distribution-dev profile defined at the end of this file
+        Keep in my mind that this pom.xml is used by both Management API & Gateway. So every dependency defined here will be bundled in both components by default.
+        To exclude a dependency from one of the component, you have to add an exclusion rule in the right assembly.xml:
+         - gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+         - gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+
+        To add a new dependency in the bundle:
+         1. Add the version in the <properties> section of the parent pom.xml
+         2. Determine the profile to use:
+           - if the dependency is opensource and has to be shipped in the default bundle, add it in the <dependencies> section of this pom.xml
+           - if the dependency is "enterprise" but has to be shipped in the default bundle, add it in the <dependencies> section of the `bundle-default` profile
+           - otherwise, add it in the <dependencies> section of the `bundle-dev` profile
+
+         The plugin must be added with <type>zip</type> and <scope>runtime</scope>.
     -->
 
+    <!-- Default dependencies, to allow a full OSS distribution with opensource plugins only -->
     <dependencies>
         <!-- Clusters -->
         <dependency>
@@ -91,41 +100,6 @@
             <scope>runtime</scope>
             <type>zip</type>
         </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-http-get</artifactId>
-            <version>${gravitee-entrypoint-http-get.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-http-post</artifactId>
-            <version>${gravitee-entrypoint-http-post.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-sse</artifactId>
-            <version>${gravitee-entrypoint-sse.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-webhook</artifactId>
-            <version>${gravitee-entrypoint-webhook.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.entrypoint</groupId>
-            <artifactId>gravitee-entrypoint-websocket</artifactId>
-            <version>${gravitee-entrypoint-websocket.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
 
         <!-- Endpoints -->
         <dependency>
@@ -141,27 +115,6 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.endpoint</groupId>
-            <artifactId>gravitee-endpoint-kafka</artifactId>
-            <version>${gravitee-endpoint-kafka.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.endpoint</groupId>
-            <artifactId>gravitee-endpoint-mqtt5</artifactId>
-            <version>${gravitee-endpoint-mqtt5.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.endpoint</groupId>
-            <artifactId>gravitee-endpoint-rabbitmq</artifactId>
-            <version>${gravitee-endpoint-rabbitmq.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
         </dependency>
 
         <!-- Fetchers -->
@@ -238,13 +191,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.graviteesource.policy</groupId>
-            <artifactId>gravitee-policy-assign-metrics</artifactId>
-            <version>${gravitee-policy-assign-metrics.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-assign-content</artifactId>
             <version>${gravitee-policy-assign-content.version}</version>
@@ -264,26 +210,6 @@
             <version>${gravitee-policy-callout-http.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.policy</groupId>
-            <artifactId>gravitee-policy-cloud-events</artifactId>
-            <version>${gravitee-policy-cloud-events.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.policy</groupId>
-            <artifactId>gravitee-policy-data-logging-masking</artifactId>
-            <version>${gravitee-policy-data-logging-masking.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.jayway.jsonpath</groupId>
-                    <artifactId>json-path</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -552,13 +478,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.graviteesource.policy</groupId>
-            <artifactId>gravitee-policy-xslt</artifactId>
-            <version>${gravitee-policy-xslt.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-json-threat-protection</artifactId>
             <version>${gravitee-policy-json-threat-protection.version}</version>
@@ -672,15 +591,6 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Reactors -->
-        <dependency>
-            <groupId>com.graviteesource.reactor</groupId>
-            <artifactId>gravitee-reactor-message</artifactId>
-            <version>${gravitee-reactor-message.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -715,12 +625,127 @@
         </pluginManagement>
     </build>
     <profiles>
+        <!-- Default Bundle profile, to build a distribution with enterprise plugins we want to ship in the release -->
         <profile>
-            <id>distribution-dev</id>
+            <id>bundle-default</id>
             <activation>
                 <property>
-                    <name>distribution-dev</name>
-                    <value>true</value>
+                    <name>bundle.default</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- Entrypoints -->
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-http-get</artifactId>
+                    <version>${gravitee-entrypoint-http-get.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-http-post</artifactId>
+                    <version>${gravitee-entrypoint-http-post.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-sse</artifactId>
+                    <version>${gravitee-entrypoint-sse.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-webhook</artifactId>
+                    <version>${gravitee-entrypoint-webhook.version}</version>
+                    <scope>runtime</scope>
+                    <type>zip</type>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-websocket</artifactId>
+                    <version>${gravitee-entrypoint-websocket.version}</version>
+                    <scope>runtime</scope>
+                    <type>zip</type>
+                </dependency>
+
+                <!-- Endpoints -->
+                <dependency>
+                    <groupId>com.graviteesource.endpoint</groupId>
+                    <artifactId>gravitee-endpoint-kafka</artifactId>
+                    <version>${gravitee-endpoint-kafka.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.endpoint</groupId>
+                    <artifactId>gravitee-endpoint-mqtt5</artifactId>
+                    <version>${gravitee-endpoint-mqtt5.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.endpoint</groupId>
+                    <artifactId>gravitee-endpoint-rabbitmq</artifactId>
+                    <version>${gravitee-endpoint-rabbitmq.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+
+                <!-- Policies -->
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-assign-metrics</artifactId>
+                    <version>${gravitee-policy-assign-metrics.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-cloud-events</artifactId>
+                    <version>${gravitee-policy-cloud-events.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-data-logging-masking</artifactId>
+                    <version>${gravitee-policy-data-logging-masking.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.jayway.jsonpath</groupId>
+                            <artifactId>json-path</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-xslt</artifactId>
+                    <version>${gravitee-policy-xslt.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+
+                <!-- Reactors -->
+                <dependency>
+                    <groupId>com.graviteesource.reactor</groupId>
+                    <artifactId>gravitee-reactor-message</artifactId>
+                    <version>${gravitee-reactor-message.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <!-- Developer profile, to add all available plugins not already added in default bundle. Useful to deploy on our dev & test environments-->
+        <profile>
+            <id>bundle-dev</id>
+            <activation>
+                <property>
+                    <name>bundle.dev</name>
                 </property>
             </activation>
             <dependencies>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -82,14 +82,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.apim.repository</groupId>
-            <artifactId>gravitee-apim-repository-redis</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
-
-        <dependency>
             <groupId>io.gravitee.apim.gateway.services</groupId>
             <artifactId>gravitee-apim-gateway-services-endpoint-discovery</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -146,7 +146,6 @@
                 <exclude>io.gravitee.cockpit:gravitee-cockpit-connectors-ws:zip</exclude>
                 <exclude>io.gravitee.fetcher:*:zip</exclude>
                 <exclude>io.gravitee.notifier:*:zip</exclude>
-                <exclude>io.gravitee.repository:gravitee-apim-repository-noop:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -143,9 +143,9 @@
             <excludes>
                 <exclude>*:*:jar</exclude>
                 <exclude>io.gravitee.fetcher:*:zip</exclude>
+                <exclude>io.gravitee.apim.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
                 <exclude>io.gravitee.cockpit:gravitee-cockpit-connectors-ws:zip</exclude>
                 <exclude>io.gravitee.notifier:*:zip</exclude>
-                <exclude>io.gravitee.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
                 <exclude>io.gravitee.repository:gravitee-apim-repository-noop:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -142,9 +142,9 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>*:*:jar</exclude>
-                <exclude>io.gravitee.fetcher:*:zip</exclude>
                 <exclude>io.gravitee.apim.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
                 <exclude>io.gravitee.cockpit:gravitee-cockpit-connectors-ws:zip</exclude>
+                <exclude>io.gravitee.fetcher:*:zip</exclude>
                 <exclude>io.gravitee.notifier:*:zip</exclude>
                 <exclude>io.gravitee.repository:gravitee-apim-repository-noop:zip</exclude>
             </excludes>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -139,14 +139,6 @@
             <scope>runtime</scope>
             <type>zip</type>
         </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.apim.repository</groupId>
-            <artifactId>gravitee-apim-repository-elasticsearch</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -163,6 +163,7 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>*:*:jar</exclude>
+                <exclude>com.graviteesource.apim:gravitee-apim-repository-bridge-http-client:zip</exclude>
                 <exclude>com.graviteesource.reactor:*:zip</exclude>
                 <exclude>com.graviteesource.reporter:*:zip</exclude>
                 <exclude>io.gravitee.apim.repository:gravitee-apim-repository-redis:zip</exclude>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -165,6 +165,7 @@
                 <exclude>*:*:jar</exclude>
                 <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
                 <exclude>com.graviteesource.reporter:*:zip</exclude>
+                <exclude>io.gravitee.apim.repository:gravitee-apim-repository-redis:zip</exclude>
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>
                 <exclude>com.graviteesource.reactor:*:zip</exclude>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -163,12 +163,12 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>*:*:jar</exclude>
-                <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
+                <exclude>com.graviteesource.reactor:*:zip</exclude>
                 <exclude>com.graviteesource.reporter:*:zip</exclude>
                 <exclude>io.gravitee.apim.repository:gravitee-apim-repository-redis:zip</exclude>
+                <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>
-                <exclude>com.graviteesource.reactor:*:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -161,6 +161,7 @@ const restApiDependenciesExclusion = [
   'io.gravitee.reporter',
   'io.gravitee.tracer',
   // ArtifactIds to exclude
+  'gravitee-apim-repository-bridge-http-client',
   'gravitee-apim-repository-redis',
   'gravitee-gateway-services-ratelimit',
 ];

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -156,11 +156,13 @@ const restApiDependenciesExclusion = [
   'io.gravitee.apim.ui',
   'io.gravitee.apim.gateway.standalone.distribution',
   'io.gravitee.apim.rest.api.standalone.distribution',
+  'com.graviteesource.reactor',
+  'com.graviteesource.reporter',
   'io.gravitee.reporter',
   'io.gravitee.tracer',
   // ArtifactIds to exclude
-  'gravitee-gateway-services-ratelimit',
   'gravitee-apim-repository-redis',
+  'gravitee-gateway-services-ratelimit',
 ];
 
 console.log(chalk.blue(`Add plugins to Rest API`));
@@ -178,12 +180,11 @@ const gatewayDependenciesExclusion = [
   'io.gravitee.apim.ui',
   'io.gravitee.apim.gateway.standalone.distribution',
   'io.gravitee.apim.rest.api.standalone.distribution',
-  'io.gravitee.cockpit',
   'io.gravitee.fetcher',
   'io.gravitee.notifier',
-  'io.gravitee.tracer',
   // ArtifactIds to exclude
   'gravitee-apim-repository-elasticsearch',
+  'gravitee-cockpit-connectors-ws',
 ];
 
 console.log(chalk.blue(`Add plugins to Gateway`));

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -63,12 +63,6 @@ const allDependencies = [
     version: releasingVersion,
     type: 'zip',
   },
-  {
-    groupId: 'io.gravitee.apim.repository',
-    artifactId: 'gravitee-apim-repository-redis',
-    version: releasingVersion,
-    type: 'zip',
-  },
 ].map((dependency) => {
   const fileName = `${dependency.artifactId}-${dependency.version}.${dependency.type}`;
   console.log(chalk.yellow(` - ${dependency.artifactId}: ${dependency.version}`));

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -57,12 +57,6 @@ const allDependencies = [
     version: releasingVersion,
     type: 'zip',
   },
-  {
-    groupId: 'io.gravitee.apim.repository',
-    artifactId: 'gravitee-apim-repository-hazelcast',
-    version: releasingVersion,
-    type: 'zip',
-  },
 ].map((dependency) => {
   const fileName = `${dependency.artifactId}-${dependency.version}.${dependency.type}`;
   console.log(chalk.yellow(` - ${dependency.artifactId}: ${dependency.version}`));
@@ -166,9 +160,7 @@ const restApiDependenciesExclusion = [
   'io.gravitee.tracer',
   // ArtifactIds to exclude
   'gravitee-gateway-services-ratelimit',
-  'gravitee-apim-repository-hazelcast',
   'gravitee-apim-repository-redis',
-  'gravitee-apim-repository-gateway-bridge-http-client',
 ];
 
 console.log(chalk.blue(`Add plugins to Rest API`));
@@ -192,8 +184,6 @@ const gatewayDependenciesExclusion = [
   'io.gravitee.tracer',
   // ArtifactIds to exclude
   'gravitee-apim-repository-elasticsearch',
-  'gravitee-apim-repository-hazelcast',
-  'gravitee-apim-repository-noop',
 ];
 
 console.log(chalk.blue(`Add plugins to Gateway`));


### PR DESCRIPTION
## Issue

N/A

## Description
To fix the "Community Build" Job:
- Create a `bundle-default` profile to add enterprise plugins we want to ship in a release.
- Keep "default" dependencies OSS only to allow Community Build
- Adapt CI and packaging process

On top of that, this PR re-aligns the `package-bundle.mjs` script with the maven assembly files so the distributions are built similarly.

Finally, this PR adds missing bridge-repository in the default released bundle

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hzfwonxgrn.chromatic.com)
<!-- Storybook placeholder end -->
