### PR TITLE
test: fix for ui-api-list-test as URL has changed from /portal to /ge…

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -172,7 +172,7 @@ describe('API List feature', { defaultCommandTimeout: 10000 }, () => {
         cy.getByDataTestId('api_list_table_row').should('have.length', noOfApis);
         cy.getByDataTestId('api_list_table_row').should('contain.text', 'admin');
         cy.getByDataTestId('api_list_edit_button').first().click();
-        cy.url().should('include', '/portal');
+        cy.url().should('include', '/general');
       });
 
       it(`should display ${noOfApis} APIs when searching for v4 APIs`, function () {


### PR DESCRIPTION
## Description
Cypress ui-api-list tests are currently failing.

This is a small adjustment of the api-list test to react on changes that have been made when displaying details of an API (URL doesn't end with _/portal_ anymore but with _/general_)