### PR TITLE
feat(console): proxy apis add http-proxy endpoint group

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointV4.ts
@@ -69,6 +69,12 @@ const SOLACE_ENDPOINT: EndpointV4 = {
   inheritConfiguration: true,
 };
 
+const HTTP_PROXY_ENDPOINT: EndpointV4 = {
+  name: 'Default HTTP Proxy Endpoint',
+  type: 'http-proxy',
+  inheritConfiguration: true,
+};
+
 export const EndpointV4Default = {
   byType: (type: string): EndpointV4 => {
     switch (type) {
@@ -86,6 +92,9 @@ export const EndpointV4Default = {
       }
       case 'mock': {
         return MOCK_ENDPOINT;
+      }
+      case 'http-proxy': {
+        return HTTP_PROXY_ENDPOINT;
       }
       default: {
         return undefined;

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -15,17 +15,17 @@
     limitations under the License.
 
 -->
-<form *ngIf="createForm" [formGroup]="createForm" (submit)="createEndpointGroup()">
+<form *ngIf="createForm && apiType" [formGroup]="createForm" (submit)="createEndpointGroup()">
   <mat-card>
-    <mat-stepper [linear]="true" #stepper>
-      <mat-step state="type" [stepControl]="createForm.get('type')">
+    <mat-stepper [linear]="true">
+      <mat-step *ngIf="apiType === 'MESSAGE'" state="type" [stepControl]="createForm.get('type')">
         <ng-template matStepperIcon="type">
           <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
         </ng-template>
         <ng-template matStepLabel>Endpoint Group Type</ng-template>
-        <api-endpoints-group-selection [endpointGroupTypeForm]="endpointGroupTypeForm"></api-endpoints-group-selection>
+        <api-endpoints-group-selection [endpointGroupTypeForm]="endpointGroupTypeForm" [apiType]="apiType"></api-endpoints-group-selection>
         <div class="api-endpoint-group-create__footer">
-          <button mat-stroked-button type="button" (click)="goBackToEndpointGroups()">Exit</button>
+          <ng-container *ngTemplateOutlet="exitButton"></ng-container>
           <button mat-raised-button type="button" color="primary" [disabled]="createForm.get('type').invalid" matStepperNext>
             Select endpoint group type
           </button>
@@ -39,7 +39,10 @@
         <ng-template matStepLabel>General</ng-template>
         <api-endpoint-group-general [generalForm]="generalForm"></api-endpoint-group-general>
         <div class="api-endpoint-group-create__footer">
-          <button mat-stroked-button type="button" matStepperPrevious>Back</button>
+          <ng-container *ngIf="apiType === 'PROXY'">
+            <ng-container *ngTemplateOutlet="exitButton"></ng-container>
+          </ng-container>
+          <button *ngIf="apiType === 'MESSAGE'" mat-stroked-button type="button" matStepperPrevious>Back</button>
           <button mat-raised-button type="button" color="primary" [disabled]="createForm.get('general').invalid" matStepperNext>
             Validate general information
           </button>
@@ -74,3 +77,7 @@
     </mat-stepper>
   </mat-card>
 </form>
+
+<ng-template #exitButton>
+  <button mat-stroked-button type="button" (click)="goBackToEndpointGroups()">Exit</button>
+</ng-template>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
@@ -26,7 +26,7 @@ import { ApiEndpointGroupConfigurationComponent } from '../configuration/api-end
 import { ApiEndpointGroupGeneralComponent } from '../general/api-endpoint-group-general.component';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { isUnique } from '../../../../../shared/utils';
-import { ApiV4, EndpointGroupV4, EndpointV4Default, UpdateApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiType, ApiV4, EndpointGroupV4, EndpointV4Default, UpdateApiV4 } from '../../../../../entities/management-api-v2';
 import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
@@ -59,6 +59,7 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
   public generalForm: FormGroup;
   public configuration: FormControl;
   public sharedConfigurationSchema: GioJsonSchema;
+  public apiType: ApiType;
 
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
@@ -76,7 +77,12 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe({
         next: (api) => {
-          this.generalForm.get('name').addValidators([isUnique((api as ApiV4).endpointGroups.map((group) => group.name))]);
+          const apiV4 = api as ApiV4;
+          this.generalForm.get('name').addValidators([isUnique(apiV4.endpointGroups.map((group) => group.name))]);
+          this.apiType = apiV4.type;
+          if (this.apiType === 'PROXY') {
+            this.endpointGroupTypeForm.get('endpointGroupType').setValue('http-proxy');
+          }
         },
       });
 
@@ -132,7 +138,7 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
           this.snackBarService.success(`Endpoint group ${newEndpointGroup.name} created!`);
           this.goBackToEndpointGroups();
         },
-        error: (err) => this.snackBarService.error(err.message ?? 'An error occurred.'),
+        error: ({ err }) => this.snackBarService.error(err.message ?? 'An error occurred.'),
       });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
@@ -19,7 +19,7 @@ import { of, Subject } from 'rxjs';
 import { FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
-import { ConnectorVM, fromConnector } from '../../../../../entities/management-api-v2';
+import { ApiType, ConnectorVM, fromConnector } from '../../../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
 import { IconService } from '../../../../../services-ngx/icon.service';
 import {
@@ -37,6 +37,8 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
 
   @Input()
   public endpointGroupTypeForm: FormGroup;
+  @Input()
+  public apiType: ApiType;
 
   public endpoints: ConnectorVM[];
 
@@ -48,7 +50,7 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
 
   ngOnInit() {
     this.connectorPluginsV2Service
-      .listEndpointPluginsByApiType('MESSAGE')
+      .listEndpointPluginsByApiType(this.apiType)
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((endpointPlugins) => {
         this.endpoints = endpointPlugins.map((endpoint) => fromConnector(this.iconService, endpoint));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2630

## Description

Automatically select http-proxy type for Proxy APIs

When opening stepper : 

![Screenshot 2023-08-31 at 15 35 16](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/cdec99d5-ce94-4675-9e49-2dca15014773)


Valid general info: 

![Screenshot 2023-08-31 at 15 35 47](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/38fc97d5-322f-486e-ba49-1d93a20eed6e)


Valid configuration:

![Screenshot 2023-08-31 at 15 36 13](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/a29ccc60-34bf-4269-98a0-cc9866435819)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qrtltnjfoo.chromatic.com)
<!-- Storybook placeholder end -->
