### PR TITLE
Remove 'max' restriction on page size when exporting subscriptions to CSV

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/ExportPageable.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/ExportPageable.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.model;
+
+import io.gravitee.rest.api.model.common.PageableImpl;
+import javax.validation.constraints.Min;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.QueryParam;
+
+public class ExportPageable {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_PAGE_NUMBER = 1;
+
+    @QueryParam("size")
+    @DefaultValue("20")
+    @Min(value = 1, message = "Page size should not be lesser than 1")
+    private int size = DEFAULT_PAGE_SIZE;
+
+    @QueryParam("page")
+    @DefaultValue("1")
+    @Min(value = 1, message = "Page number should not be lesser than 1")
+    private int page = DEFAULT_PAGE_NUMBER;
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public io.gravitee.rest.api.model.common.Pageable toPageable() {
+        return new PageableImpl(this.getPage(), this.getSize());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/ExportPageable.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/ExportPageable.java
@@ -27,12 +27,12 @@ public class ExportPageable {
 
     @QueryParam("size")
     @DefaultValue("20")
-    @Min(value = 1, message = "Page size should not be lesser than 1")
+    @Min(value = 1, message = "Page size should not be less than 1")
     private int size = DEFAULT_PAGE_SIZE;
 
     @QueryParam("page")
     @DefaultValue("1")
-    @Min(value = 1, message = "Page number should not be lesser than 1")
+    @Min(value = 1, message = "Page number should not be less than 1")
     private int page = DEFAULT_PAGE_NUMBER;
 
     public int getSize() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Pageable.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Pageable.java
@@ -32,13 +32,13 @@ public class Pageable {
 
     @QueryParam("size")
     @DefaultValue("20")
-    @Min(value = 1, message = "Page size should not be lesser than 1")
-    @Max(value = 100, message = "Page size should not be higher than 100")
+    @Min(value = 1, message = "Page size should not be less than 1")
+    @Max(value = 100, message = "Page size should not be more than 100")
     private int size = DEFAULT_PAGE_SIZE;
 
     @QueryParam("page")
     @DefaultValue("1")
-    @Min(value = 1, message = "Page number should not be lesser than 1")
+    @Min(value = 1, message = "Page number should not be less than 1")
     private int page = DEFAULT_PAGE_NUMBER;
 
     public int getSize() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
@@ -19,6 +19,7 @@ import static java.lang.String.format;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.model.ExportPageable;
 import io.gravitee.rest.api.management.rest.model.Pageable;
 import io.gravitee.rest.api.management.rest.model.Subscription;
 import io.gravitee.rest.api.management.rest.model.wrapper.SubscriptionEntityPageResult;
@@ -213,8 +214,15 @@ public class ApiSubscriptionsResource extends AbstractResource {
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.API_LOG, acls = RolePermissionAction.READ) })
-    public Response exportApiSubscriptionsLogsAsCSV(@BeanParam SubscriptionParam subscriptionParam, @Valid @BeanParam Pageable pageable) {
-        final SubscriptionEntityPageResult subscriptions = getApiSubscriptions(subscriptionParam, pageable, null);
+    public Response exportApiSubscriptionsLogsAsCSV(
+        @BeanParam SubscriptionParam subscriptionParam,
+        @Valid @BeanParam ExportPageable exportPageable
+    ) {
+        Pageable subscriptionsPageable = new Pageable();
+        subscriptionsPageable.setPage(exportPageable.getPage());
+        subscriptionsPageable.setSize(exportPageable.getSize());
+
+        final SubscriptionEntityPageResult subscriptions = getApiSubscriptions(subscriptionParam, subscriptionsPageable, null);
         return Response
             .ok(subscriptionService.exportAsCsv(subscriptions.getData(), subscriptions.getMetadata()))
             .header(HttpHeaders.CONTENT_DISPOSITION, format("attachment;filename=subscriptions-%s-%s.csv", api, System.currentTimeMillis()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
@@ -352,4 +352,15 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
             .extracting(SubscriptionQuery::getStatuses)
             .isEqualTo(List.of(SubscriptionStatus.PENDING, SubscriptionStatus.REJECTED, SubscriptionStatus.ACCEPTED));
     }
+
+    @Test
+    public void shouldExportMoreThan100SubscriptionsInCSV() {
+        when(subscriptionService.search(any(ExecutionContext.class), any(SubscriptionQuery.class), any(), anyBoolean(), anyBoolean()))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any(ExecutionContext.class), any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget("/export").queryParam("size", "10000").queryParam("page", "1").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2358

## Description

Use a dedicated Class without the `@Max` contraint on the `size` field to handle the pagination parameters.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-swcibafrdl.chromatic.com)
<!-- Storybook placeholder end -->
