### PR TITLE
fix: adapt libc6-compat to platform architecture [skip ci]

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -18,8 +18,10 @@
 FROM graviteeio/java:17 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
 
-RUN apk update && apk add --no-cache libc6-compat && \
-ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+RUN apk update  \
+    && apk add --no-cache libc6-compat  \
+    && apkArch="$(apk --print-arch)" \
+    && ln -s /lib/libc.musl-${apkArch}.so.1 /lib/ld-linux-${apkArch/_/-}.so.2
 
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio

--- a/gravitee-apim-gateway/docker/Dockerfile-from-download
+++ b/gravitee-apim-gateway/docker/Dockerfile-from-download
@@ -34,7 +34,8 @@ RUN apk update \
     && rm -rf /tmp/* \
     && chgrp -R graviteeio ${GRAVITEEIO_HOME} \
     && chmod -R g=u ${GRAVITEEIO_HOME} \
-    && ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+    && apkArch="$(apk --print-arch)" \
+    && ln -s /lib/libc.musl-${apkArch}.so.1 /lib/ld-linux-${apkArch/_/-}.so.2
 
 WORKDIR ${GRAVITEEIO_HOME}
 EXPOSE 8082


### PR DESCRIPTION
## Issue

gravitee.atlassian.net/browse/APIM-2495

## Description

Following https://github.com/gravitee-io/gravitee-api-management/pull/4942, this PR handles different platform architectures