### PR TITLE
fix: disable endpoint reordering while action is in progress

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -39,6 +39,7 @@
             class="endpoints-group-card__header__actions__button"
             aria-label="Reorder element to a higher position"
             (click)="reorderEndpointGroup(i, i - 1)"
+            [disabled]="isReordering"
           >
             <mat-icon svgIcon="gio:arrow-up"></mat-icon>
           </button>
@@ -49,6 +50,7 @@
             class="endpoints-group-card__header__actions__button"
             aria-label="Reorder element to a lower position"
             (click)="reorderEndpointGroup(i + 1, i)"
+            [disabled]="isReordering"
           >
             <mat-icon svgIcon="gio:arrow-down"></mat-icon>
           </button>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2404

## Description

Add visual feedback while endpoint reordering is in progress, as action can take a while
https://watch.screencastify.com/v/jt7tDrnj7rFKW0T7Dn0g

## Additional context

We keep the other actions enabled (though it would be better to disable everything, but in terms of UI it's a bit weird to have all buttons disabled)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hgkvudpglq.chromatic.com)
<!-- Storybook placeholder end -->
