### PR TITLE
Keep service discovery settings when saving changes on endpoint group configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.adapter.ts
@@ -14,21 +14,26 @@
  * limitations under the License.
  */
 
-import { ProxyGroupServiceDiscoveryConfiguration } from './edit/service-discovery/api-proxy-group-service-discovery.model';
-
 import { ProxyConfiguration, ProxyGroup, ProxyGroupLoadBalancerType } from '../../../../../entities/proxy';
 
 export const toProxyGroup = (
   group: ProxyGroup,
   generalData: { name: string; loadBalancerType: ProxyGroupLoadBalancerType },
   configuration: ProxyConfiguration,
-  serviceDiscoveryConfiguration: ProxyGroupServiceDiscoveryConfiguration,
+  serviceDiscoveryData: { enabled: boolean; provider: string; configuration: object },
 ): ProxyGroup => {
+  const discovery = {
+    enabled: serviceDiscoveryData.enabled,
+    ...(serviceDiscoveryData.enabled ? { provider: serviceDiscoveryData.provider, configuration: serviceDiscoveryData.configuration } : {}),
+  };
   let updatedGroup: ProxyGroup = {
     ...group,
     name: generalData.name,
     load_balancing: {
       type: generalData.loadBalancerType,
+    },
+    services: {
+      discovery,
     },
   };
 
@@ -41,26 +46,5 @@ export const toProxyGroup = (
       proxy: configuration.proxy,
     };
   }
-
-  if (serviceDiscoveryConfiguration) {
-    updatedGroup = {
-      ...updatedGroup,
-      services: {
-        discovery: {
-          ...serviceDiscoveryConfiguration.discovery,
-        },
-      },
-    };
-  } else {
-    updatedGroup = {
-      ...updatedGroup,
-      services: {
-        discovery: {
-          enabled: false,
-        },
-      },
-    };
-  }
-
   return updatedGroup;
 };

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.html
@@ -47,9 +47,7 @@
           *ngIf="serviceDiscoveryForm && serviceDiscoveryItems"
           [serviceDiscoveryForm]="serviceDiscoveryForm"
           [serviceDiscoveryItems]="serviceDiscoveryItems"
-          [group]="group"
           [isReadOnly]="isReadOnly"
-          (onServiceDiscoveryConfigurationChange)="onServiceDiscoveryChange($event)"
         ></api-proxy-group-service-discovery>
       </div>
     </mat-tab>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
@@ -210,6 +210,63 @@ describe('ApiProxyGroupEditComponent', () => {
       });
     });
 
+    describe('Edit general information of API with service discovery', () => {
+      let api: Api;
+
+      beforeEach(async () => {
+        api = fakeApi({
+          id: API_ID,
+          proxy: {
+            groups: [
+              {
+                name: DEFAULT_GROUP_NAME,
+                endpoints: [],
+                load_balancing: { type: 'ROUND_ROBIN' },
+                services: { discovery: { enabled: true, provider: 'consul-service-discovery' } },
+              },
+            ],
+          },
+        });
+        expectApiGetRequest(api);
+        expectConnectorRequest(connector);
+        expectServiceDiscoveryRequest(serviceDiscovery);
+        expectServiceDiscoverySchemaRequest();
+        await loader.getHarness(MatTabHarness.with({ label: 'General' })).then((tab) => tab.select());
+        fixture.detectChanges();
+      });
+
+      it('should keep service discovery info on save', async () => {
+        const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[aria-label="Group name input"]' }));
+        expect(await nameInput.getValue()).toEqual(DEFAULT_GROUP_NAME);
+
+        const newGroupName = 'new-group-name-service-discovery';
+        await nameInput.setValue(newGroupName);
+        expect(await nameInput.getValue()).toEqual(newGroupName);
+
+        const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await gioSaveBar.isSubmitButtonInvalid()).toBeFalsy();
+        await gioSaveBar.clickSubmit();
+
+        expectApiGetRequest(api);
+        const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'PUT' });
+
+        expect(req.request.body.proxy.groups).toEqual([
+          {
+            name: newGroupName,
+            endpoints: [],
+            load_balancing: { type: 'ROUND_ROBIN' },
+            services: {
+              discovery: {
+                enabled: true,
+                provider: 'consul-service-discovery',
+                configuration: {},
+              },
+            },
+          },
+        ]);
+      });
+    });
+
     describe('Edit configuration of existing group', () => {
       let api: Api;
 
@@ -319,25 +376,30 @@ describe('ApiProxyGroupEditComponent', () => {
         httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'PUT' });
       });
 
-      it('should disable select', async () => {
+      it('should disable service discovery', async () => {
         await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' })).then((slide) => slide.toggle());
 
-        expect(
-          await loader
-            .getHarness(MatSelectHarness.with({ selector: '[aria-label="Service discovery type"]' }))
-            .then((select) => select.isDisabled()),
-        ).toEqual(true);
-      });
+        expect((await loader.getAllHarnesses(MatSelectHarness.with({ selector: '[aria-label="Service discovery type"]' }))).length).toEqual(
+          0,
+        );
 
-      it('should mark the form as invalid when the service discovery is enabled but the url is not set', async () => {
-        const component = fixture.componentInstance;
-        component.onServiceDiscoveryChange({
-          isSchemaValid: false,
-          serviceDiscoveryValues: {},
-        });
+        const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await gioSaveBar.isSubmitButtonInvalid()).toBeFalsy();
+        await gioSaveBar.clickSubmit();
 
-        expect(component.groupForm.valid).toStrictEqual(false);
-        expect(await loader.getHarness(GioSaveBarHarness).then((saveBar) => saveBar.isSubmitButtonInvalid())).toEqual(true);
+        expectApiGetRequest(api);
+        const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'PUT' });
+
+        expect(req.request.body.proxy.groups).toEqual([
+          {
+            ...api.proxy.groups[0],
+            services: {
+              discovery: {
+                enabled: false,
+              },
+            },
+          },
+        ]);
       });
     });
 
@@ -512,12 +574,6 @@ describe('ApiProxyGroupEditComponent', () => {
         await loader
           .getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }))
           .then((slide) => slide.isDisabled()),
-      ).toBeTruthy();
-
-      expect(
-        await loader
-          .getHarness(MatSelectHarness.with({ selector: '[aria-label="Service discovery type"]' }))
-          .then((select) => select.isDisabled()),
       ).toBeTruthy();
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.validator.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.validator.ts
@@ -17,9 +17,9 @@ import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 export const serviceDiscoveryValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
   const enabled = control.get('enabled').value;
-  const type = control.get('type').value;
+  const provider = control.get('provider').value;
 
-  return enabled && !type ? { requireTypeWhenEnabled: true } : null;
+  return enabled && !provider ? { requireProviderWhenEnabled: true } : null;
 };
 
 export const isUniq = (values: string[], defaultValue: string): ValidatorFn | null => {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
@@ -20,31 +20,27 @@
     <gio-form-slide-toggle appearance="fill" class="card__group-sd__enable">
       <gio-form-label>Enabled service discovery</gio-form-label>
       By enabling service discovery, endpoints will be dynamically added or removed (without downtime).
-      <mat-slide-toggle
-        gioFormSlideToggle
-        formControlName="enabled"
-        aria-label="Enable service discovery"
-        name="enableServiceDiscoveryConfiguration"
-      ></mat-slide-toggle>
+      <mat-slide-toggle gioFormSlideToggle formControlName="enabled"></mat-slide-toggle>
     </gio-form-slide-toggle>
 
     <!-- Type -->
-    <div class="card__group-sd">
+    <div class="card__group-sd" *ngIf="serviceDiscoveryForm.get('enabled').value">
       <div class="card__group-sd__type__label">Type</div>
       <mat-form-field class="card__group-sd__type__form-field" appearance="fill">
         <mat-label>Type</mat-label>
-        <mat-select aria-label="Service discovery type" formControlName="type">
+        <mat-select aria-label="Service discovery type" formControlName="provider">
           <mat-option *ngFor="let sd of serviceDiscoveryItems" [value]="sd.id">{{ sd.name }}</mat-option>
         </mat-select>
       </mat-form-field>
     </div>
 
-    <div class="card__group-sd" *ngIf="displaySchema">
+    <div class="card__group-sd" *ngIf="schema">
       <gv-schema-form
         [attr.readonly]="isReadOnly ? isReadOnly : null"
         [schema]="schema"
-        [values]="group?.services?.discovery?.configuration"
         (:gv-schema-form:change)="onSchemaFormChange($event)"
+        ngDefaultControl
+        formControlName="configuration"
       ></gv-schema-form>
     </div>
   </mat-card>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2396

## Description

When saving group configuration without any modification to service discovery, service discovery data were replaced with empty data, causing backend check to fail. 
To fix that, I replaced using local variables by using a form control on the schema form component.

## Additional info

Issue did not exist on 3.19.x. 
I will try to use mergify to automatically apply this on master, but I will edit it to also use the new gio component for schema form, and hope it will fix the issue mentionned in the comment https://github.com/gravitee-io/gravitee-api-management/pull/5058#discussion_r1304321601
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-puwtrwddik.chromatic.com)
<!-- Storybook placeholder end -->
