### PR TITLE
Revert "chore(deps): update cypress/included docker tag to v12.17.4"

### DIFF
--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   cypress:
-    image: cypress/included:12.17.4
+    image: cypress/included:12.17.3
     working_dir: /test
     command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts'"
     volumes:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

This reverts commit 71755f64ba401438546b2d37da886ea6728bce27.
Another possibility proposed by the changelog is to pin '@cypress/webpack-batteries-included-preprocessor' to version 2.4.1 but it's not a good idea I think. I propose to repair the CI by downgrading the version of Cypress and find why it's failing before changing the version.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

