### PR TITLE
Fix java-prettier configuration

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
@@ -22,10 +22,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.flow.Flow;
-
 import java.io.IOException;
 import java.util.Set;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -15,6 +15,14 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.processor.subscription;
 
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_API;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_APPLICATION;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_CLIENT_IDENTIFIER;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_PLAN;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_SUBSCRIPTION_ID;
+import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_SKIP;
+import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
+
 import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
@@ -23,21 +31,12 @@ import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.handlers.api.context.SubscriptionTemplateVariableProvider;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
-import org.bouncycastle.util.encoders.Hex;
-
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
-
-import static io.gravitee.gateway.api.ExecutionContext.ATTR_API;
-import static io.gravitee.gateway.api.ExecutionContext.ATTR_APPLICATION;
-import static io.gravitee.gateway.api.ExecutionContext.ATTR_CLIENT_IDENTIFIER;
-import static io.gravitee.gateway.api.ExecutionContext.ATTR_PLAN;
-import static io.gravitee.gateway.api.ExecutionContext.ATTR_SUBSCRIPTION_ID;
-import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_SKIP;
-import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
+import org.bouncycastle.util.encoders.Hex;
 
 /**
  * This processor will add template variable provide for the resolved {@link Subscription} if any.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
@@ -39,11 +39,10 @@ import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.handlers.api.context.SubscriptionTemplateVariableProvider;
 import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.MultiMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import io.vertx.core.MultiMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -74,7 +73,7 @@ class SubscriptionProcessorTest extends AbstractProcessorTest {
     ArgumentCaptor<Collection<TemplateVariableProvider>> providersCaptor;
 
     private SubscriptionProcessor cut;
-    private MultiValueMap<String,String> requestParams;
+    private MultiValueMap<String, String> requestParams;
 
     @BeforeEach
     void initProcessor() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
@@ -101,15 +101,15 @@ public class VertxHttpServerResponse extends AbstractResponse {
 
             if (lazyBufferFlow().hasChunks()) {
                 return nativeResponse
-                        .rxSend(
-                                chunks()
-                                        .doOnSubscribe(subscriptionRef::set)
-                                        .map(buffer -> io.vertx.rxjava3.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
-                                        .doOnNext(buffer ->
-                                                ctx.metrics().setResponseContentLength(ctx.metrics().getResponseContentLength() + buffer.length())
-                                        )
-                        )
-                        .doOnDispose(() -> subscriptionRef.get().cancel());
+                    .rxSend(
+                        chunks()
+                            .doOnSubscribe(subscriptionRef::set)
+                            .map(buffer -> io.vertx.rxjava3.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
+                            .doOnNext(buffer ->
+                                ctx.metrics().setResponseContentLength(ctx.metrics().getResponseContentLength() + buffer.length())
+                            )
+                    )
+                    .doOnDispose(() -> subscriptionRef.get().cancel());
             }
 
             return nativeResponse.rxEnd();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -30,9 +33,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-
-import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -65,8 +65,7 @@ public class TransactionRequestProcessorTest {
     public void shouldHaveTransactionId() {
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor().handler(context -> {
-        }).handle(context);
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
         Assert.assertNotNull(context.request().transactionId());
         Assert.assertEquals(context.request().transactionId(), context.request().headers().get(DEFAULT_TRANSACTION_ID_HEADER));
@@ -96,8 +95,7 @@ public class TransactionRequestProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.parameters().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor().handler(context -> {
-        }).handle(context);
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
         Assert.assertNotNull(context.request().transactionId());
         Assert.assertEquals(transactionId, context.request().transactionId());
@@ -109,8 +107,7 @@ public class TransactionRequestProcessorTest {
     public void shouldHaveTransactionIdWithCustomHeader() {
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {
-        }).handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
         Assert.assertNotNull(context.request().transactionId());
         Assert.assertEquals(context.request().transactionId(), context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
@@ -122,8 +119,7 @@ public class TransactionRequestProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {
-        }).handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
         Assert.assertNotNull(context.request().transactionId());
         Assert.assertEquals(transactionId, context.request().transactionId());
@@ -136,14 +132,11 @@ public class TransactionRequestProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.parameters().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {
-        }).handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
         Assert.assertNotNull(context.request().transactionId());
         Assert.assertEquals(transactionId, context.request().transactionId());
         Assert.assertEquals(transactionId, context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
         Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-
     }
-
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/httppost/HttpPostEntrypointRabbitMQEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/httppost/HttpPostEntrypointRabbitMQEndpointIntegrationTest.java
@@ -39,7 +39,6 @@ import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
@@ -70,11 +69,11 @@ class HttpPostEntrypointRabbitMQEndpointIntegrationTest extends AbstractRabbitMQ
 
         subscribeToRabbitMQ(exchange, routingKey)
             .zipWith(
-                    postMessage(client, "/test", requestBody, Map.of("X-Test-Header", "header-value"))
-                        .delaySubscription(750, MILLISECONDS)
-                        .isEmpty()
-                        .toFlowable(),
-                    (c, o) -> c
+                postMessage(client, "/test", requestBody, Map.of("X-Test-Header", "header-value"))
+                    .delaySubscription(750, MILLISECONDS)
+                    .isEmpty()
+                    .toFlowable(),
+                (c, o) -> c
             )
             .test()
             .awaitDone(30, TimeUnit.SECONDS)

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationTest.java
@@ -18,9 +18,9 @@ package io.gravitee.repository.elasticsearch.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.elasticsearch.config.Endpoint;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
@@ -24,7 +24,6 @@ import io.gravitee.repository.management.model.AlertTrigger;
 import io.gravitee.repository.management.model.Tag;
 import io.gravitee.repository.management.model.TagReferenceType;
 import io.gravitee.repository.management.model.TenantReferenceType;
-
 import java.sql.PreparedStatement;
 import java.sql.Types;
 import java.util.HashSet;
@@ -100,21 +99,24 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
 
     @Override
     public Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType)
-            throws TechnicalException {
+        throws TechnicalException {
         try {
             return jdbcTemplate
-                    .query(
-                            getOrm().getSelectAllSql() + " where reference_id = ? and reference_type = ? and id in ( " +
-                            getOrm().buildInClause(tagIds) + " )",
-                            (PreparedStatement ps) -> {
-                                ps.setString(1, referenceId);
-                                ps.setString(2, referenceType.name());
-                                getOrm().setArguments(ps, tagIds, 3);
-                            },
-                            getOrm().getRowMapper()
-                    ).stream()
-                    .peek(this::addGroups)
-                    .collect(toSet());
+                .query(
+                    getOrm().getSelectAllSql() +
+                    " where reference_id = ? and reference_type = ? and id in ( " +
+                    getOrm().buildInClause(tagIds) +
+                    " )",
+                    (PreparedStatement ps) -> {
+                        ps.setString(1, referenceId);
+                        ps.setString(2, referenceType.name());
+                        getOrm().setArguments(ps, tagIds, 3);
+                    },
+                    getOrm().getRowMapper()
+                )
+                .stream()
+                .peek(this::addGroups)
+                .collect(toSet());
         } catch (final Exception ex) {
             LOGGER.error("Failed to find {} tags by ids, referenceId and referenceType:", getOrm().getTableName(), ex);
             throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by ids, referenceId and referenceType", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
@@ -67,7 +67,8 @@ public class MongoTagRepository implements TagRepository {
     }
 
     @Override
-    public Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType) throws TechnicalException {
+    public Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType)
+        throws TechnicalException {
         LOGGER.debug("Find tags by IDs and reference [{}, {}, {}]", tagIds, referenceId, referenceType);
 
         final List<TagMongo> tags = internalTagRepo.findByIdInAndReferenceIdAndReferenceType(tagIds, referenceId, referenceType);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/TagMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/TagMongoRepository.java
@@ -21,7 +21,6 @@ import io.gravitee.repository.mongodb.management.internal.model.TagMongo;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpManagementRepositoryConfiguration.java
@@ -71,5 +71,4 @@ public class NoOpManagementRepositoryConfiguration {
     public CommandRepository commandRepository() {
         return new NoOpCommandRepository();
     }
-
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
@@ -35,7 +35,7 @@ public class NoOpRepositoryProvider implements RepositoryProvider {
 
     @Override
     public Scope[] scopes() {
-        return new Scope[]{Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT};
+        return new Scope[] { Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT };
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/AbstractNoOpManagementRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/AbstractNoOpManagementRepository.java
@@ -17,7 +17,6 @@ package io.gravitee.repository.noop.management;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CrudRepository;
-
 import java.util.Optional;
 import java.util.Set;
 
@@ -43,9 +42,7 @@ public abstract class AbstractNoOpManagementRepository<U, V> implements CrudRepo
     }
 
     @Override
-    public void delete(V v) throws TechnicalException {
-
-    }
+    public void delete(V v) throws TechnicalException {}
 
     @Override
     public Set<U> findAll() throws TechnicalException {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
@@ -20,7 +20,6 @@ import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApiKey;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -30,7 +29,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public class NoOpApiKeyRepository implements ApiKeyRepository {
-
 
     @Override
     public Optional<ApiKey> findById(String id) throws TechnicalException {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpCommandRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
-
 import java.util.List;
 
 /**
@@ -26,7 +25,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public class NoOpCommandRepository extends AbstractNoOpManagementRepository<Command, String> implements CommandRepository {
-
 
     @Override
     public List<Command> search(CommandCriteria criteria) {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
-
 import java.util.Optional;
 import java.util.Set;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEventLatestRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEventLatestRepository.java
@@ -19,7 +19,6 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventLatestRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.model.Event;
-
 import java.util.List;
 
 /**
@@ -27,7 +26,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public class NoOpEventLatestRepository implements EventLatestRepository {
-
 
     @Override
     public List<Event> search(EventCriteria criteria, Event.EventProperties group, Long page, Long size) {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEventRepository.java
@@ -21,7 +21,6 @@ import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
-
 import java.util.List;
 
 /**
@@ -29,7 +28,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public class NoOpEventRepository extends AbstractNoOpManagementRepository<Event, String> implements EventRepository {
-
 
     @Override
     public Page<Event> search(EventCriteria filter, Pageable pageable) {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpInstallationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpInstallationRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InstallationRepository;
 import io.gravitee.repository.management.model.Installation;
-
 import java.util.Optional;
 
 /**
@@ -26,7 +25,6 @@ import java.util.Optional;
  * @author GraviteeSource Team
  */
 public class NoOpInstallationRepository extends AbstractNoOpManagementRepository<Installation, String> implements InstallationRepository {
-
 
     @Override
     public Optional<Installation> find() throws TechnicalException {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpOrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpOrganizationRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
-
 import java.util.Set;
 
 /**
@@ -36,5 +35,4 @@ public class NoOpOrganizationRepository extends AbstractNoOpManagementRepository
     public Set<Organization> findByHrids(Set<String> hrids) throws TechnicalException {
         return Set.of();
     }
-
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -28,7 +27,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public class NoOpPlanRepository extends AbstractNoOpManagementRepository<Plan, String> implements PlanRepository {
-
 
     @Override
     public List<Plan> findByApis(List<String> apiIds) throws TechnicalException {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
@@ -25,7 +25,6 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -35,7 +34,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public class NoOpSubscriptionRepository extends AbstractNoOpManagementRepository<Subscription, String> implements SubscriptionRepository {
-
 
     @Override
     public Page<Subscription> search(SubscriptionCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/ratelimit/NoOpRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/ratelimit/NoOpRateLimitRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.noop.ratelimit;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.reactivex.rxjava3.core.Single;
-
 import java.util.function.Supplier;
 
 /**
@@ -26,7 +25,6 @@ import java.util.function.Supplier;
  * @author GraviteeSource Team
  */
 public class NoOpRateLimitRepository implements RateLimitRepository<RateLimit> {
-
 
     @Override
     public Single<RateLimit> incrementAndGet(String key, long weight, Supplier<RateLimit> supplier) {

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryConfigurationTest.java
@@ -23,10 +23,7 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({
-        NoOpAnalyticsRepositoryConfiguration.class,
-        NoOpManagementRepositoryConfiguration.class,
-        NoOpRateLimitRepositoryConfiguration.class
-})
-public class NoOpRepositoryConfigurationTest {
-}
+@Import(
+    { NoOpAnalyticsRepositoryConfiguration.class, NoOpManagementRepositoryConfiguration.class, NoOpRateLimitRepositoryConfiguration.class }
+)
+public class NoOpRepositoryConfigurationTest {}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpApiKeyRepositoryTest.java
@@ -15,19 +15,17 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static org.junit.Assert.*;
-
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpCommandRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpCommandRepositoryTest.java
@@ -15,18 +15,16 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.List;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -44,5 +42,4 @@ class NoOpCommandRepositoryTest extends AbstractNoOpRepositoryTest {
         assertNotNull(commands);
         assertTrue(commands.isEmpty());
     }
-
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepositoryTest.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.Optional;
 import java.util.Set;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEventLatestRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEventLatestRepositoryTest.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventLatestRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.List;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -50,5 +49,4 @@ public class NoOpEventLatestRepositoryTest extends AbstractNoOpRepositoryTest {
 
         assertNull(event);
     }
-
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEventRepositoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
@@ -22,12 +24,9 @@ import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.List;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpInstallationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpInstallationRepositoryTest.java
@@ -15,16 +15,15 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InstallationRepository;
 import io.gravitee.repository.management.model.Installation;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.Optional;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Optional;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpOrganizationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpOrganizationRepositoryTest.java
@@ -15,16 +15,15 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.Set;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Set;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpPlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpPlanRepositoryTest.java
@@ -15,17 +15,16 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepositoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.noop.management;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
@@ -25,13 +27,10 @@ import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import java.util.List;
 import java.util.Set;
-
-import static org.junit.Assert.*;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -52,7 +51,11 @@ public class NoOpSubscriptionRepositoryTest extends AbstractNoOpRepositoryTest {
 
     @Test
     public void testSortablePageableSearch() throws TechnicalException {
-        Page<Subscription> subscriptions = cut.search(SubscriptionCriteria.builder().build(), new SortableBuilder().build(), new PageableBuilder().build());
+        Page<Subscription> subscriptions = cut.search(
+            SubscriptionCriteria.builder().build(),
+            new SortableBuilder().build(),
+            new PageableBuilder().build()
+        );
 
         assertNotNull(subscriptions);
         assertNotNull(subscriptions.getContent());

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepositoryTest.java
@@ -18,9 +18,8 @@ package io.gravitee.repository.noop.monitor;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
-import java.io.IOException;
-
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/ratelimit/NoOpRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/ratelimit/NoOpRateLimitRepositoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.noop.ratelimit;
 
+import static org.junit.Assert.*;
+
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
@@ -22,8 +24,6 @@ import io.reactivex.rxjava3.core.Single;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.function.SingletonSupplier;
-
-import static org.junit.Assert.*;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
@@ -17,8 +17,8 @@ package io.gravitee.repository.management;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 import io.gravitee.repository.management.model.Tag;
 import io.gravitee.repository.management.model.TagReferenceType;
@@ -131,7 +131,11 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void should_find_by_ids_and_reference_id_and_reference_type() throws Exception {
-        final Set<Tag> tags = tagRepository.findByIdsAndReference(Set.of("international", "stores", "not-to-be-found"), "DEFAULT", TagReferenceType.ORGANIZATION);
+        final Set<Tag> tags = tagRepository.findByIdsAndReference(
+            Set.of("international", "stores", "not-to-be-found"),
+            "DEFAULT",
+            TagReferenceType.ORGANIZATION
+        );
 
         assertThat(tags).hasSize(2).anyMatch(tag -> tag.getId().equals("international") && tag.getName().equals("International"));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapper.java
@@ -16,15 +16,14 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.Sampling;
 import org.mapstruct.Mapper;
-import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import org.mapstruct.Mapping;
 import org.mapstruct.ValueMapping;
 
 @Mapper
 public interface AnalyticsMapper {
-
     @Mapping(target = "sampling", source = "messageSampling")
     Analytics toAnalytics(io.gravitee.definition.model.v4.analytics.Analytics analytics);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
@@ -73,5 +73,4 @@ public interface ConfigurationSerializationMapper {
 
         return configuration;
     }
-
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapper.java
@@ -20,6 +20,10 @@ import io.gravitee.rest.api.management.v2.rest.model.GroupEvent;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.GroupEventRuleEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -27,13 +31,7 @@ import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-
-@Mapper(uses = {DateMapper.class})
+@Mapper(uses = { DateMapper.class })
 public interface GroupMapper {
     Logger logger = LoggerFactory.getLogger(GroupMapper.class);
     GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
@@ -41,22 +39,26 @@ public interface GroupMapper {
     @Mapping(source = "roles", target = "apiRole", qualifiedByName = "mapApiRole")
     @Mapping(source = "roles", target = "applicationRole", qualifiedByName = "mapApplicationRole")
     Group map(GroupEntity group);
+
     List<Group> map(List<GroupEntity> groups);
 
     default List<GroupEvent> mapGroupEventRuleEntities(List<GroupEventRuleEntity> events) {
         if (Objects.isNull(events)) {
             return null;
         }
-        return events.stream().map(event -> {
-            if (Objects.nonNull(event)) {
-                try {
-                    return GroupEvent.fromValue(event.getEvent());
-                } catch (IllegalArgumentException e) {
-                    logger.error("Unable to parse GroupEventRuleEntity: " + event.getEvent());
+        return events
+            .stream()
+            .map(event -> {
+                if (Objects.nonNull(event)) {
+                    try {
+                        return GroupEvent.fromValue(event.getEvent());
+                    } catch (IllegalArgumentException e) {
+                        logger.error("Unable to parse GroupEventRuleEntity: " + event.getEvent());
+                    }
                 }
-            }
-            return null;
-        }).collect(Collectors.toList());
+                return null;
+            })
+            .collect(Collectors.toList());
     }
 
     @Named("mapApiRole")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
@@ -78,7 +78,7 @@ public interface ServiceMapper {
     @Mapping(target = "specification", qualifiedByName = "deserializeConfiguration")
     @Mapping(target = "body", qualifiedByName = "deserializeConfiguration")
     HttpDynamicPropertyProviderConfiguration map(
-            io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration httpDynamicPropertyProviderConfiguration
+        io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration httpDynamicPropertyProviderConfiguration
     );
 
     @Named("toDynamicPropertyProviderConfiguration")
@@ -96,13 +96,18 @@ public interface ServiceMapper {
 
     @Named("toDynamicPropertyServiceConfiguration")
     default DynamicPropertyServiceConfiguration mapToDynamicPropertyServiceConfiguration(
-            DynamicPropertyProviderConfiguration configuration
+        DynamicPropertyProviderConfiguration configuration
     ) {
-        if (Objects.nonNull(configuration) && configuration instanceof io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration) {
-            var mappedConfiguration = this.map((io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration) configuration);
+        if (
+            Objects.nonNull(configuration) &&
+            configuration instanceof io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration
+        ) {
+            var mappedConfiguration =
+                this.map(
+                        (io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration) configuration
+                    );
             return new DynamicPropertyServiceConfiguration(mappedConfiguration);
         }
         return null;
     }
-
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -641,9 +641,8 @@ public class ApiResource extends AbstractResource {
                 HttpListener httpListener = (HttpListener) first.get();
                 if (httpListener.getPaths() != null && !httpListener.getPaths().isEmpty()) {
                     io.gravitee.definition.model.v4.listener.http.Path path = httpListener.getPaths().get(0);
-                    io.gravitee.definition.model.v4.listener.http.Path filteredPath = new io.gravitee.definition.model.v4.listener.http.Path(
-                        path.getPath()
-                    );
+                    io.gravitee.definition.model.v4.listener.http.Path filteredPath =
+                        new io.gravitee.definition.model.v4.listener.http.Path(path.getPath());
                     httpListener.setPaths(List.of(filteredPath));
                 }
                 httpListener.setPathMappings(null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/AnalyticsFixtures.java
@@ -36,9 +36,11 @@ public class AnalyticsFixtures {
     }
 
     public static io.gravitee.rest.api.management.v2.rest.model.Analytics aBasicAnalytics() {
-        final io.gravitee.rest.api.management.v2.rest.model.Analytics analytics = new io.gravitee.rest.api.management.v2.rest.model.Analytics();
+        final io.gravitee.rest.api.management.v2.rest.model.Analytics analytics =
+            new io.gravitee.rest.api.management.v2.rest.model.Analytics();
         analytics.setEnabled(true);
-        final io.gravitee.rest.api.management.v2.rest.model.Sampling sampling = new io.gravitee.rest.api.management.v2.rest.model.Sampling();
+        final io.gravitee.rest.api.management.v2.rest.model.Sampling sampling =
+            new io.gravitee.rest.api.management.v2.rest.model.Sampling();
         sampling.setType(io.gravitee.rest.api.management.v2.rest.model.Sampling.TypeEnum.COUNT);
         sampling.setValue("10");
         analytics.setSampling(sampling);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/FlowFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/FlowFixtures.java
@@ -38,18 +38,19 @@ public class FlowFixtures {
 
     private FlowFixtures() {}
 
-    private static final io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.ChannelSelectorBuilder BASE_CHANNEL_SELECTOR_V4 = io.gravitee.rest.api.management.v2.rest.model.ChannelSelector
-        .builder()
-        .channel("channel")
-        .type(BaseSelector.TypeEnum.CHANNEL)
-        .entrypoints(Set.of("entrypoint1", "entrypoint2"))
-        .operations(
-            Set.of(
-                io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.SUBSCRIBE,
-                io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.PUBLISH
+    private static final io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.ChannelSelectorBuilder BASE_CHANNEL_SELECTOR_V4 =
+        io.gravitee.rest.api.management.v2.rest.model.ChannelSelector
+            .builder()
+            .channel("channel")
+            .type(BaseSelector.TypeEnum.CHANNEL)
+            .entrypoints(Set.of("entrypoint1", "entrypoint2"))
+            .operations(
+                Set.of(
+                    io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.SUBSCRIBE,
+                    io.gravitee.rest.api.management.v2.rest.model.ChannelSelector.OperationsEnum.PUBLISH
+                )
             )
-        )
-        .channelOperator(io.gravitee.rest.api.management.v2.rest.model.Operator.EQUALS);
+            .channelOperator(io.gravitee.rest.api.management.v2.rest.model.Operator.EQUALS);
 
     private static final StepV4.StepV4Builder BASE_STEP_V4 = StepV4
         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
@@ -35,14 +35,14 @@ public class PlanFixtures {
 
     private PlanFixtures() {}
 
-    private static final UpdateGenericPlanSecurity.UpdateGenericPlanSecurityBuilder<?, ?> BASE_UPDATE_PLAN_SECURITY = UpdateGenericPlanSecurity
-        .builder()
-        .configuration("{\"nice\": \"config\"}");
+    private static final UpdateGenericPlanSecurity.UpdateGenericPlanSecurityBuilder<?, ?> BASE_UPDATE_PLAN_SECURITY =
+        UpdateGenericPlanSecurity.builder().configuration("{\"nice\": \"config\"}");
 
-    private static final io.gravitee.rest.api.management.v2.rest.model.PlanSecurity.PlanSecurityBuilder<?, ?> BASE_PLAN_SECURITY = io.gravitee.rest.api.management.v2.rest.model.PlanSecurity
-        .builder()
-        .type(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.API_KEY)
-        .configuration("{\"nice\": \"config\"}");
+    private static final io.gravitee.rest.api.management.v2.rest.model.PlanSecurity.PlanSecurityBuilder<?, ?> BASE_PLAN_SECURITY =
+        io.gravitee.rest.api.management.v2.rest.model.PlanSecurity
+            .builder()
+            .type(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.API_KEY)
+            .configuration("{\"nice\": \"config\"}");
 
     private static final CreatePlanV4.CreatePlanV4Builder BASE_CREATE_PLAN_V4 = CreatePlanV4
         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsMapperTest.java
@@ -15,14 +15,14 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import fixtures.AnalyticsFixtures;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
 import io.gravitee.rest.api.management.v2.rest.model.Sampling;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class AnalyticsMapperTest {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
@@ -415,12 +415,15 @@ public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTe
         apiEntity.setId(API_ID);
         apiEntity.setName(API_ID);
         apiEntity.setApiVersion("v1.0");
-        io.gravitee.definition.model.v4.listener.http.HttpListener httpListener = new io.gravitee.definition.model.v4.listener.http.HttpListener();
+        io.gravitee.definition.model.v4.listener.http.HttpListener httpListener =
+            new io.gravitee.definition.model.v4.listener.http.HttpListener();
         httpListener.setPaths(List.of(new Path("my.fake.host", "/test")));
         httpListener.setPathMappings(Set.of("/test"));
 
-        io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener subscriptionListener = new io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener();
-        io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint entrypoint = new io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint();
+        io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener subscriptionListener =
+            new io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener();
+        io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint entrypoint =
+            new io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint();
         entrypoint.setType("Entrypoint type");
         entrypoint.setQos(io.gravitee.definition.model.v4.listener.entrypoint.Qos.AT_LEAST_ONCE);
         entrypoint.setDlq(new io.gravitee.definition.model.v4.listener.entrypoint.Dlq("my-endpoint"));
@@ -428,7 +431,8 @@ public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTe
         subscriptionListener.setEntrypoints(List.of(entrypoint));
         subscriptionListener.setType(io.gravitee.definition.model.v4.listener.ListenerType.SUBSCRIPTION);
 
-        io.gravitee.definition.model.v4.listener.tcp.TcpListener tcpListener = new io.gravitee.definition.model.v4.listener.tcp.TcpListener();
+        io.gravitee.definition.model.v4.listener.tcp.TcpListener tcpListener =
+            new io.gravitee.definition.model.v4.listener.tcp.TcpListener();
         tcpListener.setType(io.gravitee.definition.model.v4.listener.ListenerType.TCP);
         tcpListener.setEntrypoints(List.of(entrypoint));
 
@@ -474,18 +478,21 @@ public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTe
         flow.setRequest(List.of(step));
         flow.setTags(Set.of("tag1", "tag2"));
 
-        io.gravitee.definition.model.v4.flow.selector.HttpSelector httpSelector = new io.gravitee.definition.model.v4.flow.selector.HttpSelector();
+        io.gravitee.definition.model.v4.flow.selector.HttpSelector httpSelector =
+            new io.gravitee.definition.model.v4.flow.selector.HttpSelector();
         httpSelector.setPath("/test");
         httpSelector.setMethods(Set.of(io.gravitee.common.http.HttpMethod.GET, io.gravitee.common.http.HttpMethod.POST));
         httpSelector.setPathOperator(io.gravitee.definition.model.flow.Operator.STARTS_WITH);
 
-        io.gravitee.definition.model.v4.flow.selector.ChannelSelector channelSelector = new io.gravitee.definition.model.v4.flow.selector.ChannelSelector();
+        io.gravitee.definition.model.v4.flow.selector.ChannelSelector channelSelector =
+            new io.gravitee.definition.model.v4.flow.selector.ChannelSelector();
         channelSelector.setChannel("my-channel");
         channelSelector.setChannelOperator(io.gravitee.definition.model.flow.Operator.STARTS_WITH);
         channelSelector.setOperations(Set.of(io.gravitee.definition.model.v4.flow.selector.ChannelSelector.Operation.SUBSCRIBE));
         channelSelector.setEntrypoints(Set.of("my-entrypoint"));
 
-        io.gravitee.definition.model.v4.flow.selector.ConditionSelector conditionSelector = new io.gravitee.definition.model.v4.flow.selector.ConditionSelector();
+        io.gravitee.definition.model.v4.flow.selector.ConditionSelector conditionSelector =
+            new io.gravitee.definition.model.v4.flow.selector.ConditionSelector();
         conditionSelector.setCondition("my-condition");
 
         flow.setSelectors(List.of(httpSelector, channelSelector, conditionSelector));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
@@ -139,12 +139,12 @@ public class GroupResource extends AbstractResource {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "List APIs or applications linked to this group")
     @ApiResponse(
-           responseCode = "200",
-           description = "Group memberships",
-           content = @Content(
-                  mediaType = APPLICATION_JSON,
-                  array = @ArraySchema(schema = @Schema(oneOf = {ApiEntity.class, ApplicationEntity.class}))
-    )
+        responseCode = "200",
+        description = "Group memberships",
+        content = @Content(
+            mediaType = APPLICATION_JSON,
+            array = @ArraySchema(schema = @Schema(oneOf = { ApiEntity.class, ApplicationEntity.class }))
+        )
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response getGroupMemberships(@QueryParam("type") String type) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleResource.java
@@ -97,10 +97,7 @@ public class RoleResource extends AbstractResource {
     @DELETE
     @Consumes(MediaType.APPLICATION_JSON)
     @Operation(summary = "Delete a role", description = "User must have the MANAGEMENT_ROLE[DELETE] permission to use this service")
-    @ApiResponse(
-        responseCode = "204",
-        description = "Role successfully deleted"
-    )
+    @ApiResponse(responseCode = "204", description = "Role successfully deleted")
     @ApiResponse(responseCode = "404", description = "Role not found")
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.DELETE) })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
@@ -26,9 +26,8 @@ import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.util.Set;
-
 import jakarta.ws.rs.core.Response;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
@@ -26,9 +26,8 @@ import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.util.Set;
-
 import jakarta.ws.rs.core.Response;
+import java.util.Set;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Before;
 import org.junit.Test;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
@@ -29,10 +29,10 @@ import io.gravitee.rest.api.model.log.SearchLogResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Objects;
 import org.junit.Before;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.junit.Test;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UserEntity.java
@@ -17,11 +17,10 @@ package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.rest.api.model.search.Indexable;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-
-import io.gravitee.rest.api.model.search.Indexable;
 import lombok.*;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
@@ -23,7 +23,6 @@ import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.search.Indexable;
-
 import java.util.Date;
 import java.util.List;
 import java.util.Map;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/GenericPlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/GenericPlanEntity.java
@@ -18,9 +18,7 @@ package io.gravitee.rest.api.model.v4.plan;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-
 import io.gravitee.rest.api.model.Identifiable;
-
 import java.util.Date;
 import java.util.List;
 
@@ -29,7 +27,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface GenericPlanEntity extends Identifiable {
-
     String getName();
 
     String getApiId();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/UpdateApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/UpdateApiEntityTest.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.model.api;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class UpdateApiEntityTest {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntityTest.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.rest.api.model.v4.api;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 public class UpdateApiEntityTest {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiIdsCalculatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiIdsCalculatorService.java
@@ -19,8 +19,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 
 public interface ApiIdsCalculatorService {
-
     ImportApiJsonNode recalculateApiDefinitionIds(final ExecutionContext executionContext, ImportApiJsonNode apiJsonNode);
-    ImportApiJsonNode recalculateApiDefinitionIds(final ExecutionContext executionContext, ImportApiJsonNode apiJsonNode,
-                                                  String urlApiId);
+    ImportApiJsonNode recalculateApiDefinitionIds(final ExecutionContext executionContext, ImportApiJsonNode apiJsonNode, String urlApiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandler.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service.cockpit.command.handler;
 
+import static io.gravitee.rest.api.service.common.SecurityContextHelper.authenticateAs;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.CommandHandler;
@@ -30,8 +32,6 @@ import io.reactivex.rxjava3.core.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
-import static io.gravitee.rest.api.service.common.SecurityContextHelper.authenticateAs;
 
 /**
  * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
@@ -32,11 +32,10 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.ApiService;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.reactivex.rxjava3.core.Single;
-import org.springframework.stereotype.Component;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)
@@ -69,9 +68,9 @@ public class V4ApiServiceCockpitImpl implements V4ApiServiceCockpit {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
         return Single
-                .just(apiServiceV4.create(executionContext, newApiEntity, userId))
-                .flatMap(apiEntity -> publishApi(executionContext, apiEntity, userId, updateApiEntity))
-                .flatMap(apiEntity -> syncDeployment(executionContext, apiEntity.getId(), userId));
+            .just(apiServiceV4.create(executionContext, newApiEntity, userId))
+            .flatMap(apiEntity -> publishApi(executionContext, apiEntity, userId, updateApiEntity))
+            .flatMap(apiEntity -> syncDeployment(executionContext, apiEntity.getId(), userId));
     }
 
     private NewApiEntity getNewApiEntity(JsonNode node) throws JsonProcessingException {
@@ -100,7 +99,12 @@ public class V4ApiServiceCockpitImpl implements V4ApiServiceCockpit {
         return Single.just((ApiEntity) apiStateService.deploy(executionContext, apiId, userId, deploymentEntity));
     }
 
-    private Single<ApiEntity> publishApi(ExecutionContext executionContext, ApiEntity apiEntity, String userId, UpdateApiEntity updateApiEntity) {
+    private Single<ApiEntity> publishApi(
+        ExecutionContext executionContext,
+        ApiEntity apiEntity,
+        String userId,
+        UpdateApiEntity updateApiEntity
+    ) {
         final UpdateApiEntity apiToUpdate = createUpdateApiEntity(apiEntity, updateApiEntity);
 
         final ApiEntity update = apiServiceV4.update(executionContext, apiEntity.getId(), apiToUpdate, userId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
@@ -277,7 +277,8 @@ public abstract class AbstractReferenceMetadataService {
             }
             final ReferenceMetadataEntity referenceMetadataEntity = convert(savedMetadata);
             if (withDefaults) {
-                metadataService.findAllDefault()
+                metadataService
+                    .findAllDefault()
                     .stream()
                     .filter(m -> m.getKey().equals(metadataEntity.getKey()))
                     .findAny()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiIdsCalculatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiIdsCalculatorServiceImpl.java
@@ -15,10 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static java.util.stream.Collectors.toMap;
+
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.ApiIdsCalculatorService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.PlanService;
@@ -27,19 +30,15 @@ import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.imports.ImportJsonNodeWithIds;
 import io.gravitee.rest.api.service.imports.ImportPlanJsonNode;
-import io.gravitee.rest.api.service.ApiIdsCalculatorService;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toMap;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -60,8 +59,11 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
     }
 
     @Override
-    public ImportApiJsonNode recalculateApiDefinitionIds(ExecutionContext executionContext, ImportApiJsonNode apiJsonNode,
-                                                         String urlApiId) {
+    public ImportApiJsonNode recalculateApiDefinitionIds(
+        ExecutionContext executionContext,
+        ImportApiJsonNode apiJsonNode,
+        String urlApiId
+    ) {
         /*
          * In case of an update, if the API definition ID is the same as the resource ID targeted by the update,
          * we don't apply any kind of ID transformation so that we don't break previous exports that don't hold
@@ -69,10 +71,10 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
          */
         if (!apiJsonNode.hasId() || !apiJsonNode.getId().equals(urlApiId)) {
             findApiByEnvironmentAndCrossId(executionContext.getEnvironmentId(), apiJsonNode.getCrossId())
-                   .ifPresentOrElse(
-                          api -> recalculateIdsFromCrossId(executionContext, apiJsonNode, api),
-                          () -> recalculateIdsFromDefinitionIds(executionContext.getEnvironmentId(), apiJsonNode, urlApiId)
-                   );
+                .ifPresentOrElse(
+                    api -> recalculateIdsFromCrossId(executionContext, apiJsonNode, api),
+                    () -> recalculateIdsFromDefinitionIds(executionContext.getEnvironmentId(), apiJsonNode, urlApiId)
+                );
         }
         return generateEmptyIds(apiJsonNode);
     }
@@ -88,26 +90,26 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
     }
 
     private void recalculatePlanIdsFromCrossIds(
-           ExecutionContext executionContext,
-           ApiEntity api,
-           List<ImportPlanJsonNode> plansNodes,
-           Map<String, String> pagesIdsMap
+        ExecutionContext executionContext,
+        ApiEntity api,
+        List<ImportPlanJsonNode> plansNodes,
+        Map<String, String> pagesIdsMap
     ) {
         Map<String, PlanEntity> plansByCrossId = planService
-               .findByApi(executionContext, api.getId())
-               .stream()
-               .filter(plan -> plan.getCrossId() != null)
-               .collect(toMap(PlanEntity::getCrossId, Function.identity()));
+            .findByApi(executionContext, api.getId())
+            .stream()
+            .filter(plan -> plan.getCrossId() != null)
+            .collect(toMap(PlanEntity::getCrossId, Function.identity()));
 
         plansNodes
-               .stream()
-               .filter(ImportJsonNodeWithIds::hasCrossId)
-               .forEach(plan -> {
-                   PlanEntity matchingPlan = plansByCrossId.get(plan.getCrossId());
-                   plan.setApi(api.getId());
-                   plan.setId(matchingPlan != null ? matchingPlan.getId() : UuidString.generateRandom());
-                   recalculateGeneralConditionsPageId(plan, pagesIdsMap);
-               });
+            .stream()
+            .filter(ImportJsonNodeWithIds::hasCrossId)
+            .forEach(plan -> {
+                PlanEntity matchingPlan = plansByCrossId.get(plan.getCrossId());
+                plan.setApi(api.getId());
+                plan.setId(matchingPlan != null ? matchingPlan.getId() : UuidString.generateRandom());
+                recalculateGeneralConditionsPageId(plan, pagesIdsMap);
+            });
     }
 
     /**
@@ -119,36 +121,36 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
      * @return the map of old ID - new ID
      */
     private Map<String, String> recalculatePageIdsFromCrossIds(
-           String environmentId,
-           ApiEntity api,
-           List<ImportJsonNodeWithIds> pagesNodes
+        String environmentId,
+        ApiEntity api,
+        List<ImportJsonNodeWithIds> pagesNodes
     ) {
         Map<String, String> idsMap = new HashMap<>();
 
         Map<String, PageEntity> pagesByCrossId = pageService
-               .findByApi(environmentId, api.getId())
-               .stream()
-               .filter(page -> page.getCrossId() != null)
-               .collect(toMap(PageEntity::getCrossId, Function.identity()));
+            .findByApi(environmentId, api.getId())
+            .stream()
+            .filter(page -> page.getCrossId() != null)
+            .collect(toMap(PageEntity::getCrossId, Function.identity()));
 
         pagesNodes
-               .stream()
-               .filter(ImportJsonNodeWithIds::hasCrossId)
-               .forEach(page -> {
-                   String pageId = page.hasId() ? page.getId() : null;
-                   PageEntity matchingPage = pagesByCrossId.get(page.getCrossId());
-                   page.setApi(api.getId());
-                   if (matchingPage != null) {
-                       idsMap.put(pageId, matchingPage.getId());
-                       page.setId(matchingPage.getId());
-                       updatePagesHierarchy(pagesNodes, pageId, matchingPage.getId());
-                   } else {
-                       String newPageId = UuidString.generateRandom();
-                       idsMap.put(pageId, newPageId);
-                       page.setId(newPageId);
-                       updatePagesHierarchy(pagesNodes, pageId, newPageId);
-                   }
-               });
+            .stream()
+            .filter(ImportJsonNodeWithIds::hasCrossId)
+            .forEach(page -> {
+                String pageId = page.hasId() ? page.getId() : null;
+                PageEntity matchingPage = pagesByCrossId.get(page.getCrossId());
+                page.setApi(api.getId());
+                if (matchingPage != null) {
+                    idsMap.put(pageId, matchingPage.getId());
+                    page.setId(matchingPage.getId());
+                    updatePagesHierarchy(pagesNodes, pageId, matchingPage.getId());
+                } else {
+                    String newPageId = UuidString.generateRandom();
+                    idsMap.put(pageId, newPageId);
+                    page.setId(newPageId);
+                    updatePagesHierarchy(pagesNodes, pageId, newPageId);
+                }
+            });
 
         return idsMap;
     }
@@ -163,19 +165,19 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
     }
 
     private void recalculatePlanIdsFromDefinitionIds(
-           List<ImportPlanJsonNode> plansNodes,
-           String environmentId,
-           String apiId,
-           Map<String, String> pagesIdsMap
+        List<ImportPlanJsonNode> plansNodes,
+        String environmentId,
+        String apiId,
+        Map<String, String> pagesIdsMap
     ) {
         plansNodes
-               .stream()
-               .filter(ImportJsonNodeWithIds::hasId)
-               .forEach(plan -> {
-                   plan.setId(UuidString.generateForEnvironment(environmentId, apiId, plan.getId()));
-                   plan.setApi(apiId);
-                   recalculateGeneralConditionsPageId(plan, pagesIdsMap);
-               });
+            .stream()
+            .filter(ImportJsonNodeWithIds::hasId)
+            .forEach(plan -> {
+                plan.setId(UuidString.generateForEnvironment(environmentId, apiId, plan.getId()));
+                plan.setApi(apiId);
+                recalculateGeneralConditionsPageId(plan, pagesIdsMap);
+            });
     }
 
     private static void recalculateGeneralConditionsPageId(ImportPlanJsonNode plan, Map<String, String> pagesIdsMap) {
@@ -193,22 +195,22 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
      * @return the map of old ID - new ID
      */
     private Map<String, String> recalculatePageIdsFromDefinitionIds(
-           List<ImportJsonNodeWithIds> pagesNodes,
-           String environmentId,
-           String apiId
+        List<ImportJsonNodeWithIds> pagesNodes,
+        String environmentId,
+        String apiId
     ) {
         Map<String, String> idsMap = new HashMap<>();
         pagesNodes
-               .stream()
-               .filter(ImportJsonNodeWithIds::hasId)
-               .forEach(page -> {
-                   String oldPageId = page.getId();
-                   String newPageId = UuidString.generateForEnvironment(environmentId, apiId, oldPageId);
-                   idsMap.put(oldPageId, newPageId);
-                   page.setId(newPageId);
-                   page.setApi(apiId);
-                   updatePagesHierarchy(pagesNodes, oldPageId, newPageId);
-               });
+            .stream()
+            .filter(ImportJsonNodeWithIds::hasId)
+            .forEach(page -> {
+                String oldPageId = page.getId();
+                String newPageId = UuidString.generateForEnvironment(environmentId, apiId, oldPageId);
+                idsMap.put(oldPageId, newPageId);
+                page.setId(newPageId);
+                page.setApi(apiId);
+                updatePagesHierarchy(pagesNodes, oldPageId, newPageId);
+            });
         return idsMap;
     }
 
@@ -227,9 +229,9 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
 
     private ImportApiJsonNode generateEmptyIds(ImportApiJsonNode apiJsonNode) {
         Stream
-               .concat(apiJsonNode.getPlans().stream(), apiJsonNode.getPages().stream())
-               .filter(node -> !node.hasId())
-               .forEach(node -> node.setId(UuidString.generateRandom()));
+            .concat(apiJsonNode.getPlans().stream(), apiJsonNode.getPages().stream())
+            .filter(node -> !node.hasId())
+            .forEach(node -> node.setId(UuidString.generateRandom()));
         return apiJsonNode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1259,7 +1259,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
     }
 
-    private void checkShardingTags(final UpdateApiEntity updateApiEntity, final ApiEntity existingAPI, ExecutionContext executionContext) throws TechnicalException {
+    private void checkShardingTags(final UpdateApiEntity updateApiEntity, final ApiEntity existingAPI, ExecutionContext executionContext)
+        throws TechnicalException {
         final Set<String> tagsToUpdate = updateApiEntity.getTags() == null ? new HashSet<>() : updateApiEntity.getTags();
         final Set<String> updatedTags;
         if (existingAPI == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -464,9 +464,8 @@ public class LogsServiceImpl implements LogsService {
             return null;
         }
 
-        io.gravitee.rest.api.model.v4.plan.PlanSecurityType planSecurityType = io.gravitee.rest.api.model.v4.plan.PlanSecurityType.valueOfLabel(
-            plan.getPlanSecurity().getType()
-        );
+        io.gravitee.rest.api.model.v4.plan.PlanSecurityType planSecurityType =
+            io.gravitee.rest.api.model.v4.plan.PlanSecurityType.valueOfLabel(plan.getPlanSecurity().getType());
         if (
             io.gravitee.rest.api.model.v4.plan.PlanSecurityType.API_KEY == planSecurityType ||
             io.gravitee.rest.api.model.v4.plan.PlanSecurityType.KEY_LESS == planSecurityType

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -240,13 +240,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 assertRoleNameAllowedForReference(reference, roleEntity);
 
                 if (member.getMemberId() != null) {
-                    Set<io.gravitee.repository.management.model.Membership> similarMemberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
-                        member.getMemberId(),
-                        convert(member.getMemberType()),
-                        convert(reference.getType()),
-                        reference.getId(),
-                        roleEntity.getId()
-                    );
+                    Set<io.gravitee.repository.management.model.Membership> similarMemberships =
+                        membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
+                            member.getMemberId(),
+                            convert(member.getMemberType()),
+                            convert(reference.getType()),
+                            reference.getId(),
+                            roleEntity.getId()
+                        );
 
                     if (!similarMemberships.isEmpty()) {
                         if (update) {
@@ -284,12 +285,13 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                         applicationAlertService.addMemberToApplication(executionContext, reference.getId(), userEntity.getEmail());
                     }
 
-                    Set<io.gravitee.repository.management.model.Membership> userRolesOnReference = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
-                        userEntity.getId(),
-                        convert(member.getMemberType()),
-                        convert(reference.getType()),
-                        reference.getId()
-                    );
+                    Set<io.gravitee.repository.management.model.Membership> userRolesOnReference =
+                        membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                            userEntity.getId(),
+                            convert(member.getMemberType()),
+                            convert(reference.getType()),
+                            reference.getId()
+                        );
                     boolean shouldNotify =
                         notify &&
                         userRolesOnReference != null &&
@@ -664,14 +666,15 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
                 .orElseThrow(() -> new TechnicalManagementException("Unable to find API Primary Owner role"));
             RoleEntity applicationPORole = roleService
-                    .findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
-                    .orElseThrow(() -> new TechnicalManagementException("Unable to find Application Primary Owner role"));
-            Set<io.gravitee.repository.management.model.Membership> memberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
-                memberId,
-                convert(memberType),
-                convert(referenceType),
-                referenceId
-            );
+                .findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+                .orElseThrow(() -> new TechnicalManagementException("Unable to find Application Primary Owner role"));
+            Set<io.gravitee.repository.management.model.Membership> memberships =
+                membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                    memberId,
+                    convert(memberType),
+                    convert(referenceType),
+                    referenceId
+                );
 
             if (MembershipReferenceType.API.equals(referenceType)) {
                 assertNoPrimaryOwnerRemoval(apiPORole, memberships);
@@ -1332,12 +1335,13 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         String userId
     ) {
         try {
-            Set<io.gravitee.repository.management.model.Membership> userMemberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
-                userId,
-                convert(MembershipMemberType.USER),
-                convert(referenceType),
-                referenceId
-            );
+            Set<io.gravitee.repository.management.model.Membership> userMemberships =
+                membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                    userId,
+                    convert(MembershipMemberType.USER),
+                    convert(referenceType),
+                    referenceId
+                );
 
             //Get entity groups
             Set<String> entityGroups = new HashSet<>();
@@ -1511,13 +1515,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         String roleId
     ) {
         try {
-            Set<io.gravitee.repository.management.model.Membership> membershipsToDelete = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
-                memberId,
-                convert(memberType),
-                convert(referenceType),
-                referenceId,
-                roleId
-            );
+            Set<io.gravitee.repository.management.model.Membership> membershipsToDelete =
+                membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
+                    memberId,
+                    convert(memberType),
+                    convert(referenceType),
+                    referenceId,
+                    roleId
+                );
             for (io.gravitee.repository.management.model.Membership m : membershipsToDelete) {
                 membershipRepository.delete(m.getId());
             }
@@ -1552,13 +1557,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         try {
             Set<io.gravitee.repository.management.model.Membership> membershipsWithOldRole = membershipRepository.findByRoleId(oldRoleId);
             for (io.gravitee.repository.management.model.Membership membership : membershipsWithOldRole) {
-                Set<io.gravitee.repository.management.model.Membership> membershipsWithNewRole = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
-                    membership.getMemberId(),
-                    membership.getMemberType(),
-                    membership.getReferenceType(),
-                    membership.getReferenceId(),
-                    newRoleId
-                );
+                Set<io.gravitee.repository.management.model.Membership> membershipsWithNewRole =
+                    membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
+                        membership.getMemberId(),
+                        membership.getMemberType(),
+                        membership.getReferenceType(),
+                        membership.getReferenceId(),
+                        newRoleId
+                    );
                 String oldMembershipId = membership.getId();
                 if (membershipsWithNewRole.isEmpty()) {
                     membership.setId(UuidString.generateRandom());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -1570,9 +1570,8 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             ClassLoader fetcherCL = fetcherPlugin.fetcher().getClassLoader();
             Fetcher fetcher;
             if (fetcherPlugin.configuration().isAssignableFrom(FilepathAwareFetcherConfiguration.class)) {
-                Class<? extends FetcherConfiguration> fetcherConfigurationClass = (Class<? extends FetcherConfiguration>) fetcherCL.loadClass(
-                    fetcherPlugin.configuration().getName()
-                );
+                Class<? extends FetcherConfiguration> fetcherConfigurationClass =
+                    (Class<? extends FetcherConfiguration>) fetcherCL.loadClass(fetcherPlugin.configuration().getName());
                 Class<? extends FilesFetcher> fetcherClass = (Class<? extends FilesFetcher>) fetcherCL.loadClass(fetcherPlugin.clazz());
                 FetcherConfiguration fetcherConfigurationInstance = fetcherConfigurationFactory.create(
                     fetcherConfigurationClass,
@@ -1580,9 +1579,8 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 );
                 fetcher = fetcherClass.getConstructor(fetcherConfigurationClass).newInstance(fetcherConfigurationInstance);
             } else {
-                Class<? extends FetcherConfiguration> fetcherConfigurationClass = (Class<? extends FetcherConfiguration>) fetcherCL.loadClass(
-                    fetcherPlugin.configuration().getName()
-                );
+                Class<? extends FetcherConfiguration> fetcherConfigurationClass =
+                    (Class<? extends FetcherConfiguration>) fetcherCL.loadClass(fetcherPlugin.configuration().getName());
                 Class<? extends Fetcher> fetcherClass = (Class<? extends Fetcher>) fetcherCL.loadClass(fetcherPlugin.clazz());
                 FetcherConfiguration fetcherConfigurationInstance = fetcherConfigurationFactory.create(
                     fetcherConfigurationClass,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
@@ -100,7 +100,11 @@ public class PlansDataFixUpgrader implements Upgrader {
         try {
             AtomicBoolean upgradeFailed = new AtomicBoolean(false);
             apiRepository
-                .search(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(), null, ApiFieldFilter.allFields())
+                .search(
+                    new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(),
+                    null,
+                    ApiFieldFilter.allFields()
+                )
                 .forEach(api -> {
                     try {
                         io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
@@ -246,11 +250,7 @@ public class PlansDataFixUpgrader implements Upgrader {
     }
 
     private boolean hasPlansDataAnomaly(Set<Plan> apiPlans, List<io.gravitee.definition.model.Plan> definitionPlans) {
-        List<String> apiPlansIds = apiPlans
-            .stream()
-            .filter(plan -> plan.getStatus() != Plan.Status.CLOSED)
-            .map(Plan::getId)
-            .toList();
+        List<String> apiPlansIds = apiPlans.stream().filter(plan -> plan.getStatus() != Plan.Status.CLOSED).map(Plan::getId).toList();
         List<String> definitionPlansIds = definitionPlans.stream().map(io.gravitee.definition.model.Plan::getId).toList();
         return apiPlansIds.size() != definitionPlansIds.size() || !definitionPlansIds.containsAll(apiPlansIds);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgrader.java
@@ -27,7 +27,6 @@ import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,7 +69,11 @@ public class PlansFlowsDefinitionUpgrader implements Upgrader {
         try {
             AtomicBoolean upgradeFailed = new AtomicBoolean(false);
             apiRepository
-                .search(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(), null, ApiFieldFilter.allFields())
+                .search(
+                    new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(),
+                    null,
+                    ApiFieldFilter.allFields()
+                )
                 .forEach(api -> {
                     try {
                         io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiIdsCalculatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiIdsCalculatorService.java
@@ -19,6 +19,5 @@ import io.gravitee.rest.api.model.v4.api.ExportApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 
 public interface ApiIdsCalculatorService {
-
     ExportApiEntity recalculateApiDefinitionIds(final ExecutionContext executionContext, ExportApiEntity toRecalculate);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
@@ -24,7 +24,6 @@ import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-
 import java.util.Optional;
 
 /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -182,8 +182,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
         if (isBlank(executionContext.getEnvironmentId())) {
             return Set.of();
         }
-        final ApiCriteria.Builder builder = new ApiCriteria.Builder()
-            .environmentId(executionContext.getEnvironmentId());
+        final ApiCriteria.Builder builder = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
         apiCriteriaList.add(builder.build());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiImportExportServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiImportExportServiceImpl.java
@@ -172,7 +172,10 @@ public class ApiImportExportServiceImpl implements ApiImportExportService {
             throw new ApiDefinitionVersionNotSupportedException(apiEntity.getDefinitionVersion().getLabel());
         }
 
-        final ExportApiEntity exportApiWithIdsRecalculated = apiIdsCalculatorService.recalculateApiDefinitionIds(executionContext, exportApiEntity);
+        final ExportApiEntity exportApiWithIdsRecalculated = apiIdsCalculatorService.recalculateApiDefinitionIds(
+            executionContext,
+            exportApiEntity
+        );
 
         ApiEntity createdApiEntity = apiServiceV4.createWithImport(executionContext, exportApiWithIdsRecalculated.getApiEntity(), userId);
 
@@ -251,11 +254,7 @@ public class ApiImportExportServiceImpl implements ApiImportExportService {
         try {
             pageService.createOrUpdatePages(executionContext, pages, createdApiEntity.getId());
         } catch (Exception e) {
-            log.warn(
-                   "Unable to create pages for imported API {}' due to : {}",
-                   createdApiEntity.getId(),
-                   e.getMessage()
-            );
+            log.warn("Unable to create pages for imported API {}' due to : {}", createdApiEntity.getId(), e.getMessage());
         }
         log.debug("Pages successfully created for imported api {}", createdApiEntity.getId());
     }
@@ -271,10 +270,10 @@ public class ApiImportExportServiceImpl implements ApiImportExportService {
                 planService.createOrUpdatePlan(executionContext, planEntity);
             } catch (Exception e) {
                 log.warn(
-                       "Unable to create plan {} for imported API {}' due to : {}",
-                       planEntity.getName(),
-                       createdApiEntity.getId(),
-                       e.getMessage()
+                    "Unable to create plan {} for imported API {}' due to : {}",
+                    planEntity.getName(),
+                    createdApiEntity.getId(),
+                    e.getMessage()
                 );
             }
         });
@@ -300,10 +299,10 @@ public class ApiImportExportServiceImpl implements ApiImportExportService {
                     apiMetadataService.update(executionContext, metadataEntity);
                 } catch (Exception e) {
                     log.warn(
-                           "Unable to create metadata {} for imported API {}' due to : {}",
-                           metadataEntity.getName(),
-                           createdApiEntity.getId(),
-                           e.getMessage()
+                        "Unable to create metadata {} for imported API {}' due to : {}",
+                        metadataEntity.getName(),
+                        createdApiEntity.getId(),
+                        e.getMessage()
                     );
                 }
             });
@@ -320,10 +319,10 @@ public class ApiImportExportServiceImpl implements ApiImportExportService {
                 mediaService.saveApiMedia(createdApiEntity.getId(), mediaEntity);
             } catch (Exception e) {
                 log.warn(
-                       "Unable to create api media {} for imported API {}' due to : {}",
-                       mediaEntity.getFileName(),
-                       createdApiEntity.getId(),
-                       e.getMessage()
+                    "Unable to create api media {} for imported API {}' due to : {}",
+                    mediaEntity.getFileName(),
+                    createdApiEntity.getId(),
+                    e.getMessage()
                 );
             }
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -694,12 +694,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public Optional<ApiEntity> findByEnvironmentIdAndCrossId(String environment, String crossId) {
         try {
-            return apiRepository.findByEnvironmentIdAndCrossId(environment, crossId)
-                   .map(api -> apiMapper.toEntity(api, null));
+            return apiRepository.findByEnvironmentIdAndCrossId(environment, crossId).map(api -> apiMapper.toEntity(api, null));
         } catch (TechnicalException e) {
             throw new TechnicalManagementException(
-                   "An error occurred while finding API by environment " + environment + " and crossId " + crossId,
-                   e
+                "An error occurred while finding API by environment " + environment + " and crossId " + crossId,
+                e
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CsvUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CsvUtilsTest.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,7 +27,7 @@ class CsvUtilsTest {
     CsvUtils csvUtils = new CsvUtils(';');
 
     @ParameterizedTest
-    @MethodSource({"csvInputs"})
+    @MethodSource({ "csvInputs" })
     void sanitize(String input, String expected) {
         assertThat(csvUtils.sanitize(input)).isEqualTo(expected);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandlerTest.java
@@ -15,6 +15,12 @@
  */
 package io.gravitee.rest.api.service.cockpit.command.handler;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.v4api.V4ApiCommand;
@@ -32,12 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -15,24 +15,23 @@
  */
 package io.gravitee.rest.api.service.cockpit.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.service.v4.ApiService;
-import io.gravitee.rest.api.service.v4.ApiStateService;
-import io.reactivex.rxjava3.observers.TestObserver;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Objects;
-
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.v4.ApiService;
+import io.gravitee.rest.api.service.v4.ApiStateService;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Ashraful Hasan (ashraful.hasan at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -43,6 +43,7 @@ import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.ApiIdsCalculatorService;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.GroupService;
@@ -66,8 +67,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import io.gravitee.rest.api.service.ApiIdsCalculatorService;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -450,15 +449,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         String plan1newId = "14b9b538-1e83-334d-a96a-ec04a825928e";
         String plan2newId = "237961c1-3675-3168-832a-d67f7df97d99";
 
-        when(apiIdsCalculatorService.recalculateApiDefinitionIds(any(), any())).thenAnswer(invocationOnMock -> {
-            // In this case, the ApiIdsCalculator service would have completed the api id
-            final ImportApiJsonNode apiJsonNode = invocationOnMock.getArgument(1, ImportApiJsonNode.class);
-            apiJsonNode.getPlans().stream().filter(plan -> plan.getId().equals("plan-id")).forEach(plan -> plan.setId(plan1newId));
-            apiJsonNode.getPlans().stream().filter(plan -> plan.getId().equals("plan-id2")).forEach(plan -> plan.setId(plan2newId));
-            return apiJsonNode;
-        });
+        when(apiIdsCalculatorService.recalculateApiDefinitionIds(any(), any()))
+            .thenAnswer(invocationOnMock -> {
+                // In this case, the ApiIdsCalculator service would have completed the api id
+                final ImportApiJsonNode apiJsonNode = invocationOnMock.getArgument(1, ImportApiJsonNode.class);
+                apiJsonNode.getPlans().stream().filter(plan -> plan.getId().equals("plan-id")).forEach(plan -> plan.setId(plan1newId));
+                apiJsonNode.getPlans().stream().filter(plan -> plan.getId().equals("plan-id2")).forEach(plan -> plan.setId(plan2newId));
+                return apiJsonNode;
+            });
         apiDuplicatorService.createWithImportedDefinition(GraviteeContext.getExecutionContext(), toBeImport);
-
 
         // check createWithApiDefinition has been called with newly generated plans IDs in API's definition
         verify(apiService, times(1))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiIdsCalculatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiIdsCalculatorServiceTest.java
@@ -15,31 +15,29 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.ApiIdsCalculatorService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.imports.ImportJsonNodeWithIds;
-import io.gravitee.rest.api.service.ApiIdsCalculatorService;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -71,16 +69,16 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "my-api-1");
 
         apiDefinition.set(
-               "plans",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "my-plan-id-1"))
-                      .add(mapper.createObjectNode().put("id", "my-plan-id-2"))
+            "plans",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "my-plan-id-1"))
+                .add(mapper.createObjectNode().put("id", "my-plan-id-2"))
         );
 
         ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               new ExecutionContext("default", "uat"),
-               new ImportApiJsonNode(apiDefinition)
+            new ExecutionContext("default", "uat"),
+            new ImportApiJsonNode(apiDefinition)
         );
 
         assertThat(newApiDefinition.getId()).isEqualTo("e0a6482a-b8a7-3db4-a1b7-d36a462a9e38");
@@ -93,17 +91,17 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "api-id-1").put("crossId", "api-cross-id");
 
         apiDefinition.set(
-               "plans",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id-1"))
-                      .add(mapper.createObjectNode().put("id", "plan-id-2").put("crossId", "plan-cross-id-2"))
+            "plans",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id-1"))
+                .add(mapper.createObjectNode().put("id", "plan-id-2").put("crossId", "plan-cross-id-2"))
         );
         when(apiService.findByEnvironmentIdAndCrossId("uat", "api-cross-id")).thenReturn(Optional.empty());
 
         ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               new ExecutionContext("default", "uat"),
-               new ImportApiJsonNode(apiDefinition)
+            new ExecutionContext("default", "uat"),
+            new ImportApiJsonNode(apiDefinition)
         );
 
         assertThat(newApiDefinition.getId()).isEqualTo("6bcde800-d5ae-3215-8413-cae196f9edfc");
@@ -116,11 +114,11 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "api-id-1").put("crossId", "api-cross-id");
 
         apiDefinition.set(
-               "plans",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id-1"))
-                      .add(mapper.createObjectNode().put("id", "plan-id-2").put("crossId", "plan-cross-id-2"))
+            "plans",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id-1"))
+                .add(mapper.createObjectNode().put("id", "plan-id-2").put("crossId", "plan-cross-id-2"))
         );
 
         ApiEntity matchingApi = new ApiEntity();
@@ -141,10 +139,7 @@ class ApiIdsCalculatorServiceTest {
 
         when(planService.findByApi(executionContext, "api-id-1")).thenReturn(Set.of(firstMatchingPlan, secondMatchingPlan));
 
-        ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               executionContext,
-               new ImportApiJsonNode(apiDefinition)
-        );
+        ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(executionContext, new ImportApiJsonNode(apiDefinition));
 
         assertThat(newApiDefinition.getId()).isEqualTo("api-id-1");
         assertThat(newApiDefinition.getPlans().get(0).getId()).isEqualTo("plan-id-1");
@@ -156,18 +151,18 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "api-id-1").put("crossId", "api-cross-id");
 
         apiDefinition.set(
-               "pages",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "root-folder-id").put("crossId", "root-folder-cross-id"))
-                      .add(
-                             mapper
-                                    .createObjectNode()
-                                    .put("id", "nested-folder-id")
-                                    .put("crossId", "nested-folder-cross-id")
-                                    .put("parentId", "root-folder-id")
-                      )
-                      .add(mapper.createObjectNode().put("id", "page-id").put("crossId", "page-cross-id").put("parentId", "nested-folder-id"))
+            "pages",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "root-folder-id").put("crossId", "root-folder-cross-id"))
+                .add(
+                    mapper
+                        .createObjectNode()
+                        .put("id", "nested-folder-id")
+                        .put("crossId", "nested-folder-cross-id")
+                        .put("parentId", "root-folder-id")
+                )
+                .add(mapper.createObjectNode().put("id", "page-id").put("crossId", "page-cross-id").put("parentId", "nested-folder-id"))
         );
 
         ApiEntity matchingApi = new ApiEntity();
@@ -190,8 +185,8 @@ class ApiIdsCalculatorServiceTest {
         when(pageService.findByApi("dev", "api-id-1")).thenReturn(List.of(rootFolder, nestedFolder, page));
 
         ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               new ExecutionContext("default", "dev"),
-               new ImportApiJsonNode(apiDefinition)
+            new ExecutionContext("default", "dev"),
+            new ImportApiJsonNode(apiDefinition)
         );
 
         assertThat(newApiDefinition.getId()).isEqualTo("api-id-1");
@@ -209,17 +204,17 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "my-api-1");
 
         apiDefinition.set(
-               "pages",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "root-folder-id"))
-                      .add(mapper.createObjectNode().put("id", "nested-folder-id").put("parentId", "root-folder-id"))
-                      .add(mapper.createObjectNode().put("id", "page-id").put("parentId", "nested-folder-id"))
+            "pages",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "root-folder-id"))
+                .add(mapper.createObjectNode().put("id", "nested-folder-id").put("parentId", "root-folder-id"))
+                .add(mapper.createObjectNode().put("id", "page-id").put("parentId", "nested-folder-id"))
         );
 
         ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               new ExecutionContext("default", "uat"),
-               new ImportApiJsonNode(apiDefinition)
+            new ExecutionContext("default", "uat"),
+            new ImportApiJsonNode(apiDefinition)
         );
 
         assertThat(newApiDefinition.getId()).isEqualTo("e0a6482a-b8a7-3db4-a1b7-d36a462a9e38");
@@ -237,19 +232,19 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "api-id-1").put("crossId", "api-cross-id");
 
         apiDefinition.set(
-               "plans",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id"))
-                      .add(mapper.createObjectNode().put("name", "I have an empty ID").put("id", ""))
+            "plans",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "plan-id-1").put("crossId", "plan-cross-id"))
+                .add(mapper.createObjectNode().put("name", "I have an empty ID").put("id", ""))
         );
 
         apiDefinition.set(
-               "pages",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "page-id-1").put("crossId", "page-cross-id"))
-                      .add(mapper.createObjectNode().put("name", "I have no ID"))
+            "pages",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "page-id-1").put("crossId", "page-cross-id"))
+                .add(mapper.createObjectNode().put("name", "I have no ID"))
         );
 
         ApiEntity matchingApi = new ApiEntity();
@@ -270,10 +265,7 @@ class ApiIdsCalculatorServiceTest {
 
         when(planService.findByApi(executionContext, "api-id-1")).thenReturn(Set.of(matchingPlan));
 
-        ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               executionContext,
-               new ImportApiJsonNode(apiDefinition)
-        );
+        ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(executionContext, new ImportApiJsonNode(apiDefinition));
 
         assertThat(newApiDefinition.getId()).isEqualTo("api-id-1");
         assertThat(newApiDefinition.getPlans().get(0).getId()).isEqualTo("plan-id-1");
@@ -289,21 +281,21 @@ class ApiIdsCalculatorServiceTest {
         ObjectNode apiDefinition = mapper.createObjectNode().put("id", "api-id-1");
 
         apiDefinition.set(
-               "plans",
-               mapper.createArrayNode().add(mapper.createObjectNode().put("id", "plan-id-1")).add(mapper.createObjectNode().put("id", ""))
+            "plans",
+            mapper.createArrayNode().add(mapper.createObjectNode().put("id", "plan-id-1")).add(mapper.createObjectNode().put("id", ""))
         );
 
         apiDefinition.set(
-               "pages",
-               mapper
-                      .createArrayNode()
-                      .add(mapper.createObjectNode().put("id", "page-id-1"))
-                      .add(mapper.createObjectNode().put("name", "no-id"))
+            "pages",
+            mapper
+                .createArrayNode()
+                .add(mapper.createObjectNode().put("id", "page-id-1"))
+                .add(mapper.createObjectNode().put("name", "no-id"))
         );
 
         ImportApiJsonNode newApiDefinition = cut.recalculateApiDefinitionIds(
-               new ExecutionContext("default", "default"),
-               new ImportApiJsonNode(apiDefinition)
+            new ExecutionContext("default", "default"),
+            new ImportApiJsonNode(apiDefinition)
         );
 
         assertThat(newApiDefinition.getId()).isEqualTo("ed5fbfe2-9cab-3306-9e51-24721d5b6e82");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
@@ -48,7 +48,6 @@ import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.Set;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -137,15 +136,15 @@ public class ApiService_CreateWithDefinitionTest {
     public static void cleanSecurityContextHolder() {
         // reset authentication to avoid side effect during test executions.
         SecurityContextHolder.setContext(
-                new SecurityContext() {
-                    @Override
-                    public Authentication getAuthentication() {
-                        return null;
-                    }
-
-                    @Override
-                    public void setAuthentication(Authentication authentication) {}
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
                 }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
         );
     }
 
@@ -280,7 +279,9 @@ public class ApiService_CreateWithDefinitionTest {
         api.setDescription("tag test example");
         api.setTags(Set.of("unit-tests"));
 
-        doThrow(TagNotFoundException.class).when(tagService).checkTagsExist(Set.of("unit-tests"), GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION);
+        doThrow(TagNotFoundException.class)
+            .when(tagService)
+            .checkTagsExist(Set.of("unit-tests"), GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION);
 
         assertThrows(TagNotFoundException.class, () -> apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition));
         verify(apiRepository, never()).create(any());
@@ -314,11 +315,13 @@ public class ApiService_CreateWithDefinitionTest {
 
         when(apiMetadataService.fetchMetadataForApi(any(), any())).thenReturn(new ApiEntity());
 
-        when(tagService.findByUser(USERNAME, GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION)).thenReturn(Set.of("a-tag", "unit-tests"));
+        when(tagService.findByUser(USERNAME, GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION))
+            .thenReturn(Set.of("a-tag", "unit-tests"));
 
         apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition);
 
-        verify(tagService, times(1)).checkTagsExist(Set.of("unit-tests"), GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION);
+        verify(tagService, times(1))
+            .checkTagsExist(Set.of("unit-tests"), GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getId().equals(definition.get("id").asText())));
     }
@@ -340,7 +343,8 @@ public class ApiService_CreateWithDefinitionTest {
         api.setDescription("tag test basic example");
         api.setTags(Set.of("unit-tests"));
 
-        when(tagService.findByUser(USERNAME, GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION)).thenReturn(Set.of("a-tag"));
+        when(tagService.findByUser(USERNAME, GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION))
+            .thenReturn(Set.of("a-tag"));
 
         assertThrows(TagNotAllowedException.class, () -> apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition));
         verify(apiRepository, never()).create(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -402,10 +402,13 @@ public class ApiService_UpdateTest {
         assertEquals(API_NAME, apiEntity.getName());
 
         // Picture management as a dedicated service, so we should reuse the same picture as the one saved
-        verify(apiRepository).update(argThat(apiToUpdate ->
-               Objects.equals(apiToUpdate.getPicture(), api.getPicture())
-                   && Objects.equals(apiToUpdate.getBackground(), api.getBackground())
-        ));
+        verify(apiRepository)
+            .update(
+                argThat(apiToUpdate ->
+                    Objects.equals(apiToUpdate.getPicture(), api.getPicture()) &&
+                    Objects.equals(apiToUpdate.getBackground(), api.getBackground())
+                )
+            );
         verify(searchEngineService, times(1)).index(eq(GraviteeContext.getExecutionContext()), any(), eq(false));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -689,16 +689,16 @@ public class ApplicationService_UpdateTest {
         PlanEntity apiKeyPlanEntity = new PlanEntity();
         apiKeyPlanEntity.setId(apiKeyPlanId);
         when(planSearchService.findByIdIn(GraviteeContext.getExecutionContext(), Set.of(apiKeyPlanId)))
-                .thenReturn(Set.of(apiKeyPlanEntity));
+            .thenReturn(Set.of(apiKeyPlanEntity));
 
         when(
-                parameterService.findAsBoolean(
-                        GraviteeContext.getExecutionContext(),
-                        Key.PLAN_SECURITY_APIKEY_SHARED_ALLOWED,
-                        ParameterReferenceType.ENVIRONMENT
-                )
+            parameterService.findAsBoolean(
+                GraviteeContext.getExecutionContext(),
+                Key.PLAN_SECURITY_APIKEY_SHARED_ALLOWED,
+                ParameterReferenceType.ENVIRONMENT
+            )
         )
-                .thenReturn(true);
+            .thenReturn(true);
 
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
         when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
@@ -720,20 +720,20 @@ public class ApplicationService_UpdateTest {
         when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
 
         final ApplicationEntity applicationEntity = applicationService.update(
-                GraviteeContext.getExecutionContext(),
-                APPLICATION_ID,
-                updateApplication
+            GraviteeContext.getExecutionContext(),
+            APPLICATION_ID,
+            updateApplication
         );
 
         assertNotNull(applicationEntity);
         assertEquals(APPLICATION_NAME, applicationEntity.getName());
 
         verify(applicationRepository)
-                .update(argThat(application -> APPLICATION_NAME.equals(application.getName()) && application.getUpdatedAt() != null));
+            .update(argThat(application -> APPLICATION_NAME.equals(application.getName()) && application.getUpdatedAt() != null));
         verify(subscriptionService).findByApplicationAndPlan(any(ExecutionContext.class), eq(APPLICATION_ID), isNull());
         verify(planSearchService).findByIdIn(any(ExecutionContext.class), eq(Set.of(apiKeyPlanId)));
-
     }
+
     @Test
     public void should_not_update_null_new_client_id() throws TechnicalException {
         ApplicationSettings settings = new ApplicationSettings();
@@ -766,17 +766,17 @@ public class ApplicationService_UpdateTest {
 
         List<SubscriptionEntity> subscriptions = List.of(subscription1, subscription2);
         when(
-                subscriptionService.search(
-                        any(),
-                        argThat(criteria ->
-                                criteria.getApplications().contains(APPLICATION_ID) &&
-                                        criteria
-                                                .getStatuses()
-                                                .containsAll(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED, SubscriptionStatus.PENDING))
-                        )
+            subscriptionService.search(
+                any(),
+                argThat(criteria ->
+                    criteria.getApplications().contains(APPLICATION_ID) &&
+                    criteria
+                        .getStatuses()
+                        .containsAll(Set.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED, SubscriptionStatus.PENDING))
                 )
+            )
         )
-                .thenReturn(subscriptions);
+            .thenReturn(subscriptions);
 
         applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_FindByIdTest.java
@@ -86,7 +86,8 @@ public class GroupService_FindByIdTest extends TestCase {
         )
             .thenReturn(true);
 
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID)).thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(new RoleEntity()));
 
         var result = groupService.findById(executionContext, GROUP_ID);
 
@@ -111,7 +112,8 @@ public class GroupService_FindByIdTest extends TestCase {
         ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, null);
 
         when(roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name(), ORGANIZATION_ID)).thenReturn(Optional.empty());
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID)).thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(new RoleEntity()));
 
         var result = groupService.findById(executionContext, GROUP_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
@@ -100,7 +100,8 @@ public class GroupService_UpdateTest {
         )
             .thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT")).thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT"))
+            .thenReturn(Optional.of(new RoleEntity()));
 
         groupService.update(GraviteeContext.getExecutionContext(), GROUP_ID, updatedGroupEntity);
 
@@ -154,7 +155,8 @@ public class GroupService_UpdateTest {
         )
             .thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT")).thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), "DEFAULT"))
+            .thenReturn(Optional.of(new RoleEntity()));
 
         groupService.update(GraviteeContext.getExecutionContext(), GROUP_ID, updatedGroupEntity);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -31,10 +31,9 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import java.util.Optional;
 import java.util.Set;
-
-import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +54,7 @@ public class MembershipService_DeleteMemberTest {
     private static final String API_ID = "789";
     private static final String APPLICATION_ID = "app#1";
 
-    private static final UserEntity USER =  UserEntity.builder().build();
+    private static final UserEntity USER = UserEntity.builder().build();
     private MembershipService membershipService;
 
     @Mock
@@ -84,8 +83,10 @@ public class MembershipService_DeleteMemberTest {
                 null,
                 null
             );
-        when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(primaryOwnerRole(RoleScope.API, API_PO_ROLE_ID));
-        when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(primaryOwnerRole(RoleScope.API, APPLICATION_PO_ROLE_ID));
+        when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID))
+            .thenReturn(primaryOwnerRole(RoleScope.API, API_PO_ROLE_ID));
+        when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), ORG_ID))
+            .thenReturn(primaryOwnerRole(RoleScope.API, APPLICATION_PO_ROLE_ID));
     }
 
     @Test
@@ -128,13 +129,16 @@ public class MembershipService_DeleteMemberTest {
         when(membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(any(), any(), any(), any()))
             .thenReturn(Set.of(membership));
 
-        assertThatThrownBy(() -> membershipService.deleteReferenceMember(
-            GraviteeContext.getExecutionContext(),
-            MembershipReferenceType.APPLICATION,
-            APPLICATION_ID,
-            MembershipMemberType.USER,
-            MEMBER_ID
-        )).isInstanceOf(PrimaryOwnerRemovalException.class);
+        assertThatThrownBy(() ->
+                membershipService.deleteReferenceMember(
+                    GraviteeContext.getExecutionContext(),
+                    MembershipReferenceType.APPLICATION,
+                    APPLICATION_ID,
+                    MembershipMemberType.USER,
+                    MEMBER_ID
+                )
+            )
+            .isInstanceOf(PrimaryOwnerRemovalException.class);
     }
 
     @Test
@@ -144,10 +148,12 @@ public class MembershipService_DeleteMemberTest {
         membership.setRoleId(APPLICATION_PO_ROLE_ID);
 
         when(membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(any(), any(), any(), any()))
-                .thenReturn(Set.of(membership));
+            .thenReturn(Set.of(membership));
 
-        assertThatThrownBy(() -> membershipService.deleteMemberForApplication(GraviteeContext.getExecutionContext(), APPLICATION_ID, MEMBER_ID))
-                .isInstanceOf(PrimaryOwnerRemovalException.class);
+        assertThatThrownBy(() ->
+                membershipService.deleteMemberForApplication(GraviteeContext.getExecutionContext(), APPLICATION_ID, MEMBER_ID)
+            )
+            .isInstanceOf(PrimaryOwnerRemovalException.class);
     }
 
     private static Optional<RoleEntity> primaryOwnerRole(RoleScope scope, String roleId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -30,11 +30,10 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagService_CheckTagsExistTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagService_CheckTagsExistTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
@@ -23,18 +26,14 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.exceptions.TagNotFoundException;
 import io.gravitee.rest.api.service.v4.ApiTagService;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TagService_CheckTagsExistTest {
@@ -70,7 +69,10 @@ public class TagService_CheckTagsExistTest {
     @Test
     public void should_throw_error_if_no_tags_found() throws TechnicalException {
         when(tagRepository.findByIdsAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of());
-        assertThrows(TagNotFoundException.class, () -> tagService.checkTagsExist(Set.of("tag-1", "tag-2"), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION));
+        assertThrows(
+            TagNotFoundException.class,
+            () -> tagService.checkTagsExist(Set.of("tag-1", "tag-2"), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION)
+        );
     }
 
     @Test
@@ -82,7 +84,10 @@ public class TagService_CheckTagsExistTest {
 
         when(tagRepository.findByIdsAndReference(tags, ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of(tag1));
 
-        assertThrows(TagNotFoundException.class, () -> tagService.checkTagsExist(tags, ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION));
+        assertThrows(
+            TagNotFoundException.class,
+            () -> tagService.checkTagsExist(tags, ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION)
+        );
 
         verify(tagRepository, times(1)).findByIdsAndReference(any(), any(), any());
     }
@@ -92,7 +97,8 @@ public class TagService_CheckTagsExistTest {
         Tag tag1 = getRepositoryTag("tag-1");
         Tag tag2 = getRepositoryTag("tag-2");
 
-        when(tagRepository.findByIdsAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of(tag1, tag2));
+        when(tagRepository.findByIdsAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION))
+            .thenReturn(Set.of(tag1, tag2));
 
         tagService.checkTagsExist(Set.of("tag-1", "tag-2"), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
@@ -109,7 +109,13 @@ public class PlansDataFixUpgraderTest {
         apiv2_2.setId("api4");
         apiv2_2.setDefinition("{\"gravitee\": \"2.0.0\"}");
         apiv2_2.setEnvironmentId("envId");
-        when(apiRepository.search(eq(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build()), eq(null), any(ApiFieldFilter.class)))
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build()),
+                eq(null),
+                any(ApiFieldFilter.class)
+            )
+        )
             .thenReturn(Stream.of(apiv2_1, apiv2_2));
 
         upgrader.upgrade();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansFlowsDefinitionUpgraderTest.java
@@ -82,7 +82,13 @@ public class PlansFlowsDefinitionUpgraderTest {
 
         Api api2 = buildApi("api2", "2.0.0");
         Api api4 = buildApi("api4", "2.0.0");
-        when(apiRepository.search(eq(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build()), eq(null), any(ApiFieldFilter.class)))
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build()),
+                eq(null),
+                any(ApiFieldFilter.class)
+            )
+        )
             .thenReturn(Stream.of(api2, api4));
 
         upgrader.upgrade();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -51,9 +51,7 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
-
 import java.util.*;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Before;
 import org.junit.Test;
@@ -167,6 +165,7 @@ public class ApiAuthorizationServiceImplTest {
 
         assertThat(apis).hasSize(1);
     }
+
     @Test
     public void findIdsByUserId() {
         final String userId = "USER#1";
@@ -181,7 +180,7 @@ public class ApiAuthorizationServiceImplTest {
         membership.setRoleId(poRoleId);
 
         when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, userId, MembershipReferenceType.API))
-                .thenReturn(Collections.singleton(membership));
+            .thenReturn(Collections.singleton(membership));
 
         RoleEntity poRole = new RoleEntity();
         poRole.setId(poRoleId);
@@ -232,6 +231,7 @@ public class ApiAuthorizationServiceImplTest {
 
         assertThat(apis).hasSize(0);
     }
+
     @Test
     public void shouldFindIdsByUserWithCriteria() {
         final String userRoleId = "API_USER";
@@ -290,21 +290,18 @@ public class ApiAuthorizationServiceImplTest {
                     query.getQuery().contains("tag\\-1")
                 )
             );
-        }
-        @Test
-        public void shouldFindIdsByEnvironmentId() {
-            List<ApiCriteria> apiCriteriaList = new ArrayList<>();
-            apiCriteriaList.add(
-                    new ApiCriteria.Builder()
-                            .environmentId("DEFAULT")
-                            .build()
-            );
+    }
 
-            when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
-            final Set<String> apis = apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext());
+    @Test
+    public void shouldFindIdsByEnvironmentId() {
+        List<ApiCriteria> apiCriteriaList = new ArrayList<>();
+        apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").build());
 
-            assertThat(apis).hasSize(1);
-        }
+        when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
+        final Set<String> apis = apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext());
+
+        assertThat(apis).hasSize(1);
+    }
 
     @Test
     public void shouldNotFindIdsByUserBecauseNotExists() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ApiModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ApiModelFixtures.java
@@ -32,36 +32,39 @@ public class ApiModelFixtures {
 
     private ApiModelFixtures() {}
 
-    private static final io.gravitee.definition.model.DefinitionContext.DefinitionContextBuilder BASE_MODEL_DEFINITION_CONTEXT = io.gravitee.definition.model.DefinitionContext
-        .builder()
-        .origin(io.gravitee.definition.model.DefinitionContext.ORIGIN_MANAGEMENT)
-        .mode(io.gravitee.definition.model.DefinitionContext.MODE_FULLY_MANAGED);
+    private static final io.gravitee.definition.model.DefinitionContext.DefinitionContextBuilder BASE_MODEL_DEFINITION_CONTEXT =
+        io.gravitee.definition.model.DefinitionContext
+            .builder()
+            .origin(io.gravitee.definition.model.DefinitionContext.ORIGIN_MANAGEMENT)
+            .mode(io.gravitee.definition.model.DefinitionContext.MODE_FULLY_MANAGED);
 
-    private static final io.gravitee.rest.api.model.api.ApiEntity.ApiEntityBuilder BASE_MODEL_API_V1 = io.gravitee.rest.api.model.api.ApiEntity
-        .builder()
-        .graviteeDefinitionVersion(io.gravitee.definition.model.DefinitionVersion.V1.getLabel())
-        .id("my-id")
-        .name("my-name")
-        .version("v1.0")
-        .properties(PropertyModelFixtures.aModelPropertiesV2())
-        .services(new Services())
-        .resources(List.of(ResourceModelFixtures.aResourceEntityV2()))
-        .responseTemplates(Map.of("key", new HashMap<>()))
-        .updatedAt(new Date())
-        .paths(Map.of("path", List.of(new Rule())));
+    private static final io.gravitee.rest.api.model.api.ApiEntity.ApiEntityBuilder BASE_MODEL_API_V1 =
+        io.gravitee.rest.api.model.api.ApiEntity
+            .builder()
+            .graviteeDefinitionVersion(io.gravitee.definition.model.DefinitionVersion.V1.getLabel())
+            .id("my-id")
+            .name("my-name")
+            .version("v1.0")
+            .properties(PropertyModelFixtures.aModelPropertiesV2())
+            .services(new Services())
+            .resources(List.of(ResourceModelFixtures.aResourceEntityV2()))
+            .responseTemplates(Map.of("key", new HashMap<>()))
+            .updatedAt(new Date())
+            .paths(Map.of("path", List.of(new Rule())));
 
-    private static final io.gravitee.rest.api.model.api.ApiEntity.ApiEntityBuilder BASE_MODEL_API_V2 = io.gravitee.rest.api.model.api.ApiEntity
-        .builder()
-        .graviteeDefinitionVersion(io.gravitee.definition.model.DefinitionVersion.V2.getLabel())
-        .id("my-id")
-        .name("my-name")
-        .version("v1.0")
-        .properties(PropertyModelFixtures.aModelPropertiesV2())
-        .services(new Services())
-        .resources(List.of(ResourceModelFixtures.aResourceEntityV2()))
-        .responseTemplates(Map.of("template-id", Map.of("application/json", new io.gravitee.definition.model.ResponseTemplate())))
-        .updatedAt(new Date())
-        .flows(List.of(FlowModelFixtures.aModelFlowV2()));
+    private static final io.gravitee.rest.api.model.api.ApiEntity.ApiEntityBuilder BASE_MODEL_API_V2 =
+        io.gravitee.rest.api.model.api.ApiEntity
+            .builder()
+            .graviteeDefinitionVersion(io.gravitee.definition.model.DefinitionVersion.V2.getLabel())
+            .id("my-id")
+            .name("my-name")
+            .version("v1.0")
+            .properties(PropertyModelFixtures.aModelPropertiesV2())
+            .services(new Services())
+            .resources(List.of(ResourceModelFixtures.aResourceEntityV2()))
+            .responseTemplates(Map.of("template-id", Map.of("application/json", new io.gravitee.definition.model.ResponseTemplate())))
+            .updatedAt(new Date())
+            .flows(List.of(FlowModelFixtures.aModelFlowV2()));
 
     private static final ApiEntity.ApiEntityBuilder BASE_MODEL_API_V4 = ApiEntity
         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EndpointModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EndpointModelFixtures.java
@@ -25,31 +25,33 @@ public class EndpointModelFixtures {
 
     private EndpointModelFixtures() {}
 
-    private static final io.gravitee.definition.model.Endpoint.EndpointBuilder BASE_MODEL_ENDPOINT_V2 = io.gravitee.definition.model.Endpoint
-        .builder()
-        .name("Endpoint name")
-        .target("http://gravitee.io")
-        .weight(1)
-        .backup(false)
-        .status(io.gravitee.definition.model.Endpoint.Status.UP)
-        .tenants(List.of("tenant1", "tenant2"))
-        .type("HTTP")
-        .inherit(true)
-        .healthCheck(io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.builder().build())
-        .configuration(null);
+    private static final io.gravitee.definition.model.Endpoint.EndpointBuilder BASE_MODEL_ENDPOINT_V2 =
+        io.gravitee.definition.model.Endpoint
+            .builder()
+            .name("Endpoint name")
+            .target("http://gravitee.io")
+            .weight(1)
+            .backup(false)
+            .status(io.gravitee.definition.model.Endpoint.Status.UP)
+            .tenants(List.of("tenant1", "tenant2"))
+            .type("HTTP")
+            .inherit(true)
+            .healthCheck(io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.builder().build())
+            .configuration(null);
 
-    private static final io.gravitee.definition.model.EndpointGroup.EndpointGroupBuilder BASE_MODEL_ENDPOINTGROUP_V2 = io.gravitee.definition.model.EndpointGroup
-        .builder()
-        .name("Endpoint group name")
-        .endpoints(Set.of(BASE_MODEL_ENDPOINT_V2.build()))
-        .loadBalancer(
-            io.gravitee.definition.model.LoadBalancer.builder().type(io.gravitee.definition.model.LoadBalancerType.ROUND_ROBIN).build()
-        )
-        .services(null)
-        .httpProxy(null)
-        .httpClientOptions(null)
-        .httpClientSslOptions(null)
-        .headers(Collections.emptyList());
+    private static final io.gravitee.definition.model.EndpointGroup.EndpointGroupBuilder BASE_MODEL_ENDPOINTGROUP_V2 =
+        io.gravitee.definition.model.EndpointGroup
+            .builder()
+            .name("Endpoint group name")
+            .endpoints(Set.of(BASE_MODEL_ENDPOINT_V2.build()))
+            .loadBalancer(
+                io.gravitee.definition.model.LoadBalancer.builder().type(io.gravitee.definition.model.LoadBalancerType.ROUND_ROBIN).build()
+            )
+            .services(null)
+            .httpProxy(null)
+            .httpClientOptions(null)
+            .httpClientSslOptions(null)
+            .headers(Collections.emptyList());
 
     private static final Endpoint.EndpointBuilder BASE_MODEL_ENDPOINT_V4 = Endpoint
         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EntrypointModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EntrypointModelFixtures.java
@@ -19,12 +19,13 @@ public class EntrypointModelFixtures {
 
     private EntrypointModelFixtures() {}
 
-    private static final io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint.EntrypointBuilder BASE_MODEL_ENTRYPOINT_V4 = io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint
-        .builder()
-        .type("Entrypoint type")
-        .qos(io.gravitee.definition.model.v4.listener.entrypoint.Qos.AT_LEAST_ONCE)
-        .dlq(new io.gravitee.definition.model.v4.listener.entrypoint.Dlq("my-endpoint"))
-        .configuration("{\"nice\": \"configuration\"}");
+    private static final io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint.EntrypointBuilder BASE_MODEL_ENTRYPOINT_V4 =
+        io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint
+            .builder()
+            .type("Entrypoint type")
+            .qos(io.gravitee.definition.model.v4.listener.entrypoint.Qos.AT_LEAST_ONCE)
+            .dlq(new io.gravitee.definition.model.v4.listener.entrypoint.Dlq("my-endpoint"))
+            .configuration("{\"nice\": \"configuration\"}");
 
     public static io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint aModelEntrypointV4() {
         return BASE_MODEL_ENTRYPOINT_V4.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ListenerModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ListenerModelFixtures.java
@@ -25,27 +25,30 @@ public class ListenerModelFixtures {
 
     private static final Path.PathBuilder BASE_MODEL_PATH_V4 = Path.builder().host("my.fake.host").path("/test").overrideAccess(true);
 
-    private static final io.gravitee.definition.model.v4.listener.http.HttpListener.HttpListenerBuilder<?, ?> BASE_MODEL_HTTP_LISTENER = io.gravitee.definition.model.v4.listener.http.HttpListener
-        .builder()
-        // Listener
-        .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
-        .servers(List.of("my-server1", "my-server2"))
-        // HttpListener specific
-        .paths(List.of(BASE_MODEL_PATH_V4.build()))
-        .pathMappings(Set.of("/test"))
-        .cors(CorsModelFixtures.aModelCors());
+    private static final io.gravitee.definition.model.v4.listener.http.HttpListener.HttpListenerBuilder<?, ?> BASE_MODEL_HTTP_LISTENER =
+        io.gravitee.definition.model.v4.listener.http.HttpListener
+            .builder()
+            // Listener
+            .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
+            .servers(List.of("my-server1", "my-server2"))
+            // HttpListener specific
+            .paths(List.of(BASE_MODEL_PATH_V4.build()))
+            .pathMappings(Set.of("/test"))
+            .cors(CorsModelFixtures.aModelCors());
 
-    private static final io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener.SubscriptionListenerBuilder<?, ?> BASE_MODEL_SUBSCRIPTION_LISTENER = io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener
-        .builder()
-        // BaseListener
-        .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
-        .servers(List.of("my-server1", "my-server2"));
+    private static final io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener.SubscriptionListenerBuilder<?, ?> BASE_MODEL_SUBSCRIPTION_LISTENER =
+        io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener
+            .builder()
+            // BaseListener
+            .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
-    private static final io.gravitee.definition.model.v4.listener.tcp.TcpListener.TcpListenerBuilder<?, ?> BASE_MODEL_TCP_LISTENER = io.gravitee.definition.model.v4.listener.tcp.TcpListener
-        .builder()
-        // BaseListener
-        .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
-        .servers(List.of("my-server1", "my-server2"));
+    private static final io.gravitee.definition.model.v4.listener.tcp.TcpListener.TcpListenerBuilder<?, ?> BASE_MODEL_TCP_LISTENER =
+        io.gravitee.definition.model.v4.listener.tcp.TcpListener
+            .builder()
+            // BaseListener
+            .entrypoints(List.of(EntrypointModelFixtures.aModelEntrypointV4()))
+            .servers(List.of("my-server1", "my-server2"));
 
     public static io.gravitee.definition.model.v4.listener.http.HttpListener aModelHttpListener() {
         return BASE_MODEL_HTTP_LISTENER.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PropertyModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PropertyModelFixtures.java
@@ -22,19 +22,11 @@ public class PropertyModelFixtures {
 
     private PropertyModelFixtures() {}
 
-    private static final io.gravitee.definition.model.Property.PropertyBuilder BASE_MODEL_PROPERTY_V2 = io.gravitee.definition.model.Property
-        .builder()
-        .dynamic(false)
-        .encrypted(false)
-        .key("prop-key")
-        .value("prop-value");
+    private static final io.gravitee.definition.model.Property.PropertyBuilder BASE_MODEL_PROPERTY_V2 =
+        io.gravitee.definition.model.Property.builder().dynamic(false).encrypted(false).key("prop-key").value("prop-value");
 
-    private static final io.gravitee.definition.model.v4.property.Property.PropertyBuilder BASE_MODEL_PROPERTY_V4 = io.gravitee.definition.model.v4.property.Property
-        .builder()
-        .dynamic(false)
-        .encrypted(false)
-        .key("prop-key")
-        .value("prop-value");
+    private static final io.gravitee.definition.model.v4.property.Property.PropertyBuilder BASE_MODEL_PROPERTY_V4 =
+        io.gravitee.definition.model.v4.property.Property.builder().dynamic(false).encrypted(false).key("prop-key").value("prop-value");
 
     private static final Properties.PropertiesBuilder BASE_MODEL_PROPERTIES_V2 = Properties
         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ResourceModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ResourceModelFixtures.java
@@ -19,19 +19,21 @@ public class ResourceModelFixtures {
 
     private ResourceModelFixtures() {}
 
-    private static final io.gravitee.definition.model.plugins.resources.Resource.ResourceBuilder BASE_RESOURCE_ENTITY_V2 = io.gravitee.definition.model.plugins.resources.Resource
-        .builder()
-        .name("role-name")
-        .type("resource-type")
-        .enabled(true)
-        .configuration("{\"key\":\"value\"}");
+    private static final io.gravitee.definition.model.plugins.resources.Resource.ResourceBuilder BASE_RESOURCE_ENTITY_V2 =
+        io.gravitee.definition.model.plugins.resources.Resource
+            .builder()
+            .name("role-name")
+            .type("resource-type")
+            .enabled(true)
+            .configuration("{\"key\":\"value\"}");
 
-    private static final io.gravitee.definition.model.v4.resource.Resource.ResourceBuilder BASE_RESOURCE_ENTITY_V4 = io.gravitee.definition.model.v4.resource.Resource
-        .builder()
-        .name("role-name")
-        .type("resource-type")
-        .enabled(true)
-        .configuration("{\"key\":\"value\"}");
+    private static final io.gravitee.definition.model.v4.resource.Resource.ResourceBuilder BASE_RESOURCE_ENTITY_V4 =
+        io.gravitee.definition.model.v4.resource.Resource
+            .builder()
+            .name("role-name")
+            .type("resource-type")
+            .enabled(true)
+            .configuration("{\"key\":\"value\"}");
 
     public static io.gravitee.definition.model.plugins.resources.Resource aResourceEntityV2() {
         return BASE_RESOURCE_ENTITY_V2.build();

--- a/pom.xml
+++ b/pom.xml
@@ -1172,7 +1172,7 @@
                     <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
                     <skip>${skip.validation}</skip>
                     <inputGlobs>
-                        <inputGlob>src/{main,test}/{java,resources}/**/*.{java}</inputGlob>
+                        <inputGlob>src/{main,test}/**/*.java</inputGlob>
                     </inputGlobs>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Issue

N/A

## Description

In glob syntax, it seems that `{}` must contains a comma to be considered as a list.

`src/{main,test}/{java,resources}/**/*.{java}` was interpreted like:

- `src/main/java/*.{java}`
- `src/test/java/*.{java}`
- `src/resources/java/*.{java}`
- `src/resources/java/*.{java}`


This PR replaces `<inputGlob>src/{main,test}/{java,resources}/**/*.{java}</inputGlob>` with `<inputGlob>src/{main,test}/**/*.java</inputGlob>`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bkkgzbfxec.chromatic.com)
<!-- Storybook placeholder end -->
