### PR TITLE
Activate HC when creating an endpoint if it's activated at the API level

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -199,7 +199,13 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
       ],
     });
 
-    this.healthCheckForm = ApiProxyHealthCheckFormComponent.NewHealthCheckFormGroup(this.endpoint?.healthcheck, this.isReadOnly);
+    // If the endpoint group has a health check enabled, by default, the endpoint will inherit it during creation
+    const defaultHealthCheck =
+      this.api?.services?.['health-check']?.enabled && this.mode === 'new' ? { enabled: true, inherit: true } : { enabled: false };
+    this.healthCheckForm = ApiProxyHealthCheckFormComponent.NewHealthCheckFormGroup(
+      this.endpoint?.healthcheck ?? defaultHealthCheck,
+      this.isReadOnly,
+    );
     this.inheritHealthCheck = this.api?.services?.['health-check'] ?? { enabled: false };
 
     this.endpointForm = this.formBuilder.group({

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,7 @@
 <h1>
   Health-check
   <button class="api-proxy-health-check__go-to-dashboard" mat-raised-button type="button" (click)="gotToHealthCheckDashboard()">
-    Go to Health-check dashboard
+    Go to health check dashboard
   </button>
 </h1>
 
@@ -28,7 +28,13 @@
 </p>
 
 <gio-banner-info class="api-proxy-health-check__banner-info">
-  <span> By enabling health-check, all non-backup endpoints will be checked except if health-check is disabled at endpoint level. </span>
+  <span
+    >Enabling health check on the API will activate health check for all non-backup endpoints, except if the health check is disabled at
+    endpoint level.
+    <br />
+    Disabling health check on the API will deactivate health check for all endpoints configured to inherit health check settings from the
+    API.
+  </span>
 </gio-banner-info>
 
 <form *ngIf="healthCheckForm" autocomplete="off" gioFormFocusInvalid [formGroup]="healthCheckForm">

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
@@ -24,6 +24,7 @@ import { ApiService } from '../../../../services-ngx/api.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiProxyHealthCheckFormComponent } from '../components/health-check-form/api-proxy-health-check-form.component';
+import { Api } from '../../../../entities/api';
 
 @Component({
   selector: 'api-proxy-health-check',
@@ -70,15 +71,18 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
       .get(this.ajsStateParams.apiId)
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap((api) =>
-          this.apiService.update({
+        switchMap((api) => {
+          const apiHealthCheck = ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm, false);
+          this.updateEndpointsHealthCheckConfig(api.proxy?.groups, apiHealthCheck.enabled);
+
+          return this.apiService.update({
             ...api,
             services: {
               ...api.services,
-              'health-check': ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm, false),
+              'health-check': apiHealthCheck,
             },
-          }),
-        ),
+          });
+        }),
         tap(() => this.snackBarService.success('Configuration successfully saved!')),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
@@ -91,5 +95,30 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
 
   gotToHealthCheckDashboard() {
     this.ajsState.go('management.apis.detail.proxy.healthCheckDashboard.visualize');
+  }
+
+  updateEndpointsHealthCheckConfig(groups: Api['proxy']['groups'], apiHealthCheckEnabled: boolean) {
+    if (apiHealthCheckEnabled === true) {
+      // If the API healthcheck is enabled, we enable the health-check for all endpoints without `healthcheck` config
+      groups.forEach((group) => {
+        group.endpoints.forEach((endpoint) => {
+          if (!endpoint.healthcheck) {
+            endpoint.healthcheck = {
+              enabled: true,
+              inherit: true,
+            };
+          }
+        });
+      });
+    } else {
+      // If the API healthcheck is disabled, we disable the health-check for all endpoints inheriting the health-check config
+      groups.forEach((group) => {
+        group.endpoints.forEach((endpoint) => {
+          if (endpoint.healthcheck?.enabled === true && endpoint.healthcheck?.inherit === true) {
+            endpoint.healthcheck.enabled = false;
+          }
+        });
+      });
+    }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2390
https://github.com/gravitee-io/issues/issues/9149

## Description

Activate HC when creating an endpoint if it's activated at the API level
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/4913/console](https://pr.team-apim.gravitee.dev/4913/console)
      Portal: [https://pr.team-apim.gravitee.dev/4913/portal](https://pr.team-apim.gravitee.dev/4913/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/4913/api/management](https://pr.team-apim.gravitee.dev/4913/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/4913](https://pr.team-apim.gravitee.dev/4913)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/4913](https://pr.gateway-v3.team-apim.gravitee.dev/4913)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oistacmzjp.chromatic.com)
<!-- Storybook placeholder end -->
