### PR TITLE
test: fix for flaky UI metadata test

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-metadata.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-metadata.spec.ts
@@ -212,8 +212,9 @@ describe('API metadata screen', () => {
   });
 
   describe('Global metadata inside API documentation', () => {
-    const globalMetadataName: string = `${faker.random.word()}-${faker.random.word()}`;
+    const globalMetadataName: string = `${faker.random.word()} ${faker.random.word()}`;
     const globalMetadataValue: string = `${faker.random.word()}`;
+    let globalMetadataKey: string;
 
     before(() => {
       cy.request({
@@ -226,7 +227,9 @@ describe('API metadata screen', () => {
           name: globalMetadataName,
           value: globalMetadataValue,
         },
-      }).ok();
+      }).then((response) => {
+        globalMetadataKey = response.body.key;
+      });
     });
 
     it('should display global metadata in API metadata overview', function () {
@@ -258,10 +261,9 @@ describe('API metadata screen', () => {
 
     after(() => {
       cy.clearCookie('Auth-Graviteeio-APIM');
-      const key = globalMetadataName.toLowerCase();
       cy.request({
         method: 'DELETE',
-        url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/metadata/${key}`,
+        url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/metadata/${globalMetadataKey}`,
         auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
       });
     });


### PR DESCRIPTION
## Description
The Cypress test for testing API metadata in the UI was sometime failing because for the deletion of a metadata the metadata key must be used instead of the metadata name. 

In the old version of this test it was already tried to modify the metadata name in a way that it can be used as a key but it turned out that the rules for the metadata key generation are more complex than expected, so now the test uses the real key that is return by the back end.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kzgxjlpxhu.chromatic.com)
<!-- Storybook placeholder end -->
