### PR TITLE
Fix redeploy banner issue

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
@@ -18,7 +18,7 @@ import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import { castArray, flatMap } from 'lodash';
 import { map, takeUntil } from 'rxjs/operators';
-import { GIO_DIALOG_WIDTH, GioMenuService } from '@gravitee/ui-particles-angular';
+import { GIO_DIALOG_WIDTH, GioBannerTypes, GioMenuService } from '@gravitee/ui-particles-angular';
 import { Observable, Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -43,7 +43,8 @@ import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 type TopBanner = {
   title: string;
-  text: 'info' | 'warning' | 'error' | 'success';
+  body?: string;
+  type: GioBannerTypes;
   action?: {
     btnText: string;
     onClick: () => void;
@@ -66,7 +67,7 @@ export class ApiNgNavigationComponent implements OnInit, OnDestroy {
   public breadcrumbItems: string[] = [];
   public banners$: Observable<TopBanner[]> = this.apiV2Service.getLastApiFetch(this.ajsStateParams.apiId).pipe(
     map((api) => {
-      const banners = [];
+      const banners: TopBanner[] = [];
 
       if (api.definitionVersion == null || api.definitionVersion === 'V1') {
         banners.push({

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -15,8 +15,8 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable, BehaviorSubject } from 'rxjs';
-import { filter, shareReplay, tap } from 'rxjs/operators';
+import { Observable, BehaviorSubject, of } from 'rxjs';
+import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
 
 import { Constants } from '../entities/Constants';
 import {
@@ -133,10 +133,9 @@ export class ApiV2Service {
   }
 
   getLastApiFetch(apiId: string): Observable<Api> {
-    if (this.lastApiFetch$.value === null) {
-      return this.get(apiId);
-    }
-    return this.lastApiFetch$.pipe(
+    const start = this.lastApiFetch$.value ? of(this.lastApiFetch$.value) : this.get(apiId);
+    return start.pipe(
+      switchMap(() => this.lastApiFetch$.asObservable()),
       filter((api) => !!api),
       shareReplay({ bufferSize: 1, refCount: true }),
     );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2394

## Description

Fix a sync problem when computing the banners to display, when an API is modified.
The fix is to always use the same kind of Observable, the one created by the  `shareReplay` method.

Linked to https://github.com/gravitee-io/gravitee-api-management/pull/5064
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-etbypqgwyv.chromatic.com)
<!-- Storybook placeholder end -->
