### PR TITLE
feat: add dependencies needed by @ConfigurationEvaluator annotation p…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -245,6 +245,15 @@
             <artifactId>guava</artifactId>
         </dependency>
 
+        <!--
+            Validator dependency for @ConfigurationEvaluator annotation processor (link to ARCHI-228)
+            This avoids to add this dependency in each plugin using it
+        -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-get/http-get-entrypoint-kafka-endpoint-dynamic-configuration.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-get/http-get-entrypoint-kafka-endpoint-dynamic-configuration.json
@@ -1,0 +1,90 @@
+{
+  "id": "http-get-entrypoint-kafka-endpoint-dynamic-configuration",
+  "name": "my-api-dynamic-conf",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount": 3,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "kafka",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "bootstrap-server"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["another_topic"],
+              "autoOffsetReset": "{#request.headers['X-AutoOffsetReset'][0]}"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/test",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+        {
+          "name": "Assign Attributes",
+          "description": "Assign header 'X-Topic-Override-Request-Level' as topics for kafka consumer",
+          "enabled": true,
+          "policy": "assign-attributes",
+          "condition": "{#request.headers['X-Topic-Override-Request-Level'] != null}",
+          "configuration": {
+            "scope": "REQUEST",
+            "attributes": [
+              {
+                "name": "gravitee.attributes.endpoint.kafka.consumer.topics",
+                "value": "{#request.headers['X-Topic-Override-Request-Level'][0]}"
+              }
+            ]
+          }
+        }
+      ],
+      "response": [],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>4.4.0-alpha.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>2.1.0-alpha.1</gravitee-plugin.version>
+        <gravitee-plugin.version>2.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.28.0</gravitee-reporter-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <guava.version>32.1.2-jre</guava.version>
         <hamcrest.version>1.3</hamcrest.version>
         <hazelcast.version>5.3.0</hazelcast.version>
+        <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <imageio.version>3.8.1</imageio.version>
         <java-jwt.version>3.19.1</java-jwt.version>
@@ -602,6 +603,12 @@
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast</artifactId>
                 <version>${hazelcast.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
         <gravitee-entrypoint-sse.version>4.0.2</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>2.0.2</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
-        <gravitee-endpoint-kafka.version>2.2.0</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>2.3.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.1.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>1.2.0</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.0.4</gravitee-endpoint-solace.version>


### PR DESCRIPTION
…rocessor

(avoid duplicate dependencies in each plugin using it)

## Issue

https://gravitee.atlassian.net/browse/ARCHI-228
## Description

An annotation processor has been implemented to ease the "dynamic configuration" implementation for plugins. This annotation processor generates code to add this feature but needs some dependencies to validate the configuration (the evaluator generated by the annotation processor can validate the configuration using jakarta validation bean annotation). To avoid adding this dependencies in each plugin, we choose to add them in the gateway to avoid duplication.

PR of the annotation processor: https://github.com/gravitee-io/gravitee-plugin/pull/110

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bwqqheszdj.chromatic.com)
<!-- Storybook placeholder end -->
