### PR TITLE
ci: use medium executor to run JDBC repository tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1345,7 +1345,7 @@ jobs:
                 default: ""
         executor:
             name: ubuntu
-            class: large
+            class: medium
             with_docker_layer_caching: true
         steps:
             - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1782,23 +1782,23 @@ jobs:
                   path: apim-result.xml
 
     job-snyk-apim-charts:
-      docker:
-        - image: cimg/base:stable
-      resource_class: small
-      steps:
-        - checkout
-        - keeper/env-export:
-            secret-url: keeper://s83JmReKpBZWjHdud6ZAlg/custom_field/gravitee_apim_org_api_token
-            var-name: SNYK_TOKEN
-        - helm/install-helm-client
-        - snyk/install
-        - run:
-            name: "build the Charts output and scan"
-            working_directory: "./helm"
-            command: |
-              helm dependency update
-              helm template . --output-dir ./output
-              snyk iac test ./output --report --target-reference="${CIRCLE_BRANCH}" --project-tags=version=${CIRCLE_BRANCH} --severity-threshold=high
+        docker:
+            - image: cimg/base:stable
+        resource_class: small
+        steps:
+            - checkout
+            - keeper/env-export:
+                  secret-url: keeper://s83JmReKpBZWjHdud6ZAlg/custom_field/gravitee_apim_org_api_token
+                  var-name: SNYK_TOKEN
+            - helm/install-helm-client
+            - snyk/install
+            - run:
+                  name: "build the Charts output and scan"
+                  working_directory: "./helm"
+                  command: |
+                      helm dependency update
+                      helm template . --output-dir ./output
+                      snyk iac test ./output --report --target-reference="${CIRCLE_BRANCH}" --project-tags=version=${CIRCLE_BRANCH} --severity-threshold=high
 
 workflows:
     pull_requests:
@@ -1825,15 +1825,15 @@ workflows:
                   requires:
                       - Setup
             - job-snyk-apim-charts:
-                name: scan snyk Helm chart
-                context: cicd-orchestrator
-                requires:
-                  - Setup
-                filters:
-                  branches:
-                    only:
-                      - master
-                      - /^\d+\.\d+\.x$/
+                  name: scan snyk Helm chart
+                  context: cicd-orchestrator
+                  requires:
+                      - Setup
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /^\d+\.\d+\.x$/
             - job-build:
                   name: Build backend
                   context: cicd-orchestrator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2104,11 +2104,7 @@ workflows:
                       - Publish APIM Console to artifactory
                       - Publish APIM Portal to artifactory
                   context: cicd-orchestrator
-            - job-publish-on-artifactory:
-                  name: Publish new SNAPSHOTS on artifactory
-                  context: cicd-orchestrator
-                  requires:
-                      - Commit and prepare next version
+
             # Package bundle
             - job-package-bundle:
                   name: Package bundle
@@ -2253,23 +2249,22 @@ workflows:
                       - Nexus staging
 
     db_repositories_test_container:
-        triggers:
-            - schedule:
-                  cron: "0 12 * * *"
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
+        when:
+            equal: [repositories_tests, << pipeline.parameters.gio_action >>]
         jobs:
             - job-setup:
                   name: Setup
                   context: cicd-orchestrator
-            - job-jdbc-test-container:
-                  name: JDBC Test container
+            - job-build:
+                  name: Build
                   context: cicd-orchestrator
                   requires:
                       - Setup
+            - job-jdbc-test-container:
+                  name: Management repository tests - JDBC - << matrix.version >>
+                  context: cicd-orchestrator
+                  requires:
+                      - Build
                   matrix:
                       parameters:
                           version:
@@ -2288,10 +2283,10 @@ workflows:
                                   "sqlserver~2017-CU12",
                               ]
             - job-mongo-test-container:
-                  name: Mongo Test container
+                  name: Management repository tests - Mongo << matrix.version >>
                   context: cicd-orchestrator
                   requires:
-                      - Setup
+                      - Build
                   matrix:
                       parameters:
                           version: ["3", "4", "5"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2118,6 +2118,7 @@ workflows:
 
             # Release Helm chart
             - job-release_helm:
+                  name: Release Helm Chart
                   context: cicd-orchestrator
                   requires:
                       - Package bundle
@@ -2166,7 +2167,7 @@ workflows:
                       - Build and push RPM packages for APIM << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
                       - Push docker images to Snyk
                       - Create release note pull request
-
+                      - Release Helm Chart
     release:
         when:
             equal: [release, << pipeline.parameters.gio_action >>]


### PR DESCRIPTION
## Issue

NA

## Description

 - Use medium executor to run JDBC repository tests
 - Wait for Helm Chart to be released before sending Slack notification
 - Rework DB repository tests to avoid failure after each release
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ahksnbhobu.chromatic.com)
<!-- Storybook placeholder end -->
