### PR TITLE
refactor: add plan and application storage services

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.model;
 
 import io.gravitee.definition.model.Origin;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -123,7 +124,10 @@ public class Application {
         this.background = cloned.background;
         this.domain = cloned.domain;
         this.apiKeyMode = cloned.apiKeyMode;
+        this.picture = cloned.picture;
+        this.type = cloned.type;
         this.origin = cloned.origin;
+        this.metadata = cloned.metadata != null ? new HashMap<>(cloned.metadata) : null;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
@@ -20,6 +20,11 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -27,6 +32,11 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class Application {
 
     public static final String METADATA_CLIENT_ID = "client_id";
@@ -95,11 +105,10 @@ public class Application {
 
     private String background;
 
+    @Builder.Default
     private ApiKeyMode apiKeyMode = ApiKeyMode.UNSPECIFIED;
 
     private Origin origin;
-
-    public Application() {}
 
     public Application(Application cloned) {
         this.id = cloned.id;
@@ -115,134 +124,6 @@ public class Application {
         this.domain = cloned.domain;
         this.apiKeyMode = cloned.apiKeyMode;
         this.origin = cloned.origin;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public String getEnvironmentId() {
-        return environmentId;
-    }
-
-    public void setEnvironmentId(String environmentId) {
-        this.environmentId = environmentId;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Set<String> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(Set<String> groups) {
-        this.groups = groups;
-    }
-
-    public String getPicture() {
-        return picture;
-    }
-
-    public void setPicture(String picture) {
-        this.picture = picture;
-    }
-
-    public ApplicationStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(ApplicationStatus status) {
-        this.status = status;
-    }
-
-    public ApplicationType getType() {
-        return type;
-    }
-
-    public void setType(ApplicationType type) {
-        this.type = type;
-    }
-
-    public Map<String, String> getMetadata() {
-        return metadata;
-    }
-
-    public void setMetadata(Map<String, String> metadata) {
-        this.metadata = metadata;
-    }
-
-    public boolean isDisableMembershipNotifications() {
-        return disableMembershipNotifications;
-    }
-
-    public void setDisableMembershipNotifications(boolean disableMembershipNotifications) {
-        this.disableMembershipNotifications = disableMembershipNotifications;
-    }
-
-    public String getBackground() {
-        return background;
-    }
-
-    public void setBackground(String background) {
-        this.background = background;
-    }
-
-    public String getDomain() {
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-        this.domain = domain;
-    }
-
-    public ApiKeyMode getApiKeyMode() {
-        return apiKeyMode;
-    }
-
-    public void setApiKeyMode(ApiKeyMode apiKeyMode) {
-        this.apiKeyMode = apiKeyMode;
-    }
-
-    public Origin getOrigin() {
-        return origin;
-    }
-
-    public void setOrigin(Origin origin) {
-        this.origin = origin;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -18,12 +18,23 @@ package io.gravitee.repository.management.model;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class Plan {
 
     public enum AuditEvent implements Audit.ApiAuditEvent {
@@ -116,9 +127,8 @@ public class Plan {
 
     private String generalConditions;
 
+    @Builder.Default
     private Set<String> tags = new HashSet<>();
-
-    public Plan() {}
 
     public Plan(Plan cloned) {
         this.id = cloned.getId();
@@ -145,206 +155,6 @@ public class Plan {
         this.generalConditions = cloned.getGeneralConditions();
     }
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public PlanValidationType getValidation() {
-        return validation;
-    }
-
-    public void setValidation(PlanValidationType validation) {
-        this.validation = validation;
-    }
-
-    public PlanType getType() {
-        return type;
-    }
-
-    public void setType(PlanType type) {
-        this.type = type;
-    }
-
-    public PlanMode getMode() {
-        return mode;
-    }
-
-    public void setMode(PlanMode mode) {
-        this.mode = mode;
-    }
-
-    public String getApi() {
-        return api;
-    }
-
-    public void setApi(String api) {
-        this.api = api;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public List<String> getCharacteristics() {
-        return characteristics;
-    }
-
-    public void setCharacteristics(List<String> characteristics) {
-        this.characteristics = characteristics;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public Date getPublishedAt() {
-        return publishedAt;
-    }
-
-    public void setPublishedAt(Date publishedAt) {
-        this.publishedAt = publishedAt;
-    }
-
-    public Date getClosedAt() {
-        return closedAt;
-    }
-
-    public void setClosedAt(Date closedAt) {
-        this.closedAt = closedAt;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
-    public PlanSecurityType getSecurity() {
-        return security;
-    }
-
-    public void setSecurity(PlanSecurityType security) {
-        this.security = security;
-    }
-
-    public String getSecurityDefinition() {
-        return securityDefinition;
-    }
-
-    public void setSecurityDefinition(String securityDefinition) {
-        this.securityDefinition = securityDefinition;
-    }
-
-    public List<String> getExcludedGroups() {
-        return excludedGroups;
-    }
-
-    public void setExcludedGroups(List<String> excludedGroups) {
-        this.excludedGroups = excludedGroups;
-    }
-
-    public Date getNeedRedeployAt() {
-        return needRedeployAt;
-    }
-
-    public void setNeedRedeployAt(Date needRedeployAt) {
-        this.needRedeployAt = needRedeployAt;
-    }
-
-    public boolean isCommentRequired() {
-        return commentRequired;
-    }
-
-    public void setCommentRequired(boolean commentRequired) {
-        this.commentRequired = commentRequired;
-    }
-
-    public String getCommentMessage() {
-        return commentMessage;
-    }
-
-    public void setCommentMessage(String commentMessage) {
-        this.commentMessage = commentMessage;
-    }
-
-    public String getSelectionRule() {
-        return selectionRule;
-    }
-
-    public void setSelectionRule(String selectionRule) {
-        this.selectionRule = selectionRule;
-    }
-
-    public Set<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Set<String> tags) {
-        this.tags = tags;
-    }
-
-    public String getGeneralConditions() {
-        return generalConditions;
-    }
-
-    public void setGeneralConditions(String generalConditions) {
-        this.generalConditions = generalConditions;
-    }
-
-    public String getCrossId() {
-        return crossId;
-    }
-
-    public void setCrossId(String crossId) {
-        this.crossId = crossId;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -352,7 +162,7 @@ public class Plan {
 
         Plan plan = (Plan) o;
 
-        return id != null ? id.equals(plan.id) : plan.id == null;
+        return Objects.equals(id, plan.id);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -30,7 +30,7 @@ import lombok.Setter;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -131,28 +131,31 @@ public class Plan {
     private Set<String> tags = new HashSet<>();
 
     public Plan(Plan cloned) {
-        this.id = cloned.getId();
-        this.crossId = cloned.getCrossId();
-        this.name = cloned.getName();
-        this.description = cloned.getDescription();
-        this.security = cloned.getSecurity();
-        this.validation = cloned.getValidation();
-        this.type = cloned.getType();
-        this.mode = cloned.getMode();
-        this.status = cloned.getStatus();
-        this.order = cloned.getOrder();
-        this.api = cloned.getApi();
-        this.createdAt = cloned.getCreatedAt();
-        this.updatedAt = cloned.getUpdatedAt();
-        this.publishedAt = cloned.getPublishedAt();
-        this.closedAt = cloned.getClosedAt();
-        this.definition = cloned.getDefinition();
-        this.characteristics = cloned.getCharacteristics();
-        this.excludedGroups = cloned.getExcludedGroups();
-        this.needRedeployAt = cloned.getNeedRedeployAt();
-        this.selectionRule = cloned.getSelectionRule();
-        this.tags = cloned.getTags();
-        this.generalConditions = cloned.getGeneralConditions();
+        this.id = cloned.id;
+        this.crossId = cloned.crossId;
+        this.name = cloned.name;
+        this.description = cloned.description;
+        this.security = cloned.security;
+        this.validation = cloned.validation;
+        this.type = cloned.type;
+        this.mode = cloned.mode;
+        this.status = cloned.status;
+        this.order = cloned.order;
+        this.api = cloned.api;
+        this.createdAt = cloned.createdAt;
+        this.updatedAt = cloned.updatedAt;
+        this.publishedAt = cloned.publishedAt;
+        this.closedAt = cloned.closedAt;
+        this.definition = cloned.definition;
+        this.characteristics = cloned.characteristics;
+        this.excludedGroups = cloned.excludedGroups;
+        this.needRedeployAt = cloned.needRedeployAt;
+        this.selectionRule = cloned.selectionRule;
+        this.tags = cloned.tags;
+        this.generalConditions = cloned.generalConditions;
+        this.commentMessage = cloned.commentMessage;
+        this.commentRequired = cloned.commentRequired;
+        this.securityDefinition = cloned.securityDefinition;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -781,7 +781,8 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         public void should_return_plan_when_v4_plan_closed() {
             final PlanEntity planEntity = PlanFixtures.aPlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
-            when(planServiceV4.close(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity.withStatus(PlanStatus.CLOSED));
+            when(planServiceV4.close(GraviteeContext.getExecutionContext(), PLAN))
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.CLOSED).build());
 
             final Response response = target.request().post(Entity.json(null));
             assertThat(response)
@@ -796,7 +797,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
             when(planServiceV4.close(GraviteeContext.getExecutionContext(), PLAN))
-                .thenReturn(planEntity.withStatus(io.gravitee.rest.api.model.PlanStatus.CLOSED));
+                .thenReturn(planEntity.toBuilder().status(io.gravitee.rest.api.model.PlanStatus.CLOSED).build());
 
             final Response response = target.request().post(Entity.json(null));
             assertThat(response)
@@ -871,7 +872,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final PlanEntity planEntity = PlanFixtures.aPlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
             when(planServiceV4.deprecate(GraviteeContext.getExecutionContext(), PLAN))
-                .thenReturn(planEntity.withStatus(PlanStatus.DEPRECATED));
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.DEPRECATED).build());
 
             final Response response = target.request().post(Entity.json(null));
 
@@ -887,7 +888,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
             when(planServiceV2.deprecate(GraviteeContext.getExecutionContext(), PLAN))
-                .thenReturn(planEntity.withStatus(io.gravitee.rest.api.model.PlanStatus.DEPRECATED));
+                .thenReturn(planEntity.toBuilder().status(io.gravitee.rest.api.model.PlanStatus.DEPRECATED).build());
 
             final Response response = target.request().post(Entity.json(null));
             assertThat(response)
@@ -962,7 +963,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final PlanEntity planEntity = PlanFixtures.aPlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
             when(planServiceV4.publish(GraviteeContext.getExecutionContext(), PLAN))
-                .thenReturn(planEntity.withStatus(PlanStatus.PUBLISHED));
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.PUBLISHED).build());
 
             final Response response = target.request().post(Entity.json(null));
 
@@ -978,7 +979,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
             when(planServiceV2.publish(GraviteeContext.getExecutionContext(), PLAN))
-                .thenReturn(planEntity.withStatus(io.gravitee.rest.api.model.PlanStatus.PUBLISHED));
+                .thenReturn(planEntity.toBuilder().status(io.gravitee.rest.api.model.PlanStatus.PUBLISHED).build());
 
             final Response response = target.request().post(Entity.json(null));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApplicationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApplicationEntity.java
@@ -16,18 +16,15 @@
 package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.gravitee.definition.model.Origin;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Date;
-import java.util.Set;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -37,46 +34,11 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder(toBuilder = true)
-public class ApplicationEntity {
-
-    @Schema(description = "Application's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
-    @EqualsAndHashCode.Include
-    private String id;
-
-    @Schema(description = "Application's name. Duplicate names can exists.", example = "My App")
-    private String name;
-
-    @Schema(
-        description = "Application's description. A short description of your App.",
-        example = "I can use a hundred characters to describe this App."
-    )
-    private String description;
-
-    @Schema(description = "Domain used by the application, if relevant", example = "https://my-app.com")
-    private String domain;
-
-    @Schema(description = "Application groups. Used to add teams to your application.", example = "['MY_GROUP1', 'MY_GROUP2']")
-    private Set<String> groups;
-
-    @Schema(description = "if the app is ACTIVE or ARCHIVED.", example = "ACTIVE")
-    private String status;
-
-    @Schema(description = "a string to describe the type of your app.", example = "iOS")
-    private String type;
-
-    private String picture;
-
-    @JsonProperty("created_at")
-    @Schema(description = "The date (as a timestamp) when the application was created.", example = "1581256457163")
-    private Date createdAt;
-
-    @JsonProperty("updated_at")
-    @Schema(description = "The last date (as a timestamp) when the application was updated.", example = "1581256457163")
-    private Date updatedAt;
+@SuperBuilder(toBuilder = true)
+public class ApplicationEntity extends BaseApplicationEntity {
 
     @JsonProperty("owner")
     @Schema(description = "The user with role PRIMARY_OWNER on this API.")
@@ -85,19 +47,7 @@ public class ApplicationEntity {
     @JsonProperty("settings")
     private ApplicationSettings settings;
 
-    @JsonProperty("disable_membership_notifications")
-    private boolean disableMembershipNotifications;
-
-    @JsonProperty("api_key_mode")
-    @Schema(description = "The API Key mode used for this application.")
-    private ApiKeyMode apiKeyMode;
-
-    private String background;
-
-    @Schema(description = "The origin used for creating this application.")
-    private Origin origin;
-
     public boolean hasApiKeySharedMode() {
-        return apiKeyMode == ApiKeyMode.SHARED;
+        return getApiKeyMode() == ApiKeyMode.SHARED;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/BaseApplicationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/BaseApplicationEntity.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Origin;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Date;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class BaseApplicationEntity {
+
+    @Schema(description = "Application's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
+    @EqualsAndHashCode.Include
+    private String id;
+
+    @Schema(description = "Application's name. Duplicate names can exists.", example = "My App")
+    private String name;
+
+    @Schema(
+        description = "Application's description. A short description of your App.",
+        example = "I can use a hundred characters to describe this App."
+    )
+    private String description;
+
+    @Schema(description = "Domain used by the application, if relevant", example = "https://my-app.com")
+    private String domain;
+
+    @Schema(description = "Application groups. Used to add teams to your application.", example = "['MY_GROUP1', 'MY_GROUP2']")
+    private Set<String> groups;
+
+    @Schema(description = "if the app is ACTIVE or ARCHIVED.", example = "ACTIVE")
+    private String status;
+
+    @Schema(description = "a string to describe the type of your app.", example = "iOS")
+    private String type;
+
+    private String picture;
+
+    @JsonProperty("created_at")
+    @Schema(description = "The date (as a timestamp) when the application was created.", example = "1581256457163")
+    private Date createdAt;
+
+    @JsonProperty("updated_at")
+    @Schema(description = "The last date (as a timestamp) when the application was updated.", example = "1581256457163")
+    private Date updatedAt;
+
+    @JsonProperty("disable_membership_notifications")
+    private boolean disableMembershipNotifications;
+
+    @JsonProperty("api_key_mode")
+    @Schema(description = "The API Key mode used for this application.")
+    private ApiKeyMode apiKeyMode;
+
+    private String background;
+
+    @Schema(description = "The origin used for creating this application.")
+    private Origin origin;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/BasePlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/BasePlanEntity.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Rule;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
+import jakarta.validation.constraints.NotNull;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.With;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@With
+public class BasePlanEntity implements GenericPlanEntity {
+
+    private String id;
+
+    /**
+     * The plan crossId uniquely identifies a plan across environments.
+     * Plans promoted between environments will share the same crossId.
+     */
+    private String crossId;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String description;
+
+    /**
+     * The way to validate subscriptions
+     */
+    @NotNull
+    private PlanValidationType validation;
+
+    @DeploymentRequired
+    @NotNull
+    private PlanSecurityType security;
+
+    @DeploymentRequired
+    private String securityDefinition;
+
+    @NotNull
+    private PlanType type;
+
+    @DeploymentRequired
+    @NotNull
+    private PlanStatus status;
+
+    @DeploymentRequired
+    private String api;
+
+    private int order;
+
+    /**
+     * Plan creation date
+     */
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    /**
+     * Plan last update date
+     */
+    @JsonProperty("updated_at")
+    private Date updatedAt;
+
+    /**
+     * Plan publication date
+     */
+    @JsonProperty("published_at")
+    private Date publishedAt;
+
+    /**
+     * Plan closing date
+     */
+    @JsonProperty("closed_at")
+    private Date closedAt;
+
+    @DeploymentRequired
+    @JsonProperty(value = "paths", required = true)
+    private Map<String, List<Rule>> paths = new HashMap<>();
+
+    private List<String> characteristics;
+
+    @JsonProperty("excluded_groups")
+    private List<String> excludedGroups;
+
+    /**
+     * last time modification introduced an api redeployment
+     */
+    @JsonIgnore
+    private Date needRedeployAt;
+
+    @JsonProperty("comment_required")
+    private boolean commentRequired;
+
+    @JsonProperty("comment_message")
+    private String commentMessage;
+
+    @JsonProperty("general_conditions")
+    private String generalConditions;
+
+    @DeploymentRequired
+    private Set<String> tags;
+
+    @DeploymentRequired
+    @JsonProperty("selection_rule")
+    private String selectionRule;
+
+    @Override
+    @JsonIgnore
+    public String getApiId() {
+        return api;
+    }
+
+    @Override
+    @JsonIgnore
+    public PlanSecurity getPlanSecurity() {
+        PlanSecurity planSecurity = new PlanSecurity();
+        if (security != null) {
+            planSecurity.setType(PlanSecurityType.valueOf(security.name()).name());
+        }
+        planSecurity.setConfiguration(securityDefinition);
+        return planSecurity;
+    }
+
+    @Override
+    @JsonIgnore
+    public io.gravitee.definition.model.v4.plan.PlanStatus getPlanStatus() {
+        if (status != null) {
+            return io.gravitee.definition.model.v4.plan.PlanStatus.valueOfLabel(status.name());
+        }
+        return null;
+    }
+
+    @Override
+    public PlanMode getPlanMode() {
+        // V2 API only manage STANDARD mode
+        return PlanMode.STANDARD;
+    }
+
+    @Override
+    @JsonIgnore
+    public io.gravitee.rest.api.model.v4.plan.PlanValidationType getPlanValidation() {
+        if (validation != null) {
+            return io.gravitee.rest.api.model.v4.plan.PlanValidationType.valueOfLabel(validation.name());
+        }
+        return null;
+    }
+
+    @Override
+    @JsonIgnore
+    public io.gravitee.rest.api.model.v4.plan.PlanType getPlanType() {
+        return io.gravitee.rest.api.model.v4.plan.PlanType.API;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        BasePlanEntity that = (BasePlanEntity) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
@@ -15,19 +15,17 @@
  */
 package io.gravitee.rest.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
-import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanMode;
-import jakarta.validation.constraints.NotNull;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.With;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -36,359 +34,16 @@ import lombok.With;
  */
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder(toBuilder = true)
+@SuperBuilder(toBuilder = true)
+@Getter
+@Setter
 @With
-public class PlanEntity implements GenericPlanEntity {
-
-    private String id;
-
-    /**
-     * The plan crossId uniquely identifies a plan across environments.
-     * Plans promoted between environments will share the same crossId.
-     */
-    private String crossId;
-
-    @NotNull
-    private String name;
-
-    @NotNull
-    private String description;
-
-    /**
-     * The way to validate subscriptions
-     */
-    @NotNull
-    private PlanValidationType validation;
-
-    @DeploymentRequired
-    @NotNull
-    private PlanSecurityType security;
-
-    @DeploymentRequired
-    private String securityDefinition;
-
-    @NotNull
-    private PlanType type;
-
-    @DeploymentRequired
-    @NotNull
-    private PlanStatus status;
-
-    @DeploymentRequired
-    private String api;
-
-    private int order;
-
-    /**
-     * Plan creation date
-     */
-    @JsonProperty("created_at")
-    private Date createdAt;
-
-    /**
-     * Plan last update date
-     */
-    @JsonProperty("updated_at")
-    private Date updatedAt;
-
-    /**
-     * Plan publication date
-     */
-    @JsonProperty("published_at")
-    private Date publishedAt;
-
-    /**
-     * Plan closing date
-     */
-    @JsonProperty("closed_at")
-    private Date closedAt;
-
-    @DeploymentRequired
-    @JsonProperty(value = "paths", required = true)
-    private Map<String, List<Rule>> paths = new HashMap<>();
+public class PlanEntity extends BasePlanEntity {
 
     @DeploymentRequired
     @JsonProperty(value = "flows", required = true)
-    private List<Flow> flows = new ArrayList();
-
-    private List<String> characteristics;
-
-    @JsonProperty("excluded_groups")
-    private List<String> excludedGroups;
-
-    /**
-     * last time modification introduced an api redeployment
-     */
-    @JsonIgnore
-    private Date needRedeployAt;
-
-    @JsonProperty("comment_required")
-    private boolean commentRequired;
-
-    @JsonProperty("comment_message")
-    private String commentMessage;
-
-    @JsonProperty("general_conditions")
-    private String generalConditions;
-
-    @DeploymentRequired
-    private Set<String> tags;
-
-    @DeploymentRequired
-    @JsonProperty("selection_rule")
-    private String selectionRule;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public PlanValidationType getValidation() {
-        return validation;
-    }
-
-    public void setValidation(PlanValidationType validation) {
-        this.validation = validation;
-    }
-
-    public PlanType getType() {
-        return type;
-    }
-
-    public void setType(PlanType type) {
-        this.type = type;
-    }
-
-    public String getApi() {
-        return api;
-    }
-
-    public void setApi(String api) {
-        this.api = api;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public Map<String, List<Rule>> getPaths() {
-        return paths;
-    }
-
-    public void setPaths(Map<String, List<Rule>> paths) {
-        this.paths = paths;
-    }
-
-    public List<Flow> getFlows() {
-        return flows;
-    }
-
-    public void setFlows(List<Flow> flows) {
-        this.flows = flows;
-    }
-
-    public List<String> getCharacteristics() {
-        return characteristics;
-    }
-
-    public void setCharacteristics(List<String> characteristics) {
-        this.characteristics = characteristics;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public PlanStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(PlanStatus status) {
-        this.status = status;
-    }
-
-    public Date getPublishedAt() {
-        return publishedAt;
-    }
-
-    public void setPublishedAt(Date publishedAt) {
-        this.publishedAt = publishedAt;
-    }
-
-    public Date getClosedAt() {
-        return closedAt;
-    }
-
-    public void setClosedAt(Date closedAt) {
-        this.closedAt = closedAt;
-    }
-
-    public PlanSecurityType getSecurity() {
-        return security;
-    }
-
-    public void setSecurity(PlanSecurityType security) {
-        this.security = security;
-    }
-
-    public String getSecurityDefinition() {
-        return securityDefinition;
-    }
-
-    public void setSecurityDefinition(String securityDefinition) {
-        this.securityDefinition = securityDefinition;
-    }
-
-    public List<String> getExcludedGroups() {
-        return excludedGroups;
-    }
-
-    public void setExcludedGroups(List<String> excludedGroups) {
-        this.excludedGroups = excludedGroups;
-    }
-
-    public Date getNeedRedeployAt() {
-        return needRedeployAt;
-    }
-
-    public void setNeedRedeployAt(Date needRedeployAt) {
-        this.needRedeployAt = needRedeployAt;
-    }
-
-    @Override
-    public boolean isCommentRequired() {
-        return commentRequired;
-    }
-
-    public void setCommentRequired(boolean commentRequired) {
-        this.commentRequired = commentRequired;
-    }
-
-    public String getCommentMessage() {
-        return commentMessage;
-    }
-
-    public void setCommentMessage(String commentMessage) {
-        this.commentMessage = commentMessage;
-    }
-
-    public Set<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Set<String> tags) {
-        this.tags = tags;
-    }
-
-    public String getSelectionRule() {
-        return selectionRule;
-    }
-
-    public void setSelectionRule(String selectionRule) {
-        this.selectionRule = selectionRule;
-    }
-
-    /**
-     * Identifier of general condition page
-     * @return id
-     */
-    public String getGeneralConditions() {
-        return generalConditions;
-    }
-
-    public void setGeneralConditions(String generalConditions) {
-        this.generalConditions = generalConditions;
-    }
-
-    public String getCrossId() {
-        return crossId;
-    }
-
-    public void setCrossId(String crossId) {
-        this.crossId = crossId;
-    }
-
-    @Override
-    @JsonIgnore
-    public String getApiId() {
-        return api;
-    }
-
-    @Override
-    @JsonIgnore
-    public PlanSecurity getPlanSecurity() {
-        PlanSecurity planSecurity = new PlanSecurity();
-        if (security != null) {
-            planSecurity.setType(PlanSecurityType.valueOf(security.name()).name());
-        }
-        planSecurity.setConfiguration(securityDefinition);
-        return planSecurity;
-    }
-
-    @Override
-    @JsonIgnore
-    public io.gravitee.definition.model.v4.plan.PlanStatus getPlanStatus() {
-        if (status != null) {
-            return io.gravitee.definition.model.v4.plan.PlanStatus.valueOfLabel(status.name());
-        }
-        return null;
-    }
-
-    @Override
-    public PlanMode getPlanMode() {
-        // V2 API only manage STANDARD mode
-        return PlanMode.STANDARD;
-    }
-
-    @Override
-    @JsonIgnore
-    public io.gravitee.rest.api.model.v4.plan.PlanValidationType getPlanValidation() {
-        if (validation != null) {
-            return io.gravitee.rest.api.model.v4.plan.PlanValidationType.valueOfLabel(validation.name());
-        }
-        return null;
-    }
-
-    @Override
-    @JsonIgnore
-    public io.gravitee.rest.api.model.v4.plan.PlanType getPlanType() {
-        return io.gravitee.rest.api.model.v4.plan.PlanType.API;
-    }
+    @Builder.Default
+    private List<Flow> flows = new ArrayList<>();
 
     @Override
     public boolean equals(Object o) {
@@ -397,11 +52,11 @@ public class PlanEntity implements GenericPlanEntity {
 
         PlanEntity that = (PlanEntity) o;
 
-        return id.equals(that.id);
+        return getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return getId().hashCode();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/BasePlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/BasePlanEntity.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.plan;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.DeploymentRequired;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class BasePlanEntity implements GenericPlanEntity {
+
+    private String id;
+    /**
+     * The plan crossId uniquely identifies a plan across environments.
+     * Plans promoted between environments will share the same crossId.
+     */
+    private String crossId;
+    private String name;
+    private String description;
+    private Date createdAt;
+    private Date updatedAt;
+    private Date publishedAt;
+    private Date closedAt;
+
+    @JsonIgnore
+    private Date needRedeployAt;
+
+    /**
+     * The way to validate subscriptions
+     */
+    private PlanValidationType validation;
+
+    private PlanType type;
+
+    private PlanMode mode;
+
+    @DeploymentRequired
+    private PlanSecurity security;
+
+    @DeploymentRequired
+    private String selectionRule;
+
+    @DeploymentRequired
+    private Set<String> tags;
+
+    @DeploymentRequired
+    private PlanStatus status;
+
+    @DeploymentRequired
+    private String apiId;
+
+    private int order;
+    private List<String> characteristics;
+    private List<String> excludedGroups;
+    private boolean commentRequired;
+    private String commentMessage;
+    private String generalConditions;
+
+    @Override
+    public PlanType getPlanType() {
+        return type;
+    }
+
+    @Override
+    public PlanMode getPlanMode() {
+        return mode;
+    }
+
+    @Override
+    public PlanSecurity getPlanSecurity() {
+        return security;
+    }
+
+    @Override
+    public PlanStatus getPlanStatus() {
+        return status;
+    }
+
+    @Override
+    public PlanValidationType getPlanValidation() {
+        return validation;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanEntity.java
@@ -15,17 +15,19 @@
  */
 package io.gravitee.rest.api.model.v4.plan;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.DeploymentRequired;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Set;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -36,84 +38,12 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @Schema(name = "PlanEntityV4")
-@Builder(toBuilder = true)
-@With
-public class PlanEntity implements GenericPlanEntity {
-
-    private String id;
-    /**
-     * The plan crossId uniquely identifies a plan across environments.
-     * Plans promoted between environments will share the same crossId.
-     */
-    private String crossId;
-    private String name;
-    private String description;
-    private Date createdAt;
-    private Date updatedAt;
-    private Date publishedAt;
-    private Date closedAt;
-
-    @JsonIgnore
-    private Date needRedeployAt;
-
-    /**
-     * The way to validate subscriptions
-     */
-    private PlanValidationType validation;
-
-    private PlanType type;
-
-    private PlanMode mode;
+@SuperBuilder(toBuilder = true)
+public class PlanEntity extends BasePlanEntity {
 
     @DeploymentRequired
-    private PlanSecurity security;
-
-    @DeploymentRequired
-    private String selectionRule;
-
-    @DeploymentRequired
+    @Builder.Default
     private List<Flow> flows = new ArrayList<>();
-
-    @DeploymentRequired
-    private Set<String> tags;
-
-    @DeploymentRequired
-    private PlanStatus status;
-
-    @DeploymentRequired
-    private String apiId;
-
-    private int order;
-    private List<String> characteristics;
-    private List<String> excludedGroups;
-    private boolean commentRequired;
-    private String commentMessage;
-    private String generalConditions;
-
-    @Override
-    public PlanType getPlanType() {
-        return type;
-    }
-
-    @Override
-    public PlanMode getPlanMode() {
-        return mode;
-    }
-
-    @Override
-    public PlanSecurity getPlanSecurity() {
-        return security;
-    }
-
-    @Override
-    public PlanStatus getPlanStatus() {
-        return status;
-    }
-
-    @Override
-    public PlanValidationType getPlanValidation() {
-        return validation;
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -337,6 +337,23 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>inmemory/**</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
@@ -39,8 +39,11 @@ public class PlanConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlanConverter.class);
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public PlanConverter(@Autowired ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     public PlanEntity toPlanEntity(Plan plan, List<Flow> flows) {
         PlanEntity entity = new PlanEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -69,7 +69,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @author GraviteeSource Team
  */
 @Configuration
-@ComponentScan("io.gravitee.rest.api.service")
+@ComponentScan(basePackages = { "io.gravitee.rest.api.service", "io.gravitee.rest.api.storage" })
 @EnableTransactionManagement
 @Import(
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/ApplicationStorageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/ApplicationStorageService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.application;
+
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+public interface ApplicationStorageService {
+    BaseApplicationEntity findById(final ExecutionContext executionContext, String applicationId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/ApplicationStorageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/ApplicationStorageServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.application;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.storage.application.adapter.ApplicationMapper;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ApplicationStorageServiceImpl implements ApplicationStorageService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public ApplicationStorageServiceImpl(@Lazy ApplicationRepository applicationRepository) {
+        this.applicationRepository = applicationRepository;
+    }
+
+    @Override
+    public BaseApplicationEntity findById(final ExecutionContext executionContext, String applicationId) {
+        try {
+            log.debug("Find application by id: {}", applicationId);
+
+            Optional<Application> applicationOptional = applicationRepository.findById(applicationId);
+
+            if (executionContext.hasEnvironmentId()) {
+                applicationOptional =
+                    applicationOptional.filter(result -> result.getEnvironmentId().equals(executionContext.getEnvironmentId()));
+            }
+
+            if (applicationOptional.isPresent()) {
+                return ApplicationMapper.mapToBaseApplication(applicationOptional.get());
+            }
+
+            throw new ApplicationNotFoundException(applicationId);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find an application using its ID {}", applicationId, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find an application using its ID " + applicationId, ex);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/adapter/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/application/adapter/ApplicationMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.application.adapter;
+
+import io.gravitee.definition.model.Origin;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.rest.api.model.ApiKeyMode;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+
+public class ApplicationMapper {
+
+    public static BaseApplicationEntity mapToBaseApplication(Application application) {
+        ApplicationEntity applicationEntity = new ApplicationEntity();
+
+        applicationEntity.setId(application.getId());
+        applicationEntity.setName(application.getName());
+        applicationEntity.setDescription(application.getDescription());
+        applicationEntity.setDomain(application.getDomain());
+        applicationEntity.setType(application.getType() != null ? application.getType().name() : null);
+        applicationEntity.setStatus(application.getStatus().toString());
+        applicationEntity.setPicture(application.getPicture());
+        applicationEntity.setBackground(application.getBackground());
+        applicationEntity.setGroups(application.getGroups());
+        applicationEntity.setCreatedAt(application.getCreatedAt());
+        applicationEntity.setUpdatedAt(application.getUpdatedAt());
+        applicationEntity.setDisableMembershipNotifications(application.isDisableMembershipNotifications());
+        applicationEntity.setApiKeyMode(
+            application.getApiKeyMode() != null ? ApiKeyMode.valueOf(application.getApiKeyMode().name()) : null
+        );
+        applicationEntity.setOrigin(application.getOrigin() != null ? application.getOrigin() : Origin.MANAGEMENT);
+        return applicationEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/PlanStorageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/PlanStorageService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.plan;
+
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+
+public interface PlanStorageService {
+    GenericPlanEntity findById(String planId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/PlanStorageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/PlanStorageServiceImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.plan;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.storage.plan.adapter.BasePlanAdapter;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class PlanStorageServiceImpl implements PlanStorageService {
+
+    private final PlanRepository planRepository;
+    private final ApiRepository apiRepository;
+    private final BasePlanAdapter planAdapter;
+
+    public PlanStorageServiceImpl(@Lazy PlanRepository planRepository, @Lazy ApiRepository apiRepository, BasePlanAdapter planAdapter) {
+        this.planRepository = planRepository;
+        this.apiRepository = apiRepository;
+        this.planAdapter = planAdapter;
+    }
+
+    @Override
+    public GenericPlanEntity findById(String planId) {
+        try {
+            log.debug("Find plan by id : {}", planId);
+            return planRepository.findById(planId).map(this::mapToGeneric).orElseThrow(() -> new PlanNotFoundException(planId));
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException(String.format("An error occurs while trying to find a plan by id: %s", planId), ex);
+        }
+    }
+
+    private GenericPlanEntity mapToGeneric(final Plan plan) {
+        try {
+            Optional<Api> apiOptional = apiRepository.findById(plan.getApi());
+            final Api api = apiOptional.orElseThrow(() -> new ApiNotFoundException(plan.getApi()));
+            return api.getDefinitionVersion() == DefinitionVersion.V4 ? planAdapter.toEntityV4(plan) : planAdapter.toEntityV2(plan);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find an API using its ID: " + plan.getApi(), e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/adapter/BasePlanAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/storage/plan/adapter/BasePlanAdapter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.plan.adapter;
+
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+import io.gravitee.rest.api.model.v4.plan.PlanType;
+import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
+import io.gravitee.rest.api.service.converter.PlanConverter;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BasePlanAdapter {
+
+    private final PlanConverter planConverter;
+
+    public BasePlanAdapter(PlanConverter planConverter) {
+        this.planConverter = planConverter;
+    }
+
+    public GenericPlanEntity toEntityV4(Plan plan) {
+        BasePlanEntity entity = new BasePlanEntity();
+
+        entity.setId(plan.getId());
+        entity.setCrossId(plan.getCrossId());
+        entity.setName(plan.getName());
+        entity.setDescription(plan.getDescription());
+        entity.setApiId(plan.getApi());
+        entity.setCreatedAt(plan.getCreatedAt());
+        entity.setUpdatedAt(plan.getUpdatedAt());
+        entity.setClosedAt(plan.getClosedAt());
+        entity.setNeedRedeployAt(plan.getNeedRedeployAt() == null ? plan.getUpdatedAt() : plan.getNeedRedeployAt());
+        entity.setPublishedAt(plan.getPublishedAt());
+        entity.setOrder(plan.getOrder());
+        entity.setExcludedGroups(plan.getExcludedGroups());
+        entity.setType(PlanType.valueOf(plan.getType().name()));
+        entity.setMode(plan.getMode() != null ? PlanMode.valueOf(plan.getMode().name()) : PlanMode.STANDARD);
+
+        // Backward compatibility
+        entity.setStatus(plan.getStatus() != null ? PlanStatus.valueOf(plan.getStatus().name()) : PlanStatus.PUBLISHED);
+
+        if (Plan.PlanMode.PUSH != plan.getMode()) {
+            entity.setSecurity(
+                PlanSecurity
+                    .builder()
+                    .type(PlanSecurityType.valueOf(plan.getSecurity().name()).getLabel())
+                    .configuration(plan.getSecurityDefinition())
+                    .build()
+            );
+        }
+
+        entity.setValidation(PlanValidationType.valueOf(plan.getValidation().name()));
+        entity.setCharacteristics(plan.getCharacteristics());
+        entity.setCommentRequired(plan.isCommentRequired());
+        entity.setCommentMessage(plan.getCommentMessage());
+        entity.setTags(plan.getTags());
+        entity.setSelectionRule(plan.getSelectionRule());
+        entity.setGeneralConditions(plan.getGeneralConditions());
+        return entity;
+    }
+
+    public GenericPlanEntity toEntityV2(Plan plan) {
+        return planConverter.toPlanEntity(plan, List.of());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationStorageServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationStorageServiceInMemory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.storage.application.ApplicationStorageService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ApplicationStorageServiceInMemory implements ApplicationStorageService, InMemoryStorageService<BaseApplicationEntity> {
+
+    private final List<BaseApplicationEntity> storage = new ArrayList<>();
+
+    @Override
+    public BaseApplicationEntity findById(ExecutionContext executionContext, String applicationId) {
+        return storage
+            .stream()
+            .filter(application -> applicationId.equals(application.getId()))
+            .findFirst()
+            .orElseThrow(() -> new ApplicationNotFoundException(applicationId));
+    }
+
+    @Override
+    public void initWith(List<BaseApplicationEntity> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<BaseApplicationEntity> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryStorageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryStorageService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import java.util.List;
+
+public interface InMemoryStorageService<T> {
+    /**
+     * Init the storage with the given items
+     * @param items the items to store
+     */
+    void initWith(List<T> items);
+
+    /** Reset the storage */
+    void reset();
+
+    /** @return the storage */
+    List<T> storage();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanStorageServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanStorageServiceInMemory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.storage.plan.PlanStorageService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class PlanStorageServiceInMemory implements PlanStorageService, InMemoryStorageService<GenericPlanEntity> {
+
+    private final List<GenericPlanEntity> storage = new ArrayList<>();
+
+    @Override
+    public GenericPlanEntity findById(String planId) {
+        return storage
+            .stream()
+            .filter(plan -> planId.equals(plan.getId()))
+            .findFirst()
+            .orElseThrow(() -> new PlanNotFoundException(planId));
+    }
+
+    @Override
+    public void initWith(List<GenericPlanEntity> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<GenericPlanEntity> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DebugApiServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DebugApiServiceTest.java
@@ -76,7 +76,7 @@ public class DebugApiServiceTest {
 
     @Before
     public void setup() {
-        debugApiService = new DebugApiServiceImpl(apiService, eventService, objectMapper, instanceService, new PlanConverter());
+        debugApiService = new DebugApiServiceImpl(apiService, eventService, objectMapper, instanceService, new PlanConverter(objectMapper));
 
         ApiEntity apiEntity = mock(ApiEntity.class);
         when(apiEntity.getReferenceId()).thenReturn(ENVIRONMENT_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
@@ -625,7 +625,7 @@ public class EventServiceTest {
         throws TechnicalException, JsonProcessingException {
         ObjectMapper realObjectMapper = new ObjectMapper();
         ReflectionTestUtils.setField(eventService, "objectMapper", realObjectMapper);
-        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter());
+        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter(objectMapper));
         when(eventRepository.create(any())).thenAnswer(i -> i.getArguments()[0]);
 
         Api api = new Api();
@@ -670,7 +670,7 @@ public class EventServiceTest {
         throws TechnicalException, JsonProcessingException {
         ObjectMapper realObjectMapper = new ObjectMapper();
         ReflectionTestUtils.setField(eventService, "objectMapper", realObjectMapper);
-        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter());
+        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter(objectMapper));
         when(eventRepository.create(any())).thenAnswer(i -> i.getArguments()[0]);
 
         Api api = new Api();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
@@ -16,7 +16,12 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
@@ -62,9 +67,6 @@ public class PlanService_CloseTest {
     private SubscriptionService subscriptionService;
 
     @Mock
-    private Plan plan;
-
-    @Mock
     private SubscriptionEntity subscription;
 
     @Mock
@@ -85,7 +87,7 @@ public class PlanService_CloseTest {
 
     @Test(expected = PlanAlreadyClosedException.class)
     public void shouldNotCloseBecauseAlreadyClosed() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.CLOSED);
+        var plan = Plan.builder().status(Plan.Status.CLOSED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -100,82 +102,90 @@ public class PlanService_CloseTest {
 
     @Test
     public void shouldClosePlanAndAcceptedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 
     @Test
     public void shouldClosePlanAndPendingSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
     }
 
     @Test
     public void shouldClosePlanAndPausedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 
     @Test
     public void shouldClosePlanButNotClosedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
@@ -59,9 +59,6 @@ public class PlanService_DeprecateTest {
     private SubscriptionService subscriptionService;
 
     @Mock
-    private Plan plan;
-
-    @Mock
     private SubscriptionEntity subscription;
 
     @Mock
@@ -75,7 +72,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanAlreadyDeprecatedException.class)
     public void shouldNotDepreciateBecauseAlreadyDepreciated() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.DEPRECATED);
+        var plan = Plan.builder().status(Plan.Status.DEPRECATED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -83,7 +80,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanAlreadyClosedException.class)
     public void shouldNotDepreciateBecauseAlreadyClosed() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.CLOSED);
+        var plan = Plan.builder().status(Plan.Status.CLOSED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -91,7 +88,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanNotYetPublishedException.class)
     public void shouldNotDepreciateBecauseNotPublished() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
+        var plan = Plan.builder().status(Plan.Status.STAGING).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -99,31 +96,35 @@ public class PlanService_DeprecateTest {
 
     @Test
     public void shouldDepreciateWithStagingPlanAndAllowStaging() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID, true);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 
     @Test(expected = PlanNotYetPublishedException.class)
     public void shouldNotDepreciateWithStagingPlanAndNotAllowStaging() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID, false);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -135,16 +136,18 @@ public class PlanService_DeprecateTest {
 
     @Test
     public void shouldDepreciate() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
@@ -61,9 +61,6 @@ public class PlanService_PublishTest {
     private SubscriptionService subscriptionService;
 
     @Mock
-    private Plan plan;
-
-    @Mock
     private SubscriptionEntity subscription;
 
     @Mock
@@ -83,7 +80,7 @@ public class PlanService_PublishTest {
 
     @Test(expected = PlanAlreadyPublishedException.class)
     public void shouldNotPublishBecauseAlreadyPublished() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
+        var plan = Plan.builder().status(Plan.Status.PUBLISHED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -91,7 +88,7 @@ public class PlanService_PublishTest {
 
     @Test(expected = PlanAlreadyClosedException.class)
     public void shouldNotPublishBecauseAlreadyClose() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.CLOSED);
+        var plan = Plan.builder().status(Plan.Status.CLOSED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -104,36 +101,40 @@ public class PlanService_PublishTest {
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
     }
 
+    @Test
     public void shouldPublishWithExistingKeylessPlan() throws TechnicalException {
-        Plan keylessPlan = mock(Plan.class);
-        when(keylessPlan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(keylessPlan.getSecurity()).thenReturn(Plan.PlanSecurityType.KEY_LESS);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
 
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getSecurity()).thenReturn(Plan.PlanSecurityType.API_KEY);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var keylessPlan = Plan.builder().status(Plan.Status.PUBLISHED).security(Plan.PlanSecurityType.KEY_LESS).build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.findByApi(API_ID)).thenReturn(Collections.singleton(keylessPlan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
-        when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
-            .thenReturn(Collections.singleton(subscription));
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
+
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.PUBLISHED).build());
     }
 
     @Test(expected = KeylessPlanAlreadyPublishedException.class)
     public void shouldNotPublishBecauseExistingKeylessPlan() throws TechnicalException {
-        Plan keylessPlan = mock(Plan.class);
-        when(keylessPlan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(keylessPlan.getSecurity()).thenReturn(Plan.PlanSecurityType.KEY_LESS);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .security(Plan.PlanSecurityType.KEY_LESS)
+            .api(API_ID)
+            .build();
 
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getSecurity()).thenReturn(Plan.PlanSecurityType.KEY_LESS);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var keylessPlan = Plan.builder().status(Plan.Status.PUBLISHED).security(Plan.PlanSecurityType.KEY_LESS).build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.findByApi(API_ID)).thenReturn(Collections.singleton(keylessPlan));
 
@@ -142,42 +143,52 @@ public class PlanService_PublishTest {
 
     @Test
     public void shouldPublish() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.PUBLISHED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.PUBLISHED).build());
     }
 
     @Test
     public void shouldPublishAndUpdatePlan() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.PUBLISHED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.PUBLISHED).build());
     }
 
     @Test
     public void shouldPublish_WithPublishGCPage() throws TechnicalException {
         final String GC_PAGE_ID = "GC_PAGE_ID";
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
-        when(plan.getGeneralConditions()).thenReturn(GC_PAGE_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .generalConditions(GC_PAGE_ID)
+            .build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
@@ -188,18 +199,21 @@ public class PlanService_PublishTest {
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.PUBLISHED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.PUBLISHED).build());
     }
 
     @Test(expected = PlanGeneralConditionStatusException.class)
     public void shouldNotPublish_WithNotPublishGCPage() throws TechnicalException {
         final String GC_PAGE_ID = "GC_PAGE_ID";
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
-        when(plan.getGeneralConditions()).thenReturn(GC_PAGE_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .generalConditions(GC_PAGE_ID)
+            .build();
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         PageEntity page = mock(PageEntity.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiDuplicateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiDuplicateServiceImplTest.java
@@ -305,8 +305,8 @@ public class ApiDuplicateServiceImplTest {
         when(pageDuplicateService.duplicatePages(any(), any(), any(), any()))
             .thenReturn(Map.ofEntries(entry("page-1", "dup-page-1"), entry("page-2", "dup-page-2")));
 
-        PlanEntity keylessPlan = aKeylessPlanV4().withGeneralConditions("page-1");
-        PlanEntity apiKeyPlan = anApiKeyPanV4().withGeneralConditions("page-2");
+        PlanEntity keylessPlan = aKeylessPlanV4().toBuilder().generalConditions("page-1").build();
+        PlanEntity apiKeyPlan = anApiKeyPanV4().toBuilder().generalConditions("page-2").build();
         ApiEntity duplicated = service.duplicate(
             GraviteeContext.getExecutionContext(),
             sourceApi.withPlans(Set.of(keylessPlan, apiKeyPlan)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CloseTest.java
@@ -72,9 +72,6 @@ public class PlanService_CloseTest {
     private SubscriptionService subscriptionService;
 
     @Mock
-    private Plan plan;
-
-    @Mock
     private SubscriptionEntity subscription;
 
     @Mock
@@ -101,7 +98,7 @@ public class PlanService_CloseTest {
 
     @Test(expected = PlanAlreadyClosedException.class)
     public void shouldNotCloseBecauseAlreadyClosed() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.CLOSED);
+        var plan = Plan.builder().status(Plan.Status.CLOSED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -116,15 +113,18 @@ public class PlanService_CloseTest {
 
     @Test
     public void shouldClosePlanV4AndAcceptedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         var api = new Api();
@@ -141,23 +141,25 @@ public class PlanService_CloseTest {
         assertThat(genericPlanEntity.getId()).isEqualTo(PLAN_ID);
         assertThat(genericPlanEntity.getApiId()).isEqualTo(API_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 
     @Test
     public void shouldClosePlanV2AndPendingSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         var api = new Api();
@@ -174,22 +176,24 @@ public class PlanService_CloseTest {
         assertThat(genericPlanEntity.getId()).isEqualTo(PLAN_ID);
         assertThat(genericPlanEntity.getApiId()).isEqualTo(API_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
     }
 
     @Test
     public void shouldClosePlanAndPausedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         var api = new Api();
@@ -198,22 +202,24 @@ public class PlanService_CloseTest {
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 
     @Test
     public void shouldClosePlanButNotClosedSubscription() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
-        when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         var api = new Api();
@@ -222,8 +228,7 @@ public class PlanService_CloseTest {
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.CLOSED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.CLOSED).build());
         verify(subscriptionService, never()).process(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeprecateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeprecateTest.java
@@ -61,9 +61,6 @@ public class PlanService_DeprecateTest {
     private SubscriptionService subscriptionService;
 
     @Mock
-    private Plan plan;
-
-    @Mock
     private SubscriptionEntity subscription;
 
     @Mock
@@ -77,7 +74,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanAlreadyDeprecatedException.class)
     public void shouldNotDepreciateBecauseAlreadyDepreciated() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.DEPRECATED);
+        var plan = Plan.builder().status(Plan.Status.DEPRECATED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -85,7 +82,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanAlreadyClosedException.class)
     public void shouldNotDepreciateBecauseAlreadyClosed() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.CLOSED);
+        var plan = Plan.builder().status(Plan.Status.CLOSED).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -93,7 +90,7 @@ public class PlanService_DeprecateTest {
 
     @Test(expected = PlanNotYetPublishedException.class)
     public void shouldNotDepreciateBecauseNotPublished() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
+        var plan = Plan.builder().status(Plan.Status.STAGING).build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
@@ -101,31 +98,35 @@ public class PlanService_DeprecateTest {
 
     @Test
     public void shouldDepreciateWithStagingPlanAndAllowStaging() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID, true);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 
     @Test(expected = PlanNotYetPublishedException.class)
     public void shouldNotDepreciateWithStagingPlanAndNotAllowStaging() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.STAGING)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID, false);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -137,16 +138,18 @@ public class PlanService_DeprecateTest {
 
     @Test
     public void shouldDepreciate() throws TechnicalException {
-        when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
-        when(plan.getType()).thenReturn(Plan.PlanType.API);
-        when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
-        when(plan.getApi()).thenReturn(API_ID);
+        var plan = Plan
+            .builder()
+            .status(Plan.Status.PUBLISHED)
+            .type(Plan.PlanType.API)
+            .validation(Plan.PlanValidationType.AUTO)
+            .api(API_ID)
+            .build();
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
         planService.deprecate(GraviteeContext.getExecutionContext(), PLAN_ID);
 
-        verify(plan, times(1)).setStatus(Plan.Status.DEPRECATED);
-        verify(planRepository, times(1)).update(plan);
+        verify(planRepository, times(1)).update(plan.toBuilder().status(Plan.Status.DEPRECATED).build());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -313,7 +313,8 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(Set.of(new PlanEntity().withStatus(PlanStatus.PUBLISHED)));
+        when(planSearchService.findByApi(executionContext, apiId))
+            .thenReturn(Set.of(PlanEntity.builder().status(PlanStatus.PUBLISHED).build()));
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
     }
 
@@ -322,7 +323,8 @@ public class ApiValidationServiceImplTest {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final String apiId = "api-id";
 
-        when(planSearchService.findByApi(executionContext, apiId)).thenReturn(Set.of(new PlanEntity().withStatus(PlanStatus.DEPRECATED)));
+        when(planSearchService.findByApi(executionContext, apiId))
+            .thenReturn(Set.of(PlanEntity.builder().status(PlanStatus.DEPRECATED).build()));
         assertTrue(apiValidationService.canDeploy(executionContext, apiId));
     }
 
@@ -341,7 +343,9 @@ public class ApiValidationServiceImplTest {
         final String apiId = "api-id";
 
         when(planSearchService.findByApi(executionContext, apiId))
-            .thenReturn(Set.of(new PlanEntity().withStatus(PlanStatus.STAGING), new PlanEntity().withStatus(PlanStatus.CLOSED)));
+            .thenReturn(
+                Set.of(PlanEntity.builder().status(PlanStatus.STAGING).build(), PlanEntity.builder().status(PlanStatus.CLOSED).build())
+            );
         assertFalse(apiValidationService.canDeploy(executionContext, apiId));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/storage/application/ApplicationStorageImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/storage/application/ApplicationStorageImplTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.Origin;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.repository.management.model.ApplicationType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ApplicationStorageImplTest {
+
+    ApplicationRepository applicationRepository;
+
+    ApplicationStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        applicationRepository = mock(ApplicationRepository.class);
+
+        service = new ApplicationStorageServiceImpl(applicationRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void should_return_application_entity_when_found() throws TechnicalException {
+            // Given
+            String applicationId = "appId";
+            when(applicationRepository.findById(any()))
+                .thenAnswer(invocation -> Optional.of(anApplication().id(invocation.getArgument(0)).build()));
+
+            // When
+            var result = service.findById(GraviteeContext.getExecutionContext(), applicationId);
+
+            // Then
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getApiKeyMode()).isEqualTo(io.gravitee.rest.api.model.ApiKeyMode.EXCLUSIVE);
+                soft.assertThat(result.getBackground()).isEqualTo("app-background");
+                soft.assertThat(result.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(result.getDescription()).isEqualTo("app-description");
+                soft.assertThat(result.isDisableMembershipNotifications()).isTrue();
+                soft.assertThat(result.getDomain()).isEqualTo("app-domain");
+                soft.assertThat(result.getGroups()).containsExactly("group1");
+                soft.assertThat(result.getId()).isEqualTo(applicationId);
+                soft.assertThat(result.getName()).isEqualTo("app-name");
+                soft.assertThat(result.getOrigin()).isEqualTo(Origin.MANAGEMENT);
+                soft.assertThat(result.getPicture()).isEqualTo("app-picture");
+                soft.assertThat(result.getStatus()).isEqualTo("ACTIVE");
+                soft.assertThat(result.getType()).isEqualTo("SIMPLE");
+                soft.assertThat(result.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+            });
+        }
+
+        @Test
+        void should_throw_when_environment_does_not_match_with_current_environment() throws TechnicalException {
+            // Given
+            String applicationId = "appId";
+            GraviteeContext.setCurrentEnvironment("OTHER");
+            when(applicationRepository.findById(any()))
+                .thenAnswer(invocation -> Optional.of(anApplication().id(invocation.getArgument(0)).build()));
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById(GraviteeContext.getExecutionContext(), applicationId));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(ApplicationNotFoundException.class)
+                .hasMessage("Application [" + applicationId + "] cannot be found.");
+        }
+
+        @Test
+        void should_throw_when_application_not_found() throws TechnicalException {
+            // Given
+            String applicationId = "unknown";
+            when(applicationRepository.findById(any())).thenReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById(GraviteeContext.getExecutionContext(), applicationId));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(ApplicationNotFoundException.class)
+                .hasMessage("Application [" + applicationId + "] cannot be found.");
+        }
+
+        @Test
+        void should_throw_when_find_fails() throws TechnicalException {
+            // Given
+            String applicationId = "unknown";
+            when(applicationRepository.findById(any())).thenThrow(new TechnicalException());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById(GraviteeContext.getExecutionContext(), applicationId));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    private Application.ApplicationBuilder anApplication() {
+        return Application
+            .builder()
+            .apiKeyMode(io.gravitee.repository.management.model.ApiKeyMode.EXCLUSIVE)
+            .background("app-background")
+            .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+            .description("app-description")
+            .disableMembershipNotifications(true)
+            .domain("app-domain")
+            .environmentId("DEFAULT")
+            .groups(Set.of("group1"))
+            .metadata(Map.of("key1", "value1"))
+            .name("app-name")
+            .origin(Origin.MANAGEMENT)
+            .picture("app-picture")
+            .status(ApplicationStatus.ACTIVE)
+            .type(ApplicationType.SIMPLE)
+            .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/storage/plan/PlanStorageServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/storage/plan/PlanStorageServiceImplTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.storage.plan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
+import io.gravitee.rest.api.model.v4.plan.PlanType;
+import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
+import io.gravitee.rest.api.service.converter.PlanConverter;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.storage.plan.adapter.BasePlanAdapter;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class PlanStorageServiceImplTest {
+
+    PlanRepository planRepository;
+    ApiRepository apiRepository;
+
+    PlanStorageServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        planRepository = mock(PlanRepository.class);
+        apiRepository = mock(ApiRepository.class);
+
+        service = new PlanStorageServiceImpl(planRepository, apiRepository, new BasePlanAdapter(new PlanConverter(new ObjectMapper())));
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void should_return_v4_plan_and_adapt_it() throws TechnicalException {
+            // Given
+            var planId = "plan-id";
+            var apiId = "api-id";
+            when(planRepository.findById(planId))
+                .thenAnswer(invocation -> Optional.of(planV4().id(invocation.getArgument(0)).api(apiId).build()));
+            when(apiRepository.findById(any(String.class)))
+                .thenAnswer(invocation ->
+                    Optional.of(Api.builder().id(invocation.getArgument(0)).definitionVersion(DefinitionVersion.V4).build())
+                );
+
+            // When
+            var result = service.findById(planId);
+
+            // Then
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result).isInstanceOf(BasePlanEntity.class);
+                BasePlanEntity plan = (BasePlanEntity) result;
+
+                soft.assertThat(plan.getApiId()).isEqualTo(apiId);
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
+                soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("general-conditions");
+                soft.assertThat(plan.getId()).isEqualTo(planId);
+                soft.assertThat(plan.getName()).isEqualTo("plan-name");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPlanMode()).isEqualTo(PlanMode.STANDARD);
+                soft
+                    .assertThat(plan.getPlanSecurity())
+                    .isEqualTo(PlanSecurity.builder().type("api-key").configuration("security-definition").build());
+                soft.assertThat(plan.getPlanStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                soft.assertThat(plan.getPlanType()).isEqualTo(PlanType.API);
+                soft.assertThat(plan.getPlanValidation()).isEqualTo(PlanValidationType.AUTO);
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.isCommentRequired()).isTrue();
+            });
+        }
+
+        @Test
+        void should_return_v2_plan_and_adapt_it() throws TechnicalException {
+            // Given
+            var planId = "plan-id";
+            var apiId = "api-id";
+            when(planRepository.findById(planId))
+                .thenAnswer(invocation -> Optional.of(planV2().id(invocation.getArgument(0)).api(apiId).build()));
+            when(apiRepository.findById(any(String.class)))
+                .thenAnswer(invocation ->
+                    Optional.of(Api.builder().id(invocation.getArgument(0)).definitionVersion(DefinitionVersion.V2).build())
+                );
+
+            // When
+            var result = service.findById(planId);
+
+            // Then
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result).isInstanceOf(io.gravitee.rest.api.model.BasePlanEntity.class);
+                io.gravitee.rest.api.model.BasePlanEntity plan = (io.gravitee.rest.api.model.BasePlanEntity) result;
+
+                soft.assertThat(plan.getApiId()).isEqualTo(apiId);
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
+                soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("general-conditions");
+                soft.assertThat(plan.getId()).isEqualTo(planId);
+                soft.assertThat(plan.getName()).isEqualTo("plan-name");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPaths()).isEqualTo(Map.of("/", List.of()));
+                soft.assertThat(plan.getPlanMode()).isEqualTo(PlanMode.STANDARD);
+                soft
+                    .assertThat(plan.getPlanSecurity())
+                    .isEqualTo(PlanSecurity.builder().type("API_KEY").configuration("security-definition").build());
+                soft.assertThat(plan.getPlanStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                soft.assertThat(plan.getPlanType()).isEqualTo(PlanType.API);
+                soft.assertThat(plan.getPlanValidation()).isEqualTo(PlanValidationType.AUTO);
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.isCommentRequired()).isTrue();
+            });
+        }
+
+        @Test
+        void should_throw_when_no_plan_found() throws TechnicalException {
+            // Given
+            String planId = "unknown";
+            when(planRepository.findById(planId)).thenReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById(planId));
+
+            // Then
+            assertThat(throwable).isInstanceOf(PlanNotFoundException.class).hasMessage("Plan [" + planId + "] cannot be found.");
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            String planId = "my-plan";
+            when(planRepository.findById(planId)).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById(planId));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurs while trying to find a plan by id: " + planId);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs_while_fetching_api() throws TechnicalException {
+            // Given
+            when(planRepository.findById(any(String.class))).thenReturn(Optional.of(planV4().api("api-id").build()));
+            when(apiRepository.findById(any(String.class))).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById("plan-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurs while trying to find an API using its ID: api-id");
+        }
+    }
+
+    private Plan.PlanBuilder planV4() {
+        return Plan
+            .builder()
+            .crossId("cross-id")
+            .name("plan-name")
+            .description("plan-description")
+            .security(Plan.PlanSecurityType.API_KEY)
+            .securityDefinition("security-definition")
+            .selectionRule("selection-rule")
+            .validation(Plan.PlanValidationType.AUTO)
+            .mode(Plan.PlanMode.STANDARD)
+            .order(1)
+            .type(Plan.PlanType.API)
+            .status(Plan.Status.PUBLISHED)
+            .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+            .publishedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+            .closedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")))
+            .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+            .characteristics(List.of("characteristic-1"))
+            .excludedGroups(List.of("excluded-group-1"))
+            .commentRequired(true)
+            .commentMessage("comment-message")
+            .generalConditions("general-conditions")
+            .tags(Set.of("tag-1"));
+    }
+
+    private Plan.PlanBuilder planV2() {
+        return Plan
+            .builder()
+            .crossId("cross-id")
+            .name("plan-name")
+            .description("plan-description")
+            .security(Plan.PlanSecurityType.API_KEY)
+            .securityDefinition("security-definition")
+            .selectionRule("selection-rule")
+            .validation(Plan.PlanValidationType.AUTO)
+            .mode(Plan.PlanMode.STANDARD)
+            .order(1)
+            .type(Plan.PlanType.API)
+            .status(Plan.Status.PUBLISHED)
+            .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+            .publishedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+            .closedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")))
+            .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+            .definition("{\"/\":[]}")
+            .characteristics(List.of("characteristic-1"))
+            .excludedGroups(List.of("excluded-group-1"))
+            .commentRequired(true)
+            .commentMessage("comment-message")
+            .generalConditions("general-conditions")
+            .tags(Set.of("tag-1"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextPath.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextPath.yml
@@ -24,8 +24,8 @@ spec:
     api: "id-api"
     order: 0
     paths: {}
-    flows: []
     comment_required: false
+    flows: []
   id: "id-api"
   path_mappings: []
   proxy:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
@@ -24,8 +24,8 @@ spec:
     api: "id-api"
     order: 0
     paths: {}
-    flows: []
     comment_required: false
+    flows: []
   id: "id-api"
   path_mappings: []
   proxy:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-noIds.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-noIds.yml
@@ -20,8 +20,8 @@ spec:
     status: "PUBLISHED"
     order: 0
     paths: {}
-    flows: []
     comment_required: false
+    flows: []
   path_mappings: []
   proxy:
     virtual_hosts:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-version.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-version.yml
@@ -24,8 +24,8 @@ spec:
     api: "id-api"
     order: 0
     paths: {}
-    flows: []
     comment_required: false
+    flows: []
   id: "id-api"
   path_mappings: []
   proxy:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource.yml
@@ -24,8 +24,8 @@ spec:
     api: "id-api"
     order: 0
     paths: {}
-    flows: []
     comment_required: false
+    flows: []
   id: "id-api"
   path_mappings: []
   proxy:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PlanModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PlanModelFixtures.java
@@ -35,7 +35,7 @@ public class PlanModelFixtures {
         .type(PlanSecurityType.API_KEY.getLabel())
         .configuration("{\"nice\": \"config\"}");
 
-    private static final PlanEntity.PlanEntityBuilder BASE_PLAN_ENTITY_V4 = PlanEntity
+    private static final PlanEntity.PlanEntityBuilder<?, ?> BASE_PLAN_ENTITY_V4 = PlanEntity
         .builder()
         .id("my-plan")
         .apiId("my-api")
@@ -57,27 +57,28 @@ public class PlanModelFixtures {
         .selectionRule("{#request.attribute['selectionRule'] != null}")
         .flows(List.of(FlowModelFixtures.aModelFlowV4()));
 
-    private static final io.gravitee.rest.api.model.PlanEntity.PlanEntityBuilder BASE_PLAN_ENTITY_V2 = io.gravitee.rest.api.model.PlanEntity
-        .builder()
-        .id("my-plan")
-        .api("my-api")
-        .name("My plan")
-        .description("Description")
-        .order(1)
-        .characteristics(List.of("characteristic1", "characteristic2"))
-        .createdAt(new Date())
-        .updatedAt(new Date())
-        .commentMessage("Comment message")
-        .crossId("my-plan-crossId")
-        .generalConditions("General conditions")
-        .tags(Set.of("tag1", "tag2"))
-        .status(io.gravitee.rest.api.model.PlanStatus.PUBLISHED)
-        .security(io.gravitee.rest.api.model.PlanSecurityType.API_KEY)
-        .type(io.gravitee.rest.api.model.PlanType.API)
-        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
-        .validation(io.gravitee.rest.api.model.PlanValidationType.AUTO)
-        .selectionRule("{#request.attribute['selectionRule'] != null}")
-        .flows(List.of(FlowModelFixtures.aModelFlowV2()));
+    private static final io.gravitee.rest.api.model.PlanEntity.PlanEntityBuilder<?, ?> BASE_PLAN_ENTITY_V2 =
+        io.gravitee.rest.api.model.PlanEntity
+            .builder()
+            .id("my-plan")
+            .api("my-api")
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .tags(Set.of("tag1", "tag2"))
+            .status(io.gravitee.rest.api.model.PlanStatus.PUBLISHED)
+            .security(io.gravitee.rest.api.model.PlanSecurityType.API_KEY)
+            .type(io.gravitee.rest.api.model.PlanType.API)
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(io.gravitee.rest.api.model.PlanValidationType.AUTO)
+            .selectionRule("{#request.attribute['selectionRule'] != null}")
+            .flows(List.of(FlowModelFixtures.aModelFlowV2()));
 
     public static PlanEntity aPlanEntityV4() {
         return BASE_PLAN_ENTITY_V4.build();

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <gatling-maven-plugin.version>4.0.1</gatling-maven-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <swagger-maven-plugin.version>>2.2.9</swagger-maven-plugin.version>
@@ -1118,6 +1119,11 @@
                             <arg>-parameters</arg>
                         </compilerArgs>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
## Description

This PR introduces two storage services I will use to implement API logs endpoint. 

This is part of the work we will tackle to improve the services architecture in MAPI by having "small" grained business focus application service (aka usecase) 
The WIP "architecture" will look like the following 

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4171593/da52fef5-2694-4cbe-bb12-50d4a6d4ed92)


## Additional context

InMemory implementation have been defined in test sources folder and we use a plugin to create a test-jar that can be "imported" in other module to have access to these implementation (like in Resource tests)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-igttjeskuc.chromatic.com)
<!-- Storybook placeholder end -->
