### PR TITLE
 display the warning message on general condition field only when it's useful

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -217,7 +217,7 @@ const states: Ng2StateDeclaration[] = [
       useAngularMaterial: true,
       docs: null,
       apiPermissions: {
-        only: ['api-plan-u'],
+        only: ['api-plan-r'],
       },
     },
   },

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -37,8 +37,8 @@
   <ng-container *ngIf="api$ | async">
     <h2>Conditions</h2>
 
-    <gio-banner-info *ngIf="mode === 'edit'">
-      This plan is published, if you change the general conditions please remember to notify your API subscribers.
+    <gio-banner-info *ngIf="mode === 'edit' && planStatus !== 'STAGING' && generalForm.get('generalConditions').enabled">
+      This plan is {{ planStatus | lowercase }}, if you change the general conditions please remember to notify your API subscribers.
     </gio-banner-info>
 
     <mat-form-field class="generalConditions-field">

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -19,7 +19,7 @@ import { includes } from 'lodash';
 import { combineLatest, of, ReplaySubject, Subject } from 'rxjs';
 import { map, startWith, switchMap, takeUntil } from 'rxjs/operators';
 
-import { ApiV2, ApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiV2, ApiV4, PlanStatus } from '../../../../../entities/management-api-v2';
 import { CurrentUserService } from '../../../../../services-ngx/current-user.service';
 import { DocumentationService } from '../../../../../services-ngx/documentation.service';
 import { GroupService } from '../../../../../services-ngx/group.service';
@@ -49,6 +49,9 @@ export class PlanEditGeneralStepComponent implements OnInit, OnDestroy {
   // Allow to display subscriptions section when plan security is not KEY_LESS
   @Input()
   displaySubscriptionsSection = true;
+
+  @Input()
+  planStatus?: PlanStatus;
 
   conditionPages$ = this.api$.pipe(
     switchMap((api) =>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -26,6 +26,7 @@
       [api]="api"
       [mode]="mode"
       [displaySubscriptionsSection]="displaySubscriptionsSection"
+      [planStatus]="planStatus"
     ></plan-edit-general-step>
   </mat-step>
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -50,6 +50,7 @@ import {
   UpdatePlan,
   PlanMode,
   ApiType,
+  PlanStatus,
 } from '../../../../entities/management-api-v2';
 import { isApiV2FromMAPIV2 } from '../../../../util';
 import { PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
@@ -125,6 +126,9 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
 
   @Input()
   planMenuItem: PlanMenuItemVM;
+
+  @Input()
+  planStatus?: PlanStatus;
 
   public isInit = false;
 

--- a/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.html
@@ -23,7 +23,14 @@
 </div>
 <form *ngIf="planForm && planMenuItem" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
   <mat-card>
-    <api-plan-form #apiPlanForm formControlName="plan" [mode]="mode" [api]="api" [planMenuItem]="planMenuItem"></api-plan-form>
+    <api-plan-form
+      #apiPlanForm
+      formControlName="plan"
+      [mode]="mode"
+      [api]="api"
+      [planMenuItem]="planMenuItem"
+      [planStatus]="currentPlanStatus"
+    ></api-plan-form>
   </mat-card>
 
   <gio-save-bar

--- a/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.ts
@@ -48,7 +48,7 @@ export class ApiGeneralPlanEditComponent implements OnInit, OnDestroy {
 
   @ViewChild('apiPlanForm')
   private apiPlanForm: ApiPlanFormComponent;
-  private currentPlanStatus: PlanStatus;
+  public currentPlanStatus: PlanStatus;
 
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,

--- a/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.html
@@ -70,7 +70,12 @@
   <!-- Display Name Column -->
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef id="name">Name</th>
-    <td mat-cell *matCellDef="let element" class="plans__table__name" (click)="navigateToPlan(element.id)">
+    <td
+      mat-cell
+      *matCellDef="let element"
+      [class.plans__table__name]="element.status !== 'CLOSED'"
+      (click)="element.status !== 'CLOSED' && navigateToPlan(element.id)"
+    >
       {{ element.name }}
     </td>
   </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.ts
@@ -292,7 +292,7 @@ export class ApiGeneralPlanListComponent implements OnInit, OnDestroy {
           this.plansTableDS = orderBy(plans, 'order', 'asc');
           this.isLoadingData = false;
         }),
-        catchError(({ error }) => {
+        catchError((error) => {
           this.snackBarService.error(error.message);
           return of({});
         }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1957

## Description

This PR:
 - remove the ability to open a plan by clicking on its name in the list, when the plan is closed.
 - allow "editing" a plan with readonly right.
 - display the warning message on general condition field only when it's useful:
   - staging => No, because no subscription has been made, so we can still change the General condition without any impact
   - published & deprecated => Yes, and the message is adapted according to the status
   - closed => It shouldn't be displayed since there is no possibility to edit a closed plan
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hdbsrtffxj.chromatic.com)
<!-- Storybook placeholder end -->
