### PR TITLE
test: move jul logs to slf4j

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -178,6 +178,12 @@
 			<artifactId>jackson-databind-nullable</artifactId>
 			<version>${jackson-databind-nullable-version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jul-to-slf4j</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
     <build>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
@@ -36,6 +36,7 @@ import org.glassfish.jersey.test.TestProperties;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -77,6 +78,9 @@ public abstract class JerseySpringTest {
 
     @Before
     public void jerseySetUp() throws Exception {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
         _jerseyTest.setUp();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
@@ -60,7 +60,7 @@ public abstract class JerseySpringTest {
         return target(path, "");
     }
 
-    private final WebTarget target(final String path, final String baseURL) {
+    private WebTarget target(final String path, final String baseURL) {
         String finalPath = "";
         String contextPath = contextPath();
         if (!contextPath.startsWith("/")) {
@@ -101,6 +101,7 @@ public abstract class JerseySpringTest {
                     ResourceConfig application = new GraviteeManagementV2Application();
 
                     application.property("contextConfig", context);
+                    application.property("jersey.config.server.wadl.disableWadl", true);
                     decorate(application);
 
                     return application;
@@ -135,7 +136,7 @@ public abstract class JerseySpringTest {
     public static class AuthenticationFilter implements ContainerRequestFilter {
 
         @Override
-        public void filter(final ContainerRequestContext requestContext) throws IOException {
+        public void filter(final ContainerRequestContext requestContext) {
             requestContext.setSecurityContext(
                 new SecurityContext() {
                     @Override
@@ -143,8 +144,7 @@ public abstract class JerseySpringTest {
                         UserDetails userDetails = new UserDetails(USER_NAME, "", Collections.emptyList());
                         userDetails.setOrganizationId(ORGANIZATION);
 
-                        UsernamePasswordAuthenticationToken principal = new UsernamePasswordAuthenticationToken(userDetails, new Object());
-                        return principal;
+                        return new UsernamePasswordAuthenticationToken(userDetails, new Object());
                     }
 
                     @Override


### PR DESCRIPTION
## Description

Make Java Logging configurable with SLF4J in tests. In production, it is already the case, but we missed some configurations to enable it in the tests. 

It allows to remove the following logs:

```
Aug 16, 2023 3:46:15 PM org.glassfish.jersey.test.jetty.JettyTestContainerFactory$JettyTestContainer <init>
INFO: Creating JettyTestContainer configured at the base URI http://localhost:<AVAILABLE-PORT>/
Aug 16, 2023 3:46:16 PM org.glassfish.jersey.test.jetty.JettyTestContainerFactory$JettyTestContainer start
INFO: Started JettyTestContainer at the base URI http://localhost:55312/
```

And

```
15:47:34.890 [main] WARN  o.g.j.s.w.WadlFeature - JAXBContext implementation could not be found. WADL feature is disabled.
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-beesmbeoag.chromatic.com)
<!-- Storybook placeholder end -->
