### PR TITLE
feat: allow to set client identifier/transaction id using query param

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -44,9 +44,12 @@ public class TransactionRequestProcessor extends AbstractProcessor<ExecutionCont
     @Override
     public void handle(final ExecutionContext context) {
         final String requestId = context.request().id();
-        String transactionId = context.request().headers().getFirst(transactionHeader);
+        String transactionId = context.request().headers().get(transactionHeader);
         if (transactionId == null) {
-            transactionId = requestId;
+            transactionId = context.request().parameters().getFirst(transactionHeader);
+            if (transactionId == null) {
+                transactionId = requestId;
+            }
             context.request().headers().set(transactionHeader, transactionId);
         }
         context.request().metrics().setTransactionId(transactionId);


### PR DESCRIPTION
## Description

To avoid forcing customers using websocket to add a platform policy to override client identifier, the PR allows setting client identifier/transaction id using query param.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-znwlnbmvot.chromatic.com)
<!-- Storybook placeholder end -->
