### PR TITLE
fix: add Default badge on default endpoint group

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
@@ -29,6 +29,7 @@
             <mat-icon svgIcon="gio:share-2"></mat-icon>
             {{ group.loadBalancerType }}
           </span>
+          <span class="gio-badge-neutral" *ngIf="i === 0"> Default </span>
         </div>
 
         <div class="endpoint-group-card__header__actions">

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.scss
@@ -33,6 +33,7 @@
       }
 
       .gio-badge-accent,
+      .gio-badge-neutral,
       .gio-badge-primary {
         margin: auto 4px auto 0;
         text-transform: unset;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2548

## Description

Add default badge on default endpoint group

![image](https://github.com/gravitee-io/gravitee-api-management/assets/13161768/824e5caa-586d-4b47-b0fb-a73cc52e3355)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wivedqnuoj.chromatic.com)
<!-- Storybook placeholder end -->
