### PR TITLE
fix: do not index folder and links on page creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageType.java
@@ -70,4 +70,8 @@ public enum PageType {
             .findFirst()
             .orElse(null);
     }
+
+    public static boolean isIndexable(PageType pageType) {
+        return !List.of(FOLDER, LINK, ROOT, SYSTEM_FOLDER).contains(pageType);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
@@ -16,9 +16,13 @@
 package io.gravitee.rest.api.model;
 
 import static io.gravitee.rest.api.model.PageType.*;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author GraviteeSource Team
@@ -154,5 +158,26 @@ public class PageTypeTest {
     @Test
     public void matchesExtension_should_return_false_when_it_doesnt_matches() {
         assertFalse(MARKDOWN.matchesExtension("mxd"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("providePageType")
+    public void shouldCheckIfIsIndexable(final PageType type, boolean expected) {
+        assertEquals(expected, PageType.isIndexable(type));
+    }
+
+    private static Stream<Arguments> providePageType() {
+        return Stream.of(
+            Arguments.of(ASCIIDOC, true),
+            Arguments.of(ASYNCAPI, true),
+            Arguments.of(MARKDOWN, true),
+            Arguments.of(MARKDOWN_TEMPLATE, true),
+            Arguments.of(SWAGGER, true),
+            Arguments.of(FOLDER, false),
+            Arguments.of(LINK, false),
+            Arguments.of(ROOT, false),
+            Arguments.of(SYSTEM_FOLDER, false),
+            Arguments.of(TRANSLATION, true)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -958,7 +958,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             }
 
             // add document in search engine
-            index(executionContext, pageEntity);
+            if (PageType.isIndexable(PageType.valueOf(pageEntity.getType()))) {
+                index(executionContext, pageEntity);
+            }
 
             return pageEntity;
         } catch (TechnicalException | FetcherException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
@@ -214,6 +214,7 @@ public class PageService_CreateTest {
         createdPage.setReferenceId("DEFAULT");
         createdPage.setReferenceType(PageReferenceType.ENVIRONMENT);
         createdPage.setVisibility("PUBLIC");
+        createdPage.setType(PageType.FOLDER.toString());
         doReturn(createdPage).when(pageRepository).create(any());
 
         final PageEntity createdFolder = pageService.createPage(new ExecutionContext("DEFAULT", "DEFAULT"), newFolder);
@@ -311,6 +312,7 @@ public class PageService_CreateTest {
         createdPage.setReferenceId("DEFAULT");
         createdPage.setReferenceType(PageReferenceType.ENVIRONMENT);
         createdPage.setVisibility("PUBLIC");
+        createdPage.setType(PageType.LINK.toString());
         doReturn(createdPage).when(pageRepository).create(any());
 
         pageService.createPage(new ExecutionContext("DEFAULT", "DEFAULT"), newFolder);
@@ -343,6 +345,7 @@ public class PageService_CreateTest {
         createdPage.setReferenceId("DEFAULT");
         createdPage.setReferenceType(PageReferenceType.ENVIRONMENT);
         createdPage.setVisibility("PUBLIC");
+        createdPage.setType(PageType.LINK.toString());
         doReturn(createdPage).when(pageRepository).create(any());
 
         pageService.createPage(new ExecutionContext("DEFAULT", "DEFAULT"), newLink);

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -93,8 +93,13 @@
 
         <!-- Unit Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2128

## Description

Do not index system folder APIM start. This can help us to avoid to avoid to have deadlocks on commands table at startup for JDBC users.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aiyndeqafm.chromatic.com)
<!-- Storybook placeholder end -->
