### PR TITLE
[APIM-2499] feat: add runtime logs menu item

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
@@ -42,11 +42,16 @@ export class ApiNgV4MenuService implements ApiMenuService {
         baseRoute: 'management.apis.ng.policyStudio',
         tabs: undefined,
       },
-      {
-        displayName: 'Messages',
-        targetRoute: 'DISABLED',
-      },
     ];
+
+    if (this.permissionService.hasAnyMatching(['api-log-r'])) {
+      subMenuItems.push({
+        displayName: 'Runtime Logs',
+        targetRoute: 'management.apis.ng.runtimeLogs',
+        baseRoute: 'management.apis.ng.runtimeLogs',
+      });
+    }
+
     const groupItems: MenuGroupItem[] = [
       this.getGeneralGroup(),
       this.getEntrypointsGroup(),
@@ -188,16 +193,9 @@ export class ApiNgV4MenuService implements ApiMenuService {
       title: 'Analytics',
       items: [],
     };
-
     if (this.permissionService.hasAnyMatching(['api-analytics-r'])) {
       analyticsGroup.items.push({
         displayName: 'Overview',
-        targetRoute: 'DISABLED',
-      });
-    }
-    if (this.permissionService.hasAnyMatching(['api-log-r'])) {
-      analyticsGroup.items.push({
-        displayName: 'Logs',
         targetRoute: 'DISABLED',
       });
     }

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -28,6 +28,7 @@ import { ApiNavigationModule } from './api-navigation/api-navigation.module';
 import { ApiNgNavigationModule } from './api-ng-navigation/api-ng-navigation.module';
 import { ApiProxyModule } from './proxy/api-proxy.module';
 import { ApiV4PolicyStudioModule } from './policy-studio-v4/api-v4-policy-studio.module';
+import { ApiRuntimeLogsModule } from './runtime-logs-v4/api-runtime-logs.module';
 import { ApiNgNavigationComponent } from './api-ng-navigation/api-ng-navigation.component';
 import { ApiGeneralInfoComponent } from './general/details/api-general-info.component';
 import { ApiGeneralPlanEditComponent } from './general/plans/edit/api-general-plan-edit.component';
@@ -75,6 +76,7 @@ import { ApiV1ResourcesComponent } from './proxy/resources-v1/resources.componen
 import { ApiV1PoliciesComponent } from './design/policies/policies.component';
 import { ApiEventsComponent } from './audit/events/api-events.component';
 import { ApiEndpointGroupComponent } from './endpoints-v4/endpoint-group/api-endpoint-group.component';
+import { ApiRuntimeLogsComponent } from './runtime-logs-v4/api-runtime-logs.component';
 
 import { NotificationsComponent } from '../../components/notifications/notifications.component';
 import { Scope } from '../../entities/scope';
@@ -1325,6 +1327,20 @@ const states: Ng2StateDeclaration[] = [
     component: ApiV4PolicyStudioDesignComponent,
   },
   {
+    name: 'management.apis.ng.runtimeLogs',
+    url: '/runtime-logs',
+    data: {
+      apiPermissions: {
+        only: ['api-log-r'],
+      },
+      docs: {
+        page: 'management-api-logs',
+      },
+      useAngularMaterial: true,
+    },
+    component: ApiRuntimeLogsComponent,
+  },
+  {
     name: 'management.apis.ng.entrypoints',
     url: '/entrypoints',
     component: ApiEntrypointsV4GeneralComponent,
@@ -1415,6 +1431,7 @@ const states: Ng2StateDeclaration[] = [
     ApiNavigationModule,
     ApiNgNavigationModule,
     ApiV4PolicyStudioModule,
+    ApiRuntimeLogsModule,
     ApisGeneralModule,
     ApiProxyModule,
     ApiEntrypointsV4Module,

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.harness.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatTabHarness } from '@angular/material/tabs/testing';
+
+export class ApiRuntimeLogsHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs';
+
+  private getRuntimeLogsTab = this.locatorFor(MatTabHarness.with({ label: 'Runtime Logs' }));
+  private getSettingsTab = this.locatorFor(MatTabHarness.with({ label: 'Settings' }));
+
+  public async clickRuntimeLogsTab() {
+    return this.getRuntimeLogsTab().then((tab) => tab.select());
+  }
+
+  public async readRuntimeLogsTabLabel() {
+    return this.getRuntimeLogsTab().then((tab) => tab.getLabel());
+  }
+
+  public async clickSettingsTab() {
+    return this.getSettingsTab().then((tab) => tab.select());
+  }
+
+  public async readSettingsTabLabel() {
+    return this.getSettingsTab().then((tab) => tab.getLabel());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.html
@@ -1,0 +1,41 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<ng-container>
+  <div class="runtime-logs__header">
+    <div>
+      <span class="mat-h2">Runtime Logs</span>
+    </div>
+    <div>
+      <span class="runtime-logs__header__subtitle">Debug and Optimize your API by displaying logs from your API runtime activities</span>
+    </div>
+  </div>
+  <mat-tab-group animationDuration="0ms">
+    <mat-tab label="Runtime Logs">
+      <!-- Runtime Logs tab content -->
+      <div class="tab-body-wrapper">
+        <span>Runtime Logs Tab</span>
+      </div>
+    </mat-tab>
+    <mat-tab label="Settings">
+      <!-- Settings tab content -->
+      <div class="tab-body-wrapper">
+        <span>Settings Tab</span>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.scss
@@ -1,0 +1,24 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+@use '../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.runtime-logs__header {
+  margin-bottom: 24px;
+
+  &__subtitle {
+    color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    @include mat.typography-level($typography, 'body-1');
+  }
+}
+
+.tab-body-wrapper {
+  margin-top: 8px;
+}

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiRuntimeLogsModule } from './api-runtime-logs.module';
+import { ApiRuntimeLogsComponent } from './api-runtime-logs.component';
+import { ApiRuntimeLogsHarness } from './api-runtime-logs.component.harness';
+
+describe('ApiRuntimeLogsComponent', () => {
+  let fixture: ComponentFixture<ApiRuntimeLogsComponent>;
+  let componentHarness: ApiRuntimeLogsHarness;
+
+  const runtimeLogsTabTitle = 'Runtime Logs';
+  const settingsTabTitle = 'Settings';
+
+  const initComponent = async () => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ApiRuntimeLogsModule, HttpClientTestingModule],
+    });
+
+    await TestBed.compileComponents();
+    fixture = TestBed.createComponent(ApiRuntimeLogsComponent);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsHarness);
+
+    fixture.detectChanges();
+  };
+
+  describe('GIVEN the current page is the Runtime Logs page', () => {
+    beforeEach(async () => {
+      await initComponent();
+    });
+    describe('WHEN the page has loaded', () => {
+      it('THEN the Runtime Logs tab should be visible', async () => {
+        expect(await componentHarness.readRuntimeLogsTabLabel()).toEqual(runtimeLogsTabTitle);
+      });
+      it('THEN the Settings tab should be visible', async () => {
+        expect(await componentHarness.readSettingsTabLabel()).toEqual(settingsTabTitle);
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.component.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'api-runtime-logs',
+  template: require('./api-runtime-logs.component.html'),
+  styles: [require('./api-runtime-logs.component.scss')],
+})
+export class ApiRuntimeLogsComponent {}

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/api-runtime-logs.module.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatIconModule } from '@angular/material/icon';
+
+import { ApiRuntimeLogsComponent } from './api-runtime-logs.component';
+
+@NgModule({
+  imports: [CommonModule, MatCardModule, MatIconModule, MatTabsModule],
+  declarations: [ApiRuntimeLogsComponent],
+  exports: [ApiRuntimeLogsComponent],
+})
+export class ApiRuntimeLogsModule {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2499

## Description

Add a Runtime Logs menu item for V4 API Only.

## Additional context

<img width="501" alt="Runtime Logs menu item for v4 " src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/934c6854-43a2-425c-88c6-4458435d1863">

**Figure 1.1** - _Runtime logs menu item_ 

<img width="1401" alt="Screenshot 2023-08-22 at 09 53 12" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/885de8ff-cc07-4b96-be69-70c5dfff1cb9">

**Figure 1.2** - _Runtime logs page - Runtime Logs tab_ 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-islxqdrycg.chromatic.com)
<!-- Storybook placeholder end -->
