### PR TITLE
feat: runtime logs empty states ui

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatTabHarness } from '@angular/material/tabs/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+
+export class ApiRuntimeLogsHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs';
+
+  private getRuntimeLogsTab = this.locatorFor(MatTabHarness.with({ label: 'Runtime Logs' }));
+  private getSettingsTab = this.locatorFor(MatTabHarness.with({ label: 'Settings' }));
+
+  private getOpenLogSettingsButton = this.locatorFor(
+    MatButtonHarness.with({
+      text: 'Open log settings',
+    }),
+  );
+
+  private getDivContainingEmptyRuntimeLogsTitle = this.locatorFor(
+    DivHarness.with({ selector: '[aria-label="No runtime logs available"]' }),
+  );
+
+  public async clickRuntimeLogsTab() {
+    return this.getRuntimeLogsTab().then((tab) => tab.select());
+  }
+
+  public async readRuntimeLogsTabLabel() {
+    return this.getRuntimeLogsTab().then((tab) => tab.getLabel());
+  }
+
+  public async clickSettingsTab() {
+    return this.getSettingsTab().then((tab) => tab.select());
+  }
+
+  public async readSettingsTabLabel() {
+    return this.getSettingsTab().then((tab) => tab.getLabel());
+  }
+
+  public async getOpenLogSettingsButtonText() {
+    return this.getOpenLogSettingsButton().then((button) => button.getText());
+  }
+
+  public async getEmptyRuntimeLogsTitle() {
+    return this.getDivContainingEmptyRuntimeLogsTitle().then((button) => button.getText());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.html
@@ -15,4 +15,29 @@
     limitations under the License.
 
 -->
-View runtime logs
+<ng-container>
+  <div class="tab-body-wrapper" *ngIf="areRuntimeLogsEnabled">
+    <mat-card class="runtime-logs-card">
+      <mat-icon svgIcon="gio:search"></mat-icon>
+      <div class="mat-h3" aria-label="No runtime logs available">No runtime logs available</div>
+      <div class="runtime-logs-card__body">
+        <span class="runtime-logs-card__body__subtitle">Start making API calls to populate your API runtime logs</span>
+      </div>
+    </mat-card>
+  </div>
+  <div class="tab-body-wrapper" *ngIf="!areRuntimeLogsEnabled">
+    <mat-card class="runtime-logs-card">
+      <mat-icon svgIcon="gio:folder-plus"></mat-icon>
+      <div class="mat-h3">Start by activating the logs</div>
+      <div class="runtime-logs-card__body">
+        <span class="runtime-logs-card__body__subtitle"
+          >Your runtime logs will live here. Start logging your API runtime activities by clicking on "Settings" and enabling logging
+          activation.</span
+        >
+      </div>
+      <div class="runtime-logs-card__actions">
+        <button mat-flat-button color="primary" class="runtime-logs-card__actions__button">Open log settings</button>
+      </div>
+    </mat-card>
+  </div>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.scss
@@ -1,0 +1,68 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+@use '../../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.runtime-logs {
+  &__header {
+    margin-bottom: 24px;
+
+    &__subtitle {
+      color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+      @include mat.typography-level($typography, 'body-1');
+    }
+  }
+}
+
+.tab-body-wrapper {
+  margin-top: 8px;
+
+  .runtime-logs-card {
+    text-align: center;
+
+    mat-icon {
+      border-radius: 30px;
+      background: #009999;
+      color: white;
+      height: 60px;
+      width: 60px;
+      padding: inherit;
+      margin-bottom: 10px;
+    }
+
+    &__body {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+
+      &__subtitle {
+        color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+        @include mat.typography-level($typography, 'body-1');
+        display: flex;
+        justify-content: center;
+        width: 60%;
+        margin-bottom: 10px;
+      }
+    }
+
+    &__actions {
+      width: 100%;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+
+      &__button {
+        display: flex;
+        justify-content: center;
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { ApiRuntimeLogsModule } from './api-runtime-logs.module';
+import { ApiRuntimeLogsComponent } from './api-runtime-logs.component';
+import { ApiRuntimeLogsHarness } from './api-runtime-logs.component.harness';
+
+import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { GioHttpTestingModule } from '../../../../shared/testing';
+import { ApiV4, fakeApiV4 } from '../../../../entities/management-api-v2';
+
+describe('ApiRuntimeLogsComponent', () => {
+  const apiId = 'apiId';
+  let api: ApiV4;
+  let fixture: ComponentFixture<ApiRuntimeLogsComponent>;
+  let componentHarness: ApiRuntimeLogsHarness;
+
+  const openLogSettingsButtonText = 'Open log settings';
+
+  const initComponent = async (testApi: ApiV4) => {
+    api = testApi;
+
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ApiRuntimeLogsModule, HttpClientTestingModule, MatIconTestingModule, GioHttpTestingModule],
+      providers: [{ provide: UIRouterStateParams, useValue: { apiId: apiId } }],
+    });
+
+    await TestBed.compileComponents();
+    fixture = TestBed.createComponent(ApiRuntimeLogsComponent);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsHarness);
+
+    fixture.detectChanges();
+  };
+
+  describe('GIVEN the current page is the Runtime Logs page', () => {
+    beforeEach(async () => {
+      api = fakeApiV4({ id: apiId, analytics: { enabled: false } });
+      await initComponent(api);
+    });
+    describe('WHEN the runtime logs are disabled', () => {
+      it('THEN the disabled runtime log UI should be visible', async () => {
+        expect(await componentHarness.getOpenLogSettingsButtonText()).toEqual(openLogSettingsButtonText);
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.module.ts
@@ -18,11 +18,13 @@ import { NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatIconModule } from '@angular/material/icon';
+import { GioAvatarModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
 
 import { ApiRuntimeLogsComponent } from './api-runtime-logs.component';
 
 @NgModule({
-  imports: [CommonModule, MatCardModule, MatIconModule, MatTabsModule],
+  imports: [CommonModule, MatCardModule, MatIconModule, MatTabsModule, CommonModule, GioAvatarModule, MatButtonModule],
   declarations: [ApiRuntimeLogsComponent],
   exports: [ApiRuntimeLogsComponent],
 })


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2472

## Description

The two initial empty states for runtime logs:

<img width="1501" alt="Screenshot 2023-08-30 at 10 24 45" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/acc8c6c6-a510-4f6e-b0af-87c6ab39f83e">

**Figure 1.1 -** _Logs enabled without data_

<img width="1497" alt="Screenshot 2023-08-30 at 10 25 11" src="https://github.com/gravitee-io/gravitee-api-management/assets/137767084/700d7194-ecb4-44ca-bb8a-8ee6b910a374">

**Figure 1.2 -** _Logs disabled_

## Additional context

To test the disabled UI:
- Click settings tab and toggle the switch on for the option `Logging activation`

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ofmututjlo.chromatic.com)
<!-- Storybook placeholder end -->
