### PR TITLE
feat: user can transfer ownership of a v4 api

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/apiTransferOwnership.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/apiTransferOwnership.ts
@@ -13,11 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { MembershipMemberType } from './membershipMemberType';
 
-export interface PrimaryOwner {
-  id?: string;
-  displayName?: string;
-  email?: string;
-  type?: MembershipMemberType;
+export interface ApiTransferOwnership {
+  /**
+   * User's technical identifier
+   */
+  userId?: string;
+  /**
+   * User's reference for user provided by an identity provider
+   */
+  userReference?: string;
+  /**
+   * The type of membership
+   */
+  userType?: MembershipMemberType;
+  /**
+   * Primary owner role's name
+   */
+  poRole?: string;
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/membershipMemberType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/membershipMemberType.ts
@@ -13,11 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MembershipMemberType } from './membershipMemberType';
 
-export interface PrimaryOwner {
-  id?: string;
-  displayName?: string;
-  email?: string;
-  type?: MembershipMemberType;
-}
+export type MembershipMemberType = 'USER' | 'GROUP';

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
@@ -20,10 +20,16 @@ import { ApiMenuService } from './ApiMenuService';
 
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { Constants } from '../../../entities/Constants';
+import { CurrentUserService } from '../../../ajs-upgraded-providers';
+import UserService from '../../../services/user.service';
 
 @Injectable()
 export class ApiNgV4MenuService implements ApiMenuService {
-  constructor(private readonly permissionService: GioPermissionService, @Inject('Constants') private readonly constants: Constants) {}
+  constructor(
+    private readonly permissionService: GioPermissionService,
+    @Inject(CurrentUserService) private readonly currentUserService: UserService,
+    @Inject('Constants') private readonly constants: Constants,
+  ) {}
 
   public getMenu(): {
     subMenuItems: MenuItem[];
@@ -129,14 +135,13 @@ export class ApiNgV4MenuService implements ApiMenuService {
         },
       );
     }
-    // TODO: add transfer ownership
-    // if (this.currentUserService.currentUser.isOrganizationAdmin() || this.permissionService.hasAnyMatching(['api-member-u'])) {
-    //   userAndGroupAccessMenuItems.tabs.push({
-    //     displayName: 'Transfer ownership',
-    //     targetRoute: 'management.apis.ng.transferOwnership',
-    //     baseRoute: 'management.apis.ng.transferOwnership',
-    //   });
-    // }
+    if (this.currentUserService.currentUser.isOrganizationAdmin() || this.permissionService.hasAnyMatching(['api-member-u'])) {
+      userAndGroupAccessMenuItems.tabs.push({
+        displayName: 'Transfer ownership',
+        targetRoute: 'management.apis.ng.transferOwnership',
+        baseRoute: 'management.apis.ng.transferOwnership',
+      });
+    }
     if (userAndGroupAccessMenuItems.tabs.length > 0) {
       generalGroup.items.push(userAndGroupAccessMenuItems);
     }

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/api-general-user-group.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/api-general-user-group.module.ts
@@ -34,6 +34,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 
 import { ApiGeneralGroupsComponent } from './groups/api-general-groups.component';
 import { ApiGeneralMembersComponent } from './members/api-general-members.component';
@@ -67,6 +68,7 @@ import { GioTableWrapperModule } from '../../../../shared/components/gio-table-w
     MatDialogModule,
     MatSlideToggleModule,
     MatRadioModule,
+    MatButtonToggleModule,
 
     GioAvatarModule,
     GioIconsModule,

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
@@ -17,26 +17,19 @@
 -->
 <form [formGroup]="form" *ngIf="form" (ngSubmit)="onSubmit()">
   <mat-card class="card">
-    <p>
-      Give full access to this API to another
-      <ng-container *ngIf="mode === 'USER'">
-        <mat-radio-group aria-label="Select User or Group" formControlName="userOrGroup">
-          <mat-radio-button class="card__userOrGroup_radio" value="apiMember">API member</mat-radio-button>
-          <span style="vertical-align: bottom"> or </span>
-          <mat-radio-button class="card__userOrGroup_radio" value="user">Other user</mat-radio-button>
-        </mat-radio-group>
-      </ng-container>
-      <ng-container *ngIf="mode === 'GROUP'">group</ng-container>
-      <ng-container *ngIf="mode === 'HYBRID'">
-        <mat-radio-group aria-label="Select User or Group" formControlName="userOrGroup">
-          <mat-radio-button class="card__userOrGroup_radio" value="apiMember">API member</mat-radio-button>
-          <span style="vertical-align: bottom"> or </span>
-          <mat-radio-button class="card__userOrGroup_radio" value="user">Other user</mat-radio-button>
-          <span style="vertical-align: bottom"> or </span>
-          <mat-radio-button class="card__userOrGroup_radio" value="group">Group</mat-radio-button>
-        </mat-radio-group>
-      </ng-container>
-    </p>
+    <div class="card__header">
+      <div>
+        <h3>Transfer ownership</h3>
+        <p>Select your preferred method for granting complete API access</p>
+      </div>
+    </div>
+    <ng-container *ngIf="mode && mode !== 'GROUP'">
+      <mat-button-toggle-group aria-label="Select User or Group" class="card__userOrGroup__toggle-group" formControlName="userOrGroup">
+        <mat-button-toggle class="card__userOrGroup__toggle" value="apiMember"> API member </mat-button-toggle>
+        <mat-button-toggle class="card__userOrGroup__toggle" value="user"> Other user </mat-button-toggle>
+        <mat-button-toggle *ngIf="mode === 'HYBRID'" class="card__userOrGroup__toggle" value="group"> Group </mat-button-toggle>
+      </mat-button-toggle-group>
+    </ng-container>
 
     <div class="card__userOrGroup" *ngIf="form.get('userOrGroup').value === 'apiMember'">
       <mat-form-field class="card__userOrGroup__field">

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.scss
@@ -1,10 +1,21 @@
 @use '../../../../../scss/gio-layout' as gio-layout;
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'sass:map';
+
+$typography: map.get(gio.$mat-theme, typography);
 
 :host {
   @include gio-layout.gio-responsive-content-container;
 }
 
 .card {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
   &__userOrGroup_radio {
     padding-left: 8px;
   }
@@ -13,5 +24,33 @@
     &__field {
       width: 100%;
     }
+  }
+
+  &__userOrGroup__toggle-group {
+    border: solid 1px mat.get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+    padding: 4px;
+    height: 44px;
+    margin-top: 6px;
+    margin-bottom: 10px;
+  }
+
+  &__userOrGroup__toggle {
+    @include mat.typography-level($typography, body-2);
+    border-radius: 4px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  // Selected entry
+  &__userOrGroup__toggle.mat-button-toggle-checked {
+    color: mat.get-color-from-palette(gio.$mat-accent-palette, default-contrast);
+    background-color: mat.get-color-from-palette(gio.$mat-accent-palette, 'darker20');
+  }
+
+  // Remove border between buttons
+  &__userOrGroup__toggle.mat-button-toggle + .mat-button-toggle {
+    border: none;
+    margin-left: 8px;
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-member-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-member-v2.service.ts
@@ -41,9 +41,4 @@ export class ApiMemberV2Service {
   deleteMember(api: string, memberId: string): Observable<void> {
     return this.http.delete<void>(`${this.constants.env.v2BaseURL}/apis/${api}/members/${memberId}`);
   }
-
-  // TODO add this when needed
-  // transferOwnership(api: string, ownership: ApiMembership): Observable<any> {
-  //   return this.http.post(`${this.constants.env.v2BaseURL}/apis/${api}/members/transfer_ownership`, ownership);
-  // }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -20,6 +20,7 @@ import { ApiV2Service } from './api-v2.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
 import { fakeApiV4, fakeBaseApplication, fakeCreateApiV4, fakeUpdateApiV4 } from '../entities/management-api-v2';
+import { ApiTransferOwnership } from '../entities/management-api-v2/api/apiTransferOwnership';
 
 describe('ApiV2Service', () => {
   let httpTestingController: HttpTestingController;
@@ -315,6 +316,31 @@ describe('ApiV2Service', () => {
       });
 
       req.flush([fakeBaseApplication()]);
+    });
+  });
+
+  describe('transfer ownership', () => {
+    it('should call the API', (done) => {
+      const apiId = 'apiId';
+
+      const transferOwnership: ApiTransferOwnership = {
+        userId: 'user',
+        userReference: 'userRef',
+        userType: 'USER',
+        poRole: 'role',
+      };
+
+      apiV2Service.transferOwnership(apiId, transferOwnership).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_transfer-ownership`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual(transferOwnership);
+      req.flush(null);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -29,6 +29,7 @@ import {
   CreateApi,
   UpdateApi,
 } from '../entities/management-api-v2';
+import { ApiTransferOwnership } from '../entities/management-api-v2/api/apiTransferOwnership';
 
 @Injectable({
   providedIn: 'root',
@@ -134,5 +135,9 @@ export class ApiV2Service {
       filter((api) => !!api),
       shareReplay({ bufferSize: 1, refCount: true }),
     );
+  }
+
+  transferOwnership(api: string, ownership: ApiTransferOwnership): Observable<any> {
+    return this.http.post(`${this.constants.env.v2BaseURL}/apis/${api}/_transfer-ownership`, ownership);
   }
 }

--- a/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
@@ -1,0 +1,440 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test, describe, expect, afterAll } from '@jest/globals';
+import { APIMembersApi, APIsApi, ApiV4, HttpListener } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import {
+  API_USER,
+  forManagementAsAdminUser,
+  forManagementV2,
+  forManagementV2AsAdminUser,
+  forManagementV2AsApiUser,
+} from '@gravitee/utils/configuration';
+import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
+import { created, fail, forbidden, noContent, succeed } from '@lib/jest-utils';
+import { UsersFaker } from '@gravitee/fixtures/management/UsersFaker';
+import { UsersApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/UsersApi';
+import { RoleScope } from '../../../../../lib/management-webclient-sdk/src/lib/models';
+import { RoleFaker } from '@gravitee/fixtures/management/RoleFaker';
+import { ConfigurationApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/ConfigurationApi';
+import { UserRegistrationApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/UserRegistrationApi';
+import { GroupsFaker } from '@gravitee/fixtures/management/GroupsFaker';
+import { GroupsApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/GroupsApi';
+import { GroupMembershipsApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/GroupMembershipsApi';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const v1ConfigurationResourceAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
+const v1UsersResourceAsAdmin = new UsersApi(forManagementAsAdminUser());
+const v1GroupsResourceAsAdmin = new GroupsApi(forManagementAsAdminUser());
+const v1GroupMembershipResourceAsAdmin = new GroupMembershipsApi(forManagementAsAdminUser());
+const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
+const v2ApisResourceAsAdmin = new APIsApi(forManagementV2AsAdminUser());
+const v2ApiMembersResourceAsApiPublisher = new APIMembersApi(forManagementV2AsApiUser());
+const v2ApiMembersResourceAsAdmin = new APIMembersApi(forManagementV2AsAdminUser());
+
+describe('API - V4 - Transfer Ownership', () => {
+  describe('Transfer ownership to other user', () => {
+    const roleName = 'TRANSFER_OWNERSHIP_ROLE';
+    let importedApi;
+    let user;
+    let customRole;
+
+    test('should create member and custom role', async () => {
+      user = await succeed(
+        v1UsersResourceAsAdmin.createUserRaw({
+          orgId,
+          envId,
+          newPreRegisterUserEntity: UsersFaker.newNewPreRegisterUserEntity(),
+        }),
+      );
+
+      customRole = await succeed(
+        v1ConfigurationResourceAsAdmin.createRoleRaw({
+          orgId,
+          scope: RoleScope.API,
+          newRoleEntity: RoleFaker.newRoleEntity({ name: roleName, scope: RoleScope.API }),
+        }),
+      );
+    });
+
+    test('should import v4 API', async () => {
+      importedApi = await created(
+        v2ApisResourceAsApiPublisher.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4(),
+        }),
+      );
+    });
+
+    test('should get created v4 API with generated ID', async () => {
+      const apiV4 = await succeed(
+        v2ApisResourceAsApiPublisher.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(apiV4).toBeTruthy();
+      expect(apiV4.id).toStrictEqual(importedApi.id);
+    });
+
+    test('should transfer ownership to other user', async () => {
+      await succeed(
+        v2ApisResourceAsApiPublisher.transferOwnershipRaw({
+          envId,
+          apiId: importedApi.id,
+          apiTransferOwnership: {
+            userId: user.id,
+            userType: 'USER',
+            userReference: user.referenceId,
+            poRole: customRole.name,
+          },
+        }),
+      );
+    });
+
+    test('should not be able to see member as original api publisher', async () => {
+      await forbidden(
+        v2ApiMembersResourceAsApiPublisher.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+
+    test('should verify other user is primary owner', async () => {
+      let membersResponse = await succeed(
+        // Ideally, we should list members as the 'Other user'
+        v2ApiMembersResourceAsAdmin.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(membersResponse).toBeTruthy();
+      const apiPublisher = membersResponse.data.find((member) => member.displayName === API_USER.username);
+      const otherUser = membersResponse.data.find((member) => member.id === user.id);
+
+      expect(apiPublisher.roles).toHaveLength(1);
+      expect(apiPublisher.roles[0].name).toStrictEqual(customRole.name);
+
+      expect(otherUser.roles).toHaveLength(1);
+      expect(otherUser.roles[0].name).toStrictEqual('PRIMARY_OWNER');
+    });
+
+    afterAll(async () => {
+      await noContent(
+        v1ConfigurationResourceAsAdmin.deleteRoleRaw({
+          orgId,
+          role: roleName,
+          scope: RoleScope.API,
+        }),
+      );
+      await noContent(
+        v1UsersResourceAsAdmin.deleteUserRaw({
+          orgId,
+          envId,
+          userId: user.id,
+        }),
+      );
+      await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+  });
+  describe('Transfer ownership to an api member', () => {
+    const roleName = 'TRANSFER_OWNERSHIP_ROLE';
+    let importedApi;
+    let user;
+    let customRole;
+
+    test('should create member and custom role', async () => {
+      user = await succeed(
+        v1UsersResourceAsAdmin.createUserRaw({
+          orgId,
+          envId,
+          newPreRegisterUserEntity: UsersFaker.newNewPreRegisterUserEntity(),
+        }),
+      );
+
+      customRole = await succeed(
+        v1ConfigurationResourceAsAdmin.createRoleRaw({
+          orgId,
+          scope: RoleScope.API,
+          newRoleEntity: RoleFaker.newRoleEntity({ name: roleName, scope: RoleScope.API }),
+        }),
+      );
+    });
+
+    test('should import v4 API', async () => {
+      importedApi = await created(
+        v2ApisResourceAsApiPublisher.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4(),
+        }),
+      );
+    });
+
+    test('should add user as api member', async () => {
+      v2ApiMembersResourceAsApiPublisher.addApiMember({
+        envId,
+        apiId: importedApi.id,
+        addApiMember: {
+          userId: user.id,
+          externalReference: user.referenceId,
+          roleName: 'USER',
+        },
+      });
+    });
+
+    test('should get created v4 API with generated ID', async () => {
+      const apiV4 = await succeed(
+        v2ApisResourceAsApiPublisher.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(apiV4).toBeTruthy();
+      expect(apiV4.id).toStrictEqual(importedApi.id);
+    });
+
+    test('should transfer ownership to other user', async () => {
+      await succeed(
+        v2ApisResourceAsApiPublisher.transferOwnershipRaw({
+          envId,
+          apiId: importedApi.id,
+          apiTransferOwnership: {
+            userId: user.id,
+            userType: 'USER',
+            userReference: user.referenceId,
+            poRole: customRole.name,
+          },
+        }),
+      );
+    });
+
+    test('should not be able to see member as original api publisher', async () => {
+      await forbidden(
+        v2ApiMembersResourceAsApiPublisher.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+
+    test('should verify other user is primary owner', async () => {
+      let membersResponse = await succeed(
+        // Ideally, we should list members as the 'Other user'
+        v2ApiMembersResourceAsAdmin.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(membersResponse).toBeTruthy();
+      const apiPublisher = membersResponse.data.find((member) => member.displayName === API_USER.username);
+      const otherUser = membersResponse.data.find((member) => member.id === user.id);
+
+      expect(apiPublisher.roles).toHaveLength(1);
+      expect(apiPublisher.roles[0].name).toStrictEqual(customRole.name);
+
+      expect(otherUser.roles).toHaveLength(1);
+      expect(otherUser.roles[0].name).toStrictEqual('PRIMARY_OWNER');
+    });
+
+    afterAll(async () => {
+      await noContent(
+        v1ConfigurationResourceAsAdmin.deleteRoleRaw({
+          orgId,
+          role: roleName,
+          scope: RoleScope.API,
+        }),
+      );
+      await noContent(
+        v1UsersResourceAsAdmin.deleteUserRaw({
+          orgId,
+          envId,
+          userId: user.id,
+        }),
+      );
+      await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+  });
+  describe('Transfer ownership to a group', () => {
+    const roleName = 'TRANSFER_OWNERSHIP_ROLE';
+    let importedApi;
+    let user;
+    let customRole;
+    let group;
+
+    test('should create member and custom role', async () => {
+      user = await succeed(
+        v1UsersResourceAsAdmin.createUserRaw({
+          orgId,
+          envId,
+          newPreRegisterUserEntity: UsersFaker.newNewPreRegisterUserEntity(),
+        }),
+      );
+
+      customRole = await succeed(
+        v1ConfigurationResourceAsAdmin.createRoleRaw({
+          orgId,
+          scope: RoleScope.API,
+          newRoleEntity: RoleFaker.newRoleEntity({ name: roleName, scope: RoleScope.API }),
+        }),
+      );
+    });
+
+    test('should create group', async () => {
+      group = await created(
+        v1GroupsResourceAsAdmin.createGroupRaw({
+          orgId,
+          envId,
+          newGroupEntity: GroupsFaker.newGroup(),
+        }),
+      );
+
+      await succeed(
+        v1GroupMembershipResourceAsAdmin.addOrUpdateGroupMemberRaw({
+          envId,
+          orgId,
+          group: group.id,
+          groupMembership: [
+            {
+              id: user.id,
+              reference: user.reference,
+              roles: [
+                {
+                  name: 'PRIMARY_OWNER',
+                  scope: 'API',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+    });
+
+    test('should import v4 API', async () => {
+      importedApi = await created(
+        v2ApisResourceAsApiPublisher.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4({}),
+        }),
+      );
+    });
+
+    test('should get created v4 API with generated ID', async () => {
+      const apiV4 = await succeed(
+        v2ApisResourceAsApiPublisher.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(apiV4).toBeTruthy();
+      expect(apiV4.id).toStrictEqual(importedApi.id);
+    });
+
+    test('should transfer ownership to group', async () => {
+      await succeed(
+        v2ApisResourceAsApiPublisher.transferOwnershipRaw({
+          envId,
+          apiId: importedApi.id,
+          apiTransferOwnership: {
+            userId: group.id,
+            userType: 'GROUP',
+            userReference: null,
+            poRole: customRole.name,
+          },
+        }),
+      );
+    });
+
+    test('should not be able to see member as original api publisher', async () => {
+      await forbidden(
+        v2ApiMembersResourceAsApiPublisher.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+
+    test('should verify api publisher is not primary owner anymore', async () => {
+      let membersResponse = await succeed(
+        // Ideally, we should list members as the 'Other user'
+        v2ApiMembersResourceAsAdmin.listApiMembersRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      expect(membersResponse).toBeTruthy();
+      expect(membersResponse.data).toHaveLength(1);
+      const apiPublisher = membersResponse.data.find((member) => member.displayName === API_USER.username);
+
+      expect(apiPublisher.roles).toHaveLength(1);
+      expect(apiPublisher.roles[0].name).toStrictEqual(customRole.name);
+    });
+
+    test('should verify group is primary owner', async () => {
+      let groupResponse = await succeed(
+        v1GroupsResourceAsAdmin.getGroupRaw({
+          orgId,
+          envId,
+          group: group.id,
+        }),
+      );
+      expect(groupResponse).toBeTruthy();
+      expect(groupResponse.apiPrimaryOwner).toEqual(user.id);
+      expect(groupResponse.primary_owner).toBeTruthy();
+    });
+
+    afterAll(async () => {
+      await noContent(
+        v1ConfigurationResourceAsAdmin.deleteRoleRaw({
+          orgId,
+          role: roleName,
+          scope: RoleScope.API,
+        }),
+      );
+      await noContent(
+        v1GroupsResourceAsAdmin.deleteGroupRaw({
+          orgId,
+          envId,
+          group: group.id,
+        }),
+      );
+      await noContent(
+        v1UsersResourceAsAdmin.deleteUserRaw({
+          orgId,
+          envId,
+          userId: user.id,
+        }),
+      );
+      await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+    });
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -423,6 +423,36 @@ paths:
                     description: API successfully stopped
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/_transfer-ownership:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Transfer the ownership of the API
+            description: |-
+                Transfer the ownership of the API to a user, a group or an api member.
+                
+                Return a 404 HTTP Error if API cannot be found.
+
+                Return a 400 HTTP Error:
+                 - when user tries to stop an ARCHIVED API
+                 - when the API is already STOPPED.
+
+                User must have the API_MEMBER[UPDATE] permission.
+            operationId: transferOwnership
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiTransferOwnership"
+                required: true
+            responses:
+                "204":
+                    description: Ownership has been transfered successfully
+                default:
+                    $ref: "#/components/responses/Error"
 
     # API Reviews
     /environments/{envId}/apis/{apiId}/reviews/_ask:
@@ -2125,6 +2155,20 @@ components:
                     type: string
                     description: The URL to the API's background.
                     example: https://gravitee.example.com/management/v2/environments/00f8c9e7-78fc-4907-b8c9-e778fc790750/apis/6c530064-0b2c-4004-9300-640b2ce0047b/background
+        ApiTransferOwnership:
+            type: object
+            properties:
+                userId:
+                    type: string
+                    description: The new primary owner ID (user's technical identifier). Can be null if userReference is defined.
+                userReference:
+                    type: string
+                    description: The new primary owner reference (user's reference provided by an identity provider). Can be null if userId is defined.
+                userType:
+                    $ref: "#/components/schemas/MembershipMemberType"
+                poRole:
+                    type: string
+                    description: The name of the role that will be assigned to the current primary owner after the transfer.
 
         CreateApi:
             oneOf:
@@ -4004,12 +4048,7 @@ components:
                     example: John Doe
                     minLength: 1
                 type:
-                    type: string
-                    description: Owner's type.
-                    example: USER
-                    enum:
-                        - USER
-                        - GROUP
+                    $ref: "#/components/schemas/MembershipMemberType"
         Property:
             type: object
             required:
@@ -4080,6 +4119,12 @@ components:
                     description: The value of the sampling
             required:
                 - type
+        MembershipMemberType:
+            type: string
+            description: The type of membership
+            enum:
+                - USER
+                - GROUP
         Selector:
             oneOf:
                 - $ref: "#/components/schemas/HttpSelector"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PrimaryOwnerFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PrimaryOwnerFixtures.java
@@ -15,6 +15,7 @@
  */
 package fixtures;
 
+import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
 import io.gravitee.rest.api.management.v2.rest.model.PrimaryOwner;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 
@@ -28,7 +29,7 @@ public class PrimaryOwnerFixtures {
         .id("primary-owner-id")
         .displayName("primary-owner-displayName")
         .email("primary-owner@email.com")
-        .type(PrimaryOwner.TypeEnum.USER);
+        .type(MembershipMemberType.USER);
 
     public static PrimaryOwner aPrimaryOwner() {
         return BASE_PRIMARY_OWNER.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -112,6 +112,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     protected ApiWorkflowStateService apiWorkflowStateService;
 
+    @Autowired
+    protected RoleService roleService;
+
     @Before
     public void setUp() {
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -48,7 +48,8 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
             apiServiceV4,
             apiService,
             apiLicenseService,
-            apiWorkflowStateService
+            apiWorkflowStateService,
+            roleService
         );
         GraviteeContext.cleanContext();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
@@ -52,6 +52,7 @@ import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.management.v2.rest.model.PageType;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MetadataFormat;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.permissions.RolePermission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_TransferOwnershipTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import io.gravitee.rest.api.management.v2.rest.model.ApiTransferOwnership;
+import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApiResource_TransferOwnershipTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_transfer-ownership";
+    }
+
+    @Test
+    public void should_not_transfer_ownership_if_api_does_not_exist() {
+        when(apiSearchServiceV4.exists(API)).thenReturn(false);
+        try (Response response = rootTarget().request().post(null)) {
+            assertThat(NOT_FOUND_404).isEqualTo(response.getStatus());
+        }
+    }
+
+    @Test
+    public void should_transfer_ownership_without_roles() {
+        when(apiSearchServiceV4.exists(API)).thenReturn(true);
+
+        final ApiTransferOwnership apiTransferOwnership = fakeApiTransferOwnership();
+        apiTransferOwnership.setPoRole(null);
+        try (Response response = rootTarget().request().post(Entity.json(apiTransferOwnership))) {
+            verify(roleService, never()).findByScopeAndName(any(), any(), any());
+            verify(membershipService).transferApiOwnership(
+                   any(ExecutionContext.class),
+                   eq(API),
+                   argThat(arg ->
+                          arg.getMemberId().equals(apiTransferOwnership.getUserId())
+                          && arg.getReference().equals(apiTransferOwnership.getUserReference())
+                          && arg.getMemberType().name().equals(apiTransferOwnership.getUserType().name())
+                   ),
+                   eq(List.of())
+            );
+            assertThat(NO_CONTENT_204).isEqualTo(response.getStatus());
+        }
+    }
+
+    @Test
+    public void should_transfer_ownership_with_roles() {
+        when(apiSearchServiceV4.exists(API)).thenReturn(true);
+        final ApiTransferOwnership apiTransferOwnership = fakeApiTransferOwnership();
+        final RoleEntity roleEntity = new RoleEntity();
+        roleEntity.setId("role");
+        roleEntity.setName("a-role-from-db");
+        when(roleService.findByScopeAndName(RoleScope.API, apiTransferOwnership.getPoRole(), GraviteeContext.getCurrentOrganization()))
+               .thenReturn(
+                      Optional.of(
+                             roleEntity
+                      )
+               );
+
+        try (Response response = rootTarget().request().post(Entity.json(apiTransferOwnership))) {
+            verify(roleService).findByScopeAndName(any(), any(), any());
+            verify(membershipService).transferApiOwnership(
+                   any(ExecutionContext.class),
+                   eq(API),
+                   argThat(arg ->
+                          arg.getMemberId().equals(apiTransferOwnership.getUserId())
+                                 && arg.getReference().equals(apiTransferOwnership.getUserReference())
+                                 && arg.getMemberType().name().equals(apiTransferOwnership.getUserType().name())
+                   ),
+                   eq(List.of(roleEntity))
+            );
+            assertThat(NO_CONTENT_204).isEqualTo(response.getStatus());
+        }
+    }
+
+    // Fakers
+    private ApiTransferOwnership fakeApiTransferOwnership() {
+        var apiTransferOwnership = new ApiTransferOwnership();
+        apiTransferOwnership.setUserId("user");
+        apiTransferOwnership.setUserReference("reference");
+        apiTransferOwnership.setUserType(MembershipMemberType.USER);
+        apiTransferOwnership.setPoRole("role");
+        return apiTransferOwnership;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanType;
 import io.gravitee.rest.api.management.v2.rest.model.Visibility;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -57,6 +57,7 @@ import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.GroupNameAlreadyExistsException;
@@ -372,7 +373,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 throw new GroupNotFoundException(groupId);
             }
             logger.debug("findById {} - DONE", group.get());
-            GroupEntity groupEntity = this.map(group.get());
+            GroupEntity groupEntity = this.map(executionContext, group.get());
 
             if (groupEntity == null) {
                 logger.error("An error occurs while trying to find a group {}", groupId);
@@ -911,6 +912,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     private GroupEntity map(Group group) {
+        return map(null, group);
+    }
+
+    private GroupEntity map(ExecutionContext executionContext, Group group) {
         if (group == null) {
             return null;
         }
@@ -919,6 +924,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         entity.setId(group.getId());
         entity.setName(group.getName());
         entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
+        if (executionContext != null) {
+            populateGroupFlags(executionContext, List.of(entity));
+        }
 
         if (group.getEventRules() != null && !group.getEventRules().isEmpty()) {
             List<GroupEventRuleEntity> groupEventRules = new ArrayList<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByEventTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByEventTest.java
@@ -25,8 +25,10 @@ import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.GroupEvent;
 import io.gravitee.repository.management.model.GroupEventRule;
 import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.GroupServiceImpl;
 import java.util.*;
@@ -53,6 +55,9 @@ public class GroupService_FindByEventTest {
 
     @Mock
     private MembershipService membershipService;
+
+    @Mock
+    private RoleService roleService;
 
     @Test
     public void shouldGetGroupsByEvents() throws Exception {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByIdTest.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -85,6 +86,8 @@ public class GroupService_FindByIdTest extends TestCase {
         )
             .thenReturn(true);
 
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID)).thenReturn(Optional.of(new RoleEntity()));
+
         var result = groupService.findById(executionContext, GROUP_ID);
 
         verify(permissionService)
@@ -108,6 +111,7 @@ public class GroupService_FindByIdTest extends TestCase {
         ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, null);
 
         when(roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name(), ORGANIZATION_ID)).thenReturn(Optional.empty());
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID)).thenReturn(Optional.of(new RoleEntity()));
 
         var result = groupService.findById(executionContext, GROUP_ID);
 
@@ -121,7 +125,7 @@ public class GroupService_FindByIdTest extends TestCase {
                 eq(RolePermissionAction.DELETE)
             );
         verify(roleService).findByScopeAndName(eq(RoleScope.GROUP), eq(SystemRole.ADMIN.name()), eq(ORGANIZATION_ID));
-        verify(membershipService, times(0)).getMembershipsByMemberAndReferenceAndRole(any(), any(), any(), any());
+        verify(membershipService, times(1)).getMembershipsByMemberAndReferenceAndRole(any(), any(), any(), any());
         assertThat(result).isNotNull().extracting(GroupEntity::getId, GroupEntity::isManageable).containsExactly(GROUP_ID, false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
@@ -25,13 +25,16 @@ import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
 import java.util.Optional;
@@ -61,6 +64,9 @@ public class GroupService_UpdateTest {
 
     @Mock
     private PermissionService permissionService;
+
+    @Mock
+    private RoleService roleService;
 
     @Mock
     private AuditService auditService;
@@ -94,6 +100,7 @@ public class GroupService_UpdateTest {
         )
             .thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT")).thenReturn(Optional.of(new RoleEntity()));
 
         groupService.update(GraviteeContext.getExecutionContext(), GROUP_ID, updatedGroupEntity);
 
@@ -147,6 +154,7 @@ public class GroupService_UpdateTest {
         )
             .thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT")).thenReturn(Optional.of(new RoleEntity()));
 
         groupService.update(GraviteeContext.getExecutionContext(), GROUP_ID, updatedGroupEntity);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1410

## Description

Allow a user to transfer ownership of a v4 API. It should still work for v2 apis.

The screen has been redesigned a bit.
Originally, it was:
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/9d4afdd2-19d6-4577-8791-979d89508c9e)

An now:
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/4a7b5741-a18e-4692-aeea-8e0785764f72)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hnsagcvtha.chromatic.com)
<!-- Storybook placeholder end -->
