### PR TITLE
fix: save tenant id instead of name for endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -45,7 +45,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
   const DEFAULT_GROUP_NAME = 'default-group';
   const DEFAULT_ENDPOINT_NAME = 'endpoint#1';
   const fakeUiRouter = { go: jest.fn() };
-  const tenants = [fakeTenant({ id: 'tenant#1', name: 'tenant#1' }), fakeTenant({ id: 'tenant#2', name: 'tenant#2' })];
+  const tenants = [fakeTenant({ id: 'tenant#1', name: 'tenant#1-name' }), fakeTenant({ id: 'tenant#2', name: 'tenant#2' })];
   const currentUser = new User();
   currentUser.userPermissions = ['api-definition-u'];
 
@@ -163,6 +163,10 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
         await nameInput.setValue(newEndpointName);
         expect(await nameInput.getValue()).toEqual(newEndpointName);
 
+        const tenantsSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Endpoint tenants"]' }));
+        await tenantsSelect.clickOptions({ text: tenants[0].name });
+        expect(await tenantsSelect.getValueText()).toEqual(tenants[0].name);
+
         const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
         expect(await gioSaveBar.isSubmitButtonInvalid()).toBeFalsy();
         await gioSaveBar.clickSubmit();
@@ -181,7 +185,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   backup: false,
                   type: 'HTTP',
                   inherit: true,
-                  tenants: null,
+                  tenants: [tenants[0].id],
                   healthcheck: {
                     enabled: false,
                   },

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
@@ -70,7 +70,7 @@
       <mat-form-field class="card__group-endpoint__row__tenant__form-field" appearance="fill">
         <mat-label>Tenants</mat-label>
         <mat-select aria-label="Endpoint tenants" formControlName="tenants" multiple>
-          <mat-option *ngFor="let tenant of tenants" [value]="tenant.name">
+          <mat-option *ngFor="let tenant of tenants" [value]="tenant.id">
             <span class="card__group-endpoint__row__tenant__name" [matTooltip]="tenant.description">{{ tenant.name }}</span>
           </mat-option>
         </mat-select>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2468

## Description

When saving endpoints configuration, the tenant name was save in the api definition.
When deploying the API, the gateway was trying to match API endpoint's tenants with the configured one for the gateway.

The problem is the gateway is configured for a tenant id, while the API was referencing tenant name.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ygrziehtuy.chromatic.com)
<!-- Storybook placeholder end -->
