### PR TITLE
fix: rename group to primary owner group to avoid confusion

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.html
@@ -27,7 +27,9 @@
       <mat-button-toggle-group aria-label="Select User or Group" class="card__userOrGroup__toggle-group" formControlName="userOrGroup">
         <mat-button-toggle class="card__userOrGroup__toggle" value="apiMember"> API member </mat-button-toggle>
         <mat-button-toggle class="card__userOrGroup__toggle" value="user"> Other user </mat-button-toggle>
-        <mat-button-toggle *ngIf="mode === 'HYBRID'" class="card__userOrGroup__toggle" value="group"> Group </mat-button-toggle>
+        <mat-button-toggle *ngIf="mode === 'HYBRID'" class="card__userOrGroup__toggle" value="group">
+          Primary owner group
+        </mat-button-toggle>
       </mat-button-toggle-group>
     </ng-container>
 
@@ -50,7 +52,7 @@
       </gio-banner-warning>
 
       <mat-form-field class="card__userOrGroup__field">
-        <mat-label>Select group</mat-label>
+        <mat-label>Select a primary owner group</mat-label>
         <mat-select formControlName="groupId">
           <mat-option *ngFor="let group of poGroups" [value]="group.id">{{ group.name }}</mat-option>
         </mat-select>

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/transfer-ownership/api-general-transfer-ownership.component.spec.ts
@@ -204,7 +204,7 @@ describe('ApiGeneralTransferOwnershipComponent', () => {
 
       // Select Group mode
       const userOrGroupRadio = await loader.getHarness(MatButtonToggleGroupHarness.with({ selector: '[formControlName="userOrGroup"]' }));
-      const otherUserButton = await userOrGroupRadio.getToggles({ text: 'Group' });
+      const otherUserButton = await userOrGroupRadio.getToggles({ text: 'Primary owner group' });
       await otherUserButton[0].check();
 
       // Select group


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2528

## Description

Rename group to primary owner group to avoid confusion

## Additional context

Before:
<img width="557" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/b4f3b0ea-b232-4653-9d3d-bc4f4899cda7">

After:
<img width="557" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/d48d076e-3888-447e-b712-c9f84e00c3c1">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oolychlhqd.chromatic.com)
<!-- Storybook placeholder end -->
