### PR TITLE
feat(console): add cannot view group members error message

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-group-members/api-general-group-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-group-members/api-general-group-members.component.html
@@ -15,43 +15,49 @@
     limitations under the License.
 
 -->
-<mat-card class="card" *ngIf="dataSourceGroup">
-  <h3>Group {{ dataSourceGroup.groupName }} inherited members ({{ dataSourceGroup.dataSource.length }})</h3>
+<mat-card class="card">
+  <ng-container *ngIf="!canViewGroupMembers">
+    <h3>Group {{ groupData.name }}</h3>
+    <p id="cannot-view-members">You do not have the appropriate permissions to view members of this group.</p>
+  </ng-container>
+  <ng-container *ngIf="canViewGroupMembers">
+    <h3>Group {{ groupData.name }} inherited members ({{ dataSourceGroup.memberTotalCount }})</h3>
 
-  <gio-table-wrapper
-    [disableSearchInput]="true"
-    [length]="dataSourceGroup.memberTotalCount"
-    [filters]="filters"
-    (filtersChange)="onFiltersChanged($event)"
-    [paginationPageSizeOptions]="[5, 10, 25, 50]"
-  >
-    <table
-      mat-table
-      *ngIf="dataSourceGroup"
-      [dataSource]="dataSourceGroup.dataSource"
-      class="card__table"
-      [attr.aria-label]="'Group ' + dataSourceGroup.groupName + ' members table'"
+    <gio-table-wrapper
+      [disableSearchInput]="true"
+      [length]="dataSourceGroup.memberTotalCount"
+      [filters]="filters"
+      (filtersChange)="onFiltersChanged($event)"
+      [paginationPageSizeOptions]="[5, 10, 25, 50]"
     >
-      <ng-container matColumnDef="picture">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let member">
-          <gio-avatar [src]="member.picture" [name]="member.displayName" size="24" [roundedBorder]="true"></gio-avatar>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="displayName">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
-          {{ member.displayName }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="role">
-        <th mat-header-cell *matHeaderCellDef>Role</th>
-        <td mat-cell *matCellDef="let member">
-          {{ member.role }}
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
-  </gio-table-wrapper>
+      <table
+        mat-table
+        *ngIf="dataSourceGroup"
+        [dataSource]="dataSourceGroup.membersPageResult"
+        class="card__table"
+        [attr.aria-label]="'Group ' + groupData.name + ' members table'"
+      >
+        <ng-container matColumnDef="picture">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let member">
+            <gio-avatar [src]="member.picture" [name]="member.displayName" size="24" [roundedBorder]="true"></gio-avatar>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="displayName">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
+            {{ member.displayName }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="role">
+          <th mat-header-cell *matHeaderCellDef>Role</th>
+          <td mat-cell *matCellDef="let member">
+            {{ member.role }}
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </gio-table-wrapper>
+  </ng-container>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-group-members/api-general-group-members.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-group-members/api-general-group-members.harness.ts
@@ -19,15 +19,22 @@ import { MatTableHarness } from '@angular/material/table/testing';
 export class ApiGeneralGroupMembersHarness extends ComponentHarness {
   static hostSelector = 'api-general-group-members';
 
-  protected getGroupTable = (groupName: string) =>
-    this.locatorFor(MatTableHarness.with({ selector: '[aria-label="Group ' + groupName + ' members table"]' }))();
+  protected getGroupTable = () => this.locatorFor(MatTableHarness)();
 
-  public getGroupTableByGroupName(groupName: string): Promise<MatTableHarness> {
-    return this.getGroupTable(groupName);
+  protected getDoNotHavePermissionMessage = () => this.locatorFor('#cannot-view-members')();
+
+  public getGroupTableByGroupName(): Promise<MatTableHarness> {
+    return this.getGroupTable();
   }
 
-  public groupTableExistsByGroupName(groupName: string): Promise<boolean> {
-    return this.getGroupTable(groupName)
+  public groupTableExistsByGroupName(): Promise<boolean> {
+    return this.getGroupTable()
+      .then((_) => true)
+      .catch((_) => false);
+  }
+
+  public userCannotViewGroupMembers(): Promise<boolean> {
+    return this.getDoNotHavePermissionMessage()
       .then((_) => true)
       .catch((_) => false);
   }

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-members.component.html
@@ -86,7 +86,7 @@
     <ng-container *ngFor="let group of groupData">
       <api-general-group-members
         *ngIf="group.isVisible"
-        [groupId]="group.groupId"
+        [groupData]="group"
         (destroy)="group.isVisible = false"
       ></api-general-group-members>
     </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/members/api-general-members.component.spec.ts
@@ -35,7 +35,7 @@ import { Role } from '../../../../../entities/role/role';
 import { fakeRole } from '../../../../../entities/role/role.fixture';
 import { User } from '../../../../../entities/user';
 import { fakeSearchableUser } from '../../../../../entities/user/searchableUser.fixture';
-import { ApiV4, fakeApiV4, MembersResponse } from '../../../../../entities/management-api-v2';
+import { ApiV4, fakeApiV4, fakeGroup, fakeGroupsResponse, MembersResponse } from '../../../../../entities/management-api-v2';
 
 describe('ApiGeneralMembersComponent', () => {
   let fixture: ComponentFixture<ApiGeneralMembersComponent>;
@@ -83,18 +83,14 @@ describe('ApiGeneralMembersComponent', () => {
   describe('API member change notification', () => {
     it('should uncheck box when notifications are off', async () => {
       const api = fakeApiV4({ id: apiId, disableMembershipNotifications: true });
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest();
-      expectGetGroupMembersRequest();
+      expectRequests(api);
 
       expect(await harness.isNotificationsToggleChecked()).toEqual(false);
     });
 
     it('should show save bar when toggle is toggles', async () => {
       const api = fakeApiV4({ id: apiId, disableMembershipNotifications: false });
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest();
-      expectGetGroupMembersRequest();
+      expectRequests(api);
 
       expect(await harness.isNotificationsToggleChecked()).toEqual(true);
       await harness.toggleNotificationToggle();
@@ -104,9 +100,7 @@ describe('ApiGeneralMembersComponent', () => {
 
     it('should save notifications modifications when clicking on save bar', async () => {
       const api = fakeApiV4({ id: apiId, disableMembershipNotifications: false });
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest();
-      expectGetGroupMembersRequest();
+      expectRequests(api);
 
       await harness.toggleNotificationToggle();
 
@@ -121,6 +115,7 @@ describe('ApiGeneralMembersComponent', () => {
       // init
       expectApiGetRequest(api);
       expectApiMembersGetRequest();
+      expectGetGroupsListRequest(api.groups);
       expectGetGroupMembersRequest();
     });
   });
@@ -134,9 +129,7 @@ describe('ApiGeneralMembersComponent', () => {
           { id: '2', displayName: 'Simba', roles: [{ name: 'Prince', scope: 'API' }] },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect((await harness.getTableRows()).length).toEqual(2);
       expect(await harness.getMembersName()).toEqual(['Mufasa', 'Simba']);
@@ -145,9 +138,7 @@ describe('ApiGeneralMembersComponent', () => {
     it('should make role readonly when user is PRIMARY OWNER', async () => {
       const api = fakeApiV4({ id: apiId, disableMembershipNotifications: false });
       const members: MembersResponse = { data: [{ id: '1', displayName: 'admin', roles: [{ name: 'PRIMARY_OWNER', scope: 'API' }] }] };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect(await harness.isMemberRoleSelectDisabled(0)).toEqual(true);
     });
@@ -155,9 +146,7 @@ describe('ApiGeneralMembersComponent', () => {
     it('should make role editable when user is not PRIMARY OWNER', async () => {
       const api = fakeApiV4({ id: apiId, disableMembershipNotifications: false });
       const members: MembersResponse = { data: [{ id: '1', displayName: 'owner', roles: [{ name: 'OWNER', scope: 'API' }] }] };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect(await harness.isMemberRoleSelectDisabled(0)).toEqual(false);
       const roleOptions: MatOptionHarness[] = await harness.getMemberRoleSelectOptions(0);
@@ -182,9 +171,7 @@ describe('ApiGeneralMembersComponent', () => {
           },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       await harness.getMemberRoleSelectForRowIndex(1).then(async (select) => {
         await select.open();
@@ -199,9 +186,7 @@ describe('ApiGeneralMembersComponent', () => {
       req.flush({});
       expect(req.request.body).toEqual({ memberId: '2', roleName: 'USER' });
       // init
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest();
-      expectGetGroupMembersRequest();
+      expectRequests(api);
     });
   });
 
@@ -217,9 +202,7 @@ describe('ApiGeneralMembersComponent', () => {
           },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect(await harness.isMemberDeleteButtonVisible(0)).toEqual(false);
     });
@@ -236,9 +219,7 @@ describe('ApiGeneralMembersComponent', () => {
           },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect(await harness.isMemberDeleteButtonVisible(1)).toEqual(true);
 
@@ -265,9 +246,7 @@ describe('ApiGeneralMembersComponent', () => {
           },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       expect(await harness.isMemberDeleteButtonVisible(1)).toEqual(true);
 
@@ -296,9 +275,7 @@ describe('ApiGeneralMembersComponent', () => {
           },
         ],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       const memberToAdd = fakeSearchableUser({ id: 'user', displayName: 'User Id' });
 
@@ -341,9 +318,7 @@ describe('ApiGeneralMembersComponent', () => {
       const members: MembersResponse = {
         data: [{ id: '1', displayName: 'Existing User', roles: [{ name: 'PRIMARY_OWNER', scope: 'API' }] }],
       };
-      expectApiGetRequest(api);
-      expectApiMembersGetRequest(members);
-      expectGetGroupMembersRequest();
+      expectRequests(api, members);
 
       const memberToAdd = fakeSearchableUser({ id: undefined, displayName: 'User from LDAP' });
 
@@ -359,6 +334,13 @@ describe('ApiGeneralMembersComponent', () => {
       expect(req.request.body).toEqual({ userId: undefined, externalReference: memberToAdd.reference, roleName: 'USER' });
     });
   });
+
+  function expectRequests(api: ApiV4, members: MembersResponse = { data: [] }) {
+    expectApiGetRequest(api);
+    expectGetGroupsListRequest(api.groups);
+    expectApiMembersGetRequest(members);
+    expectGetGroupMembersRequest();
+  }
 
   function expectApiGetRequest(api: ApiV4) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}`, method: 'GET' }).flush(api);
@@ -386,6 +368,13 @@ describe('ApiGeneralMembersComponent', () => {
     httpTestingController
       .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups/${groupId}/members?page=1&perPage=10`, method: 'GET' })
       .flush({ data: [], metadata: { groupName: 'group1' }, pagination: {} });
+    fixture.detectChanges();
+  }
+
+  function expectGetGroupsListRequest(groups: string[]) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=9999`, method: 'GET' })
+      .flush(fakeGroupsResponse({ data: groups.map((id) => fakeGroup({ id, name: id + '-name' })) }));
     fixture.detectChanges();
   }
 });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2491

## Description

- Add error message for when user does not have permission to view a group's members
- Slight refactoring to clean up code

![Screen Shot 2023-08-14 at 15 04 19](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/08e82956-a05a-46bf-b152-4f2aebf9ed21)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oqpetirfvg.chromatic.com)
<!-- Storybook placeholder end -->
