### PR TITLE
fix(e2e-mapi-v2): reorder resource clean-up in afterAll

### DIFF
--- a/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/mapi-v2/apis/transfer-ownership/api-transfer-ownership.spec.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 import { test, describe, expect, afterAll } from '@jest/globals';
-import { APIMembersApi, APIsApi, ApiV4, HttpListener } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import {
+  APIMembersApi,
+  ApiResponse,
+  APIsApi,
+  Api,
+  ApiV4,
+  HttpListener,
+  MembersResponse,
+} from '@gravitee/management-v2-webclient-sdk/src/lib';
 import {
   API_USER,
   forManagementAsAdminUser,
@@ -81,7 +89,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should get created v4 API with generated ID', async () => {
-      const apiV4 = await succeed(
+      const apiV4: Api = await succeed(
         v2ApisResourceAsApiPublisher.getApiRaw({
           envId,
           apiId: importedApi.id,
@@ -116,7 +124,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should verify other user is primary owner', async () => {
-      let membersResponse = await succeed(
+      let membersResponse: MembersResponse = await succeed(
         // Ideally, we should list members as the 'Other user'
         v2ApiMembersResourceAsAdmin.listApiMembersRaw({
           envId,
@@ -136,6 +144,12 @@ describe('API - V4 - Transfer Ownership', () => {
 
     afterAll(async () => {
       await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      await noContent(
         v1ConfigurationResourceAsAdmin.deleteRoleRaw({
           orgId,
           role: roleName,
@@ -147,12 +161,6 @@ describe('API - V4 - Transfer Ownership', () => {
           orgId,
           envId,
           userId: user.id,
-        }),
-      );
-      await noContent(
-        v2ApisResourceAsAdmin.deleteApiRaw({
-          envId,
-          apiId: importedApi.id,
         }),
       );
     });
@@ -203,7 +211,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should get created v4 API with generated ID', async () => {
-      const apiV4 = await succeed(
+      const apiV4: Api = await succeed(
         v2ApisResourceAsApiPublisher.getApiRaw({
           envId,
           apiId: importedApi.id,
@@ -238,7 +246,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should verify other user is primary owner', async () => {
-      let membersResponse = await succeed(
+      let membersResponse: MembersResponse = await succeed(
         // Ideally, we should list members as the 'Other user'
         v2ApiMembersResourceAsAdmin.listApiMembersRaw({
           envId,
@@ -258,6 +266,12 @@ describe('API - V4 - Transfer Ownership', () => {
 
     afterAll(async () => {
       await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      await noContent(
         v1ConfigurationResourceAsAdmin.deleteRoleRaw({
           orgId,
           role: roleName,
@@ -269,12 +283,6 @@ describe('API - V4 - Transfer Ownership', () => {
           orgId,
           envId,
           userId: user.id,
-        }),
-      );
-      await noContent(
-        v2ApisResourceAsAdmin.deleteApiRaw({
-          envId,
-          apiId: importedApi.id,
         }),
       );
     });
@@ -344,7 +352,7 @@ describe('API - V4 - Transfer Ownership', () => {
     });
 
     test('should get created v4 API with generated ID', async () => {
-      const apiV4 = await succeed(
+      const apiV4: Api = await succeed(
         v2ApisResourceAsApiPublisher.getApiRaw({
           envId,
           apiId: importedApi.id,
@@ -409,6 +417,12 @@ describe('API - V4 - Transfer Ownership', () => {
 
     afterAll(async () => {
       await noContent(
+        v2ApisResourceAsAdmin.deleteApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      await noContent(
         v1ConfigurationResourceAsAdmin.deleteRoleRaw({
           orgId,
           role: roleName,
@@ -427,12 +441,6 @@ describe('API - V4 - Transfer Ownership', () => {
           orgId,
           envId,
           userId: user.id,
-        }),
-      );
-      await noContent(
-        v2ApisResourceAsAdmin.deleteApiRaw({
-          envId,
-          apiId: importedApi.id,
         }),
       );
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1410

## Description

Delete the API before deleting the user to avoid error that the given user is still Primary Owner of an API.
Previous error: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/23946/workflows/c4639ac3-5cf3-4d39-8c3c-2ae247909d4a/jobs/422080

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uckeyazhdv.chromatic.com)
<!-- Storybook placeholder end -->
