### PR TITLE
fix(portal): make entrypoint required on push plan subscription

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
@@ -225,9 +225,8 @@ export class ApiSubscribeComponent implements OnInit {
           if (this.isSubscription()) {
             this.subscribeForm.get('entrypoint').setValidators(Validators.required);
           } else {
-            this.subscribeForm.get('channel').setValue(null);
             this.subscribeForm.get('channel').clearValidators();
-            this.subscribeForm.get('entrypoint').setValue(null);
+            this.subscribeForm.get('channel').setValue(null);
             this.subscribeForm.get('entrypoint').clearValidators();
             this.subscribeForm.get('entrypoint').setValue(null);
             this.subscribeForm.get('entrypointConfiguration').clearValidators();
@@ -236,6 +235,8 @@ export class ApiSubscribeComponent implements OnInit {
 
           this.subscribeForm.get('general_conditions_accepted').setValue(false);
           this.subscribeForm.get('general_conditions_content_revision').setValue(null);
+
+          this.subscribeForm.updateValueAndValidity();
         });
 
         this.subscribeForm.valueChanges

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step3/application-creation-step3.component.ts
@@ -118,7 +118,20 @@ export class ApplicationCreationStep3Component implements OnInit, OnDestroy {
         this.planForm.get('general_conditions_accepted').clearValidators();
       }
 
+      if (this.selectedPlan?.mode.toUpperCase() === 'PUSH') {
+        this.planForm.get('entrypoint').setValidators(Validators.required);
+      } else {
+        this.planForm.get('channel').clearValidators();
+        this.planForm.get('channel').setValue(null);
+        this.planForm.get('entrypoint').clearValidators();
+        this.planForm.get('entrypoint').setValue(null);
+        this.planForm.get('entrypointConfiguration').clearValidators();
+        this.planForm.get('entrypointConfiguration').setValue(null);
+      }
+
       this.planForm.get('general_conditions_accepted').setValue(false);
+      this.planForm.updateValueAndValidity();
+
       this._generalConditionsAccepted = false;
       this.ref.detectChanges();
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2177

## Description

Add a "required" validator on entrypoint field when a "PUSH" plan is selected.
Same behavior is already implemented here: https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts#L225
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-viczpjnjzv.chromatic.com)
<!-- Storybook placeholder end -->
