### PR TITLE
Improve design for endpoint groups

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -16,8 +16,8 @@
 
 -->
 <ng-container *ngIf="groupsTableData">
-  <mat-card class="endpoints-group-card">
-    <ng-container *ngFor="let group of groupsTableData; let i = index">
+  <ng-container *ngFor="let group of groupsTableData; let i = index">
+    <mat-card class="endpoints-group-card">
       <div class="endpoints-group-card__header">
         <div class="endpoints-group-card__header__title">
           <span class="mat-h4">{{ group?.name }}</span>
@@ -33,17 +33,10 @@
 
         <div class="endpoints-group-card__header__actions">
           <button
-            *gioPermission="{ anyOf: ['api-definition-u'] }"
-            mat-stroked-button
-            aria-label="Edit endpoint group"
-            (click)="editEndpointGroup(i)"
-          >
-            Configure group defaults
-          </button>
-          <button
             id="{{ 'moveUpBtn-' + i }}"
             *ngIf="groupsTableData?.length > 1 && i !== 0"
             mat-stroked-button
+            class="endpoints-group-card__header__actions__button"
             aria-label="Reorder element to a higher position"
             (click)="reorderEndpointGroup(i, i - 1)"
           >
@@ -53,10 +46,19 @@
             id="{{ 'moveDownBtn-' + i }}"
             *ngIf="groupsTableData?.length > 1 && i !== groupsTableData.length - 1"
             mat-stroked-button
+            class="endpoints-group-card__header__actions__button"
             aria-label="Reorder element to a lower position"
             (click)="reorderEndpointGroup(i + 1, i)"
           >
             <mat-icon svgIcon="gio:arrow-down"></mat-icon>
+          </button>
+          <button
+            *gioPermission="{ anyOf: ['api-definition-u'] }"
+            mat-stroked-button
+            aria-label="Edit endpoint group"
+            (click)="editEndpointGroup(i)"
+          >
+            <mat-icon svgIcon="gio:edit-pencil"></mat-icon>Edit
           </button>
           <ng-container *gioPermission="{ anyOf: ['api-definition-u'] }">
             <button
@@ -147,6 +149,15 @@
           >Add endpoint</a
         >
       </mat-card-content>
-    </ng-container>
-  </mat-card>
+    </mat-card>
+  </ng-container>
 </ng-container>
+<button
+  *gioPermission="{ anyOf: ['api-definition-u'] }"
+  mat-flat-button
+  color="primary"
+  aria-label="Add endpoint group"
+  (click)="addEndpointGroup()"
+>
+  Add endpoint group
+</button>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.scss
@@ -45,9 +45,17 @@
       flex-direction: row;
       justify-content: flex-end;
 
-      .mat-stroked-button,
-      .mat-flat-button {
+      .mat-stroked-button {
         margin-right: 8px;
+      }
+
+      &__button {
+        display: flex;
+        justify-content: center;
+
+        mat-icon {
+          margin: 0;
+        }
       }
     }
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
@@ -166,4 +166,8 @@ export class ApiEndpointsGroupsComponent implements OnInit, OnDestroy {
   public editEndpointGroup(groupIndex: number): void {
     this.ajsState.go('management.apis.ng.endpoints-group', { groupIndex });
   }
+
+  addEndpointGroup() {
+    throw new Error('addEndpointGroup not implemented yet');
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2398

## Description

Delete was already implemented. I just changed the page design a bit to make it clearer

BEFORE
![Screenshot 2023-08-17 at 09 05 54](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/e924bce8-e284-4f69-87f9-f3e1c4345b18)

AFTER
![Screenshot 2023-08-17 at 10 02 42](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/8b702b23-e7c6-421e-83f1-e859fb6b5ee0)



## Additional context

I added the "Add group" button, but no associated implementation. This will be done in another US.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zavzsrlfje.chromatic.com)
<!-- Storybook placeholder end -->
