### PR TITLE
Remove git branch creation and PR process in Helm release

### DIFF
--- a/release/ci-steps/release-helm.mjs
+++ b/release/ci-steps/release-helm.mjs
@@ -6,13 +6,11 @@ console.log(chalk.magenta(`#############################################`));
 
 const releasingVersion = await extractVersion();
 const helmRepository = 'https://github.com/gravitee-io/helm-charts';
-const gitBranch = `release-apim-chart-${releasingVersion}`;
 
 echo(chalk.blue(`# Clone helm-charts repository`));
 cd('/home/circleci');
 await $`git clone --depth 1  ${helmRepository} --single-branch --branch=gh-pages`;
 cd('/home/circleci/helm-charts');
-await $`git checkout -b ${gitBranch}`;
 
 await $`cp /home/circleci/project/helm/charts/apim-${releasingVersion}.tgz /home/circleci/helm-charts/helm/apim/apim-${releasingVersion}.tgz`;
 await $`cp /home/circleci/project/helm/charts/apim3-${releasingVersion}.tgz /home/circleci/helm-charts/helm/apim3/apim3-${releasingVersion}.tgz`;
@@ -22,13 +20,4 @@ await $`helm repo index --url https://helm.gravitee.io/helm helm`;
 await $`mv helm/index.yaml .`;
 
 await $`git add . && git commit -m "chore: Release APIM Chart ${releasingVersion}"`;
-await $`git push --set-upstream origin ${gitBranch}`;
-
-const prBody = `
-# New APIM Helm Chart version ${releasingVersion} has been released
-`;
-echo(chalk.blue('# Create PR on Github helm-charts repository'));
-echo(prBody);
-process.env.PR_BODY = prBody;
-
-await $`gh pr create --title "[APIM] Helm charts ${releasingVersion} release" --body "$PR_BODY" --base gh-pages --head ${gitBranch}`;
+await $`git push --set-upstream origin gh-pages`;


### PR DESCRIPTION
## Issue

NA

## Description

Revised the process of releasing Helm charts so that it no longer creates a unique release branch or a PR. Instead, changes are committed and pushed directly on the gh-pages branch. This simplifies the workflow, accelerates the release process, and reduces the need for manual PR reviews and merges.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-euymawueda.chromatic.com)
<!-- Storybook placeholder end -->
