### PR TITLE
fix: e2e tests for API ownership transfer

### DIFF
--- a/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
@@ -92,7 +92,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should transfer ownership to other user', async () => {
-      await succeed(
+      await noContent(
         v2ApisResourceAsApiPublisher.transferOwnershipRaw({
           envId,
           apiId: importedApi.id,
@@ -214,7 +214,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should transfer ownership to other user', async () => {
-      await succeed(
+      await noContent(
         v2ApisResourceAsApiPublisher.transferOwnershipRaw({
           envId,
           apiId: importedApi.id,
@@ -355,7 +355,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should transfer ownership to group', async () => {
-      await succeed(
+      await noContent(
         v2ApisResourceAsApiPublisher.transferOwnershipRaw({
           envId,
           apiId: importedApi.id,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1410

## Description

Following the change of return code for transfer ownership, some E2E tests were failing
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jspojzwpsa.chromatic.com)
<!-- Storybook placeholder end -->
