### PR TITLE
fix: index system folder locally

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -54,6 +54,8 @@ public interface PageService {
 
     PageEntity createPage(ExecutionContext executionContext, String apiId, NewPageEntity page);
 
+    PageEntity createPage(ExecutionContext executionContext, String apiId, NewPageEntity page, boolean indexLocally);
+
     PageEntity createPage(ExecutionContext executionContext, NewPageEntity page);
 
     PageEntity update(ExecutionContext executionContext, String pageId, UpdatePageEntity updatePageEntity);
@@ -88,7 +90,13 @@ public interface PageService {
 
     PageEntity createAsideFolder(ExecutionContext executionContext, String apiId);
 
-    PageEntity createSystemFolder(ExecutionContext executionContext, String apiId, SystemFolderType systemFolderType, int order);
+    PageEntity createSystemFolder(
+        ExecutionContext executionContext,
+        String apiId,
+        SystemFolderType systemFolderType,
+        int order,
+        boolean indexLocally
+    );
 
     PageEntity createWithDefinition(ExecutionContext executionContext, String apiId, String toString);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
@@ -91,7 +91,7 @@ public class DocumentationSystemFolderUpgrader extends EnvironmentUpgrader {
             List<String> apiIds = apiRepository.searchIds(apiCriteriaList, pageable, null).getContent();
 
             while (!apiIds.isEmpty()) {
-                apiIds.forEach(apiId -> pageService.createSystemFolder(executionContext, apiId, SystemFolderType.ASIDE, 0));
+                apiIds.forEach(apiId -> pageService.createSystemFolder(executionContext, apiId, SystemFolderType.ASIDE, 0, false));
                 pageable = new PageableBuilder().pageNumber(page++).pageSize(size).build();
                 apiIds = apiRepository.searchIds(apiCriteriaList, pageable, null).getContent();
             }
@@ -106,7 +106,7 @@ public class DocumentationSystemFolderUpgrader extends EnvironmentUpgrader {
         newFolder.setParentId(parentId);
         newFolder.setVisibility(Visibility.PUBLIC);
 
-        return pageService.createPage(executionContext, newFolder);
+        return pageService.createPage(executionContext, null, newFolder, true);
     }
 
     private void createLink(
@@ -137,7 +137,7 @@ public class DocumentationSystemFolderUpgrader extends EnvironmentUpgrader {
 
         newLink.setConfiguration(configuration);
 
-        pageService.createPage(executionContext, newLink);
+        pageService.createPage(executionContext, null, newLink, true);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgraderTest.java
@@ -15,12 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -77,7 +72,7 @@ public class DocumentationSystemFolderUpgraderTest {
         verify(pageService, never()).createPage(any(ExecutionContext.class), any(NewPageEntity.class));
         verify(apiRepository, never()).searchIds(any(), any(), any());
         verify(pageService, never())
-            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class));
+            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class), anyBoolean());
     }
 
     @Test
@@ -92,10 +87,10 @@ public class DocumentationSystemFolderUpgraderTest {
         verify(pageService, times(1)).initialize(executionContext);
         verify(pageService, times(1))
             .search(eq(ENV_ID), argThat(pageQuery -> pageQuery.getType() == null && !pageQuery.getHomepage() && pageQuery.getRootParent()));
-        verify(pageService, times(1)).createPage(any(ExecutionContext.class), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(any(ExecutionContext.class), isNull(), any(NewPageEntity.class), eq(true));
         verify(apiRepository, times(1)).searchIds(any(), any(), any());
         verify(pageService, never())
-            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class));
+            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class), anyBoolean());
     }
 
     @Test
@@ -111,7 +106,9 @@ public class DocumentationSystemFolderUpgraderTest {
         when(
             pageService.createPage(
                 eq(executionContext),
-                argThat(newPageEntity -> newPageEntity.getType() == PageType.FOLDER && newPageEntity.getParentId().equals("top-footer-id"))
+                isNull(),
+                argThat(newPageEntity -> newPageEntity.getType() == PageType.FOLDER && newPageEntity.getParentId().equals("top-footer-id")),
+                eq(true)
             )
         )
             .thenReturn(documentationFolderPage);
@@ -135,10 +132,10 @@ public class DocumentationSystemFolderUpgraderTest {
         verify(pageService, times(1)).initialize(executionContext);
         verify(pageService, times(1))
             .search(eq(ENV_ID), argThat(pageQuery -> pageQuery.getType() == null && !pageQuery.getHomepage() && pageQuery.getRootParent()));
-        verify(pageService, times(3)).createPage(any(ExecutionContext.class), any(NewPageEntity.class));
+        verify(pageService, times(3)).createPage(any(ExecutionContext.class), isNull(), any(NewPageEntity.class), eq(true));
         verify(apiRepository, times(1)).searchIds(any(), any(), any());
         verify(pageService, never())
-            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class));
+            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class), eq(false));
     }
 
     @Test
@@ -158,9 +155,9 @@ public class DocumentationSystemFolderUpgraderTest {
         verify(pageService, times(1)).initialize(executionContext);
         verify(pageService, times(1))
             .search(eq(ENV_ID), argThat(pageQuery -> pageQuery.getType() == null && !pageQuery.getHomepage() && pageQuery.getRootParent()));
-        verify(pageService, times(1)).createPage(any(ExecutionContext.class), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(any(ExecutionContext.class), isNull(), any(NewPageEntity.class), eq(true));
         verify(apiRepository, times(3)).searchIds(any(), any(), any());
         verify(pageService, times(2))
-            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class));
+            .createSystemFolder(any(ExecutionContext.class), anyString(), any(SystemFolderType.class), any(Integer.class), eq(false));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2128

## Description

Index system folder locally on APIM start. This can help us to avoid to avoid to have deadlocks on commands table at startup for JDBC users.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zmftyrplbb.chromatic.com)
<!-- Storybook placeholder end -->
