### PR TITLE
fix: map sampling in API V4 analytics

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.rest.api.management.v2.rest.model.Sampling;
+import org.mapstruct.Mapper;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
+import org.mapstruct.Mapping;
+import org.mapstruct.ValueMapping;
+
+@Mapper
+public interface AnalyticsMapper {
+
+    @Mapping(target = "sampling", source = "messageSampling")
+    Analytics toAnalytics(io.gravitee.definition.model.v4.analytics.Analytics analytics);
+
+    @Mapping(target = "messageSampling", source = "sampling")
+    io.gravitee.definition.model.v4.analytics.Analytics fromAnalytics(Analytics analytics);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 @Mapper(
     uses = {
+        AnalyticsMapper.class,
         DateMapper.class,
         DefinitionContextMapper.class,
         EndpointMapper.class,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -4205,7 +4205,6 @@ components:
                         - PROBABILITY
                         - TEMPORAL
                         - COUNT
-                        - QUERY
                 value:
                     type: string
                     description: The value of the sampling

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsFixtures.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures;
+
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.sampling.Sampling;
+import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+
+public class AnalyticsFixtures {
+
+    private AnalyticsFixtures() {}
+
+    public static Analytics anAnalytics() {
+        final Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        final Sampling sampling = new Sampling();
+        sampling.setType(SamplingType.COUNT);
+        sampling.setValue("10");
+        analytics.setMessageSampling(sampling);
+        analytics.setLogging(new Logging());
+        return analytics;
+    }
+
+    public static io.gravitee.rest.api.management.v2.rest.model.Analytics aBasicAnalytics() {
+        final io.gravitee.rest.api.management.v2.rest.model.Analytics analytics = new io.gravitee.rest.api.management.v2.rest.model.Analytics();
+        analytics.setEnabled(true);
+        final io.gravitee.rest.api.management.v2.rest.model.Sampling sampling = new io.gravitee.rest.api.management.v2.rest.model.Sampling();
+        sampling.setType(io.gravitee.rest.api.management.v2.rest.model.Sampling.TypeEnum.COUNT);
+        sampling.setValue("10");
+        analytics.setSampling(sampling);
+        analytics.setLogging(new io.gravitee.rest.api.management.v2.rest.model.LoggingV4());
+        return analytics;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapperTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import fixtures.AnalyticsFixtures;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.rest.api.management.v2.rest.model.Sampling;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class AnalyticsMapperTest {
+
+    private final AnalyticsMapper analyticsMapper = Mappers.getMapper(AnalyticsMapper.class);
+
+    @Test
+    void shouldMapDefinitionModelToRestModel() {
+        Analytics analytics = AnalyticsFixtures.anAnalytics();
+        var mappedAnalytics = analyticsMapper.toAnalytics(analytics);
+        assertThat(mappedAnalytics).isNotNull();
+        assertThat(mappedAnalytics.getEnabled()).isEqualTo(analytics.isEnabled());
+        assertThat(mappedAnalytics.getSampling()).isNotNull();
+        assertThat("10").isEqualTo(mappedAnalytics.getSampling().getValue());
+        assertThat(Sampling.TypeEnum.COUNT).isEqualTo(mappedAnalytics.getSampling().getType());
+        assertThat(mappedAnalytics.getLogging()).isNotNull();
+    }
+
+    @Test
+    void shouldMapRestModelToDefinitionModel() {
+        io.gravitee.rest.api.management.v2.rest.model.Analytics analytics = AnalyticsFixtures.aBasicAnalytics();
+        var mappedAnalytics = analyticsMapper.fromAnalytics(analytics);
+        assertThat(mappedAnalytics).isNotNull();
+        assertThat(mappedAnalytics.isEnabled()).isEqualTo(analytics.getEnabled());
+        assertThat(mappedAnalytics.getMessageSampling()).isNotNull();
+        assertThat("10").isEqualTo(mappedAnalytics.getMessageSampling().getValue());
+        assertThat(Sampling.TypeEnum.COUNT.toString()).isEqualTo(mappedAnalytics.getMessageSampling().getType().toString());
+        assertThat(mappedAnalytics.getLogging()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2471

## Description

Map sampling. Currently we lose the sampling when we get or export an API. 
When saving an API the sampling is ignored and when can only have the default settings if we use the rest API V2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-muntkkcakm.chromatic.com)
<!-- Storybook placeholder end -->
