### PR TITLE
feat(helm): allow to fix node port values in services

### DIFF
--- a/helm/templates/api/api-service.yaml
+++ b/helm/templates/api/api-service.yaml
@@ -32,6 +32,11 @@ spec:
   ports:
     - port: {{ .Values.api.service.externalPort }}
       targetPort: {{ .Values.api.service.internalPort }}
+      {{- if eq .Values.api.service.type "NodePort" }}
+      {{- if .Values.api.service.nodePort }}
+      nodePort: {{ .Values.api.service.nodePort }}
+      {{- end }}
+      {{- end }}
       protocol: TCP
       {{- if (include "common.service.supportsAppProtocol" .) }}
       {{ if .Values.api.service.appProtocol }}

--- a/helm/templates/gateway/gateway-service.yaml
+++ b/helm/templates/gateway/gateway-service.yaml
@@ -37,6 +37,11 @@ spec:
   ports:
     - port: {{ .Values.gateway.service.externalPort }}
       targetPort: {{ .Values.gateway.service.internalPort }}
+      {{- if eq .Values.gateway.service.type "NodePort" }}
+      {{- if .Values.gateway.service.nodePort }}
+      nodePort: {{ .Values.gateway.service.nodePort }}
+      {{- end }}
+      {{- end }}
       protocol: TCP
       {{- if (include "common.service.supportsAppProtocol" .) }}
       {{ if .Values.gateway.service.appProtocol }}

--- a/helm/templates/portal/portal-service.yaml
+++ b/helm/templates/portal/portal-service.yaml
@@ -32,6 +32,11 @@ spec:
   ports:
     - port: {{ .Values.portal.service.externalPort }}
       targetPort: {{ .Values.portal.service.internalPort }}
+      {{- if eq .Values.portal.service.type "NodePort" }}
+      {{- if .Values.portal.service.nodePort }}
+      nodePort: {{ .Values.portal.service.nodePort }}
+      {{- end }}
+      {{- end }}
       protocol: TCP
       {{- if (include "common.service.supportsAppProtocol" .) }}
       {{ if .Values.portal.service.appProtocol }}

--- a/helm/templates/ui/ui-service.yaml
+++ b/helm/templates/ui/ui-service.yaml
@@ -32,6 +32,11 @@ spec:
   ports:
     - port: {{ .Values.ui.service.externalPort }}
       targetPort: {{ .Values.ui.service.internalPort }}
+      {{- if eq .Values.ui.service.type "NodePort" }}
+      {{- if .Values.ui.service.nodePort }}
+      nodePort: {{ .Values.ui.service.nodePort }}
+      {{- end }}
+      {{- end }}
       protocol: TCP
       {{- if (include "common.service.supportsAppProtocol" .) }}
       {{ if .Values.ui.service.appProtocol }}

--- a/helm/tests/api/service_test.yaml
+++ b/helm/tests/api/service_test.yaml
@@ -104,6 +104,26 @@ tests:
           path: spec.externalTrafficPolicy
           value: Local
 
+  - it: Deploy with NodePort and fixed port
+    template: api/api-service.yaml
+    set:
+      api:
+        service:
+          type: NodePort
+          nodePort: 30083
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.ports
+          content:
+            port: 83
+            targetPort: 8083
+            nodePort: 30083
+            protocol: TCP
+            name: api
+            appProtocol: http
+
   - it: Deploy with LoadBalancer and externalTrafficPolicy
     template: api/api-service.yaml
     set:

--- a/helm/tests/gateway/service_test.yaml
+++ b/helm/tests/gateway/service_test.yaml
@@ -102,6 +102,26 @@ tests:
           path: spec.externalTrafficPolicy
           value: Local
 
+  - it: Deploy with NodePort and fixed port
+    template: gateway/gateway-service.yaml
+    set:
+      gateway:
+        service:
+          type: NodePort
+          nodePort: 30082
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.ports
+          content:
+            port: 82
+            targetPort: 8082
+            nodePort: 30082
+            protocol: TCP
+            name: gateway
+            appProtocol: http
+
   - it: Deploy with LoadBalancer and externalTrafficPolicy
     template: gateway/gateway-service.yaml
     set:

--- a/helm/tests/portal/service_test.yaml
+++ b/helm/tests/portal/service_test.yaml
@@ -84,6 +84,28 @@ tests:
           path: spec.externalTrafficPolicy
           value: Local
 
+  - it: Deploy with NodePort and fixed port
+    template: portal/portal-service.yaml
+    set:
+      portal:
+        service:
+          type: NodePort
+          nodePort: 30003
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.ports
+          content:
+            port: 8003
+            targetPort: 8080
+            nodePort: 30003
+            protocol: TCP
+            name: portal
+            appProtocol: http
+
+
+
   - it: Deploy with LoadBalancer and externalTrafficPolicy
     template: portal/portal-service.yaml
     set:

--- a/helm/tests/ui/service_test.yaml
+++ b/helm/tests/ui/service_test.yaml
@@ -84,6 +84,26 @@ tests:
           path: spec.externalTrafficPolicy
           value: Local
 
+  - it: Deploy with NodePort and fixed port
+    template: ui/ui-service.yaml
+    set:
+      ui:
+        service:
+          type: NodePort
+          nodePort: 30002
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.ports
+          content:
+            port: 8002
+            targetPort: 8080
+            nodePort: 30002
+            protocol: TCP
+            name: ui
+            appProtocol: http
+
   - it: Deploy with LoadBalancer and externalTrafficPolicy
     template: ui/ui-service.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -617,6 +617,9 @@ api:
     externalTrafficPolicy: Cluster
     externalPort: 83
     internalPort: 8083
+    # used only if the type of your service is "NodePort" and must be in the range 30000-32767
+    # if not set a random port will be used in that range
+    # nodePort: 30083
     internalPortName: http
 #    appProtocol: http
   # annotations:
@@ -1034,6 +1037,9 @@ gateway:
     # externalTrafficPolicy is used only when configuring type "NodePort" or "LoadBalancer"
     externalTrafficPolicy: Cluster
     externalPort: 82
+    # used only if the type of your service is "NodePort" and must be in the range 30000-32767
+    # if not set a random port will be used in that range
+    # nodePort: 30082
     internalPort: 8082
     internalPortName: http
 #    appProtocol: http
@@ -1212,6 +1218,9 @@ portal:
     externalTrafficPolicy: Cluster
     externalPort: 8003
     internalPort: 8080
+    # used only if the type of your service is "NodePort" and must be in the range 30000-32767
+    # if not set a random port will be used in that range
+    # nodePort: 30003
     internalPortName: http
 #    appProtocol: http
   # annotations:
@@ -1396,6 +1405,9 @@ ui:
     externalTrafficPolicy: Cluster
     externalPort: 8002
     internalPort: 8080
+    # used only if the type of your service is "NodePort" and must be in the range 30000-32767
+    # if not set a random port will be used in that range
+    # nodePort: 30002
     internalPortName: http
 #    appProtocol: http
   # annotations:


### PR DESCRIPTION
This came as a feedback from the tech writers team.

Having such a capability can be handy when writing a guide based on a toy cluster such as minikube in order to have a reproducible setup.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cvuikidrsx.chromatic.com)
<!-- Storybook placeholder end -->
