### PR TITLE
test: remove junit jupiter dependency and parameterized test

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
@@ -16,13 +16,9 @@
 package io.gravitee.rest.api.model;
 
 import static io.gravitee.rest.api.model.PageType.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.Assert.*;
 
-import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Test;
 
 /**
  * @author GraviteeSource Team
@@ -158,26 +154,5 @@ public class PageTypeTest {
     @Test
     public void matchesExtension_should_return_false_when_it_doesnt_matches() {
         assertFalse(MARKDOWN.matchesExtension("mxd"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("providePageType")
-    public void shouldCheckIfIsIndexable(final PageType type, boolean expected) {
-        assertEquals(expected, PageType.isIndexable(type));
-    }
-
-    private static Stream<Arguments> providePageType() {
-        return Stream.of(
-            Arguments.of(ASCIIDOC, true),
-            Arguments.of(ASYNCAPI, true),
-            Arguments.of(MARKDOWN, true),
-            Arguments.of(MARKDOWN_TEMPLATE, true),
-            Arguments.of(SWAGGER, true),
-            Arguments.of(FOLDER, false),
-            Arguments.of(LINK, false),
-            Arguments.of(ROOT, false),
-            Arguments.of(SYSTEM_FOLDER, false),
-            Arguments.of(TRANSLATION, true)
-        );
     }
 }

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -93,13 +93,8 @@
 
         <!-- Unit Tests -->
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2128

## Description

Junit Jupiter seems to mess all the tests and it is not worth trying to fix it since this test is not absolutely required and it's working in higher version of APIM.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lqizrfekyu.chromatic.com)
<!-- Storybook placeholder end -->
