### PR TITLE
Activate video recording and screenshots for Cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1706,7 +1706,7 @@ jobs:
     job-e2e-cypress:
         executor:
             name: ubuntu
-            class: medium
+            class: large
         steps:
             - checkout
             - attach_workspace:
@@ -1726,6 +1726,8 @@ jobs:
                   path: ./gravitee-apim-e2e/.tmp/screenshots
             - store_artifacts:
                   path: ./gravitee-apim-e2e/.tmp/videos
+            - store_artifacts:
+                  path: ./gravitee-apim-e2e/.logs
 
     job-publish-rpm-packages:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1722,6 +1722,10 @@ jobs:
                       APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=$TAG npm run test:ui
             - cmd-docker-azure-logout
             - cmd-notify-on-failure
+            - store_artifacts:
+                  path: ./gravitee-apim-e2e/.tmp/screenshots
+            - store_artifacts:
+                  path: ./gravitee-apim-e2e/.tmp/videos
 
     job-publish-rpm-packages:
         parameters:
@@ -2019,23 +2023,23 @@ jobs:
                   path: apim-result.xml
 
     job-snyk-apim-charts:
-      docker:
-        - image: cimg/base:stable
-      resource_class: small
-      steps:
-        - checkout
-        - keeper/env-export:
-            secret-url: keeper://s83JmReKpBZWjHdud6ZAlg/custom_field/gravitee_apim_org_api_token
-            var-name: SNYK_TOKEN
-        - helm/install-helm-client
-        - snyk/install
-        - run:
-            name: "build the Charts output and scan"
-            working_directory: "./helm"
-            command: |
-              helm dependency update
-              helm template . --output-dir ./output
-              snyk iac test ./output --report --target-reference="${CIRCLE_BRANCH}" --project-tags=version=${CIRCLE_BRANCH} --severity-threshold=high
+        docker:
+            - image: cimg/base:stable
+        resource_class: small
+        steps:
+            - checkout
+            - keeper/env-export:
+                  secret-url: keeper://s83JmReKpBZWjHdud6ZAlg/custom_field/gravitee_apim_org_api_token
+                  var-name: SNYK_TOKEN
+            - helm/install-helm-client
+            - snyk/install
+            - run:
+                  name: "build the Charts output and scan"
+                  working_directory: "./helm"
+                  command: |
+                      helm dependency update
+                      helm template . --output-dir ./output
+                      snyk iac test ./output --report --target-reference="${CIRCLE_BRANCH}" --project-tags=version=${CIRCLE_BRANCH} --severity-threshold=high
 
 workflows:
     pull_requests:
@@ -2062,15 +2066,15 @@ workflows:
                   requires:
                       - Setup
             - job-snyk-apim-charts:
-                name: scan snyk Helm chart
-                context: cicd-orchestrator
-                requires:
-                  - Setup
-                filters:
-                  branches:
-                    only:
-                      - master
-                      - /^\d+\.\d+\.x$/
+                  name: scan snyk Helm chart
+                  context: cicd-orchestrator
+                  requires:
+                      - Setup
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /^\d+\.\d+\.x$/
             - job-danger-js:
                   name: Run Danger JS
                   context: cicd-orchestrator

--- a/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
+++ b/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "cypress";
+import { unlinkSync } from "fs";
 
 export default defineConfig({
     env: {
@@ -27,11 +28,23 @@ export default defineConfig({
         screenshotsFolder: "./ui-test/screenshots",
         supportFile: "./ui-test/support/e2e.ts",
         videosFolder: "./ui-test/videos",
-        video: false,
-        screenshotOnRunFailure: false,
+        video: true,
+        screenshotOnRunFailure: true,
         baseUrl: "http://nginx/console",
         setupNodeEvents(on, config) {
-            // implement node event listeners here
+            // Delete videos for successful tests
+            on('after:spec', (spec, results) => {
+                if (results && results.video) {
+                    // Do we have failures for any retry attempts?
+                    const failures = results.tests && results.tests.some((test) =>
+                      test.attempts.some((attempt) => attempt.state === 'failed')
+                    )
+                    if (!failures) {
+                        // delete the video if the spec passed and no tests retried
+                        unlinkSync(results.video)
+                    }
+                }
+            })
         },
     },
 });

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -26,6 +26,9 @@ services:
       - ./docker/ui-tests/conf/cypress-ui-config.ts:/test/cypress-ui-config.ts
       - ./.tmp/screenshots:/test/ui-test/screenshots
       - ./.tmp/videos:/test/ui-test/videos
+    environment:
+      # Disable colors in Cypress output to avoid ANSI escape sequences in logs
+      - NO_COLOR=1
     depends_on:
       nginx:
         condition: service_healthy

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   cypress:
-    image: cypress/included:12.2.0
+    image: cypress/included:12.17.3
     working_dir: /test
     command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts'"
     volumes:

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -24,6 +24,8 @@ services:
     volumes:
       - ./:/test
       - ./docker/ui-tests/conf/cypress-ui-config.ts:/test/cypress-ui-config.ts
+      - ./.tmp/screenshots:/test/ui-test/screenshots
+      - ./.tmp/videos:/test/ui-test/videos
     depends_on:
       nginx:
         condition: service_healthy

--- a/gravitee-apim-e2e/scripts/run-docker-compose.sh
+++ b/gravitee-apim-e2e/scripts/run-docker-compose.sh
@@ -26,6 +26,10 @@ fi
 
 if [ -n "$1" ] && [ -n "$2" ]; then
   clean
+  # Create a tmp directory with video and screenshot folders for cypress
+  mkdir -p .tmp/screenshots
+  mkdir -p .tmp/videos
+
   mode="$1"
   databaseType="$2"
 

--- a/gravitee-apim-e2e/scripts/run-docker-compose.sh
+++ b/gravitee-apim-e2e/scripts/run-docker-compose.sh
@@ -29,6 +29,7 @@ if [ -n "$1" ] && [ -n "$2" ]; then
   # Create a tmp directory with video and screenshot folders for cypress
   mkdir -p .tmp/screenshots
   mkdir -p .tmp/videos
+  mkdir -p .logs
 
   mode="$1"
   databaseType="$2"
@@ -51,6 +52,17 @@ if [ -n "$1" ] && [ -n "$2" ]; then
   elif [ "$mode" = "ui-test" ]; then
     DB_PROVIDER=$databaseType docker-compose -f ./docker/common/docker-compose-base.yml -f ./docker/common/docker-compose-$databaseType.yml -f ./docker/common/docker-compose-apis.yml -f ./docker/common/docker-compose-wiremock.yml -f ./docker/common/docker-compose-uis.yml -f ./docker/ui-tests/docker-compose-ui-tests.yml --project-directory $PWD up --no-build --abort-on-container-exit --exit-code-from cypress
   fi
+
+  # Extract logs from containers
+  docker logs gravitee-apim-e2e-cypress-1 > ./.logs/cypress.log
+  docker logs gravitee-apim-e2e-gateway > ./.logs/gateway.log
+  docker logs gravitee-apim-e2e-management_api > ./.logs/management_api.log
+  docker logs gravitee-apim-e2e-management_ui > ./.logs/management_ui.log
+  docker logs gravitee-apim-e2e-portal_ui > ./.logs/portal_ui.log
+  docker logs gravitee-apim-e2e-nginx > ./.logs/nginx.log
+  docker logs gravitee-apim-e2e-wiremock > ./.logs/wiremock.log
+  docker logs gravitee-apim-e2e-elasticsearch > ./.logs/elasticsearch.log
+  # TODO: Need to add DB logs
 else
   echo "Usage: $0 [clean|only-apim|api-test|ui-test] [mongo|jdbc|bridge]"
 fi


### PR DESCRIPTION
## Issue

NA

## Description

This PR aims to ease the debugging when the Cypress tests fail. Currently, we only have the logs and they are all mixed up.
So, this PR: 
 - Activate video recording and screenshots for failing Cypress tests
 - Extract logs from containers after the test run
 - Upload videos, screenshots, and logs as CircleCI artifacts

Example of run with error: 
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/23664/workflows/0cb3be83-48d7-410d-adac-332ceb6709a4/jobs/415755/artifacts

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/467a1454-5c41-4337-ad4f-bc21fd8aa8d0)

For example, when everything is ok, the logs are there: 
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/23681/workflows/d33f6646-c24d-48f5-a7ef-e67a1c9af9ab/jobs/416097/artifacts
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/db04d276-f7d7-4445-9474-330a684e0d22)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yeshzfpjsq.chromatic.com)
<!-- Storybook placeholder end -->
