### PR TITLE
fix(e2e): allow null plans in teardownApi

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
@@ -18,7 +18,7 @@ import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
 import { Visibility } from '@gravitee/management-webclient-sdk/src/lib/models';
 import faker from '@faker-js/faker';
 import ApiDetails from 'ui-test/support/PageObjects/Apis/ApiDetails';
-import { ApiImport } from '@model/api-imports';
+import { Api } from '@model/apis';
 
 describe('API Info Page functionality', () => {
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe('API Info Page functionality', () => {
       body: ApisFaker.apiImport({ visibility: Visibility.PUBLIC }),
     }).then((response) => {
       expect(response.status).to.eq(200);
-      api = response.body;
+      api = { ...response.body };
     });
   });
 
@@ -46,8 +46,8 @@ describe('API Info Page functionality', () => {
   const apiDescription = faker.lorem.words(10);
   const apiFileName = `${apiName.replace(/ /g, '-')}-${apiVersion}`;
   const path = require('path');
-  let api: ApiImport;
-  let duplicateApi: ApiImport;
+  let api: Api;
+  let duplicateApi: Api;
 
   it('Verify Info Page Elements', () => {
     cy.getByDataTestId('api_list_edit_button', { timeout: 5000 }).first().click();

--- a/gravitee-apim-e2e/ui-test/model/apis.ts
+++ b/gravitee-apim-e2e/ui-test/model/apis.ts
@@ -32,6 +32,7 @@ export interface Api {
   owner: string;
   workflow_state: string;
   labels?: string[];
+  plans?: Plan[];
 }
 
 export interface ApiDefinition {

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -29,11 +29,12 @@ import { ApiImportFakers } from '@fakers/api-imports';
 import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
 import { ApiImport, ImportSwaggerDescriptorEntity, ImportSwaggerDescriptorEntityType } from '@model/api-imports';
 import faker from '@faker-js/faker';
+import { Api } from '@model/apis';
 
 declare global {
   namespace Cypress {
     interface Chainable<Subject> {
-      teardownApi(api: ApiImport): void;
+      teardownApi(api: ApiImport | Api): void;
       teardownV4Api(apiId: string): void;
       createAndStartApiFromSwagger(swaggerImport: string, attributes?: Partial<ImportSwaggerDescriptorEntity>): any;
       callGateway(contextPath: string, maxRetries?: number, retryDelay?: number): any;
@@ -69,9 +70,13 @@ Cypress.Commands.add('callGateway', (contextPath, maxRetries = 5, retryDelay = 1
 
 Cypress.Commands.add('teardownApi', (api) => {
   cy.log(`----- Removing API "${api.name}" -----`);
-  cy.log(`Number of plans: ${api.plans.length}`);
-  if (api.plans.length > 0) {
-    api.plans.forEach((plan) => closePlan(ADMIN_USER, api.id, plan.id).ok());
+  const plans: any[] = [];
+  if (api.plans) {
+    plans.push(...api.plans);
+  }
+  cy.log(`Number of plans: ${plans.length}`);
+  if (plans.length > 0) {
+    plans.forEach((plan) => closePlan(ADMIN_USER, api.id, plan.id).ok());
   }
   stopApi(ADMIN_USER, api.id);
   deleteApi(ADMIN_USER, api.id).noContent();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2307

## Description

Allow null plans on API for clean-up after tests

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uaulrsoxnc.chromatic.com)
<!-- Storybook placeholder end -->
