### PR TITLE
feat(qos): sort QoS to have consistent order

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/connectorVM.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/connectorVM.ts
@@ -1,4 +1,4 @@
-import { ConnectorPlugin, ListenerType } from '../../index';
+import { ConnectorPlugin, ListenerType, Qos } from '../../index';
 
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
@@ -25,6 +25,7 @@ export type ConnectorVM = {
    */
   isEnterprise: boolean;
   supportedListenerType: ListenerType;
+  supportedQos: Qos[];
   icon: string;
   deployed: boolean;
 };
@@ -36,6 +37,7 @@ export const fromConnector: (iconService, connector: ConnectorPlugin) => Connect
     description: connector.description,
     isEnterprise: connector.id.endsWith('-advanced'),
     supportedListenerType: connector.supportedListenerType,
+    supportedQos: connector.supportedQos,
     icon: iconService.registerSvg(connector.id, connector.icon),
     deployed: connector.deployed,
   };

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-v4-menu.service.ts
@@ -180,7 +180,7 @@ export class ApiNgV4MenuService implements ApiMenuService {
           {
             displayName: 'General',
             targetRoute: 'management.apis.ng.entrypoints',
-            baseRoute: 'management.apis.ng.entrypoints',
+            baseRoute: ['management.apis.ng.entrypoints', 'management.apis.ng.entrypoints-edit'],
           },
         ],
       };

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.html
@@ -1,0 +1,40 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="gio-form-qos">
+  <h3>Quality of service</h3>
+  <gio-banner-info>
+    Define the guaranteed level of message delivery.
+    <div gioBannerBody>
+      A given quality of service may or may not be supported by a given endpoint. Support also depends on the protocol used for the
+      entrypoint. Please check the documentation for QoS compatibility.
+      <a
+        href="https://documentation.gravitee.io/apim/guides/api-configuration/v4-api-configuration/quality-of-service"
+        aria-label="learn more"
+        rel="noopener"
+        target="_blank"
+        >Learn more</a
+      >
+    </div>
+  </gio-banner-info>
+  <mat-form-field class="gio-form-qos__select">
+    <mat-label>Quality of Service</mat-label>
+    <mat-select [name]="id + '-qos'" aria-label="Quality of service" required [(ngModel)]="selectedQos">
+      <mat-option *ngFor="let qos of supportedQos" [value]="qos">{{ qos }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.scss
@@ -1,0 +1,13 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.gio-form-qos {
+  padding: 8px;
+  border: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+  border-radius: 8px;
+  box-shadow: none;
+
+  &__select {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.component.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, forwardRef, Input, OnDestroy } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { isEmpty } from 'lodash';
+
+import { Qos } from '../../../../entities/management-api-v2';
+
+@Component({
+  selector: 'gio-form-qos',
+  template: require('./gio-form-qos.component.html'),
+  styles: [require('./gio-form-qos.component.scss')],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => GioFormQosComponent),
+      multi: true,
+    },
+  ],
+})
+export class GioFormQosComponent implements OnDestroy, ControlValueAccessor {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+  @Input()
+  public id: string;
+
+  @Input()
+  public supportedQos?: Qos[];
+
+  public _selectedQos: Qos;
+
+  get selectedQos() {
+    return this._selectedQos;
+  }
+  set selectedQos(selection: Qos) {
+    this._selectedQos = selection;
+    this._onTouched();
+    this._onChange(selection);
+  }
+  protected _onChange: (_selection: Qos | null) => void = () => ({});
+
+  protected _onTouched: () => void = () => ({});
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  // From ControlValueAccessor interface
+  public writeValue(selection: Qos | null): void {
+    if (!selection || isEmpty(selection)) {
+      return;
+    }
+
+    this.selectedQos = selection;
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnChange(fn: (selection: Qos | null) => void): void {
+    this._onChange = fn;
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.harness.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BaseHarnessFilters, ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+import { Qos } from '../../../../entities/management-api-v2';
+
+export class GioFormQosHarness extends ComponentHarness {
+  public static hostSelector = 'gio-form-qos';
+
+  /**
+   * Get Harness with the given filter.
+   *
+   * @param options Options for filtering which input instances are considered a match.
+   * @return a `HarnessPredicate` configured with the given options.
+   */
+  public static with(options: BaseHarnessFilters = {}): HarnessPredicate<GioFormQosHarness> {
+    return new HarnessPredicate(GioFormQosHarness, options);
+  }
+
+  async getSelectedQos() {
+    const qosSelect = await this.locatorFor(MatSelectHarness)();
+    return qosSelect.getValueText();
+  }
+
+  async selectOption(qos: Qos) {
+    const qosSelect = await this.locatorFor(MatSelectHarness)();
+    return qosSelect.clickOptions({ text: qos });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-qos/gio-form-qos.module.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+
+import { GioFormQosComponent } from './gio-form-qos.component';
+
+import { GioConnectorListModule } from '../../../../shared/components/gio-connector-list-option/gio-connector-list.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    MatInputModule,
+    MatFormFieldModule,
+    ReactiveFormsModule,
+    MatListModule,
+    GioConnectorListModule,
+    GioIconsModule,
+    MatButtonModule,
+    FormsModule,
+    GioBannerModule,
+    MatCardModule,
+    MatOptionModule,
+    MatSelectModule,
+  ],
+  declarations: [GioFormQosComponent],
+  exports: [GioFormQosComponent],
+})
+export class GioFormQosModule {}

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -434,6 +434,7 @@ describe('ApiCreationV4Component', () => {
             name: 'SSE',
             icon: 'gio-literal:sse',
             supportedListenerType: 'HTTP',
+            selectedQos: 'AUTO',
             deployed: true,
           },
           {
@@ -453,6 +454,7 @@ describe('ApiCreationV4Component', () => {
             name: 'Webhook',
             icon: 'gio-literal:webhook',
             supportedListenerType: 'SUBSCRIPTION',
+            selectedQos: 'AUTO',
             deployed: true,
           },
         ]);
@@ -530,6 +532,7 @@ describe('ApiCreationV4Component', () => {
             name: 'SSE',
             icon: 'gio-literal:sse',
             supportedListenerType: 'HTTP',
+            selectedQos: 'AUTO',
             deployed: true,
           },
         ]);
@@ -543,8 +546,8 @@ describe('ApiCreationV4Component', () => {
         const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
         expectEntrypointsGetRequest([
-          { id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE' },
-          { id: 'webhook', supportedApiType: 'MESSAGE', name: 'Webhook' },
+          { id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE', supportedQos: ['NONE', 'AUTO'] },
+          { id: 'webhook', supportedApiType: 'MESSAGE', name: 'Webhook', supportedQos: ['AUTO', 'AT_MOST_ONCE'] },
         ]);
         expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
@@ -552,8 +555,22 @@ describe('ApiCreationV4Component', () => {
 
         await step2Harness.clickValidate();
         expect(component.currentStep.payload.selectedEntrypoints).toEqual([
-          { icon: 'gio-literal:sse', id: 'sse', name: 'SSE', supportedListenerType: 'HTTP', deployed: true },
-          { icon: 'gio-literal:webhook', id: 'webhook', name: 'Webhook', supportedListenerType: 'HTTP', deployed: true },
+          {
+            icon: 'gio-literal:sse',
+            id: 'sse',
+            name: 'SSE',
+            supportedListenerType: 'HTTP',
+            supportedQos: ['NONE', 'AUTO'],
+            deployed: true,
+          },
+          {
+            icon: 'gio-literal:webhook',
+            id: 'webhook',
+            name: 'Webhook',
+            supportedListenerType: 'HTTP',
+            supportedQos: ['AUTO', 'AT_MOST_ONCE'],
+            deployed: true,
+          },
         ]);
         exceptEnvironmentGetRequest(fakeEnvironment());
         expectSchemaGetRequest([
@@ -563,6 +580,8 @@ describe('ApiCreationV4Component', () => {
         expectApiGetPortalSettings();
 
         const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+        await step21Harness.selectQos('sse', 'NONE');
+        await step21Harness.selectQos('webhook', 'AT_MOST_ONCE');
         await step21Harness.fillPathsAndValidate('/api/my-api-3');
         expectVerifyContextPathGetRequest();
         await step21Harness.clickValidate();
@@ -583,6 +602,8 @@ describe('ApiCreationV4Component', () => {
             id: 'sse',
             name: 'SSE',
             supportedListenerType: 'HTTP',
+            supportedQos: ['NONE', 'AUTO'],
+            selectedQos: 'NONE',
             deployed: true,
           },
           {
@@ -602,6 +623,8 @@ describe('ApiCreationV4Component', () => {
             id: 'webhook',
             name: 'Webhook',
             supportedListenerType: 'HTTP',
+            supportedQos: ['AUTO', 'AT_MOST_ONCE'],
+            selectedQos: 'AT_MOST_ONCE',
             deployed: true,
           },
         ]);
@@ -653,6 +676,7 @@ describe('ApiCreationV4Component', () => {
             id: 'http-post',
             name: 'HTTP POST',
             supportedListenerType: 'HTTP',
+            selectedQos: 'AUTO',
             icon: 'gio-literal:http-post',
             deployed: true,
             configuration: {},
@@ -725,6 +749,7 @@ describe('ApiCreationV4Component', () => {
               id: 'http-proxy',
               name: 'HTTP Proxy',
               supportedListenerType: 'HTTP',
+              selectedQos: 'AUTO',
               deployed: true,
               configuration: {},
             },
@@ -819,6 +844,7 @@ describe('ApiCreationV4Component', () => {
           id: 'entrypoint-1',
           name: 'initial entrypoint',
           supportedListenerType: 'HTTP',
+          selectedQos: 'AUTO',
           deployed: true,
         },
         {
@@ -827,6 +853,7 @@ describe('ApiCreationV4Component', () => {
           id: 'entrypoint-2',
           name: 'new entrypoint',
           supportedListenerType: 'SUBSCRIPTION',
+          selectedQos: 'AUTO',
           deployed: true,
         },
       ]);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
@@ -182,9 +182,10 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
     const listeners: Listener[] = listenersType.reduce((listeners, listenersType) => {
       const entrypoints: Entrypoint[] = apiCreationPayload.selectedEntrypoints
         .filter((e) => e.supportedListenerType === listenersType)
-        .map(({ id, configuration }) => ({
+        .map(({ id, configuration, selectedQos }) => ({
           type: id,
           configuration: configuration,
+          qos: selectedQos,
         }));
 
       const listenerConfig = {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.module.ts
@@ -35,6 +35,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatTableModule } from '@angular/material/table';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
 
 import { ApiCreationV4Component } from './api-creation-v4.component';
 import { Step1ApiDetailsComponent } from './steps/step-1-api-details/step-1-api-details.component';
@@ -61,6 +63,7 @@ import { GioEntrypointsSelectionListModule } from '../component/gio-entrypoints-
 import { GioConnectorDialogModule } from '../../../components/gio-connector-dialog/gio-connector-dialog.module';
 import { ApiPlanFormModule } from '../component/plan/api-plan-form.module';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { GioFormQosModule } from '../component/gio-form-qos/gio-form-qos.module';
 
 @NgModule({
   imports: [
@@ -85,6 +88,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioConfirmDialogModule,
     GioFormJsonSchemaModule,
     ApiCreationStepperMenuModule,
+    GioFormQosModule,
     GioFormListenersContextPathModule,
     GioFormListenersVirtualHostModule,
     GioEntrypointsSelectionListModule,
@@ -94,6 +98,8 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioFormFocusInvalidModule,
     GioPermissionModule,
     MatMenuModule,
+    MatOptionModule,
+    MatSelectModule,
   ],
   declarations: [
     ApiCreationV4Component,

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/models/ApiCreationPayload.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/models/ApiCreationPayload.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiType, CreatePlanV4, ListenerType, PathV4 } from '../../../../entities/management-api-v2';
+import { ApiType, CreatePlanV4, ListenerType, PathV4, Qos } from '../../../../entities/management-api-v2';
 
 export type ApiCreationPayload = Partial<{
   // API details
@@ -29,6 +29,8 @@ export type ApiCreationPayload = Partial<{
     name: string;
     icon: string;
     supportedListenerType: ListenerType;
+    supportedQos?: Qos[];
+    selectedQos?: Qos;
     configuration?: unknown;
     deployed: boolean;
   }[];

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
@@ -119,7 +119,14 @@ export class Step2Entrypoints1ListComponent implements OnInit, OnDestroy {
   private saveChanges() {
     const selectedEntrypointsIds = this.formGroup.getRawValue().selectedEntrypointsIds ?? [];
     const selectedEntrypoints = this.entrypoints
-      .map(({ id, name, supportedListenerType, icon, deployed }) => ({ id, name, supportedListenerType, icon, deployed }))
+      .map(({ id, name, supportedListenerType, supportedQos, icon, deployed }) => ({
+        id,
+        name,
+        supportedListenerType,
+        supportedQos,
+        icon,
+        deployed,
+      }))
       .filter((e) => selectedEntrypointsIds.includes(e.id));
 
     this.stepService.validStep((previousPayload) => ({

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
@@ -46,7 +46,17 @@
     <ng-container *ngFor="let entrypoint of selectedEntrypoints">
       <div *ngIf="entrypointSchemas[entrypoint.id]" class="api-creation-v4__form-container">
         <h3>{{ entrypoint.name }}</h3>
-        <gio-form-json-schema [jsonSchema]="entrypointSchemas[entrypoint.id]" [formControlName]="entrypoint.id"></gio-form-json-schema>
+        <gio-form-json-schema
+          [jsonSchema]="entrypointSchemas[entrypoint.id]"
+          [formControlName]="entrypoint.id + '-config'"
+        ></gio-form-json-schema>
+
+        <gio-form-qos
+          *ngIf="entrypoint"
+          [id]="entrypoint.id"
+          [supportedQos]="entrypoint.supportedQos"
+          [formControlName]="entrypoint.id + '-qos'"
+        ></gio-form-qos>
       </div>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.scss
@@ -9,3 +9,8 @@
     margin-bottom: 8px;
   }
 }
+
+gio-form-qos {
+  display: block;
+  margin-top: 8px;
+}

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.harness.ts
@@ -18,6 +18,8 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { GioFormListenersContextPathHarness } from '../../../component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.harness';
 import { GioFormListenersVirtualHostHarness } from '../../../component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.harness';
+import { Qos } from '../../../../../entities/management-api-v2';
+import { GioFormQosHarness } from '../../../component/gio-form-qos/gio-form-qos.harness';
 
 export class Step2Entrypoints2ConfigHarness extends ComponentHarness {
   static hostSelector = 'step-2-entrypoints-2-config';
@@ -41,6 +43,9 @@ export class Step2Entrypoints2ConfigHarness extends ComponentHarness {
   );
 
   protected getListenersDiv = this.locatorFor('#listeners');
+
+  protected getQosSelect = (entrypointId: string) =>
+    this.locatorFor(GioFormQosHarness.with({ selector: '[ng-reflect-id="' + entrypointId + '"]' }));
 
   async clickPrevious(): Promise<void> {
     return this.getPreviousButton().then((elt) => elt.click());
@@ -98,5 +103,10 @@ export class Step2Entrypoints2ConfigHarness extends ComponentHarness {
     }
 
     await this.clickValidate();
+  }
+
+  async selectQos(entrypointId: string, qos: Qos) {
+    const gioFormQos = await this.getQosSelect(entrypointId)();
+    await gioFormQos.selectOption(qos);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -63,6 +63,12 @@
             <div class="entrypoints__type__table__type"><mat-icon [svgIcon]="element.icon"></mat-icon> {{ element.type }}</div>
           </td>
         </ng-container>
+        <ng-container matColumnDef="qos">
+          <th mat-header-cell *matHeaderCellDef>Quality of Service</th>
+          <td mat-cell *matCellDef="let element">
+            <div class="entrypoints__type__table__type">{{ element.qos }}</div>
+          </td>
+        </ng-container>
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let element" class="entrypoints__type__table__actions">

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.ts
@@ -48,6 +48,7 @@ type EntrypointVM = {
   id: string;
   icon: string;
   type: string;
+  qos: string;
 };
 @Component({
   selector: 'api-entrypoints-v4-general',
@@ -60,7 +61,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit {
   public api: ApiV4;
   public formGroup: FormGroup;
   public pathsFormControl: FormControl;
-  public displayedColumns = ['type', 'actions'];
+  public displayedColumns = ['type', 'qos', 'actions'];
   public dataSource: EntrypointVM[] = [];
   private allEntrypoints: ConnectorPlugin[];
   public enableVirtualHost = false;
@@ -134,6 +135,7 @@ export class ApiEntrypointsV4GeneralComponent implements OnInit {
             id: entrypoint.type,
             icon: this.iconService.registerSvg(matchingEntrypoint.id, matchingEntrypoint.icon),
             type: matchingEntrypoint.name,
+            qos: entrypoint.qos,
           };
           return entry;
         }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
@@ -19,11 +19,14 @@ import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
-import { GioFormJsonSchemaModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormJsonSchemaModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
 
 import { ApiEntrypointsV4GeneralComponent } from './api-entrypoints-v4-general.component';
 import { ApiEntrypointsV4EditComponent } from './edit/api-entrypoints-v4-edit.component';
@@ -33,6 +36,7 @@ import { GioFormListenersContextPathModule } from '../component/gio-form-listene
 import { GioFormListenersVirtualHostModule } from '../component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.module';
 import { GioGoBackButtonModule } from '../../../shared/components/gio-go-back-button/gio-go-back-button.module';
 import { GioEntrypointsSelectionListModule } from '../component/gio-entrypoints-selection-list/gio-entrypoints-selection-list.module';
+import { GioFormQosModule } from '../component/gio-form-qos/gio-form-qos.module';
 
 @NgModule({
   imports: [
@@ -54,6 +58,11 @@ import { GioEntrypointsSelectionListModule } from '../component/gio-entrypoints-
     MatSnackBarModule,
     MatTableModule,
     MatTooltipModule,
+    GioBannerModule,
+    MatFormFieldModule,
+    MatOptionModule,
+    MatSelectModule,
+    GioFormQosModule,
   ],
   declarations: [ApiEntrypointsV4GeneralComponent, ApiEntrypointsV4EditComponent, ApiEntrypointsV4AddDialogComponent],
 })

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.html
@@ -23,7 +23,15 @@
   <form [formGroup]="form" *ngIf="form; else loader" (ngSubmit)="onSaveEntrypointConfig()">
     <div *ngIf="entrypointSchema" class="api-creation-v4__form-container">
       <h3>{{ entrypointName }}</h3>
-      <gio-form-json-schema [jsonSchema]="entrypointSchema" [formControlName]="entrypoint.type"></gio-form-json-schema>
+
+      <gio-form-json-schema [jsonSchema]="entrypointSchema" [formControlName]="entrypoint.type + '-config'"></gio-form-json-schema>
+
+      <gio-form-qos
+        *ngIf="entrypoint"
+        [id]="entrypoint.type"
+        [supportedQos]="supportedQos"
+        [formControlName]="entrypoint.type + '-qos'"
+      ></gio-form-qos>
     </div>
 
     <div class="footer">

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.scss
@@ -18,6 +18,11 @@
   margin-top: 24px;
 }
 
+gio-form-qos {
+  display: block;
+  margin-top: 8px;
+}
+
 gio-loader {
   width: 32px;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
@@ -88,7 +88,13 @@ public abstract class AbstractConnectorPluginService<T extends ConfigurablePlugi
                 supportedQos = ((EndpointAsyncConnectorFactory) connectorFactory).supportedQos();
             }
             if (supportedQos != null) {
-                entity.setSupportedQos(supportedQos.stream().map(qos -> Qos.fromLabel(qos.getLabel())).collect(Collectors.toSet()));
+                entity.setSupportedQos(
+                    supportedQos
+                        .stream()
+                        .map(qos -> Qos.fromLabel(qos.getLabel()))
+                        .sorted()
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
+                );
             }
         }
         if (connectorFactory.supportedModes() != null) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1820

## Description

In this PR, I added the possibility to select a QoS on an entrypoint. As the backend service was already available, it is mainly a matter of UI/UX. Though I had to apply a sort on the supported Qos list.

Mainly this PR adds:
 - a banner that explains a little bit what is a quality of service and display a link to our documentation page
 - a select input with the list of Qos supported by the entrypoint

By default, the Qos is always 'AUTO'.

Even if it was not asked, I found it interesting to display the Qos in the entrypoints list (the table was quite empty ^^)


## Additional context

### API Creation workflow
<img width="1463" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/870ac464-919e-493b-bd74-748bc0dc1560">

### Entrypoint edition
<img width="1463" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/7d6fa586-7549-4507-91dc-57c2f9574f66">

### Entrypoints list
<img width="1196" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/ccc365ee-ebf3-4392-98e4-734ffa587563">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rugyfahgld.chromatic.com)
<!-- Storybook placeholder end -->
