### PR TITLE
fix: exclude APIs that user cannot manage from API list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -381,11 +381,11 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
         }
 
         // get user apis
-        final Set<String> userApiIds = this.findUserApiIdsFromMemberships(userId, false);
+        final Set<String> userApiIds = this.findUserApiIdsFromMemberships(userId, true);
         apiIds.addAll(userApiIds);
 
         // get user groups apis
-        final Set<String> userGroupApiIds = this.findApiIdsByUserGroups(executionContext, userId, apiQuery, false);
+        final Set<String> userGroupApiIds = this.findApiIdsByUserGroups(executionContext, userId, apiQuery, true);
         apiIds.addAll(userGroupApiIds);
 
         return apiIds;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2494

## Description

Members having only `USER` permission on APIs should not be able to view them on the console (only on the portal) 

## Additional context

When testing, we should make sure that the APIs are not listed in the API list in the console, but can be viewed in the portal.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cexaogihcq.chromatic.com)
<!-- Storybook placeholder end -->
