### PR TITLE
refactor: make Pagination total a long

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
@@ -22,7 +22,7 @@ public class PaginationInfo {
 
     private PaginationInfo() {}
 
-    public static Pagination computePaginationInfo(Integer totalCount, Integer pageItemsCount, PaginationParam paginationParam) {
+    public static Pagination computePaginationInfo(long totalCount, Integer pageItemsCount, PaginationParam paginationParam) {
         Pagination pagination = new Pagination();
         if (totalCount > 0) {
             pagination

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.pagination;
+
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+
+public class PaginationInfo {
+
+    private PaginationInfo() {}
+
+    public static Pagination computePaginationInfo(Integer totalCount, Integer pageItemsCount, PaginationParam paginationParam) {
+        Pagination pagination = new Pagination();
+        if (paginationParam.getPerPage() > 0 && totalCount > 0) {
+            pagination
+                .page(paginationParam.getPage())
+                .perPage(paginationParam.getPerPage())
+                .pageItemsCount(pageItemsCount)
+                .pageCount((int) Math.ceil((double) totalCount / paginationParam.getPerPage()))
+                .totalCount(totalCount);
+        }
+        return pagination;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfo.java
@@ -24,7 +24,7 @@ public class PaginationInfo {
 
     public static Pagination computePaginationInfo(Integer totalCount, Integer pageItemsCount, PaginationParam paginationParam) {
         Pagination pagination = new Pagination();
-        if (paginationParam.getPerPage() > 0 && totalCount > 0) {
+        if (totalCount > 0) {
             pagination
                 .page(paginationParam.getPage())
                 .perPage(paginationParam.getPerPage())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.pagination;
+
+import io.gravitee.rest.api.management.v2.rest.model.Links;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+
+public class PaginationLinks {
+
+    private PaginationLinks() {}
+
+    public static Links computePaginationLinks(
+        URI requestUri,
+        MultivaluedMap<String, String> queryParameters,
+        int totalElements,
+        PaginationParam paginationParam
+    ) {
+        if (totalElements == 0) {
+            return null;
+        }
+
+        int totalPages = (int) Math.ceil((double) totalElements / paginationParam.getPerPage());
+        if (totalPages == 1) {
+            return new Links().self(requestUri.toString());
+        }
+
+        if (paginationParam.getPage() <= 0 || paginationParam.getPage() > totalPages) {
+            return null;
+        }
+
+        final String pageToken = "{page}";
+        final String perPageToken = "{perPage}";
+        String linkTemplate = requestUri.toString();
+
+        if (queryParameters.isEmpty()) {
+            linkTemplate += "?" + PaginationParam.PAGE_QUERY_PARAM_NAME + "=" + pageToken;
+        } else {
+            final String queryPage = queryParameters.getFirst(PaginationParam.PAGE_QUERY_PARAM_NAME);
+            final String queryPerPage = queryParameters.getFirst(PaginationParam.PER_PAGE_QUERY_PARAM_NAME);
+
+            if (queryPage != null) {
+                linkTemplate =
+                    linkTemplate.replaceFirst(
+                        PaginationParam.PAGE_QUERY_PARAM_NAME + "=(\\w*)",
+                        PaginationParam.PAGE_QUERY_PARAM_NAME + "=" + pageToken
+                    );
+            } else {
+                linkTemplate += "&" + PaginationParam.PAGE_QUERY_PARAM_NAME + "=" + pageToken;
+            }
+            if (queryPerPage != null) {
+                linkTemplate =
+                    linkTemplate.replaceFirst(
+                        PaginationParam.PER_PAGE_QUERY_PARAM_NAME + "=(\\w*)",
+                        PaginationParam.PER_PAGE_QUERY_PARAM_NAME + "=" + perPageToken
+                    );
+            }
+        }
+
+        Integer firstPage = 1;
+        Integer lastPage = totalPages;
+        Integer nextPage = Math.min(paginationParam.getPage() + 1, lastPage);
+        Integer prevPage = Math.max(firstPage, paginationParam.getPage() - 1);
+        String perPageAsString = String.valueOf(paginationParam.getPerPage());
+        Links paginatedLinks = new Links()
+            .first(linkTemplate.replace(pageToken, String.valueOf(firstPage)).replace(perPageToken, perPageAsString))
+            .last(linkTemplate.replace(pageToken, String.valueOf(lastPage)).replace(perPageToken, perPageAsString))
+            .next(linkTemplate.replace(pageToken, String.valueOf(nextPage)).replace(perPageToken, perPageAsString))
+            .previous(linkTemplate.replace(pageToken, String.valueOf(prevPage)).replace(perPageToken, perPageAsString))
+            .self(requestUri.toString());
+
+        if (paginationParam.getPage() == 1) {
+            paginatedLinks.setPrevious(null);
+        } else if (paginationParam.getPage().equals(totalPages)) {
+            paginatedLinks.setNext(null);
+        }
+        return paginatedLinks;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
@@ -27,7 +27,7 @@ public class PaginationLinks {
     public static Links computePaginationLinks(
         URI requestUri,
         MultivaluedMap<String, String> queryParameters,
-        int totalElements,
+        long totalElements,
         PaginationParam paginationParam
     ) {
         if (totalElements == 0) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinks.java
@@ -30,12 +30,8 @@ public class PaginationLinks {
         long totalElements,
         PaginationParam paginationParam
     ) {
-        if (totalElements == 0) {
-            return null;
-        }
-
         int totalPages = (int) Math.ceil((double) totalElements / paginationParam.getPerPage());
-        if (totalPages == 1) {
+        if (totalElements == 0 || totalPages == 1) {
             return new Links().self(requestUri.toString());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
@@ -21,7 +21,6 @@ import static io.gravitee.rest.api.model.MembershipReferenceType.GROUP;
 
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
-import io.gravitee.rest.api.management.v2.rest.model.Pagination;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.RoleEntity;
@@ -43,9 +42,21 @@ import io.gravitee.rest.api.service.exceptions.PreconditionFailedException;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import jakarta.inject.Inject;
-import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.glassfish.jersey.message.internal.HttpHeaderReader;
@@ -272,19 +283,6 @@ public abstract class AbstractResource {
             throw new PaginationInvalidException();
         }
         return new ArrayList<>(list).subList(startIndex, lastIndex);
-    }
-
-    protected Pagination computePaginationInfo(Integer totalCount, Integer pageItemsCount, PaginationParam paginationParam) {
-        Pagination pagination = new Pagination();
-        if (paginationParam.getPerPage() > 0 && totalCount > 0) {
-            pagination
-                .page(paginationParam.getPage())
-                .perPage(paginationParam.getPerPage())
-                .pageItemsCount(pageItemsCount)
-                .pageCount((int) Math.ceil((double) totalCount / paginationParam.getPerPage()))
-                .totalCount(totalCount);
-        }
-        return pagination;
     }
 
     protected Links computePaginationLinks(int totalElements, PaginationParam paginationParam) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
@@ -285,7 +285,7 @@ public abstract class AbstractResource {
         return new ArrayList<>(list).subList(startIndex, lastIndex);
     }
 
-    protected Links computePaginationLinks(int totalElements, PaginationParam paginationParam) {
+    protected Links computePaginationLinks(long totalElements, PaginationParam paginationParam) {
         return PaginationLinks.computePaginationLinks(
             uriInfo.getRequestUri(),
             uriInfo.getQueryParameters(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResource.java
@@ -64,7 +64,7 @@ public class ApiLogsResource extends AbstractResource {
                         .build()
                 )
             )
-            .pagination(PaginationInfo.computePaginationInfo(1, 1, paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo(1L, 1, paginationParam))
             .links(computePaginationLinks(1, paginationParam))
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLog;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLogsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.BasePlan;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
@@ -63,7 +64,7 @@ public class ApiLogsResource extends AbstractResource {
                         .build()
                 )
             )
-            .pagination(computePaginationInfo(1, 1, paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo(1, 1, paginationParam))
             .links(computePaginationLinks(1, paginationParam))
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.management.v2.rest.model.AddApiMember;
 import io.gravitee.rest.api.management.v2.rest.model.Member;
 import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiMember;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
@@ -69,7 +70,7 @@ public class ApiMembersResource extends AbstractResource {
 
         return new MembersResponse()
             .data(membersSubList)
-            .pagination(computePaginationInfo(members.size(), membersSubList.size(), paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo(members.size(), membersSubList.size(), paginationParam))
             .links(computePaginationLinks(members.size(), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResource.java
@@ -70,7 +70,7 @@ public class ApiMembersResource extends AbstractResource {
 
         return new MembersResponse()
             .data(membersSubList)
-            .pagination(PaginationInfo.computePaginationInfo(members.size(), membersSubList.size(), paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo((long) members.size(), membersSubList.size(), paginationParam))
             .links(computePaginationLinks(members.size(), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.PlanMapper;
 import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
@@ -112,7 +113,7 @@ public class ApiPlansResource extends AbstractResource {
 
         return new PlansResponse()
             .data(planMapper.convert(paginationData))
-            .pagination(computePaginationInfo(plans.size(), paginationData.size(), paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo(plans.size(), paginationData.size(), paginationParam))
             .links(computePaginationLinks(plans.size(), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -113,7 +113,7 @@ public class ApiPlansResource extends AbstractResource {
 
         return new PlansResponse()
             .data(planMapper.convert(paginationData))
-            .pagination(PaginationInfo.computePaginationInfo(plans.size(), paginationData.size(), paginationParam))
+            .pagination(PaginationInfo.computePaginationInfo((long) plans.size(), paginationData.size(), paginationParam))
             .links(computePaginationLinks(plans.size(), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.management.v2.rest.model.SubscribersResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApi;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.LifecycleAction;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
@@ -511,15 +512,11 @@ public class ApiResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
+        Integer totalCount = Math.toIntExact(subscribersApplicationPage.getTotalElements());
+        Integer pageItemsCount = Math.toIntExact(subscribersApplicationPage.getPageElements());
         return new SubscribersResponse()
             .data(ApplicationMapper.INSTANCE.mapToBaseApplicationList(subscribersApplicationPage.getContent()))
-            .pagination(
-                computePaginationInfo(
-                    Math.toIntExact(subscribersApplicationPage.getTotalElements()),
-                    Math.toIntExact(subscribersApplicationPage.getPageElements()),
-                    paginationParam
-                )
-            )
+            .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
             .links(computePaginationLinks(Math.toIntExact(subscribersApplicationPage.getTotalElements()), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -512,12 +512,12 @@ public class ApiResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
-        Integer totalCount = Math.toIntExact(subscribersApplicationPage.getTotalElements());
+        long totalCount = subscribersApplicationPage.getTotalElements();
         Integer pageItemsCount = Math.toIntExact(subscribersApplicationPage.getPageElements());
         return new SubscribersResponse()
             .data(ApplicationMapper.INSTANCE.mapToBaseApplicationList(subscribersApplicationPage.getContent()))
             .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
-            .links(computePaginationLinks(Math.toIntExact(subscribersApplicationPage.getTotalElements()), paginationParam));
+            .links(computePaginationLinks(totalCount, paginationParam));
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -110,12 +110,12 @@ public class ApiSubscriptionsResource extends AbstractResource {
         final List<Subscription> subscriptions = subscriptionMapper.mapToList(subscriptionPage.getContent());
         expandData(subscriptions, expands);
 
-        Integer totalCount = Math.toIntExact(subscriptionPage.getTotalElements());
+        long totalCount = subscriptionPage.getTotalElements();
         Integer pageItemsCount = Math.toIntExact(subscriptionPage.getPageElements());
         return new SubscriptionsResponse()
             .data(subscriptions)
             .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
-            .links(computePaginationLinks(Math.toIntExact(subscriptionPage.getTotalElements()), paginationParam));
+            .links(computePaginationLinks(totalCount, paginationParam));
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.*;
 import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.SubscriptionStatus;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
@@ -109,15 +110,11 @@ public class ApiSubscriptionsResource extends AbstractResource {
         final List<Subscription> subscriptions = subscriptionMapper.mapToList(subscriptionPage.getContent());
         expandData(subscriptions, expands);
 
+        Integer totalCount = Math.toIntExact(subscriptionPage.getTotalElements());
+        Integer pageItemsCount = Math.toIntExact(subscriptionPage.getPageElements());
         return new SubscriptionsResponse()
             .data(subscriptions)
-            .pagination(
-                computePaginationInfo(
-                    Math.toIntExact(subscriptionPage.getTotalElements()),
-                    Math.toIntExact(subscriptionPage.getPageElements()),
-                    paginationParam
-                )
-            )
+            .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
             .links(computePaginationLinks(Math.toIntExact(subscriptionPage.getTotalElements()), paginationParam));
     }
 
@@ -486,7 +483,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .ok(
                 new SubscriptionApiKeysResponse()
                     .data(apiKeysSubList)
-                    .pagination(computePaginationInfo(apiKeys.size(), apiKeysSubList.size(), paginationParam))
+                    .pagination(PaginationInfo.computePaginationInfo(apiKeys.size(), apiKeysSubList.size(), paginationParam))
                     .links(computePaginationLinks(apiKeys.size(), paginationParam))
             )
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -103,7 +103,7 @@ public class ApisResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
-        Integer totalCount = Math.toIntExact(apis.getTotalElements());
+        long totalCount = apis.getTotalElements();
         Integer pageItemsCount = Math.toIntExact(apis.getPageElements());
         return new ApisResponse()
             .data(
@@ -119,7 +119,7 @@ public class ApisResource extends AbstractResource {
                 )
             )
             .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
-            .links(computePaginationLinks(Math.toIntExact(apis.getTotalElements()), paginationParam));
+            .links(computePaginationLinks(totalCount, paginationParam));
     }
 
     @POST
@@ -196,7 +196,7 @@ public class ApisResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
-        Integer totalCount = Math.toIntExact(apis.getTotalElements());
+        long totalCount = apis.getTotalElements();
         Integer pageItemsCount = Math.toIntExact(apis.getPageElements());
         return new ApisResponse()
             .data(
@@ -212,7 +212,7 @@ public class ApisResource extends AbstractResource {
                 )
             )
             .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
-            .links(computePaginationLinks(Math.toIntExact(apis.getTotalElements()), paginationParam));
+            .links(computePaginationLinks(totalCount, paginationParam));
     }
 
     @Path("{apiId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.ImportExportApiMapper;
 import io.gravitee.rest.api.management.v2.rest.model.*;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.ApiSortByParam;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
@@ -49,10 +50,9 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Objects;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -103,6 +103,8 @@ public class ApisResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
+        Integer totalCount = Math.toIntExact(apis.getTotalElements());
+        Integer pageItemsCount = Math.toIntExact(apis.getPageElements());
         return new ApisResponse()
             .data(
                 ApiMapper.INSTANCE.map(
@@ -116,9 +118,7 @@ public class ApisResource extends AbstractResource {
                     }
                 )
             )
-            .pagination(
-                computePaginationInfo(Math.toIntExact(apis.getTotalElements()), Math.toIntExact(apis.getPageElements()), paginationParam)
-            )
+            .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
             .links(computePaginationLinks(Math.toIntExact(apis.getTotalElements()), paginationParam));
     }
 
@@ -196,6 +196,8 @@ public class ApisResource extends AbstractResource {
             paginationParam.toPageable()
         );
 
+        Integer totalCount = Math.toIntExact(apis.getTotalElements());
+        Integer pageItemsCount = Math.toIntExact(apis.getPageElements());
         return new ApisResponse()
             .data(
                 ApiMapper.INSTANCE.map(
@@ -209,9 +211,7 @@ public class ApisResource extends AbstractResource {
                     }
                 )
             )
-            .pagination(
-                computePaginationInfo(Math.toIntExact(apis.getTotalElements()), Math.toIntExact(apis.getPageElements()), paginationParam)
-            )
+            .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
             .links(computePaginationLinks(Math.toIntExact(apis.getTotalElements()), paginationParam));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResource.java
@@ -20,26 +20,22 @@ import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
 import io.gravitee.rest.api.management.v2.rest.model.GroupsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.Member;
 import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
 import io.gravitee.rest.api.management.v2.rest.security.Permissions;
 import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.model.GroupSimpleEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
-import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.*;
-import jakarta.ws.rs.container.ResourceContext;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
-
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -47,6 +43,7 @@ import java.util.stream.Collectors;
 
 @Path("/environments/{envId}/groups")
 public class GroupsResource extends AbstractResource {
+
     @Inject
     private GroupService groupService;
 
@@ -54,16 +51,16 @@ public class GroupsResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = { RolePermissionAction.READ })})
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = { RolePermissionAction.READ }) })
     public GroupsResponse listGroups(@BeanParam @Valid PaginationParam paginationParam) {
         List<GroupEntity> groups = groupService.findAll(GraviteeContext.getExecutionContext());
 
         List<GroupEntity> groupsSubset = computePaginationData(groups, paginationParam);
 
         return new GroupsResponse()
-                .data(mapper.map(groupsSubset))
-                .pagination(computePaginationInfo(groups.size(), groupsSubset.size(), paginationParam))
-                .links(computePaginationLinks(groups.size(), paginationParam));
+            .data(mapper.map(groupsSubset))
+            .pagination(PaginationInfo.computePaginationInfo(groups.size(), groupsSubset.size(), paginationParam))
+            .links(computePaginationLinks(groups.size(), paginationParam));
     }
 
     @GET
@@ -79,18 +76,18 @@ public class GroupsResource extends AbstractResource {
         metadata.put("groupName", groupEntity.getName());
 
         var members = membershipService
-                .getMembersByReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.GROUP, groupId)
-                .stream()
-                .map(MemberMapper.INSTANCE::map)
-                .sorted(Comparator.comparing(Member::getId))
-                .collect(Collectors.toList());
+            .getMembersByReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.GROUP, groupId)
+            .stream()
+            .map(MemberMapper.INSTANCE::map)
+            .sorted(Comparator.comparing(Member::getId))
+            .collect(Collectors.toList());
 
         List<Member> membersSubset = computePaginationData(members, paginationParam);
 
         return new MembersResponse()
-                .data(membersSubset)
-                .pagination(computePaginationInfo(members.size(), membersSubset.size(), paginationParam))
-                .links(computePaginationLinks(members.size(), paginationParam))
-                .metadata(metadata);
+            .data(membersSubset)
+            .pagination(PaginationInfo.computePaginationInfo(members.size(), membersSubset.size(), paginationParam))
+            .links(computePaginationLinks(members.size(), paginationParam))
+            .metadata(metadata);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
@@ -19,7 +19,15 @@ import io.gravitee.rest.api.model.common.PageableImpl;
 import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class PaginationParam {
 
     public static final String PAGE_QUERY_PARAM_NAME = "page";
@@ -37,22 +45,6 @@ public class PaginationParam {
     @QueryParam(PER_PAGE_QUERY_PARAM_NAME)
     @Min(value = 1, message = "Pagination perPage param must be >= 1")
     Integer perPage;
-
-    public Integer getPage() {
-        return page;
-    }
-
-    public void setPage(Integer page) {
-        this.page = page;
-    }
-
-    public Integer getPerPage() {
-        return perPage;
-    }
-
-    public void setPerPage(Integer perPage) {
-        this.perPage = perPage;
-    }
 
     public io.gravitee.rest.api.model.common.Pageable toPageable() {
         return new PageableImpl(this.getPage(), this.getPerPage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
@@ -24,7 +24,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -45,6 +44,13 @@ public class PaginationParam {
     @QueryParam(PER_PAGE_QUERY_PARAM_NAME)
     @Min(value = 1, message = "Pagination perPage param must be >= 1")
     Integer perPage;
+
+    public PaginationParam(Integer page, Integer perPage) {
+        if (perPage < 1) throw new IllegalArgumentException("Pagination perPage param must be >= 1");
+
+        this.page = page;
+        this.perPage = perPage;
+    }
 
     public io.gravitee.rest.api.model.common.Pageable toPageable() {
         return new PageableImpl(this.getPage(), this.getPerPage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -3206,6 +3206,7 @@ components:
                     description: The number of items for the current page.
                 totalCount:
                     type: integer
+                    format: int64
                     description: The total number of items.
 
         PathV4:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.pagination;
+
+import static io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo.computePaginationInfo;
+
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class PaginationInfoTest {
+
+    @Test
+    void should_build_pagination_info() {
+        var total = 20;
+        var pageItemsCount = 10;
+        var page = 2;
+        var perPage = 5;
+
+        var pagination = computePaginationInfo(total, pageItemsCount, new PaginationParam(page, perPage));
+
+        Assertions
+            .assertThat(pagination)
+            .isEqualTo(
+                Pagination.builder().page(page).perPage(perPage).totalCount(total).pageItemsCount(pageItemsCount).pageCount(4).build()
+            );
+    }
+
+    @Test
+    void should_return_empty_pagination_when_no_result() {
+        var total = 0;
+        var pageItemsCount = 0;
+        var page = 1;
+        var perPage = 5;
+
+        var pagination = computePaginationInfo(total, pageItemsCount, new PaginationParam(page, perPage));
+
+        Assertions.assertThat(pagination).isEqualTo(new Pagination());
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = "|",
+        textBlock = """
+        # TOTAL | PER_PAGE | EXPECTED_PAGE_COUNT
+        20      | 5        | 4
+        25      | 9        | 3
+        5       | 20       | 1
+        """
+    )
+    void should_count_pages_based_on_total_and_provided_pagination_param(Integer total, Integer perPage, Integer expectedPageCount) {
+        var pagination = computePaginationInfo(total, 10, new PaginationParam(1, perPage));
+
+        Assertions.assertThat(pagination).extracting(Pagination::getPageCount).isEqualTo(expectedPageCount);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationInfoTest.java
@@ -28,7 +28,7 @@ public class PaginationInfoTest {
 
     @Test
     void should_build_pagination_info() {
-        var total = 20;
+        var total = 20L;
         var pageItemsCount = 10;
         var page = 2;
         var perPage = 5;
@@ -44,7 +44,7 @@ public class PaginationInfoTest {
 
     @Test
     void should_return_empty_pagination_when_no_result() {
-        var total = 0;
+        var total = 0L;
         var pageItemsCount = 0;
         var page = 1;
         var perPage = 5;
@@ -64,7 +64,7 @@ public class PaginationInfoTest {
         5       | 20       | 1
         """
     )
-    void should_count_pages_based_on_total_and_provided_pagination_param(Integer total, Integer perPage, Integer expectedPageCount) {
+    void should_count_pages_based_on_total_and_provided_pagination_param(Long total, Integer perPage, Integer expectedPageCount) {
         var pagination = computePaginationInfo(total, 10, new PaginationParam(1, perPage));
 
         Assertions.assertThat(pagination).extracting(Pagination::getPageCount).isEqualTo(expectedPageCount);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
@@ -34,13 +34,13 @@ public class PaginationLinksTest {
     private static final MultivaluedMap<String, String> NO_QUERY_PARAMETERS = new MultivaluedHashMap<>();
 
     @Test
-    void should_return_null_when_no_result() {
+    void should_build_only_self_link_when_no_result() {
         int total = 0;
         int perPage = 10;
 
         var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
 
-        assertThat(result).isNull();
+        assertThat(result).isEqualTo(Links.builder().self(REQUEST_URI.toString()).build());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/pagination/PaginationLinksTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.pagination;
+
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.management.v2.rest.model.Links;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class PaginationLinksTest {
+
+    private static final URI REQUEST_URI = URI.create("http://localhost:8083/management/path");
+    private static final MultivaluedMap<String, String> NO_QUERY_PARAMETERS = new MultivaluedHashMap<>();
+
+    @Test
+    void should_return_null_when_no_result() {
+        int total = 0;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void should_build_only_self_link_when_only_one_page() {
+        int total = 5;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
+
+        assertThat(result).isEqualTo(Links.builder().self(REQUEST_URI.toString()).build());
+    }
+
+    @Test
+    void should_build_links_when_displaying_the_1st_page_with_default_per_page_param() {
+        int total = 35;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(1, perPage));
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI.toString())
+                    .first(REQUEST_URI + "?page=1")
+                    .next(REQUEST_URI + "?page=2")
+                    .last(REQUEST_URI + "?page=4")
+                    .build()
+            );
+    }
+
+    @Test
+    void should_build_links_when_displaying_the_1st_page_with_provided_per_page_param() {
+        int total = 35;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(
+            URI.create(REQUEST_URI + "?perPage=" + perPage),
+            new MultivaluedHashMap<>(ofEntries(entry(PaginationParam.PER_PAGE_QUERY_PARAM_NAME, String.valueOf(perPage)))),
+            total,
+            new PaginationParam(1, perPage)
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI + "?perPage=10")
+                    .first(REQUEST_URI + "?perPage=10&page=1")
+                    .next(REQUEST_URI + "?perPage=10&page=2")
+                    .last(REQUEST_URI + "?perPage=10&page=4")
+                    .build()
+            );
+    }
+
+    @Test
+    void should_build_links_when_displaying_the_1st_page_when_explicitly_requested() {
+        int total = 35;
+        int page = 1;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(
+            URI.create(REQUEST_URI + "?page=" + page),
+            new MultivaluedHashMap<>(ofEntries(entry(PaginationParam.PAGE_QUERY_PARAM_NAME, String.valueOf(page)))),
+            total,
+            new PaginationParam(page, perPage)
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI + "?page=1")
+                    .first(REQUEST_URI + "?page=1")
+                    .next(REQUEST_URI + "?page=2")
+                    .last(REQUEST_URI + "?page=4")
+                    .build()
+            );
+    }
+
+    @Test
+    void should_build_links_when_displaying_a_page() {
+        int total = 35;
+        int page = 2;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(
+            URI.create(REQUEST_URI + "?page=" + page),
+            new MultivaluedHashMap<>(ofEntries(entry(PaginationParam.PAGE_QUERY_PARAM_NAME, String.valueOf(page)))),
+            total,
+            new PaginationParam(page, perPage)
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI + "?page=2")
+                    .first(REQUEST_URI + "?page=1")
+                    .next(REQUEST_URI + "?page=3")
+                    .previous(REQUEST_URI + "?page=1")
+                    .last(REQUEST_URI + "?page=4")
+                    .build()
+            );
+    }
+
+    @Test
+    void should_build_links_when_displaying_last_page() {
+        int total = 35;
+        int page = 4;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(
+            URI.create(REQUEST_URI + "?page=" + page),
+            new MultivaluedHashMap<>(ofEntries(entry(PaginationParam.PAGE_QUERY_PARAM_NAME, String.valueOf(page)))),
+            total,
+            new PaginationParam(page, perPage)
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI + "?page=4")
+                    .first(REQUEST_URI + "?page=1")
+                    .previous(REQUEST_URI + "?page=3")
+                    .last(REQUEST_URI + "?page=4")
+                    .build()
+            );
+    }
+
+    @Test
+    void should_keep_perPage_query_param_when_provided() {
+        int total = 35;
+        int page = 2;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(
+            URI.create(REQUEST_URI + "?page=" + page + "&perPage=" + perPage),
+            new MultivaluedHashMap<>(
+                ofEntries(
+                    entry(PaginationParam.PAGE_QUERY_PARAM_NAME, String.valueOf(page)),
+                    entry(PaginationParam.PER_PAGE_QUERY_PARAM_NAME, String.valueOf(perPage))
+                )
+            ),
+            total,
+            new PaginationParam(page, perPage)
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                Links
+                    .builder()
+                    .self(REQUEST_URI + "?page=2&perPage=10")
+                    .first(REQUEST_URI + "?page=1&perPage=10")
+                    .next(REQUEST_URI + "?page=3&perPage=10")
+                    .previous(REQUEST_URI + "?page=1&perPage=10")
+                    .last(REQUEST_URI + "?page=4&perPage=10")
+                    .build()
+            );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 55 })
+    void should_return_null_on_invalid_situation(int page) {
+        int total = 35;
+        int perPage = 10;
+
+        var result = PaginationLinks.computePaginationLinks(REQUEST_URI, NO_QUERY_PARAMETERS, total, new PaginationParam(page, perPage));
+
+        assertThat(result).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -101,7 +101,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                                 .build()
                         )
                     )
-                    .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1).build())
+                    .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
                     .links(Links.builder().self(target.getUri().toString()).build())
                     .build()
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiMembersResourceTest.java
@@ -179,7 +179,7 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
                 .isEqualTo(
                     MembersResponse
                         .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).totalCount(1).pageItemsCount(1).build())
+                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1).build())
                         .data(Stream.of(member).map(MemberMapper.INSTANCE::map).toList())
                         .links(Links.builder().self(target.getUri().toString()).build())
                         .build()
@@ -246,7 +246,7 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
                 .isEqualTo(
                     MembersResponse
                         .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(2).perPage(2).totalCount(4).pageItemsCount(2).build())
+                        .pagination(Pagination.builder().page(1).pageCount(2).perPage(2).totalCount(4L).pageItemsCount(2).build())
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .links(
                             Links

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -172,7 +172,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .isEqualTo(
                     PlansResponse
                         .builder()
-                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2).pageCount(1).build())
+                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
                         .data(
                             Stream
                                 .of(plan3, plan1)
@@ -236,7 +236,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
                 .isEqualTo(
                     PlansResponse
                         .builder()
-                        .pagination(Pagination.builder().page(1).perPage(1).pageItemsCount(1).totalCount(2).pageCount(2).build())
+                        .pagination(Pagination.builder().page(1).perPage(1).pageItemsCount(1).totalCount(2L).pageCount(2).build())
                         .data(
                             Stream
                                 .of(plan1)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -152,7 +152,14 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(PlansResponse.class)
-                .isEqualTo(PlansResponse.builder().pagination(Pagination.builder().build()).data(List.of()).build());
+                .isEqualTo(
+                    PlansResponse
+                        .builder()
+                        .pagination(Pagination.builder().build())
+                        .data(List.of())
+                        .links(Links.builder().self(target.getUri().toString()).build())
+                        .build()
+                );
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListApiKeysTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListApiKeysTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import assertions.MAPIAssertions;
 import fixtures.SubscriptionFixtures;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
@@ -80,7 +81,7 @@ public class ApiSubscriptionsResource_ListApiKeysTest extends ApiSubscriptionsRe
 
         // Check links
         Links links = subscriptionApiKeysResponse.getLinks();
-        assertNull(links);
+        MAPIAssertions.assertThat(links).isEqualTo(Links.builder().self(rootTarget().getUri().toString()).build());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ListTest.java
@@ -18,6 +18,8 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import assertions.MAPIAssertions;
 import fixtures.ApplicationFixtures;
 import fixtures.PlanFixtures;
 import fixtures.SubscriptionFixtures;
@@ -80,7 +83,7 @@ public class ApiSubscriptionsResource_ListTest extends ApiSubscriptionsResourceT
 
         // Check links
         Links links = subscriptionsResponse.getLinks();
-        assertNull(links);
+        MAPIAssertions.assertThat(links).isEqualTo(Links.builder().self(rootTarget().getUri().toString()).build());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -173,7 +173,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                     GroupsResponse
                         .builder()
                         .data(Stream.of(group1, group2).map(GroupMapper.INSTANCE::map).toList())
-                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2).build())
+                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L).build())
                         .links(Links.builder().self(target.getUri().toString()).build())
                         .build()
                 );
@@ -265,7 +265,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .isEqualTo(
                     MembersResponse
                         .builder()
-                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2).build())
+                        .pagination(Pagination.builder().page(1).pageCount(1).perPage(10).pageItemsCount(2).totalCount(2L).build())
                         .data(Stream.of(member1, member2).map(MemberMapper.INSTANCE::map).toList())
                         .metadata(Map.of("groupName", GROUP_NAME))
                         .links(Links.builder().self(target.getUri().toString()).build())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -113,12 +113,20 @@ public class GroupsResourceTest extends AbstractResourceTest {
         public void should_return_empty_list_if_no_results() {
             when(groupService.findAll(GraviteeContext.getExecutionContext())).thenReturn(List.of());
 
-            final Response response = target.queryParam("perPage", 10).queryParam("page", 1).request().get();
+            var paginatedTarget = target.queryParam("perPage", 10).queryParam("page", 1);
+            final Response response = paginatedTarget.request().get();
 
             assertThat(response)
                 .hasStatus(OK_200)
                 .asEntity(GroupsResponse.class)
-                .isEqualTo(GroupsResponse.builder().data(List.of()).pagination(Pagination.builder().build()).build());
+                .isEqualTo(
+                    GroupsResponse
+                        .builder()
+                        .data(List.of())
+                        .pagination(Pagination.builder().build())
+                        .links(Links.builder().self(paginatedTarget.getUri().toString()).build())
+                        .build()
+                );
         }
 
         @Test
@@ -245,6 +253,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                         .pagination(Pagination.builder().build())
                         .data(List.of())
                         .metadata(Map.of("groupName", GROUP_NAME))
+                        .links(Links.builder().self(target.getUri().toString()).build())
                         .build()
                 );
         }


### PR DESCRIPTION
## Description

Make `total` a long to prevent converting `Long` to `Int`.

This PR includes 2 extractions related to PaginationInfo and PaginationLinks. I noticed some gap in the coverage so I've created unit tests for them and it was easier to extract them.

I've also tried to improve the design of `PaginationParam` to prevent us from building the object with an incorrect state (❤️  [Value Object](https://martinfowler.com/bliki/ValueObject.html)). This would prevent us from writing some `ifs`. However, I fear I couldn't push enough 😢  as if I understand correctly we need to keep a no-arg constructor for Jersey 🤔  

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-esppxecorw.chromatic.com)
<!-- Storybook placeholder end -->
