### PR TITLE
fix: read pem certs and keys as list for elasticsearch configuration

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.configuration;
 import io.gravitee.common.util.EnvironmentUtils;
 import io.gravitee.elasticsearch.config.Endpoint;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,13 +91,11 @@ public class RepositoryConfiguration {
     /**
      * Elasticsearch ssl pem certs paths
      */
-    @Value("${analytics.elasticsearch.ssl.keystore.certs}")
     private List<String> sslPemCerts;
 
     /**
      * Elasticsearch ssl pem keys paths
      */
-    @Value("${analytics.elasticsearch.ssl.keystore.keys}")
     private List<String> sslPemKeys;
 
     /**
@@ -212,6 +211,10 @@ public class RepositoryConfiguration {
     }
 
     public List<String> getSslPemCerts() {
+        if (sslPemCerts == null) {
+            sslPemCerts = readPropertyAsList("analytics.elasticsearch.ssl.keystore.certs");
+        }
+
         return sslPemCerts;
     }
 
@@ -220,6 +223,10 @@ public class RepositoryConfiguration {
     }
 
     public List<String> getSslPemKeys() {
+        if (sslPemKeys == null) {
+            sslPemKeys = readPropertyAsList("analytics.elasticsearch.ssl.keystore.keys");
+        }
+
         return sslPemKeys;
     }
 
@@ -274,6 +281,25 @@ public class RepositoryConfiguration {
 
     public void setCrossClusterMapping(Map<String, String> crossClusterMapping) {
         this.crossClusterMapping = crossClusterMapping;
+    }
+
+    private List<String> readPropertyAsList(String property) {
+        String key = String.format("%s[%s]", property, 0);
+        List<String> properties = new ArrayList<>();
+
+        while (environment.containsProperty(key)) {
+            String p = environment.getProperty(key);
+            properties.add(p);
+
+            key = String.format("%s[%s]", property, properties.size());
+        }
+
+        // fallback to single value style for backward compatibility
+        if (properties.isEmpty()) {
+            properties.add(environment.getProperty(property));
+        }
+
+        return properties;
     }
 
     private List<Endpoint> initializeEndpoints() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/ElasticsearchRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/ElasticsearchRepositoryConfigurationTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.configuration;
 
 import io.gravitee.repository.elasticsearch.spring.YamlPropertySourceFactory;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,5 +64,15 @@ public class ElasticsearchRepositoryConfigurationTest {
     public void shouldHaveClientTimeout() {
         Assert.assertNotNull(configuration.getRequestTimeout());
         Assert.assertEquals(30000, configuration.getRequestTimeout().longValue());
+    }
+
+    @Test
+    public void shouldHaveKeystoreCerts() {
+        Assertions.assertThat(configuration.getSslPemCerts()).hasSize(2).containsExactly("cert1", "cert2");
+    }
+
+    @Test
+    public void shouldHaveKeystoreKeys() {
+        Assertions.assertThat(configuration.getSslPemKeys()).hasSize(1).containsExactly("unique-key");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
@@ -11,3 +11,9 @@ analytics:
         tenant2: cluster2
     http:
       timeout: 30000
+    ssl:
+      keystore:
+        certs:
+          - cert1
+          - cert2
+        keys: unique-key


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2575

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kloptlhvcp.chromatic.com)
<!-- Storybook placeholder end -->
