### PR TITLE
[4.0.x] Fix service discovery configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.module.ts
@@ -19,7 +19,12 @@ import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { MatTabsModule } from '@angular/material/tabs';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
-import { GioSaveBarModule, GioFormSlideToggleModule, GioFormFocusInvalidModule } from '@gravitee/ui-particles-angular';
+import {
+  GioSaveBarModule,
+  GioFormSlideToggleModule,
+  GioFormFocusInvalidModule,
+  GioFormJsonSchemaModule,
+} from '@gravitee/ui-particles-angular';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -62,6 +67,7 @@ import { GioGoBackButtonModule } from '../../../../../shared/components/gio-go-b
     GioFormSlideToggleModule,
 
     ApiProxyGroupEndpointModule,
+    GioFormJsonSchemaModule,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
@@ -329,7 +329,7 @@ describe('ApiProxyGroupEditComponent', () => {
       });
 
       it('should display service discovery gv-schema-form and save url', async () => {
-        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form-group')).toBeTruthy();
+        expect(fixture.debugElement.nativeElement.querySelector('gio-form-json-schema')).toBeTruthy();
 
         await loader.getHarness(GioSaveBarHarness).then((saveBar) => saveBar.clickSubmit());
 

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.component.ts
@@ -127,21 +127,16 @@ export class ApiProxyGroupEditComponent implements OnInit, OnDestroy {
   }
 
   public getServiceDiscoveryConfiguration(): ProxyGroupServiceDiscoveryConfiguration {
-    const enabled = this.serviceDiscoveryForm.get('enabled')?.value;
-
-    if (!enabled) {
-      return {
-        discovery: {
-          enabled,
-        },
-      };
-    }
-
+    const enabled: boolean = this.serviceDiscoveryForm.get('enabled')?.value;
     return {
       discovery: {
         enabled,
-        provider: this.serviceDiscoveryForm.get('type').value,
-        configuration: this.serviceDiscoveryForm.get('configuration').value,
+        ...(enabled
+          ? {
+              provider: this.serviceDiscoveryForm.get('provider').value,
+              configuration: this.serviceDiscoveryForm.get('configuration').value,
+            }
+          : {}),
       },
     };
   }
@@ -173,10 +168,10 @@ export class ApiProxyGroupEditComponent implements OnInit, OnDestroy {
     this.serviceDiscoveryForm = this.formBuilder.group(
       {
         enabled: [{ value: group?.services?.discovery.enabled ?? false, disabled: this.isReadOnly }],
-        type: [
+        provider: [
           {
             value: group?.services?.discovery.provider ?? null,
-            disabled: !group?.services?.discovery.enabled || this.isReadOnly,
+            disabled: this.isReadOnly,
           },
         ],
         configuration: [{ value: group?.services?.discovery?.configuration ?? {}, disabled: this.isReadOnly }],

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.validator.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/api-proxy-group-edit.validator.ts
@@ -17,9 +17,9 @@ import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 export const serviceDiscoveryValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
   const enabled = control.get('enabled').value;
-  const type = control.get('type').value;
+  const type = control.get('provider').value;
 
-  return enabled && !type ? { requireTypeWhenEnabled: true } : null;
+  return enabled && !type ? { requireProviderWhenEnabled: true } : null;
 };
 
 export const isUniq = (values: string[], defaultValue: string): ValidatorFn | null => {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
@@ -40,13 +40,7 @@
     </div>
 
     <div class="card__group-sd" *ngIf="serviceDiscoveryForm.get('enabled').value && schema">
-      <gv-schema-form-group
-        ngDefaultControl
-        formControlName="configuration"
-        [schema]="schema"
-        [attr.readonly]="serviceDiscoveryForm.get('configuration').enabled ? null : true"
-        (:gv-schema-form-group:error)="onConfigurationError($event.detail)"
-      ></gv-schema-form-group>
+      <gio-form-json-schema ngDefaultControl formControlName="configuration" [jsonSchema]="schema"> </gio-form-json-schema>
     </div>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.html
@@ -29,17 +29,17 @@
     </gio-form-slide-toggle>
 
     <!-- Type -->
-    <div class="card__group-sd">
+    <div class="card__group-sd" *ngIf="serviceDiscoveryForm.get('enabled').value">
       <div class="card__group-sd__type__label">Type</div>
       <mat-form-field class="card__group-sd__type__form-field">
         <mat-label>Type</mat-label>
-        <mat-select aria-label="Service discovery type" formControlName="type">
+        <mat-select aria-label="Service discovery provider" formControlName="provider">
           <mat-option *ngFor="let sd of serviceDiscoveryItems" [value]="sd.id">{{ sd.name }}</mat-option>
         </mat-select>
       </mat-form-field>
     </div>
 
-    <div class="card__group-sd" *ngIf="displaySchema">
+    <div class="card__group-sd" *ngIf="serviceDiscoveryForm.get('enabled').value && schema">
       <gv-schema-form-group
         ngDefaultControl
         formControlName="configuration"

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.component.ts
@@ -17,7 +17,6 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import '@gravitee/ui-components/wc/gv-schema-form-group';
 
 import { ResourceListItem } from '../../../../../../../entities/resource/resourceListItem';
 import { ServiceDiscoveryService } from '../../../../../../../services-ngx/service-discovery.service';
@@ -54,13 +53,6 @@ export class ApiProxyGroupServiceDiscoveryComponent implements OnInit, OnDestroy
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);
     this.unsubscribe$.complete();
-  }
-
-  onConfigurationError(error: unknown) {
-    // Set error at the end of js task. Otherwise it will be reset on value change
-    setTimeout(() => {
-      this.serviceDiscoveryForm.get('configuration').setErrors(error ? { error: true } : null);
-    }, 0);
   }
 
   private getProviderSchema(provider: string) {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.model.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/edit/service-discovery/api-proxy-group-service-discovery.model.ts
@@ -17,8 +17,3 @@
 import { Services } from '../../../../../../../entities/services';
 
 export type ProxyGroupServiceDiscoveryConfiguration = Pick<Services, 'discovery'>;
-
-export interface ServiceDiscoveryEvent {
-  isSchemaValid: boolean;
-  serviceDiscoveryValues: unknown;
-}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2396

## Description

When saving group configuration without any modification to service discovery, service discovery data were replaced with empty data, causing backend check to fail.
To fix that, I replaced using local variables by using a form control on the schema form component.

## Additional context

This [PR](https://github.com/gravitee-io/gravitee-api-management/pull/5058) was done on 3.20.x but component had been refactored on 4.x branches so I had to do it again.

Also took the opportunity to replace old gv component for json schema by the new gio one.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qbutpfzxrc.chromatic.com)
<!-- Storybook placeholder end -->
