### PR TITLE
fix(mongodb): improve mongodb indexes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -16,12 +16,11 @@ db.getCollection(`${prefix}applications`).reIndex();
 
 // "events" collection
 db.getCollection(`${prefix}events`).dropIndexes();
-db.getCollection(`${prefix}events`).createIndex( { "type" : 1 }, { "name": "t1" } );
 db.getCollection(`${prefix}events`).createIndex( { "updatedAt" : 1 }, { "name": "u1" } );
 db.getCollection(`${prefix}events`).createIndex( { "updatedAt" : -1, "_id" : -1 }, { "name": "u1i1" } );
-db.getCollection(`${prefix}events`).createIndex( { "properties.api_id" : 1 }, { "name": "pa1" } );
 db.getCollection(`${prefix}events`).createIndex( { "properties.api_id":1, "type":1}, { "name": "pa1t1" } );
-db.getCollection(`${prefix}events`).createIndex( { "properties.api_id":1, "updatedAt" : 1.0}, { "name": "pa1u1" } );
+db.getCollection(`${prefix}events`).createIndex( { "properties.api_id":1, "updatedAt" : 1}, { "name": "pa1u1" } );
+db.getCollection(`${prefix}events`).createIndex( { "properties.dictionary_id":1, "updatedAt" : -1}, { "name": "pdi1u1" } );
 db.getCollection(`${prefix}events`).createIndex( { "type" : 1, "updatedAt" : 1}, { "name": "t1u1" } );
 db.getCollection(`${prefix}events`).reIndex();
 
@@ -134,3 +133,8 @@ db.getCollection(`${prefix}custom_user_fields`).reIndex();
 db.getCollection(`${prefix}client_registration_providers`).dropIndexes();
 db.getCollection(`${prefix}client_registration_providers`).createIndex({ environmentId: 1 }, { name: "e1" });
 db.getCollection(`${prefix}client_registration_providers`).reIndex();
+
+// "node_monitoring" collection
+db.getCollection(`${prefix}node_monitoring`).dropIndexes();
+db.getCollection(`${prefix}node_monitoring`).createIndex({ type: 1, updatedAt: 1 }, { name: "t1u1" });
+db.getCollection(`${prefix}node_monitoring`).reIndex();


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-2444

## Description

Mongo Atlas Performance Advisor raised warnings about:
- 2 missing indexes
- 2 redundant indexes.

FYI, an index that is a prefix of another compound index is redundant and can be removed to improve write performance.
Since these indexes are prefix of another compound index, removing them will not affect your read performance.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uqyaiffclt.chromatic.com)
<!-- Storybook placeholder end -->
