### PR TITLE
feat(helm): avoid empty user

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -19,5 +19,6 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
+    - Avoid empty user when disabling admin user
     - Add revision history limit on portal
     - Add podSecurityContext

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -255,8 +255,8 @@ data:
           password-encoding-algo: {{ .Values.inMemoryAuth.passwordEncodingAlgo | default "bcrypt" }}
           allow-email-in-search-results: {{ .Values.inMemoryAuth.allowEmailInSearchResults }}
           users:
-            - user:
             {{- if .Values.adminAccountEnable }}
+            - user:
               username: admin
               password: {{ .Values.adminPasswordBcrypt }}
               roles: ORGANIZATION:ADMIN, ENVIRONMENT:ADMIN

--- a/helm/tests/api/configmap_test.yaml
+++ b/helm/tests/api/configmap_test.yaml
@@ -115,3 +115,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Set adminAccountEnable to false
+    template: api/api-configmap.yaml
+    set:
+      adminAccountEnable: false
+    asserts:
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * users:\n
+				    *  - user:\n
+                    *  - user:"


### PR DESCRIPTION
When we set `adminAccountEnable: false`
The code  generate an empty user in the gravitee.yml:
```
users:
  - user:
  - user:
```
This commit fix the issue
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flthvzqyhs.chromatic.com)
<!-- Storybook placeholder end -->
