### PR TITLE
fix: enable right click on menu items

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
@@ -27,26 +27,22 @@
       ></gio-menu-selector>
     </gio-menu-header>
     <gio-menu-list>
-      <gio-menu-item
-        *ngFor="let item of mainMenuItems"
-        tabIndex="1"
-        [title]="item.displayName"
-        [icon]="item.icon"
-        (click)="navigateTo(item.targetRoute)"
-        [active]="isActive(item.baseRoute)"
-        >{{ item.displayName }}</gio-menu-item
+      <ng-container *ngFor="let item of mainMenuItems">
+        <a [uiSref]="item.targetRoute">
+          <gio-menu-item tabIndex="1" [title]="item.displayName" [icon]="item.icon" [active]="isActive(item.baseRoute)">{{
+            item.displayName
+          }}</gio-menu-item></a
+        ></ng-container
       >
     </gio-menu-list>
 
     <gio-menu-footer *ngIf="footerMenuItems.length > 0">
-      <gio-menu-item
-        *ngFor="let item of footerMenuItems"
-        tabIndex="1"
-        [title]="item.displayName"
-        [icon]="item.icon"
-        (click)="navigateTo(item.targetRoute)"
-        [active]="isActive(item.baseRoute)"
-        >{{ item.displayName }}</gio-menu-item
+      <ng-container *ngFor="let item of footerMenuItems">
+        <a [uiSref]="item.targetRoute">
+          <gio-menu-item tabIndex="1" [title]="item.displayName" [icon]="item.icon" [active]="isActive(item.baseRoute)">{{
+            item.displayName
+          }}</gio-menu-item></a
+        ></ng-container
       >
     </gio-menu-footer>
   </gio-menu>

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.scss
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.scss
@@ -24,4 +24,8 @@
   &__menu {
     flex: 1 1 auto;
   }
+
+  a {
+    text-decoration: none;
+  }
 }

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -152,13 +152,7 @@ export class GioSideNavComponent implements OnInit {
   }
 
   private filterMenuByPermission(menuItems: MenuItem[]): MenuItem[] {
-    return menuItems
-      .filter((item) => !item.permissions || this.permissionService.hasAnyMatching(item.permissions))
-      .filter((item) => (item.permissions?.includes('environment-alert-r') ? this.constants.org?.settings?.alert?.enabled : true)); // Dirty hack to remove the "Alert" menu item if the alert feature is not enabled
-  }
-
-  navigateTo(route: string) {
-    this.ajsState.go(route);
+    return menuItems.filter((item) => !item.permissions || this.permissionService.hasAnyMatching(item.permissions));
   }
 
   isActive(route: string): boolean {

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
@@ -17,11 +17,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { GioMenuModule } from '@gravitee/ui-particles-angular';
 import { MatSelectModule } from '@angular/material/select';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { GioSideNavComponent } from './gio-side-nav.component';
 
 @NgModule({
-  imports: [CommonModule, GioMenuModule, MatSelectModule],
+  imports: [CommonModule, GioMenuModule, MatSelectModule, UIRouterModule],
   declarations: [GioSideNavComponent],
   exports: [GioSideNavComponent],
   entryComponents: [GioSideNavComponent],

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
@@ -35,37 +35,29 @@
         </button>
       </span>
       <ng-container *ngFor="let menuItem of this.subMenuItems">
-        <gio-submenu-item
-          *ngIf="!menuItem?.targetRoute && menuItem?.tabs?.length > 0"
-          tabIndex="1"
-          (click)="navigateTo(menuItem?.tabs[0]?.targetRoute)"
-          [active]="isTabActive(menuItem?.tabs)"
-          >{{ menuItem?.displayName }}</gio-submenu-item
-        >
-        <gio-submenu-item
-          *ngIf="menuItem?.targetRoute"
-          tabIndex="1"
-          (click)="navigateTo(menuItem?.targetRoute)"
-          [active]="isActive(menuItem?.baseRoute)"
-          >{{ menuItem?.displayName }}</gio-submenu-item
+        <ng-container *ngIf="!menuItem?.targetRoute && menuItem?.tabs?.length > 0">
+          <a [uiSref]="menuItem?.tabs[0]?.targetRoute">
+            <gio-submenu-item tabIndex="1" [active]="isTabActive(menuItem?.tabs)">{{ menuItem?.displayName }}</gio-submenu-item></a
+          >
+        </ng-container>
+        <ng-container *ngIf="menuItem?.targetRoute">
+          <a [uiSref]="menuItem?.targetRoute">
+            <gio-submenu-item tabIndex="1" [active]="isActive(menuItem?.baseRoute)">{{ menuItem?.displayName }}</gio-submenu-item></a
+          ></ng-container
         >
       </ng-container>
       <ng-container *ngFor="let group of this.groupItems">
         <gio-submenu-group [title]="group.title" *ngIf="group.title">
           <ng-container *ngFor="let subItem of group.items">
-            <gio-submenu-item
-              *ngIf="!subItem?.targetRoute && subItem?.tabs?.length > 0"
-              tabIndex="1"
-              (click)="navigateTo(subItem?.tabs[0]?.targetRoute)"
-              [active]="isTabActive(subItem?.tabs)"
-              >{{ subItem?.displayName }}</gio-submenu-item
+            <ng-container *ngIf="!subItem?.targetRoute && subItem?.tabs?.length > 0">
+              <a [uiSref]="subItem?.tabs[0]?.targetRoute">
+                <gio-submenu-item tabIndex="1" [active]="isTabActive(subItem?.tabs)">{{ subItem?.displayName }}</gio-submenu-item></a
+              ></ng-container
             >
-            <gio-submenu-item
-              *ngIf="subItem?.targetRoute"
-              tabIndex="1"
-              (click)="navigateTo(subItem?.targetRoute)"
-              [active]="isActive(subItem?.baseRoute)"
-              >{{ subItem?.displayName }}</gio-submenu-item
+            <ng-container *ngIf="subItem?.targetRoute">
+              <a [uiSref]="subItem?.targetRoute">
+                <gio-submenu-item tabIndex="1" [active]="isActive(subItem?.baseRoute)">{{ subItem?.displayName }}</gio-submenu-item></a
+              ></ng-container
             >
           </ng-container>
         </gio-submenu-group>

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.scss
@@ -26,6 +26,10 @@
   justify-content: flex-start;
   height: 100%;
 
+  a {
+    text-decoration: none;
+  }
+
   &__menu {
     display: flex;
     flex-direction: column;

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
@@ -418,10 +418,6 @@ export class ApiNavigationComponent implements OnInit {
     return items.filter((item) => item.tabs).find((item) => this.isTabActive(item.tabs));
   }
 
-  navigateTo(route: string) {
-    this.ajsState.go(route);
-  }
-
   isActive(baseRoute: MenuItem['baseRoute']): boolean {
     return castArray(baseRoute).some((baseRoute) => this.ajsState.includes(baseRoute));
   }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.module.ts
@@ -17,13 +17,22 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { GioIconsModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { ApiNavigationComponent } from './api-navigation.component';
 import { ApiNavigationTitleModule } from './api-navigation-title/api-navigation-title.module';
 import { ApiNavigationTabsModule } from './api-navigation-tabs/api-navigation-tabs.module';
 
 @NgModule({
-  imports: [CommonModule, GioSubmenuModule, ApiNavigationTitleModule, ApiNavigationTabsModule, GioIconsModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    GioSubmenuModule,
+    ApiNavigationTitleModule,
+    ApiNavigationTabsModule,
+    GioIconsModule,
+    MatButtonModule,
+    UIRouterModule,
+  ],
   declarations: [ApiNavigationComponent],
   exports: [ApiNavigationComponent],
   entryComponents: [ApiNavigationComponent],

--- a/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.html
@@ -19,9 +19,11 @@
   <gio-submenu class="application-navigation__menu">
     <div gioSubmenuTitle class="application-navigation__menu__title">{{ this.applicationName }}</div>
     <ng-container *ngFor="let item of this.subMenuItems">
-      <gio-submenu-item *ngIf="item.targetRoute" tabIndex="1" (click)="navigateTo(item.targetRoute)" [active]="isActive(item.baseRoute)">{{
-        item.displayName
-      }}</gio-submenu-item>
+      <a [uiSref]="item.targetRoute">
+        <gio-submenu-item *ngIf="item.targetRoute" tabIndex="1" [active]="isActive(item.baseRoute)">{{
+          item.displayName
+        }}</gio-submenu-item></a
+      >
     </ng-container>
   </gio-submenu>
 </div>

--- a/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.scss
@@ -32,5 +32,9 @@
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
+    a {
+      text-decoration: none;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.ts
@@ -109,10 +109,6 @@ export class ApplicationNavigationComponent implements OnInit, OnDestroy {
     return [];
   }
 
-  navigateTo(route: string) {
-    this.ajsState.go(route);
-  }
-
   isActive(route: string): boolean {
     return this.ajsState.includes(route);
   }

--- a/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.module.ts
@@ -16,11 +16,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { ApplicationNavigationComponent } from './application-navigation.component';
 
 @NgModule({
-  imports: [CommonModule, GioSubmenuModule],
+  imports: [CommonModule, GioSubmenuModule, UIRouterModule],
   declarations: [ApplicationNavigationComponent],
   exports: [ApplicationNavigationComponent],
   entryComponents: [ApplicationNavigationComponent],

--- a/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.html
@@ -19,13 +19,11 @@
   <gio-submenu class="settings-navigation__submenu">
     <ng-container *ngFor="let group of this.groupItems">
       <gio-submenu-group [title]="group.title" *ngIf="group.items && group.items.length > 0">
-        <gio-submenu-item
-          *ngFor="let item of group.items"
-          tabIndex="1"
-          (click)="navigateTo(item.targetRoute)"
-          [active]="isActive(item.baseRoute)"
-          >{{ item.displayName }}</gio-submenu-item
-        >
+        <ng-container *ngFor="let item of group.items">
+          <a [uiSref]="item.targetRoute">
+            <gio-submenu-item tabIndex="1" [active]="isActive(item.baseRoute)">{{ item.displayName }}</gio-submenu-item>
+          </a>
+        </ng-container>
       </gio-submenu-group>
     </ng-container>
   </gio-submenu>

--- a/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.scss
@@ -23,5 +23,9 @@
   &__submenu {
     z-index: 70;
     flex: 1 1 auto;
+
+    a {
+      text-decoration: none;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.ts
@@ -193,10 +193,6 @@ export class SettingsNavigationComponent implements OnInit {
     });
   }
 
-  navigateTo(route: string) {
-    this.ajsState.go(route);
-  }
-
   isActive(route: string): boolean {
     return this.ajsState.includes(route);
   }

--- a/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.module.ts
@@ -16,11 +16,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { SettingsNavigationComponent } from './settings-navigation.component';
 
 @NgModule({
-  imports: [CommonModule, GioSubmenuModule],
+  imports: [CommonModule, GioSubmenuModule, UIRouterModule],
   declarations: [SettingsNavigationComponent],
   exports: [SettingsNavigationComponent],
   entryComponents: [SettingsNavigationComponent],


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2385

## Description

New menu links were managed with `onClick` callback instead of router links, so right click on element or cmd+click was not possible

Before fix
![Screenshot 2023-08-21 at 11 45 08](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/42f5fe38-3a57-4ff2-bd80-1e70d4db086e)


After fix
![Screenshot 2023-08-21 at 11 44 21](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/d77bfc99-3267-4a65-a5a9-4ebb143dd133)


## Additional info
Fix on 3.20.x will be applied on master.
No need to fix on 3.19.x as it was the old menu.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fkftnafnzl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5026/console](https://pr.team-apim.gravitee.dev/5026/console)
      Portal: [https://pr.team-apim.gravitee.dev/5026/portal](https://pr.team-apim.gravitee.dev/5026/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5026/api/management](https://pr.team-apim.gravitee.dev/5026/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5026](https://pr.team-apim.gravitee.dev/5026)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5026](https://pr.gateway-v3.team-apim.gravitee.dev/5026)

<!-- Environment placeholder end -->
