### PR TITLE
ci: upgrade sonar-scanner version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,7 +452,7 @@ jobs:
                 default: "gravitee-apim-rest-api"
                 type: string
         docker:
-            - image: sonarsource/sonar-scanner-cli:4.7
+            - image: sonarsource/sonar-scanner-cli:5.0.1
         resource_class: large
         steps:
             - run:


### PR DESCRIPTION
## Description

This new version will run the scan using Java17. It will fix a warning displayed in GitHub checks informing that Java 11 is deprecated

>Warning
The version of Java (11.0.17) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
Read more [here](https://docs.sonarcloud.io/appendices/scanner-environment/)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ddbbbnpvqg.chromatic.com)
<!-- Storybook placeholder end -->
