### PR TITLE
test(ui): fixing flaky plans test failing in circleci

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -190,6 +190,7 @@ describe('API Plans Feature', () => {
     cy.contains(`${planName}-Keyless`).should('be.visible');
     cy.getByDataTestId('api_plans_edit_plan_button').first().click();
     cy.getByDataTestId('api_plans_name_field').type('EDIT');
+    cy.contains('Configuration successfully saved!').should('not.exist');
     cy.get('[type="submit"]').contains('Save').click();
     cy.contains('Configuration successfully saved!').should('be.visible');
     cy.get('[type="button"]').contains('STAGING').click();


### PR DESCRIPTION
## Issue

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/24732/workflows/5cf301b1-b85a-444a-b70a-3a2e1f430b94/jobs/440832

## Description

It feels like a bit of a bandaid solution but for some reason, cypress seemed to be having an issue finding the save button when editing a plan - I believe this is due to the "Configuration successfully saved" message from creating the api still being visible on the screen when cypress is editing the api... Adding an assertion to check that this message does not exist before it saves the edit seems to have fixed the problem locally. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wlkqgghijd.chromatic.com)
<!-- Storybook placeholder end -->
