### PR TITLE
fix: use criteria to filter APIs in plan upgraders

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
@@ -100,7 +100,7 @@ public class PlansDataFixUpgrader implements Upgrader {
         try {
             AtomicBoolean upgradeFailed = new AtomicBoolean(false);
             apiRepository
-                .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
+                .search(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(), null, ApiFieldFilter.allFields())
                 .forEach(api -> {
                     try {
                         io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
@@ -108,7 +108,7 @@ public class PlansDataFixUpgrader implements Upgrader {
                             io.gravitee.definition.model.Api.class
                         );
                         ExecutionContext executionContext = getApiExecutionContext(api);
-                        if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion() && executionContext != null) {
+                        if (executionContext != null) {
                             fixApiPlans(executionContext, api, apiDefinition);
                         }
                     } catch (Exception e) {
@@ -250,8 +250,8 @@ public class PlansDataFixUpgrader implements Upgrader {
             .stream()
             .filter(plan -> plan.getStatus() != Plan.Status.CLOSED)
             .map(Plan::getId)
-            .collect(toList());
-        List<String> definitionPlansIds = definitionPlans.stream().map(io.gravitee.definition.model.Plan::getId).collect(toList());
+            .toList();
+        List<String> definitionPlansIds = definitionPlans.stream().map(io.gravitee.definition.model.Plan::getId).toList();
         return apiPlansIds.size() != definitionPlansIds.size() || !definitionPlansIds.containsAll(apiPlansIds);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
@@ -27,6 +27,8 @@ import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
+
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -68,16 +70,14 @@ public class PlansFlowsDefinitionUpgrader implements Upgrader {
         try {
             AtomicBoolean upgradeFailed = new AtomicBoolean(false);
             apiRepository
-                .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
+                .search(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(), null, ApiFieldFilter.allFields())
                 .forEach(api -> {
                     try {
                         io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
                             api.getDefinition(),
                             io.gravitee.definition.model.Api.class
                         );
-                        if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion()) {
-                            migrateApiFlows(api.getId(), apiDefinition);
-                        }
+                        migrateApiFlows(api.getId(), apiDefinition);
                     } catch (Exception e) {
                         upgradeFailed.set(true);
                         throw new RuntimeException(e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -79,18 +80,16 @@ public class PlansFlowsDefinitionUpgraderTest {
     public void upgrade_should_convert_flows_of_every_v2_apis() throws Exception {
         doNothing().when(upgrader).migrateApiFlows(any(), any());
 
-        Api api1 = buildApi("api1", "1.0.0");
         Api api2 = buildApi("api2", "2.0.0");
-        Api api3 = buildApi("api3", "1.0.0");
         Api api4 = buildApi("api4", "2.0.0");
-        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class)))
-            .thenReturn(Stream.of(api1, api2, api3, api4));
+        when(apiRepository.search(eq(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build()), eq(null), any(ApiFieldFilter.class)))
+            .thenReturn(Stream.of(api2, api4));
 
         upgrader.upgrade();
 
-        verify(upgrader, times(1)).migrateApiFlows(eq("api2"), argThat(api -> api.getId().equals("api2")));
-        verify(upgrader, times(1)).migrateApiFlows(eq("api4"), argThat(api -> api.getId().equals("api4")));
-        verify(upgrader, times(1)).upgrade();
+        verify(upgrader).migrateApiFlows(eq("api2"), argThat(api -> api.getId().equals("api2")));
+        verify(upgrader).migrateApiFlows(eq("api4"), argThat(api -> api.getId().equals("api4")));
+        verify(upgrader).upgrade();
         verifyNoMoreInteractions(upgrader);
     }
 


### PR DESCRIPTION

## Description

When searching the database in Plan upgraders, API filter should happen at request level.

## Additional context

Cockpit is sending v4 APIs to trials. This is happening  before upgraders are executed, causing APIM to crash

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ikbhpzwkrn.chromatic.com)
<!-- Storybook placeholder end -->
