### PR TITLE
fix: endpoint edition navigation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -78,7 +78,7 @@
     </div>
 
     <div class="endpoint-card__actions">
-      <a mat-stroked-button type="button" (click)="onPrevious()">Previous</a>
+      <a mat-stroked-button type="button" [uiSref]="'management.apis.ng.endpoint-groups'">Previous</a>
       <button
         mat-flat-button
         aria-label="Validate my endpoints"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -148,7 +148,7 @@ describe('ApiEndpointComponent', () => {
         ],
       };
       expectApiPutRequest(updatedApi);
-      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
+      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoint-groups');
     });
 
     it('should edit and save an existing endpoint', async () => {
@@ -179,7 +179,7 @@ describe('ApiEndpointComponent', () => {
         ],
       };
       expectApiPutRequest(updatedApi);
-      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
+      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoint-groups');
     });
 
     it('should inherit configuration from parent', async () => {
@@ -219,19 +219,6 @@ describe('ApiEndpointComponent', () => {
 
       await componentHarness.toggleConfigurationButton();
       fixture.detectChanges();
-    });
-  });
-
-  describe('onPreviousClick', () => {
-    it('should go back to endpoints groups list page', async () => {
-      const apiV4 = fakeApiV4({
-        id: API_ID,
-      });
-      await initComponent(apiV4);
-
-      await componentHarness.clickPreviousButton();
-
-      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -85,10 +85,6 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
     this.unsubscribe$.unsubscribe();
   }
 
-  public onPrevious() {
-    this.ajsState.go('management.apis.ng.endpoints');
-  }
-
   public onSave() {
     const inheritConfiguration = this.formGroup.get('inheritConfiguration').value;
 
@@ -125,7 +121,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
         }),
         map(() => {
           this.snackBarService.success(`Endpoint successfully created!`);
-          this.ajsState.go('management.apis.ng.endpoints');
+          this.ajsState.go('management.apis.ng.endpoint-groups');
         }),
         takeUntil(this.unsubscribe$),
       )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

When we changed the URLs of the endpoint groups we forget 2 buttons, here is a PR to navigate to groups properly

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kefbowemkj.chromatic.com)
<!-- Storybook placeholder end -->
