### PR TITLE
Make sure to keep service discovery settings until provider is modified

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
@@ -222,7 +222,7 @@ describe('ApiProxyGroupEditComponent', () => {
                 name: DEFAULT_GROUP_NAME,
                 endpoints: [],
                 load_balancing: { type: 'ROUND_ROBIN' },
-                services: { discovery: { enabled: true, provider: 'consul-service-discovery' } },
+                services: { discovery: { enabled: true, provider: 'consul-service-discovery', configuration: { service: 'service' } } },
               },
             ],
           },
@@ -259,7 +259,9 @@ describe('ApiProxyGroupEditComponent', () => {
               discovery: {
                 enabled: true,
                 provider: 'consul-service-discovery',
-                configuration: {},
+                configuration: {
+                  service: 'service',
+                },
               },
             },
           },

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
@@ -34,7 +34,7 @@
       </mat-form-field>
     </div>
 
-    <div class="card__group-sd" *ngIf="schema">
+    <div class="card__group-sd" *ngIf="serviceDiscoveryForm.get('enabled').value && schema">
       <gv-schema-form
         [attr.readonly]="isReadOnly ? isReadOnly : null"
         [schema]="schema"

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.ts
@@ -47,6 +47,7 @@ export class ApiProxyGroupServiceDiscoveryComponent implements OnInit, OnDestroy
       .get('provider')
       .valueChanges.pipe(takeUntil(this.unsubscribe$))
       .subscribe((value) => {
+        this.serviceDiscoveryForm.get('configuration').reset({});
         this.onFormValuesChange(value);
       });
   }
@@ -75,7 +76,6 @@ export class ApiProxyGroupServiceDiscoveryComponent implements OnInit, OnDestroy
         .getSchema(provider)
         .pipe(
           map((schema) => {
-            this.serviceDiscoveryForm.get('configuration').reset({});
             this.schema = schema;
           }),
         )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2396

## Description

When loading service discovery, settings previously entered were not show because form control was reset. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zrfzexygmy.chromatic.com)
<!-- Storybook placeholder end -->
