### PR TITLE
fix: transfer ownership in group mode should show group selection

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
@@ -20,10 +20,10 @@
     <div class="card__header">
       <div>
         <h3>Transfer ownership</h3>
-        <p>Select your preferred method for granting complete API access</p>
       </div>
     </div>
     <ng-container *ngIf="mode && mode !== 'GROUP'">
+      <p>Select your preferred method for granting complete API access</p>
       <mat-button-toggle-group aria-label="Select User or Group" class="card__userOrGroup__toggle-group" formControlName="userOrGroup">
         <mat-button-toggle class="card__userOrGroup__toggle" value="apiMember"> API member </mat-button-toggle>
         <mat-button-toggle class="card__userOrGroup__toggle" value="user"> Other user </mat-button-toggle>

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.ts
@@ -159,7 +159,7 @@ export class ApiGeneralTransferOwnershipComponent implements OnInit {
   private initForm(defaultRolePO: Role) {
     this.form = new FormGroup(
       {
-        userOrGroup: new FormControl('apiMember'),
+        userOrGroup: new FormControl(this.mode === 'GROUP' ? 'group' : 'apiMember'),
         user: new FormControl(),
         groupId: new FormControl(),
         roleId: new FormControl(defaultRolePO.name),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2516

## Description

When settings for API Primary Owner is in GROUP mode, then API transfer ownership should show a form to select a group (and only a group)

![Screenshot 2023-08-16 at 16 44 44](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/0e949973-3c88-4bb6-b49b-54cb537d3895)
![Screenshot 2023-08-16 at 16 44 57](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/359b5a9a-8773-40a3-a396-5473c6e9c68c)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xlvyshgyml.chromatic.com)
<!-- Storybook placeholder end -->
