### PR TITLE
fix: always the same confirmation button

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.spec.ts
@@ -472,6 +472,7 @@ describe('ApiGeneralPlanListComponent', () => {
           expectGetApiPlanSubscriptionsRequest(plan.id);
 
           const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+          expect(await rootLoader.getHarness(MatButtonHarness.with({ text: 'Yes, close this plan.' }))).toBeTruthy();
           await confirmDialog.confirm();
 
           const updatedPlan: Plan = { ...plan, status: 'CLOSED' };
@@ -496,6 +497,7 @@ describe('ApiGeneralPlanListComponent', () => {
           expectGetApiPlanSubscriptionsRequest(plan.id);
 
           const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+          expect(await rootLoader.getHarness(MatButtonHarness.with({ text: 'Yes, close this plan.' }))).toBeTruthy();
           await confirmDialog.confirm();
 
           const updatedPlan: Plan = { ...plan, status: 'CLOSED' };
@@ -507,27 +509,6 @@ describe('ApiGeneralPlanListComponent', () => {
           table = await computePlansTableCells();
           expect(table.rowCells).toEqual([['There is no plan (yet).']]);
         });
-      });
-
-      it('should change delete plan button message', async () => {
-        const plan = fakePlanV2({ apiId: API_ID, name: 'key plan 🔑️', status: 'PUBLISHED', security: { type: 'API_KEY' } });
-        await initComponent([plan]);
-
-        const table = await computePlansTableCells();
-        expect(table.rowCells).toEqual([['', 'key plan 🔑️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
-
-        await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Close the plan"]' })).then((btn) => btn.click());
-
-        expectGetApiPlanSubscriptionsRequest(plan.id);
-
-        const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
-        expect(await rootLoader.getHarness(MatButtonHarness.with({ text: 'Yes, delete this plan' }))).toBeTruthy();
-        await confirmDialog.confirm();
-
-        const updatedPlan: Plan = { ...plan, status: 'CLOSED' };
-        expectApiPlanCloseRequest(updatedPlan);
-        expectApiGetRequest();
-        expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.ts
@@ -226,10 +226,6 @@ export class ApiGeneralPlanListComponent implements OnInit, OnDestroy {
               content = `There are <code>subscriptions</code> subscription(s) associated to this plan.<br/> By closing this plan, all relative active subscriptions will also be closed.`;
             }
           }
-          let confirmButton = 'Yes, close this plan.';
-          if (subscriptions.page.size === 0 && plan.security?.type === 'API_KEY') {
-            confirmButton = 'Yes, delete this plan';
-          }
           return this.matDialog
             .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
               width: '500px',
@@ -239,7 +235,7 @@ export class ApiGeneralPlanListComponent implements OnInit, OnDestroy {
                 validationMessage: `Please, type in the name of the plan <code>${plan.name}</code> to confirm.`,
                 validationValue: plan.name,
                 content,
-                confirmButton,
+                confirmButton: 'Yes, close this plan.',
               },
               role: 'alertdialog',
               id: 'closePlanDialog',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2203

## Description

Simplify the rule for the confirmation button when deleting a plan.
Always "Yes, close the plan."