### PR TITLE
test: added tests for the deletion of flows in Policy Studio

### DIFF
--- a/gravitee-apim-e2e/lib/fixtures/management/MAPIV2ApisFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/MAPIV2ApisFaker.ts
@@ -20,11 +20,13 @@ import {
   CreateApiV4,
   DefinitionVersion,
   ExportApiV4,
+  EndpointGroupV4,
   FlowExecution,
   FlowMode,
   HttpListener,
   ListenerType,
   SubscriptionListener,
+  FlowV4,
 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 
 export class MAPIV2ApisFaker {
@@ -137,9 +139,9 @@ export class MAPIV2ApisFaker {
     return {
       // @ts-ignore
       type: 'HTTP',
-      paths: [],
+      paths: [{ path: `/${faker.random.word()}-${faker.datatype.uuid()}-${Math.floor(Date.now() / 1000)}` }],
       pathMappings: [],
-      entrypoints: [],
+      entrypoints: [{ type: 'http-proxy' }],
       ...attributes,
     };
   }
@@ -149,6 +151,62 @@ export class MAPIV2ApisFaker {
       // @ts-ignore
       type: 'SUBSCRIPTION',
       entrypoints: [],
+      ...attributes,
+    };
+  }
+
+  static newHttpEndpointGroup(attributes?: Partial<EndpointGroupV4>): EndpointGroupV4 {
+    return {
+      name: 'Default HTTP proxy group',
+      type: 'http-proxy',
+      loadBalancer: {
+        type: 'ROUND_ROBIN',
+      },
+      endpoints: [
+        {
+          name: 'Default HTTP proxy',
+          type: 'http-proxy',
+          configuration: {
+            target: `${Cypress.env('wiremockUrl')}/hello`,
+          },
+        },
+      ],
+      ...attributes,
+    };
+  }
+
+  static newFlow(attributes?: Partial<FlowV4>): FlowV4 {
+    return {
+      name: `${faker.random.word()} flow`,
+      enabled: true,
+      selectors: [
+        {
+          type: 'HTTP',
+          path: '/',
+          pathOperator: 'EQUALS',
+          methods: [],
+        },
+      ],
+      request: [],
+      response: [
+        {
+          name: 'Transform Headers',
+          enabled: true,
+          policy: 'transform-headers',
+          configuration: {
+            whitelistHeaders: [],
+            addHeaders: [
+              {
+                name: 'x-header-added-by-common-flow',
+                value: faker.random.word(),
+              },
+            ],
+          },
+        },
+      ],
+      subscribe: [],
+      publish: [],
+      tags: [],
       ...attributes,
     };
   }

--- a/gravitee-apim-e2e/lib/fixtures/management/MAPIV2PlansFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/MAPIV2PlansFaker.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 import faker from '@faker-js/faker';
-import { PlanValidation, PlanSecurityType, PlanMode, CreatePlan, PlanV4, PlanStatus } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import {
+  PlanValidation,
+  PlanSecurityType,
+  PlanMode,
+  CreatePlan,
+  FlowV4,
+  PlanV4,
+  PlanStatus,
+} from '@gravitee/management-v2-webclient-sdk/src/lib';
 
 export class MAPIV2PlansFaker {
   static newPlanV4(attributes?: Partial<CreatePlan>): CreatePlan {
@@ -50,6 +58,40 @@ export class MAPIV2PlansFaker {
       order: 1,
       characteristics: [],
       flows: [],
+      ...attributes,
+    };
+  }
+
+  static newFlowV4(attributes?: Partial<FlowV4>): FlowV4 {
+    const name = faker.commerce.productName();
+
+    return {
+      name,
+      enabled: true,
+      selectors: [
+        {
+          type: 'HTTP',
+          path: '/',
+          pathOperator: 'STARTS_WITH',
+        },
+      ],
+      response: [
+        {
+          name: 'Transform Headers',
+          enabled: true,
+          policy: 'transform-headers',
+          configuration: {
+            whitelistHeaders: [],
+            addHeaders: [
+              {
+                name: 'x-header-added-by-plan-flow',
+                value: faker.random.word(),
+              },
+            ],
+            // scope : "REQUEST",
+          },
+        },
+      ],
       ...attributes,
     };
   }

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-delete-flow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-delete-flow.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
+import { ApiType, ApiV4, FlowV4, HttpListener } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
+
+const envId = 'DEFAULT';
+
+describe('Deleting a flow', () => {
+  let v4api: ApiV4;
+  const planFlow: FlowV4 = MAPIV2PlansFaker.newFlowV4();
+  const commonFlow: FlowV4 = MAPIV2ApisFaker.newFlow();
+  const addedPlanFlowHeader = planFlow.response[0].configuration.addHeaders[0];
+  const addedCommonFlowHeader = commonFlow.response[0].configuration.addHeaders[0];
+  const httpListener: HttpListener = MAPIV2ApisFaker.newHttpListener();
+  const apiPath: string = httpListener.paths[0].path;
+
+  before(() => {
+    cy.log('Create v4 API');
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis`,
+      auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
+      body: MAPIV2ApisFaker.newApi({
+        type: ApiType.PROXY,
+        listeners: [httpListener],
+        endpointGroups: [MAPIV2ApisFaker.newHttpEndpointGroup()],
+        flows: [commonFlow],
+      }),
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      v4api = response.body;
+
+      cy.log('Create a plan with a flow');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/plans`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+        body: MAPIV2PlansFaker.newPlanV4({ flows: [planFlow] }),
+      })
+        .then((response) => {
+          expect(response.status).to.eq(201);
+          return response.body.id;
+        })
+        .then((planId) => {
+          cy.log('Publish Plan');
+          cy.request({
+            method: 'POST',
+            url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${v4api.id}/plans/${planId}/_publish`,
+            auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+          }).then((response) => {
+            expect(response.status).to.eq(200);
+          });
+        });
+
+      cy.log('Deploy API');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/deployments`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+      }).then((response) => {
+        expect(response.status).to.eq(202);
+      });
+
+      cy.log('Start API');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/_start`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+      }).then((response) => {
+        expect(response.status).to.eq(204);
+      });
+    });
+  });
+
+  describe('Verify that both flows are working on the Gateway', () => {
+    it('should have additional header added by API flows', () => {
+      cy.callGateway(apiPath)
+        .its('headers')
+        .should((headers) => {
+          expect(headers).to.have.property(addedCommonFlowHeader.name, addedCommonFlowHeader.value);
+          expect(headers).to.have.property(addedPlanFlowHeader.name, addedPlanFlowHeader.value);
+        });
+    });
+  });
+
+  describe('Verify that flow deletion works in Policy Studio', () => {
+    beforeEach(() => {
+      cy.loginInAPIM(API_PUBLISHER_USER.username, API_PUBLISHER_USER.password);
+      cy.visit(`/#!/environments/default/apis/ng/${v4api.id}/policy-studio`);
+      cy.url().should('include', '/policy-studio');
+    });
+
+    it('should delete a common flow using trash icon', () => {
+      cy.contains('.list__flowsGroup__flow__name', commonFlow.name, { timeout: 60000 }).should('be.visible').click();
+      cy.get('.header__configBtn__delete').click();
+      cy.contains('.list__flowsGroup__flow__name', commonFlow.name).should('not.exist');
+      cy.contains('button', 'Save').click();
+      cy.contains('Policy Studio configuration saved').should('be.visible');
+      cy.contains('.banner__wrapper__title', 'This API is out of sync').scrollIntoView().should('be.visible');
+    });
+
+    it('should delete a plan-flow using trash icon', () => {
+      cy.contains('.list__flowsGroup__flow__name', planFlow.name, { timeout: 60000 }).should('be.visible').click();
+      cy.get('.header__configBtn__delete').click();
+      cy.contains('.list__flowsGroup__flow__name', planFlow.name).should('not.exist');
+      cy.contains('button', 'Save').click();
+      cy.contains('Policy Studio configuration saved').should('be.visible');
+      cy.contains('.banner__wrapper__title', 'This API is out of sync').scrollIntoView().should('be.visible');
+    });
+
+    after(() => {
+      cy.log('Deploy API');
+      cy.contains('button', 'Deploy API').click();
+      cy.get('.mat-raised-button > .mat-button-wrapper').click();
+    });
+  });
+
+  describe('Verify that flow is no longer working on the Gateway', () => {
+    it(
+      'should no longer have additional header from API flows after flows deleted',
+      {
+        retries: 5, // deployment can take some time
+      },
+      () => {
+        cy.callGateway(apiPath)
+          .its('headers')
+          .should((responseHeader) => {
+            expect(responseHeader).to.not.have.property(addedCommonFlowHeader.name);
+            expect(responseHeader).to.not.have.property(addedPlanFlowHeader.name);
+          });
+      },
+    );
+  });
+
+  after(() => {
+    cy.clearCookie('Auth-Graviteeio-APIM');
+    cy.teardownV4Api(v4api.id);
+  });
+});

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
@@ -18,7 +18,7 @@ import faker from '@faker-js/faker';
 
 describe('API creation workflow', () => {
   const apiVersion = `${faker.datatype.number({ min: 1, max: 9 })}.${faker.datatype.number({ min: 1, max: 9 })}`;
-  const apiPath = faker.commerce.productName().replace(/ /g, '_');
+  const apiPath = `/${faker.commerce.productName().replace(/ /g, '_')}`;
   const apiName = faker.commerce.productName();
   let apiId: string;
 

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -37,7 +37,7 @@ declare global {
       teardownApi(api: ApiImport | Api): void;
       teardownV4Api(apiId: string): void;
       createAndStartApiFromSwagger(swaggerImport: string, attributes?: Partial<ImportSwaggerDescriptorEntity>): any;
-      callGateway(contextPath: string, maxRetries?: number, retryDelay?: number): any;
+      callGateway(contextPath: string, maxRetries?: number, retryDelay?: number): Cypress.Chainable<Cypress.Response<any>>;
     }
   }
 }
@@ -48,7 +48,7 @@ Cypress.Commands.add('callGateway', (contextPath, maxRetries = 5, retryDelay = 1
 
   const sendRequest = () => {
     retries++;
-    const url = `${Cypress.env('gatewayServer')}/${contextPath}`;
+    const url = `${Cypress.env('gatewayServer')}${contextPath}`;
     cy.log(`Calling gateway: ${url} - Attempt ${retries} of ${maxRetries}`);
 
     return cy.request({ url, failOnStatusCode: false }).then((response) => {


### PR DESCRIPTION
APIM-2374

## Description

This PR will add tests for the deletion of flows in Policy Studio. It verifies that flows can be deleted for both:
- common flows
- plan flows

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-miictiuvho.chromatic.com)
<!-- Storybook placeholder end -->
