### PR TITLE
fix(mongodb): improve mongodb indexes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdNameDefinitionVersionIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdNameDefinitionVersionIndexUpgrader.java
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.apis;
 
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
 import org.springframework.stereotype.Component;
 
-/**
- * @author GraviteeSource Team
- */
-@Component("EventsTypeIndexUpgrader")
-public class TypeIndexUpgrader extends IndexUpgrader {
+@Component("ApisEnvironmentIdNameDefinitionVersionIndexUpgrader")
+public class EnvironmentIdNameDefinitionVersionIndexUpgrader extends IndexUpgrader {
 
     @Override
     protected Index buildIndex() {
         return Index
             .builder()
-            .collection("events")
-            .name("t1")
-            .key("type", ascending())
+            .collection("apis")
+            .name("ei1n1dv1")
+            .key("environmentId", ascending())
+            .key("name", ascending())
+            .key("definitionVersion", ascending())
             .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdTypeIndexUpgrader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.eventslatest;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
 
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
@@ -22,16 +22,17 @@ import org.springframework.stereotype.Component;
 /**
  * @author GraviteeSource Team
  */
-@Component("EventsLatestPropertyApiIdIndexUpgrader")
-public class PropertyApiIdIndexUpgrader extends IndexUpgrader {
+@Component("EventsPropertiesDictionaryIdIndexUpgrader")
+public class PropertiesApiIdTypeIndexUpgrader extends IndexUpgrader {
 
     @Override
     protected Index buildIndex() {
         return Index
             .builder()
-            .collection("events_latest")
-            .name("pai1")
+            .collection("events")
+            .name("pa1t1")
             .key("properties.api_id", ascending())
+            .key("type", ascending())
             .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdUpdatedAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdUpdatedAtIndexUpgrader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.apis;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
 
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
@@ -22,16 +22,17 @@ import org.springframework.stereotype.Component;
 /**
  * @author GraviteeSource Team
  */
-@Component("ApisEnvironmentIdIndexUpgrader")
-public class EnvironmentIdIndexUpgrader extends IndexUpgrader {
+@Component("EventsPropertiesApiIdUpdatedAtIndexUpgrader")
+public class PropertiesApiIdUpdatedAtIndexUpgrader extends IndexUpgrader {
 
     @Override
     protected Index buildIndex() {
         return Index
             .builder()
-            .collection("apis")
-            .name("ei1")
-            .key("environmentId", ascending())
+            .collection("events")
+            .name("pa1u1")
+            .key("properties.api_id", ascending())
+            .key("updatedAt", ascending())
             .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesDictionaryIdUpdatedAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesDictionaryIdUpdatedAtIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("EventsPropertiesDictionaryIdUpdatedAtIndexUpgrader")
+public class PropertiesDictionaryIdUpdatedAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("events")
+            .name("pdi1u1")
+            .key("properties.dictionary_id", ascending())
+            .key("updatedAt", descending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/TypeUpdatedAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/TypeUpdatedAtIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("EventsTypeUpdatedAtIndexUpgrader")
+public class TypeUpdatedAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("events")
+            .name("t1u1")
+            .key("type", ascending())
+            .key("updatedAt", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/UpdatedAtAscIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/UpdatedAtAscIndexUpgrader.java
@@ -13,25 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
 
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
 import org.springframework.stereotype.Component;
 
-/**
- * @author GraviteeSource Team
- */
-@Component("EventsPropertiesDictionaryIdIndexUpgrader")
-public class PropertiesDictionaryIdIndexUpgrader extends IndexUpgrader {
+@Component("SubscriptionsUpdatedAtAscIndexUpgrader")
+public class UpdatedAtAscIndexUpgrader extends IndexUpgrader {
 
     @Override
     protected Index buildIndex() {
         return Index
             .builder()
-            .collection("events")
-            .name("pdi1")
-            .key("properties.dictionary_id", ascending())
+            .collection("subscriptions")
+            .name("ua1")
+            .key("updatedAt", ascending())
             .build();
     }
 }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-2444

## Description

Mongo Atlas Performance Advisor raised warnings about:
- 2 missing indexes
- 2 redundant indexes.

FYI, an index that is a prefix of another compound index is redundant and can be removed to improve write performance.
Since these indexes are prefix of another compound index, removing them will not affect your read performance.

I've also noticed some index missing compared to the one defined in 3.20
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dllrippgwm.chromatic.com)
<!-- Storybook placeholder end -->
