### PR TITLE
Apim 2640 improve console tests

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.spec.ts
@@ -208,7 +208,6 @@ describe('GioMetadataComponent', () => {
 
       const dia = await rootLoader.getHarness(GioConfirmDialogHarness);
       expect(dia).toBeTruthy();
-      await dia.confirm();
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
@@ -15,11 +15,15 @@
  */
 import { IComponentControllerService } from 'angular';
 
-import { setupAngularJsTesting } from '../../../../jest.setup';
+/**
+ * DEPRECATED
+ *
+ * Tests skipped because they are very slow and the component will be migrated to Angular in the future
+ */
 
-setupAngularJsTesting();
+// setupAngularJsTesting();
 
-describe('WidgetDataStatsConfigurationComponent', () => {
+describe.skip('WidgetDataStatsConfigurationComponent', () => {
   let $componentController: IComponentControllerService;
   let widgetDataStatsConfigurationComponent: any;
 

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
@@ -27,6 +27,11 @@ interface Stat {
   fallback?: any;
 }
 
+/**
+ * DEPRECATED
+ *
+ * Tests no longer supported for this component
+ */
 class WidgetDataStatsConfigurationController implements IOnInit {
   public chart: {
     request: { type: string; field: any };

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.spec.ts
@@ -24,7 +24,6 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatInputHarness } from '@angular/material/input/testing';
-import { MatSnackBarHarness } from '@angular/material/snack-bar/testing';
 
 import { ApiPathMappingsComponent } from './api-path-mappings.component';
 import { ApiPathMappingsModule } from './api-path-mappings.module';
@@ -128,7 +127,7 @@ describe('ApiPathMappingsComponent', () => {
       expectApiGetRequest(api);
       expectApiPagesGetRequest(api, []);
 
-      let { rowCells } = await computeApisTableCells();
+      const { rowCells } = await computeApisTableCells();
       expect(rowCells).toEqual([
         ['/test', ''],
         ['/test/:id', ''],
@@ -147,14 +146,11 @@ describe('ApiPathMappingsComponent', () => {
       expectApiPutRequest(updatedApi);
       expectApiGetRequest(updatedApi);
       expectApiPagesGetRequest(api, []);
-
-      ({ rowCells } = await computeApisTableCells());
-      expect(rowCells).toEqual([['/test', '']]);
     });
   });
 
   describe('edit path mapping', () => {
-    it('should edit a path mapping', async () => {
+    it('should open edit path dialog', async () => {
       const api = fakeApi({
         id: API_ID,
         path_mappings: ['/test', '/test/:id'],
@@ -162,7 +158,7 @@ describe('ApiPathMappingsComponent', () => {
       expectApiGetRequest(api);
       expectApiPagesGetRequest(api, []);
 
-      let { rowCells } = await computeApisTableCells();
+      const { rowCells } = await computeApisTableCells();
       expect(rowCells).toEqual([
         ['/test', ''],
         ['/test/:id', ''],
@@ -175,28 +171,16 @@ describe('ApiPathMappingsComponent', () => {
       await dialog
         .getHarness(MatInputHarness.with({ selector: '[aria-label="Path mapping input"]' }))
         .then((input) => input.setValue('/updated/:id'));
-      await dialog.getHarness(MatButtonHarness.with({ selector: '[aria-label="Save path mapping"]' })).then((element) => element.click());
-
-      expectApiGetRequest(api);
-      const updatedApi = { ...api, path_mappings: ['/test', '/updated/:id'] };
-      expectApiPutRequest(updatedApi);
-
-      const snackBars = await rootLoader.getAllHarnesses(MatSnackBarHarness);
-      expect(snackBars.length).toBe(1);
-
-      expectApiGetRequest(updatedApi);
-      expectApiPagesGetRequest(api, []);
-      ({ rowCells } = await computeApisTableCells());
-      expect(rowCells).toEqual([
-        ['/test', ''],
-        ['/updated/:id', ''],
-      ]);
+      expect(
+        await dialog
+          .getHarness(MatButtonHarness.with({ selector: '[aria-label="Save path mapping"]' }))
+          .then((element) => element.isDisabled()),
+      ).toEqual(false);
     });
   });
 
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
-    fixture.detectChanges();
   }
 
   function expectApiPagesGetRequest(api: Api, pages: Page[]) {
@@ -211,7 +195,6 @@ describe('ApiPathMappingsComponent', () => {
     expect(req.request.body).toBeTruthy();
     expect(req.request.body.path_mappings).toStrictEqual(api.path_mappings);
     req.flush(api);
-    fixture.detectChanges();
   }
 
   async function computeApisTableCells() {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -125,7 +125,6 @@ describe('ApiCreationV4Component', () => {
     fixture = TestBed.createComponent(ApiCreationV4Component);
     httpTestingController = TestBed.inject(HttpTestingController);
     component = fixture.componentInstance;
-    fixture.detectChanges();
     harnessLoader = await TestbedHarnessEnvironment.loader(fixture);
   };
 
@@ -203,7 +202,6 @@ describe('ApiCreationV4Component', () => {
       expect(step1Harness).toBeDefined();
       await step1Harness.clickExit();
 
-      fixture.detectChanges();
       expect(fakeAjsState.go).toHaveBeenCalled();
     });
 
@@ -219,7 +217,6 @@ describe('ApiCreationV4Component', () => {
       await dialogHarness.cancel();
       expect(component.currentStep.group.label).toEqual('API details');
 
-      fixture.detectChanges();
       expect(fakeAjsState.go).not.toHaveBeenCalled();
     });
 
@@ -236,7 +233,6 @@ describe('ApiCreationV4Component', () => {
       await dialogHarness.confirm();
       expect(component.currentStep.payload).toEqual({});
 
-      fixture.detectChanges();
       expect(fakeAjsState.go).toHaveBeenCalled();
     });
   });
@@ -268,6 +264,7 @@ describe('ApiCreationV4Component', () => {
         await step20ArchitectureHarness.fillAndValidate('PROXY');
         // For sync api type, http-proxy endpoint is automatically added
         expectEndpointGetRequest({ id: 'http-proxy', name: 'HTTP Proxy' });
+        fixture.detectChanges();
 
         expect(component.currentStep.payload.type).toEqual('PROXY');
         expect(component.currentStep.payload.selectedEntrypoints).toEqual([
@@ -726,6 +723,7 @@ describe('ApiCreationV4Component', () => {
 
         await step20ArchitectureHarness.clickValidate();
         expectEndpointGetRequest({ id: 'http-proxy', name: 'HTTP Proxy' });
+        fixture.detectChanges();
 
         // Init Step 2 config
         exceptEnvironmentGetRequest(fakeEnvironment());
@@ -892,8 +890,6 @@ describe('ApiCreationV4Component', () => {
       ]);
       expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
-      fixture.detectChanges();
-
       await step3Harness.fillAndValidate(['mock', 'kafka']);
 
       expect(component.currentStep.payload.selectedEndpoints).toEqual([
@@ -928,8 +924,6 @@ describe('ApiCreationV4Component', () => {
         { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
       ]);
       expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-
-      fixture.detectChanges();
 
       await step3Harness.fillAndValidate(['mock', 'kafka']);
 
@@ -1011,7 +1005,6 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep2Entrypoints2Config();
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
-        fixture.detectChanges();
       });
       describe('step4 - plans list', () => {
         it('should add default keyless and push plans to payload', async () => {
@@ -1083,7 +1076,6 @@ describe('ApiCreationV4Component', () => {
         ]);
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
-        fixture.detectChanges();
       });
 
       it('should add default keyless plan only', async () => {
@@ -1253,7 +1245,6 @@ describe('ApiCreationV4Component', () => {
         ]);
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
-        fixture.detectChanges();
       });
 
       it('should add default push plan only', async () => {
@@ -1293,7 +1284,6 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
-        fixture.detectChanges();
       });
 
       it('should display payload info', async () => {
@@ -1324,7 +1314,6 @@ describe('ApiCreationV4Component', () => {
         const step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
         await step6Harness.clickChangeButton(1);
 
-        fixture.detectChanges();
         const step1Harness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
         expect(await step1Harness.getName()).toEqual('API name');
         expect(await step1Harness.getVersion()).toEqual('1.0');
@@ -1336,7 +1325,6 @@ describe('ApiCreationV4Component', () => {
         let step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
         await step6Harness.clickChangeButton(2);
         expectEntrypointsGetRequest([]);
-        fixture.detectChanges();
 
         const step2Harness0Architecture = await harnessLoader.getHarness(Step2Entrypoints0ArchitectureHarness);
         expect(await step2Harness0Architecture.getArchitecture().then((s) => s.getValue())).toEqual('MESSAGE');
@@ -1351,12 +1339,10 @@ describe('ApiCreationV4Component', () => {
         const list = await step2Harness.getEntrypoints();
         expect(await list.getListValues({ selected: true })).toEqual(['entrypoint-1', 'entrypoint-2']);
         await list.deselectOptionByValue('entrypoint-1');
-        fixture.detectChanges();
 
         await step2Harness.clickValidate();
         const dialogHarness = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
         await dialogHarness.confirm();
-        fixture.detectChanges();
 
         await fillAndValidateStep2Entrypoints2Config([{ id: 'entrypoint-2', name: 'new entrypoint' }], ['/my-api/v4']);
 
@@ -1375,24 +1361,20 @@ describe('ApiCreationV4Component', () => {
         expectLicenseGetRequest({ tier: '', features: [], packs: [] });
         let step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
         await step6Harness.clickChangeButton(3);
-        fixture.detectChanges();
 
         const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
         expectEndpointsGetRequest([
           { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
           { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
         ]);
-
         const list = await step3Harness.getEndpoints();
 
         expect(await list.getListValues({ selected: true })).toEqual(['kafka', 'mock']);
         await list.deselectOptionByValue('kafka');
         expect(await list.getListValues({ selected: true })).toEqual(['mock']);
-        fixture.detectChanges();
         await step3Harness.clickValidate();
         const dialogHarness = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
         await dialogHarness.confirm();
-
         await fillAndValidateStep3Endpoints2Config([{ id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' }]);
 
         await fillAndValidateStep4Security1PlansList();
@@ -1412,8 +1394,6 @@ describe('ApiCreationV4Component', () => {
         expect(step4Summary).toContain('Update name' + 'KEY_LESS');
 
         await step6Harness.clickChangeButton(4);
-
-        fixture.detectChanges();
 
         const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
         expect(await step4Security1PlansHarness.countNumberOfRows()).toEqual(2);
@@ -1443,7 +1423,6 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
-        fixture.detectChanges();
       });
 
       it('should go to confirmation page after clicking Deploy my API', async () => {
@@ -1469,7 +1448,6 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
-        fixture.detectChanges();
       });
 
       it('should go to confirmation page after clicking Save API & Ask for review', async () => {
@@ -1529,7 +1507,6 @@ describe('ApiCreationV4Component', () => {
     httpTestingController
       .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${fullConnector.id}`, method: 'GET' })
       .flush(fullConnector);
-    fixture.detectChanges();
   }
 
   async function fillAndValidateStep1ApiDetails(name = 'API name', version = '1.0', description = 'description') {
@@ -1557,7 +1534,6 @@ describe('ApiCreationV4Component', () => {
       // For sync api type, we need to select the http proxy endpoint
       expectEndpointGetRequest({ id: 'http-proxy', name: 'HTTP Proxy' });
     }
-    fixture.detectChanges();
   }
 
   async function fillAndValidateStep3Endpoints1List(
@@ -1621,7 +1597,6 @@ describe('ApiCreationV4Component', () => {
       },
     };
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
-    fixture.detectChanges();
   }
 
   function expectVerifyContextPathGetRequest() {
@@ -1630,7 +1605,6 @@ describe('ApiCreationV4Component', () => {
 
   function exceptEnvironmentGetRequest(environment: Environment) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}`, method: 'GET' }).flush(environment);
-    fixture.detectChanges();
   }
 
   function expectCallsForApiCreation(apiId: string, planId: string) {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -1168,8 +1168,7 @@ describe('ApiCreationV4Component', () => {
         it('should edit default keyless plan', async () => {
           const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
 
-          await step4Security1PlansHarness.editDefaultKeylessPlanName('Update name', httpTestingController);
-          await step4Security1PlansHarness.addRateLimitToPlan(httpTestingController);
+          await step4Security1PlansHarness.editDefaultKeylessPlanNameAndAddRateLimit('Update name', httpTestingController);
           expectLicenseGetRequest({ tier: '', features: [], packs: [] });
           await step4Security1PlansHarness.clickValidate();
 
@@ -1274,6 +1273,7 @@ describe('ApiCreationV4Component', () => {
   describe('step5', () => {
     const API_ID = 'my-api';
     const PLAN_ID = 'my-plan';
+    let step5Harness: Step5SummaryHarness;
 
     describe('with HTTP and SUBSCRIPTION entrypoint', () => {
       beforeEach(async () => {
@@ -1284,35 +1284,32 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
+        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       });
 
       it('should display payload info', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        const step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-
-        const step1Summary = await step6Harness.getStepSummaryTextContent(1);
+        const step1Summary = await step5Harness.getStepSummaryTextContent(1);
         expect(step1Summary).toContain('API name:' + 'API name');
         expect(step1Summary).toContain('Version:' + '1.0');
         expect(step1Summary).toContain('Description:' + ' description');
 
-        const step2Summary = await step6Harness.getStepSummaryTextContent(2);
+        const step2Summary = await step5Harness.getStepSummaryTextContent(2);
         expect(step2Summary).toContain('Path:' + '/api/my-api-3');
         expect(step2Summary).toContain('Type:' + 'HTTP' + 'SUBSCRIPTION');
         expect(step2Summary).toContain('EntrypointsPath:/api/my-api-3Type:HTTPSUBSCRIPTIONEntrypoints');
 
-        const step3Summary = await step6Harness.getStepSummaryTextContent(3);
+        const step3Summary = await step5Harness.getStepSummaryTextContent(3);
         expect(step3Summary).toContain('Endpoints' + 'Endpoints: ' + 'Kafka ' + ' Mock Change');
         expect(step3Summary).toContain('Kafka');
         expect(step3Summary).toContain('Mock');
 
-        const step4Summary = await step6Harness.getStepSummaryTextContent(4);
+        const step4Summary = await step5Harness.getStepSummaryTextContent(4);
         expect(step4Summary).toContain('Update name' + 'KEY_LESS');
       });
 
       it('should go back to step 1 after clicking Change button', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        const step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        await step6Harness.clickChangeButton(1);
+        await step5Harness.clickChangeButton(1);
 
         const step1Harness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
         expect(await step1Harness.getName()).toEqual('API name');
@@ -1321,13 +1318,10 @@ describe('ApiCreationV4Component', () => {
       });
 
       it('should go back to step 2 after clicking Change button', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        let step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        await step6Harness.clickChangeButton(2);
+        await step5Harness.clickChangeButton(2);
         expectEntrypointsGetRequest([]);
 
         const step2Harness0Architecture = await harnessLoader.getHarness(Step2Entrypoints0ArchitectureHarness);
-        expect(await step2Harness0Architecture.getArchitecture().then((s) => s.getValue())).toEqual('MESSAGE');
         await step2Harness0Architecture.fillAndValidate('MESSAGE');
 
         const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
@@ -1350,17 +1344,15 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
 
-        // Reinitialize step6Harness after last step validation
-        step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        const step2Summary = await step6Harness.getStepSummaryTextContent(2);
+        // Reinitialize step5Harness after last step validation
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+        const step2Summary = await step5Harness.getStepSummaryTextContent(2);
 
         expect(step2Summary).toContain('EntrypointsPath:/my-api/v4Type:HTTPEntrypoints: new entrypointChange');
       });
 
       it('should go back to step 3 after clicking Change button', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        let step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        await step6Harness.clickChangeButton(3);
+        await step5Harness.clickChangeButton(3);
 
         const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
         expectEndpointsGetRequest([
@@ -1379,21 +1371,18 @@ describe('ApiCreationV4Component', () => {
 
         await fillAndValidateStep4Security1PlansList();
 
-        // Reinitialize step6Harness after step2 validation
-        step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        const step2Summary = await step6Harness.getStepSummaryTextContent(3);
+        // Reinitialize step5Harness after step2 validation
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+        const step2Summary = await step5Harness.getStepSummaryTextContent(3);
 
         expect(step2Summary).toContain('Endpoints' + 'Endpoints: Mock Change');
       });
 
       it('should go back to step 4 after clicking Change button', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        let step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-
-        let step4Summary = await step6Harness.getStepSummaryTextContent(4);
+        let step4Summary = await step5Harness.getStepSummaryTextContent(4);
         expect(step4Summary).toContain('Update name' + 'KEY_LESS');
 
-        await step6Harness.clickChangeButton(4);
+        await step5Harness.clickChangeButton(4);
 
         const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
         expect(await step4Security1PlansHarness.countNumberOfRows()).toEqual(2);
@@ -1404,10 +1393,10 @@ describe('ApiCreationV4Component', () => {
 
         await step4Security1PlansHarness.clickValidate();
 
-        // Reinitialize step6Harness after step4 validation
-        step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+        // Reinitialize step5Harness after step4 validation
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
 
-        step4Summary = await step6Harness.getStepSummaryTextContent(4);
+        step4Summary = await step5Harness.getStepSummaryTextContent(4);
         expect(step4Summary).toContain('No plans are selected.');
       });
     });
@@ -1423,12 +1412,12 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
+        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       });
 
       it('should go to confirmation page after clicking Deploy my API', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        const step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        await step6Harness.clickDeployMyApiButton();
+        await step5Harness.clickDeployMyApiButton();
 
         expectCallsForApiDeployment(API_ID, PLAN_ID);
 
@@ -1448,12 +1437,12 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep3Endpoints1List();
         await fillAndValidateStep3Endpoints2Config();
         await fillAndValidateStep4Security1PlansList();
+        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+        step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       });
 
       it('should go to confirmation page after clicking Save API & Ask for review', async () => {
-        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-        const step6Harness = await harnessLoader.getHarness(Step5SummaryHarness);
-        await step6Harness.clickCreateAndAskForReviewMyApiButton();
+        await step5Harness.clickCreateAndAskForReviewMyApiButton();
 
         expectCallsForApiCreation(API_ID, PLAN_ID);
 
@@ -1585,8 +1574,7 @@ describe('ApiCreationV4Component', () => {
   async function fillAndValidateStep4Security1PlansList() {
     const step4 = await harnessLoader.getHarness(Step4Security1PlansHarness);
 
-    await step4.editDefaultKeylessPlanName('Update name', httpTestingController);
-    await step4.addRateLimitToPlan(httpTestingController);
+    await step4.editDefaultKeylessPlanNameAndAddRateLimit('Update name', httpTestingController);
     await step4.clickValidate();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -86,8 +86,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     await (await this.getButtonByText('Add plan')).click();
   }
 
-  async editDefaultKeylessPlanName(newPlanName: string, httpTestingController: HttpTestingController): Promise<void> {
-    // Find DefaultKeyless Row anf get actions cell
+  async editDefaultKeylessPlanNameAndAddRateLimit(newPlanName: string, httpTestingController: HttpTestingController): Promise<void> {
     const tableDefaultKeylessActionsCell = await this.matTable()
       .then((t) => t.getRows())
       .then((row) => row[0])
@@ -102,24 +101,6 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     // Change plan name
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(newPlanName));
-
-    await (await this.getButtonByText('Next')).click();
-    await (await this.getButtonByText('Save changes')).click();
-  }
-
-  async addRateLimitToPlan(httpTestingController: HttpTestingController): Promise<void> {
-    const tableDefaultKeylessActionsCell = await this.matTable()
-      .then((t) => t.getRows())
-      .then((row) => row[0])
-      .then((row) => row.getCells({ columnName: 'actions' }))
-      .then((cell) => cell[0]);
-
-    // Click on Edit plan button
-    await tableDefaultKeylessActionsCell.getHarness(MatButtonHarness.with({ selector: '[aria-label="Edit plan"]' })).then((b) => b.click());
-
-    const apiPlanFormHarness = await this.locatorFor(ApiPlanFormHarness)();
-
-    apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
 
     await (await this.getButtonByText('Next')).click();
     const rateLimitToggle = await apiPlanFormHarness.getRateLimitEnabledInput();

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -342,11 +342,6 @@ describe('ApiProxyV4EntrypointsComponent', () => {
         ],
       };
       saveReq.flush(updatedApi);
-
-      fixture.detectChanges();
-      // Check row is removed and entrypoint marked for deletion
-      const rows = await harness.getEntrypointsTableRows();
-      expect(rows.length).toEqual(2);
     });
 
     it('should not remove entrypoint on cancel', async () => {
@@ -472,12 +467,6 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       };
       expect(saveReq.request.body).toEqual(expectedUpdateApi);
       saveReq.flush(API);
-
-      // Check row is removed and entrypoint marked for deletion
-      const rows = await harness.getEntrypointsTableRows();
-      expect(rows.length).toEqual(1);
-
-      expect(await harness.getDeleteBtnByRowIndex(0).then((btn) => btn.isDisabled())).toEqual(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/general/documentation/metadata/api-portal-documentation-metadata.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/documentation/metadata/api-portal-documentation-metadata.component.spec.ts
@@ -110,10 +110,6 @@ describe('ApiPortalDocumentationMetadataComponent', () => {
     req.flush(newMetadata);
 
     expectMetadataList([newMetadata, fakeMetadata({ key: 'key1' }), fakeMetadata({ key: 'key2' })]);
-
-    expect(await gioMetadata.countRows()).toEqual(3);
-    const row1 = await gioMetadata.getRowByIndex(0);
-    expect(row1.name).toEqual('my new name');
   });
 
   it('should update metadata and reload metadata list', async () => {
@@ -122,7 +118,7 @@ describe('ApiPortalDocumentationMetadataComponent', () => {
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
     expect(await gioMetadata.countRows()).toEqual(2);
 
-    let row1 = await gioMetadata.getRowByIndex(0);
+    const row1 = await gioMetadata.getRowByIndex(0);
     const row1UpdateBtn = row1.updateButton;
     await row1UpdateBtn.click();
 
@@ -142,10 +138,6 @@ describe('ApiPortalDocumentationMetadataComponent', () => {
     req.flush(updateMetadata);
 
     expectMetadataList([updateMetadata, fakeMetadata({ key: 'key2' })]);
-
-    expect(await gioMetadata.countRows()).toEqual(2);
-    row1 = await gioMetadata.getRowByIndex(0);
-    expect(row1.name).toEqual('my new name');
   });
 
   it('should delete metadata and reload metadata list', async () => {
@@ -154,7 +146,7 @@ describe('ApiPortalDocumentationMetadataComponent', () => {
     const gioMetadata = await loader.getHarness(GioMetadataHarness);
     expect(await gioMetadata.countRows()).toEqual(2);
 
-    let row1 = await gioMetadata.getRowByIndex(0);
+    const row1 = await gioMetadata.getRowByIndex(0);
     const row1DeleteBtn = row1.deleteButton;
     await row1DeleteBtn.click();
 
@@ -164,10 +156,6 @@ describe('ApiPortalDocumentationMetadataComponent', () => {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/metadata/key1`, method: 'DELETE' }).flush({});
 
     expectMetadataList([fakeMetadata({ key: 'key2' })]);
-
-    expect(await gioMetadata.countRows()).toEqual(1);
-    row1 = await gioMetadata.getRowByIndex(0);
-    expect(row1.key).toEqual('key2');
   });
 
   function expectMetadataList(list: Metadata[] = [fakeMetadata({ key: 'key1' }), fakeMetadata({ key: 'key2' })]) {

--- a/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/list/api-general-plan-list.component.spec.ts
@@ -364,7 +364,7 @@ describe('ApiGeneralPlanListComponent', () => {
         await loader.getHarness(MatButtonToggleHarness.with({ text: /STAGING/ })).then((btn) => btn.toggle());
         expectApiPlansListRequest([plan], 'STAGING');
 
-        let table = await computePlansTableCells();
+        const table = await computePlansTableCells();
         expect(table.rowCells).toEqual([['', 'publish me ☁️️', 'API_KEY', 'STAGING', 'tag1', '']]);
 
         await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then((btn) => btn.click());
@@ -378,9 +378,6 @@ describe('ApiGeneralPlanListComponent', () => {
         expect(fakeRootScope.$broadcast).toHaveBeenCalledWith('apiChangeSuccess', { apiId: API_ID });
         expectApiGetRequest();
         expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-        table = await computePlansTableCells();
-        expect(table.rowCells).toEqual([['', 'publish me ☁️️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
       });
 
       it('With a plan V4', async () => {
@@ -390,7 +387,7 @@ describe('ApiGeneralPlanListComponent', () => {
         await loader.getHarness(MatButtonToggleHarness.with({ text: /STAGING/ })).then((btn) => btn.toggle());
         expectApiPlansListRequest([plan], 'STAGING');
 
-        let table = await computePlansTableCells();
+        const table = await computePlansTableCells();
         expect(table.rowCells).toEqual([['', 'publish me ☁️️', 'API_KEY', 'STAGING', 'tag1', '']]);
 
         await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Publish the plan"]' })).then((btn) => btn.click());
@@ -404,9 +401,6 @@ describe('ApiGeneralPlanListComponent', () => {
         expect(fakeRootScope.$broadcast).not.toHaveBeenCalled();
         expectApiGetRequest();
         expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-        table = await computePlansTableCells();
-        expect(table.rowCells).toEqual([['', 'publish me ☁️️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
       });
     });
 
@@ -415,7 +409,7 @@ describe('ApiGeneralPlanListComponent', () => {
         const plan = fakePlanV2({ apiId: API_ID, name: 'deprecate me 😥️', status: 'PUBLISHED' });
         await initComponent([plan]);
 
-        let table = await computePlansTableCells();
+        const table = await computePlansTableCells();
         expect(table.rowCells).toEqual([['', 'deprecate me 😥️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
 
         await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Deprecate the plan"]' })).then((btn) => btn.click());
@@ -429,16 +423,13 @@ describe('ApiGeneralPlanListComponent', () => {
         expect(fakeRootScope.$broadcast).toHaveBeenCalledWith('apiChangeSuccess', { apiId: API_ID });
         expectApiGetRequest();
         expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-        table = await computePlansTableCells();
-        expect(table.rowCells).toEqual([['There is no plan (yet).']]);
       });
 
       it('With a plan V4', async () => {
         const plan = fakePlanV4({ apiId: API_ID, name: 'deprecate me 😥️', status: 'PUBLISHED' });
         await initComponent([plan]);
 
-        let table = await computePlansTableCells();
+        const table = await computePlansTableCells();
         expect(table.rowCells).toEqual([['', 'deprecate me 😥️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
 
         await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Deprecate the plan"]' })).then((btn) => btn.click());
@@ -452,9 +443,6 @@ describe('ApiGeneralPlanListComponent', () => {
         expect(fakeRootScope.$broadcast).not.toHaveBeenCalled();
         expectApiGetRequest();
         expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-        table = await computePlansTableCells();
-        expect(table.rowCells).toEqual([['There is no plan (yet).']]);
       });
     });
 
@@ -464,7 +452,7 @@ describe('ApiGeneralPlanListComponent', () => {
           const plan = fakePlanV2({ apiId: API_ID, name: 'close me 🚪️', status: 'PUBLISHED' });
           await initComponent([plan]);
 
-          let table = await computePlansTableCells();
+          const table = await computePlansTableCells();
           expect(table.rowCells).toEqual([['', 'close me 🚪️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
 
           await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Close the plan"]' })).then((btn) => btn.click());
@@ -480,16 +468,13 @@ describe('ApiGeneralPlanListComponent', () => {
           expect(fakeRootScope.$broadcast).toHaveBeenCalledWith('apiChangeSuccess', { apiId: API_ID });
           expectApiGetRequest();
           expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-          table = await computePlansTableCells();
-          expect(table.rowCells).toEqual([['There is no plan (yet).']]);
         });
 
         it('With a plan V4', async () => {
           const plan = fakePlanV4({ apiId: API_ID, name: 'close me 🚪️', status: 'PUBLISHED' });
           await initComponent([plan]);
 
-          let table = await computePlansTableCells();
+          const table = await computePlansTableCells();
           expect(table.rowCells).toEqual([['', 'close me 🚪️', 'API_KEY', 'PUBLISHED', 'tag1', '']]);
 
           await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Close the plan"]' })).then((btn) => btn.click());
@@ -505,9 +490,6 @@ describe('ApiGeneralPlanListComponent', () => {
           expect(fakeRootScope.$broadcast).not.toHaveBeenCalled();
           expectApiGetRequest();
           expectApiPlansListRequest([updatedPlan], [...PLAN_STATUS]);
-
-          table = await computePlansTableCells();
-          expect(table.rowCells).toEqual([['There is no plan (yet).']]);
         });
       });
     });

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.spec.ts
@@ -188,6 +188,20 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expect(await harness.rejectBtnIsVisible()).toEqual(false);
     });
 
+    it('should display closed subscription', async () => {
+      const closedSubscription = BASIC_SUBSCRIPTION();
+      closedSubscription.status = 'CLOSED';
+      await initComponent(closedSubscription);
+      expectApplicationGet();
+      expectApiKeyListGet();
+
+      const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
+
+      expect(await harness.getStatus()).toEqual('CLOSED');
+      expect(await harness.pauseBtnIsVisible()).toEqual(false);
+      expect(await harness.resumeBtnIsVisible()).toEqual(false);
+    });
+
     it('should not load footer in read-only mode', async () => {
       await initComponent(BASIC_SUBSCRIPTION(), ['api-subscription-r']);
       expectApplicationGet(ApiKeyMode.SHARED);
@@ -203,7 +217,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       const pushPlanSubscription = BASIC_SUBSCRIPTION();
       pushPlanSubscription.plan = fakeBasePlan({ id: PLAN_ID, security: { type: undefined, configuration: {} } });
       await initComponent(pushPlanSubscription);
-
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
       expect(await harness.transferBtnIsVisible()).toEqual(true);
 
@@ -227,7 +240,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expect(await radioGroup.getRadioButtons().then((buttons) => buttons.length)).toEqual(2);
       expect(await radioGroup.getRadioButtons({ label: 'other' }).then((btn) => btn[0].isDisabled())).toEqual(true);
       expect(await radioGroup.getRadioButtons({ label: 'new' }).then((btn) => btn[0].isDisabled())).toEqual(false);
-
       const transferBtn = await transferDialog.getHarness(MatButtonHarness.with({ text: 'Transfer' }));
       expect(await transferBtn.isDisabled()).toEqual(true);
 
@@ -250,8 +262,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
         security: { type: undefined, configuration: {} },
       });
       expectApiSubscriptionGet(newSubscription);
-
-      expect(await harness.getPlan()).toEqual('new');
     });
 
     it('should not transfer subscription on cancel', async () => {
@@ -314,10 +324,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(pausedSubscription);
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('PAUSED');
-      expect(await harness.pauseBtnIsVisible()).toEqual(false);
-      expect(await harness.resumeBtnIsVisible()).toEqual(true);
     });
     it('should not pause subscription on cancel', async () => {
       await initComponent();
@@ -377,10 +383,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
-      expect(await harness.pauseBtnIsVisible()).toEqual(true);
-      expect(await harness.resumeBtnIsVisible()).toEqual(false);
     });
     it('should not resume subscription on cancel', async () => {
       await initComponent(pausedSubscription);
@@ -407,6 +409,7 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
+      expect(await harness.getEndingAt()).toEqual('-');
       expect(await harness.changeEndDateBtnIsVisible()).toEqual(true);
       await harness.openChangeEndDateDialog();
 
@@ -445,8 +448,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(newEndDateSubscription);
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getEndingAt()).toEqual('Jan 1, 2080 12:00:00.000 AM');
     });
     it('should change existing end date', async () => {
       const endingAt = new Date('01/01/2080');
@@ -497,8 +498,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(newEndDateSubscription);
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getEndingAt()).toEqual('Jan 2, 2080 12:00:00.000 AM');
     });
     it('should not change end date on cancel', async () => {
       await initComponent();
@@ -525,6 +524,7 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
     it('should close subscription', async () => {
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
       expect(await harness.closeBtnIsVisible()).toEqual(true);
+      expect(await harness.getStatus()).toEqual('ACCEPTED');
 
       await harness.openCloseDialog();
 
@@ -543,10 +543,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(closedSubscription);
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('CLOSED');
-      expect(await harness.pauseBtnIsVisible()).toEqual(false);
-      expect(await harness.resumeBtnIsVisible()).toEqual(false);
     });
     it('should not close subscription on cancel', async () => {
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
@@ -592,9 +588,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
-      expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should validate with extra information', async () => {
       await initComponent(pendingSubscription);
@@ -640,9 +633,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
-      expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should validate with sharedApiKeyMode and cannot use custom key', async () => {
       await initComponent(pendingSubscription, undefined, false);
@@ -708,9 +698,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
       expectApiKeyListGet();
-
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
-      expect(await harness.validateBtnIsVisible()).toEqual(false);
     };
   });
 
@@ -743,9 +730,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       const rejectedSubscription = BASIC_SUBSCRIPTION();
       rejectedSubscription.status = 'REJECTED';
       expectApiSubscriptionGet(rejectedSubscription);
-
-      expect(await harness.getStatus()).toEqual('REJECTED');
-      expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should reject subscription with reason specified', async () => {
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
@@ -767,9 +751,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       const rejectedSubscription = BASIC_SUBSCRIPTION();
       rejectedSubscription.status = 'REJECTED';
       expectApiSubscriptionGet(rejectedSubscription);
-
-      expect(await harness.getStatus()).toEqual('REJECTED');
-      expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should not reject subscription on cancel', async () => {
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
@@ -818,6 +799,8 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
 
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
       expect(await harness.renewApiKeyBtnIsVisible()).toEqual(true);
+      expect(await harness.getApiKeyByRowIndex(0)).toContain('49765a30-659b-4284-b65a-30659be28431');
+
       await harness.openRenewApiKeyDialog();
 
       const renewDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
@@ -839,15 +822,14 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
       expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ key: 'renewed-api-key' })]);
-
-      expect(await harness.getApiKeyByRowIndex(0)).toContain('renewed-api-key');
     });
     it('should renew API Key with customApiKey enabled', async () => {
       await initComponent();
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
-      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ id: 'my-api-key' })]);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ id: 'my-api-key', key: 'old-key' })]);
 
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
+      expect(await harness.getApiKeyByRowIndex(0)).toContain('old-key');
       await harness.openRenewApiKeyDialog();
 
       const renewDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
@@ -867,8 +849,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
       expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ id: 'my-api-key', key: '12345678' })]);
-
-      expect(await harness.getApiKeyByRowIndex(0)).toContain('12345678');
     });
     it('should not renew API Key on cancel', async () => {
       await initComponent();
@@ -884,8 +864,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
 
       const cancelBtn = await renewDialog.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
       await cancelBtn.click();
-
-      expect(await harness.getApiKeyByRowIndex(0)).toContain('my-api-key');
     });
   });
 
@@ -971,6 +949,8 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ expireAt: undefined })]);
 
       const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
+      expect(await harness.getApiKeyEndDateByRowIndex(0)).toEqual('-');
+
       const expireBtn = await harness.getExpireApiKeyBtn(0);
       expect(await expireBtn.isDisabled()).toEqual(false);
       await expireBtn.click();
@@ -998,8 +978,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
       expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ expireAt: endingAt })]);
-
-      expect(await harness.getApiKeyEndDateByRowIndex(0)).toEqual('Jan 1, 2080 12:00:00.000 AM');
     });
     it('should change existing expiration date', async () => {
       const endingAt = new Date('01/01/2080');
@@ -1035,8 +1013,6 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
       expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ expireAt: newEndingAt })]);
-
-      expect(await harness.getApiKeyEndDateByRowIndex(0)).toEqual('Jan 2, 2080 12:00:00.000 AM');
     });
     it('should not change expiration date on cancel', async () => {
       await initComponent();

--- a/gravitee-apim-console-webui/src/management/api/general/user-group-access/groups/api-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/user-group-access/groups/api-general-groups.component.spec.ts
@@ -111,12 +111,6 @@ describe('ApiPortalGroupsComponent', () => {
       // expect reloaded component
       expectOneGroupList([fakeGroup({ id: 'my_group', name: 'My Group' }), fakeGroup({ id: 'new_group', name: 'New Group' })]);
       expectOneApiGet(fakeApiV2({ id: API_ID, groups: ['my_group', 'new_group'] }));
-
-      expect(await harness.isFillFormControlDirty()).toEqual(false);
-
-      const newSelectedGroups = await harness.getSelectedGroups();
-      expect(newSelectedGroups.length).toEqual(2);
-      expect(await harness.isSaveBarVisible()).toEqual(false);
     });
 
     it('should be read-only for V1 API', async () => {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -73,7 +73,6 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
   });
 
   afterEach(() => {
-    TestBed.resetTestingModule();
     httpTestingController.verify();
   });
 
@@ -220,11 +219,38 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
         ],
       };
 
-      await fixture.whenStable();
-      fixture.detectChanges();
-
       await policyStudioHarness.addFlow('Common flows', flowToAdd);
       await policyStudioHarness.save();
+
+      const updatedApi: ApiV4 = {
+        ...api,
+        flows: [
+          {
+            enabled: true,
+            name: 'my flow',
+            selectors: [
+              {
+                channel: 'my-channel',
+                channelOperator: 'EQUALS',
+                type: 'CHANNEL',
+              },
+            ],
+          },
+          {
+            enabled: true,
+            name: flowToAdd.name,
+            selectors: [
+              {
+                channel: 'my-channel',
+                channelOperator: 'EQUALS',
+                entrypoints: [],
+                operations: [],
+                type: 'CHANNEL',
+              },
+            ],
+          },
+        ],
+      };
 
       // Fetch fresh API before save
       expectGetApi(api);
@@ -258,27 +284,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
           ],
         },
       ]);
-      req.flush(api);
-
-      // Check that the flow has been added in the UI
-      const flowsMenu = await policyStudioHarness.getFlowsMenu();
-      expect(flowsMenu.find((f) => f.name === 'Common flows')).toStrictEqual({
-        name: 'Common flows',
-        flows: [
-          {
-            infos: 'PUBSUBmy-channel',
-            isSelected: false,
-            name: 'my flow',
-            hasCondition: true,
-          },
-          {
-            infos: 'PUBSUBmy-channel',
-            isSelected: true,
-            name: 'New common flow',
-            hasCondition: true,
-          },
-        ],
-      });
+      req.flush(updatedApi);
 
       expectNewNgOnInit();
     });
@@ -295,9 +301,6 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
           },
         ],
       };
-
-      await fixture.whenStable();
-      fixture.detectChanges();
 
       await policyStudioHarness.addFlow(planA.name, flowToAdd);
       await policyStudioHarness.save();
@@ -325,26 +328,6 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
         },
       ]);
       req.flush(planA);
-
-      // Check that the flow has been added in the UI
-      const flowsMenu = await policyStudioHarness.getFlowsMenu();
-      expect(flowsMenu.find((f) => f.name === 'PlanA')).toStrictEqual({
-        name: 'PlanA',
-        flows: [
-          {
-            infos: 'PUBSUBmy-channel',
-            isSelected: false,
-            name: 'PlanA flow',
-            hasCondition: true,
-          },
-          {
-            infos: 'PUBSUBmy-channel',
-            isSelected: true,
-            name: 'New plan flow',
-            hasCondition: true,
-          },
-        ],
-      });
 
       expectNewNgOnInit();
     });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
@@ -337,10 +337,6 @@ describe('ApiProxyEndpointListComponent', () => {
           ],
         },
       });
-
-      expect(await endpointsGroupHarness.getTableRows(0)).toEqual([
-        ['default', 'favorite', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
-      ]);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs-settings/runtime-logs-message-settings/api-runtime-logs-message-settings.harness.ts
@@ -66,12 +66,20 @@ export class ApiRuntimeLogsMessageSettingsHarness extends ComponentHarness {
     return await this.getRequestPhaseCheckbox().then((checkbox) => checkbox.check());
   };
 
+  public uncheckRequestPhase = async (): Promise<void> => {
+    return await this.getRequestPhaseCheckbox().then((checkbox) => checkbox.uncheck());
+  };
+
   public isResponsePhaseChecked = async (): Promise<boolean> => {
     return await this.getResponsePhaseCheckbox().then((checkbox) => checkbox.isChecked());
   };
 
   public checkResponsePhase = async (): Promise<void> => {
     return await this.getResponsePhaseCheckbox().then((checkbox) => checkbox.check());
+  };
+
+  public uncheckResponsePhase = async (): Promise<void> => {
+    return await this.getResponsePhaseCheckbox().then((checkbox) => checkbox.uncheck());
   };
 
   public isMessageContentChecked = async (): Promise<boolean> => {

--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
@@ -82,6 +82,7 @@ describe('OrgSettingsTagsComponent', () => {
     fixture = TestBed.createComponent(OrgSettingsTagsComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    fixture.detectChanges();
   }
 
   describe('without license', () => {
@@ -90,7 +91,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should display tags table', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
@@ -124,7 +124,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should edit default configuration', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(
@@ -156,7 +155,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should lock default configuration entrypoint input', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(
@@ -176,7 +174,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should display entrypoint mappings table', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
@@ -206,7 +203,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should delete a tag', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] }), fakeTag({ id: 'tag-2' })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
@@ -244,7 +240,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should delete a tag without entrypoint mapping', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1' })]);
       expectGroupListByOrganizationRequest([]);
       expectPortalSettingsGetRequest(fakePortalSettings());
@@ -264,7 +259,6 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should delete a mapping', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] }), fakeTag({ id: 'tag-2' })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
@@ -286,12 +280,10 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should not create a new tag without license', async () => {
-      fixture.detectChanges();
       expectTagsListRequest();
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
-      fixture.detectChanges();
 
       const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to add a tag"]' }));
       await addButton.click();
@@ -303,12 +295,10 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should update a tag', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' }), fakeGroup({ id: 'group-b', name: 'Group B' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
-      fixture.detectChanges();
 
       const table = await loader.getHarness(MatTableHarness.with({ selector: '#tagsTable' }));
       const rows = await table.getRows();
@@ -349,12 +339,10 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should create a new mapping', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
-      fixture.detectChanges();
 
       const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to add a mapping"]' }));
       await addButton.click();
@@ -377,22 +365,13 @@ describe('OrgSettingsTagsComponent', () => {
         value: 'https://my.entry',
         tags: ['tag-1'],
       });
-      req.flush(null);
-
-      // expect new ngOnInit()
-      expectTagsListRequest();
-      expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-      expectPortalSettingsGetRequest(fakePortalSettings());
-      expectEntrypointsListRequest();
     });
 
     it('should update a mapping', async () => {
-      fixture.detectChanges();
       expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
       expectGroupListByOrganizationRequest([]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest([fakeEntrypoint({ id: 'entrypointIdA', tags: ['tag-1'] })]);
-      fixture.detectChanges();
 
       const table = await loader.getHarness(MatTableHarness.with({ selector: '#entrypointsTable' }));
       const rows = await table.getRows();
@@ -422,13 +401,6 @@ describe('OrgSettingsTagsComponent', () => {
         value: 'https://my.new.entry',
         tags: ['tag-2'],
       });
-      req.flush(null);
-
-      // expect new ngOnInit()
-      expectTagsListRequest();
-      expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-      expectPortalSettingsGetRequest(fakePortalSettings());
-      expectEntrypointsListRequest();
     });
   });
 
@@ -438,12 +410,10 @@ describe('OrgSettingsTagsComponent', () => {
     });
 
     it('should create a new tag', async () => {
-      fixture.detectChanges();
       expectTagsListRequest();
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
-      fixture.detectChanges();
 
       const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to add a tag"]' }));
       await addButton.click();

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -26,7 +26,6 @@ import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
-import { MatInputHarness } from '@angular/material/input/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { OrgSettingsUserDetailComponent } from './org-settings-user-detail.component';
@@ -573,7 +572,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     ]);
   });
 
-  it('should create a token', async () => {
+  it('should open dialog to create a token', async () => {
     const user = fakeUser({
       id: 'userId',
       source: 'gravitee',
@@ -604,31 +603,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     await generateTokenButton.click();
 
     const dialog = await rootLoader.getHarness(MatDialogHarness);
-    const generateButton = await dialog.getHarness(MatButtonHarness.with({ text: 'Generate' }));
-
-    const nameInput = await dialog.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
-    await nameInput.setValue('My token');
-
-    await generateButton.click();
-
-    const reqPost = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/users/${user.id}/tokens`);
-    expect(reqPost.request.method).toEqual('POST');
-    expect(reqPost.request.body.name).toEqual('My token');
-
-    const tokenResponse: Token = fakeUserToken({ name: 'My token' });
-    reqPost.flush(tokenResponse);
-
-    const closeButton = await dialog.getHarness(MatButtonHarness.with({ text: 'Close' }));
-    await closeButton.click();
-
-    expectUserTokensGetRequest(user, [tokenResponse]);
-    expectUserGetRequest(user);
-    expectEnvironmentListRequest();
-    expectUserGroupsGetRequest(user.id, [
-      fakeGroup({ id: 'groupA', roles: { GROUP: 'ADMIN', API: 'ROLE_API', APPLICATION: 'ROLE_APP_OWNER' } }),
-    ]);
-    expectUserMembershipGetRequest(user.id, 'api');
-    expectUserMembershipGetRequest(user.id, 'application');
+    expect(dialog).toBeTruthy();
   });
 
   it('should delete a token', async () => {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/tokens/org-settings-user-generate-token.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/tokens/org-settings-user-generate-token.component.spec.ts
@@ -94,11 +94,6 @@ describe('OrgSettingsUserGenerateTokenComponent', () => {
 
       expect(component.hasBeenGenerated).toBeTruthy();
       expect(component.token).toEqual(tokenResponse);
-
-      const closeButton = await loader.getHarness(MatButtonHarness.with({ text: /^Close/ }));
-      await closeButton.click();
-
-      expect(matDialogRefMock.close).toHaveBeenCalledWith(false);
     });
 
     it('should not be able to create a token because it already exists', async () => {

--- a/gravitee-apim-console-webui/src/services-ngx/category.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/category.service.spec.ts
@@ -18,11 +18,8 @@ import { TestBed } from '@angular/core/testing';
 
 import { CategoryService } from './category.service';
 
-import { setupAngularJsTesting } from '../../jest.setup.js';
 import { GioHttpTestingModule } from '../shared/testing';
 import { Category } from '../entities/category/Category';
-
-setupAngularJsTesting();
 
 describe('CategoryService', () => {
   let httpTestingController: HttpTestingController;

--- a/gravitee-apim-console-webui/src/services-ngx/debug-api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/debug-api.service.spec.ts
@@ -19,11 +19,8 @@ import { TestBed } from '@angular/core/testing';
 import { DebugApiService } from './debug-api.service';
 
 import { fakeEvent } from '../entities/event/event.fixture';
-import { setupAngularJsTesting } from '../../jest.setup.js';
 import { GioHttpTestingModule } from '../shared/testing';
 import { fakeApi } from '../entities/api/Api.fixture';
-
-setupAngularJsTesting();
 
 describe('DebugApiService', () => {
   let httpTestingController: HttpTestingController;

--- a/gravitee-apim-console-webui/src/services-ngx/event.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/event.service.spec.ts
@@ -19,10 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { EventService } from './event.service';
 
 import { fakeEvent } from '../entities/event/event.fixture';
-import { setupAngularJsTesting } from '../../jest.setup.js';
 import { GioHttpTestingModule } from '../shared/testing';
-
-setupAngularJsTesting();
 
 describe('EventService', () => {
   let httpTestingController: HttpTestingController;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2640

## Description

Try to reduce the time spent on console tests by... : 
- Not using unnecessary `setupAngularJsTesting` in `ngx-service` -- about 5-7 seconds
- Remove unnecessary detect changes 
- Simplify tests to not "double check" a view (i.e. Step 4 harness in v4 API creation workflow) -- 200+ms
- Get rid of checking a view after save (!!). This is unnecessary because we test the body of the post for the save and have other unit tests for the rendering of certain infos. -- 3+ seconds
- Fix flaky test for policy studio test -- 3+seconds * 2
- Deprecate gv widget stat configuration test because it is _very_ slow and will be migrated :) -- 70+s

No loss of code coverage -- Stays at 55.8% coverage.
Lint & Test UI Console -- about 13m30 from 15m+ before

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tdmrzwxvzy.chromatic.com)
<!-- Storybook placeholder end -->
