### PR TITLE
fix: add missing tooltip on the default badge

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
@@ -29,7 +29,13 @@
             <mat-icon svgIcon="gio:share-2"></mat-icon>
             {{ group.loadBalancerType }}
           </span>
-          <span class="gio-badge-neutral" *ngIf="i === 0"> Default </span>
+          <span
+            class="gio-badge-neutral"
+            *ngIf="i === 0"
+            [matTooltip]="'The default group of endpoints used by the API is the first one listed'"
+          >
+            Default
+          </span>
         </div>
 
         <div class="endpoint-group-card__header__actions">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2565

## Description

Add the missing tooltip for the default badge

<img width="630" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/7a863f9d-4fdb-4b45-9a4b-17345411c45b">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vabiwyyirw.chromatic.com)
<!-- Storybook placeholder end -->
