### PR TITLE
Use medium machines to run JDBC tests instead of large ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1479,7 +1479,7 @@ jobs:
                 default: ""
         executor:
             name: ubuntu
-            class: large
+            class: medium
             with_docker_layer_caching: true
         steps:
             - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2387,11 +2387,6 @@ workflows:
                       - Publish APIM Console to artifactory
                       - Publish APIM Portal to artifactory
                   context: cicd-orchestrator
-            - job-publish-on-artifactory:
-                  name: Publish new SNAPSHOTS on artifactory
-                  context: cicd-orchestrator
-                  requires:
-                      - Commit and prepare next version
 
             # Package bundle
             - job-package-bundle:


### PR DESCRIPTION
## Issue

NA

## Description

 - Use medium machines to run JDBC tests instead of large ones
 - Remove the job to publish new SNAPSHOTS on Artifactory during a release as it's not working


