### PR TITLE
test(ui):fix: amending duplicate api url and bandaid solution for flaky plans test

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
@@ -97,7 +97,7 @@ describe('API Info Page functionality', () => {
     cy.getByDataTestId('api_info_duplicate_menu').click();
     cy.getByDataTestId('api_info_duplicate_path').type(`${apiFileName}-duplicate`);
     cy.getByDataTestId('api_info_duplicate_version').type(`${apiVersion}`);
-    cy.intercept('POST', '**/duplicate').as('duplicateApi');
+    cy.intercept('POST', '**/_duplicate').as('duplicateApi');
     cy.getByDataTestId('api_info_duplicate_api').click();
     cy.wait('@duplicateApi').then((interception) => {
       expect(interception.response.statusCode).to.eq(200);

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -243,6 +243,7 @@ describe('API Plans Feature', () => {
     cy.contains(`The plan ${planName}-Keyless has been published with success.`).should('be.visible');
     cy.contains(`${planName}-Keyless`).should('not.exist');
     cy.get('[type="button"]').contains('PUBLISHED').click();
+    cy.url().should('include', '/plans?status=PUBLISHED');
     cy.contains(`${planName}-Keyless`).should('be.visible');
     cy.getByDataTestId('api_plans_deprecate_plan_button').first().click();
     cy.getByDataTestId('confirm-dialog').click();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2547

## Description

Amending /duplicate api url to reflect #4962 changes :) 

Includes tiny one line bandaid fix for plans test... Hasn't failed recently but seemed to help with the issue locally last week. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qvmbqjdtrx.chromatic.com)
<!-- Storybook placeholder end -->
