### PR TITLE
fix: preserve parent route params

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-routing.module.ts
@@ -60,7 +60,8 @@ export class GioPolicyStudioRoutingModule {
     const states = [
       {
         name: `${config.stateNamePrefix}`,
-        url: '/policy-studio',
+        // Here URL should not start with a `/` in order to preserve parent route params (like API id)
+        url: 'policy-studio',
         component: GioPolicyStudioLayoutComponent,
         redirectTo: { state: `${config.stateNamePrefix}.design`, params: { psPage: 'design' } },
         data: {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2489

## Description

When navigating to policy studio directly, we had a blank screen and an error in the logs showing that we try to fetch permissions with `undefined` as API ID


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/4938/console](https://pr.team-apim.gravitee.dev/4938/console)
      Portal: [https://pr.team-apim.gravitee.dev/4938/portal](https://pr.team-apim.gravitee.dev/4938/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/4938/api/management](https://pr.team-apim.gravitee.dev/4938/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/4938](https://pr.team-apim.gravitee.dev/4938)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/4938](https://pr.gateway-v3.team-apim.gravitee.dev/4938)

<!-- Environment placeholder end -->
