### PR TITLE
DLQ: Allow to configure DLQ for eligible entrypoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4.module.ts
@@ -19,7 +19,13 @@ import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
-import { GioBannerModule, GioFormJsonSchemaModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import {
+  GioBannerModule,
+  GioFormJsonSchemaModule,
+  GioFormSlideToggleModule,
+  GioIconsModule,
+  GioLoaderModule,
+} from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -27,6 +33,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatOptionModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { ApiEntrypointsV4GeneralComponent } from './api-entrypoints-v4-general.component';
 import { ApiEntrypointsV4EditComponent } from './edit/api-entrypoints-v4-edit.component';
@@ -63,6 +70,8 @@ import { GioFormQosModule } from '../component/gio-form-qos/gio-form-qos.module'
     MatOptionModule,
     MatSelectModule,
     GioFormQosModule,
+    GioFormSlideToggleModule,
+    MatSlideToggleModule,
   ],
   declarations: [ApiEntrypointsV4GeneralComponent, ApiEntrypointsV4EditComponent, ApiEntrypointsV4AddDialogComponent],
 })

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.html
@@ -19,9 +19,9 @@
   <gio-go-back-button [ajsGo]="{ to: 'management.apis.ng.entrypoints', params: { apiId } }"></gio-go-back-button>Go back to your entrypoints
 </div>
 
-<mat-card>
+<mat-card class="api-entrypoints-v4-edit">
   <form [formGroup]="form" *ngIf="form; else loader" (ngSubmit)="onSaveEntrypointConfig()">
-    <div *ngIf="entrypointSchema" class="api-creation-v4__form-container">
+    <div *ngIf="entrypointSchema" class="api-entrypoints-v4-edit__form-container">
       <h3>{{ entrypointName }}</h3>
 
       <gio-form-json-schema [jsonSchema]="entrypointSchema" [formControlName]="entrypoint.type + '-config'"></gio-form-json-schema>
@@ -32,9 +32,65 @@
         [supportedQos]="supportedQos"
         [formControlName]="entrypoint.type + '-qos'"
       ></gio-form-qos>
+
+      <mat-card *ngIf="supportDlq" class="api-entrypoints-v4-edit__form-container__dlq">
+        <h3>Dead Letter Queue</h3>
+        <p>
+          Define an external storage where each unsuccessfully pushed message will be stored, and configure a replay strategy to push them
+          again. You can select either an entire endpoint group or a single endpoint within a group.
+        </p>
+        <gio-form-slide-toggle class="api-entrypoints-v4-edit__form-container__dlq__toggle">
+          <div>Enable Dead Letter Queue</div>
+          <mat-slide-toggle gioFormSlideToggle formControlName="enabledDlq" aria-label="Enable Dead Letter toggle"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+
+        <mat-card *ngIf="enabledDlq" class="api-entrypoints-v4-edit__form-container__dlq">
+          <h3>Create from existing endpoint</h3>
+          <ng-container *ngIf="dlqElements.length > 0; else noElement">
+            <mat-form-field>
+              <mat-select
+                aria-label="Dead letter queue endpoint"
+                required
+                formControlName="dlqElement"
+                class="api-entrypoints-v4-edit__form-container__dlq__select"
+              >
+                <mat-select-trigger *ngIf="form.get('dlqElement').value">
+                  <ng-container *ngTemplateOutlet="dlqTpl; context: { $implicit: form.get('dlqElement').value }"> </ng-container>
+                </mat-select-trigger>
+                <mat-optgroup *ngFor="let optgroup of dlqElements" [label]="optgroup.name">
+                  <mat-option *ngFor="let dlqElement of optgroup.elements" [value]="dlqElement">
+                    <ng-container *ngTemplateOutlet="dlqTpl; context: { $implicit: dlqElement }"> </ng-container>
+                  </mat-option>
+                </mat-optgroup>
+              </mat-select>
+
+              <!-- Template use to display a DLQ element, use many times in the mat-select above-->
+              <ng-template #dlqTpl let-dlqElement>
+                {{ dlqElement.name }}
+                <span *ngIf="dlqElement" class="gio-badge-neutral">
+                  <mat-icon [svgIcon]="dlqElement.icon"></mat-icon>
+                  {{ dlqElement.type }}
+                </span>
+              </ng-template>
+              <mat-hint>This endpoint or endpoint group will receive sent messages again</mat-hint>
+            </mat-form-field>
+          </ng-container>
+
+          <ng-template #noElement>
+            <mat-form-field>
+              <mat-select
+                aria-label="Dead letter queue endpoint"
+                class="api-entrypoints-v4-edit__form-container__dlq__select"
+                placeholder="No compatible endpoint or endpoint group available"
+              >
+              </mat-select>
+            </mat-form-field>
+          </ng-template>
+        </mat-card>
+      </mat-card>
     </div>
 
-    <div class="footer">
+    <div class="api-entrypoints-v4-edit__footer">
       <button mat-flat-button color="primary" type="submit" [disabled]="form.pristine || form.invalid">Save changes</button>
     </div>
   </form>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.scss
@@ -12,15 +12,41 @@
   padding-bottom: 24px;
 }
 
-.footer {
-  display: flex;
-  justify-content: flex-start;
-  margin-top: 24px;
+.gio-badge-neutral {
+  margin: auto 4px auto 0;
+  text-transform: unset;
+
+  mat-icon {
+    margin-right: 6px;
+  }
 }
 
-gio-form-qos {
-  display: block;
-  margin-top: 8px;
+.api-entrypoints-v4-edit {
+  &__form-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    &__dlq {
+      display: flex;
+      flex-direction: column;
+
+      padding: 8px;
+      border: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+      border-radius: 8px;
+      box-shadow: none;
+
+      &__select {
+        width: 100%;
+      }
+    }
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-start;
+    margin-top: 24px;
+  }
 }
 
 gio-loader {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1929

## Description

This PR adds the possibility to configure a DLQ for eligible entrypoint (currently only webhook can be configured).

When the DLQ is enabled, a list of endpoint and endpoint-groups is displayed. These endpoints can't be the default ones (same for the endpoint-group).

This PR **does not** add the possibility to create an endpoint from this screen. It will be done with APIM-2607.

## Additional context

#### With no available endpoint
<img width="688" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/9336e08a-d50f-4173-8f55-4499923c11d9">


#### With available endpoints
<img width="688" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/8dffc165-9a98-49e3-8814-2eb67de1add7">
<img width="688" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/b7b354a4-2c7f-4523-a9fc-b04eb4b7eee2">
<img width="688" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/9021b3ee-6754-4f61-b39f-fd7aef05f759">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-okdchsbqud.chromatic.com)
<!-- Storybook placeholder end -->
