### PR TITLE
feat(helm): remove smtp default example configuration

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -10,6 +10,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - Add podSecurityContext
 - Add support for DB less mode on gateway
 - Add nodePort value to all services
+- Remove smtp default example values
 
 ### 4.0.2
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,3 +24,4 @@ annotations:
     - Add podSecurityContext
     - Add support for DB less mode on gateway
     - Add nodePort value to all services
+    - Remove smtp default example values

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -360,23 +360,13 @@ data:
             {{- end }}
           {{- end }}
         {{- end }}
-    # SMTP configuration used to send mails
+    
     {{- if .Values.smtp }}
+    # SMTP configuration used to send mails
     email:
-      enabled: {{ .Values.smtp.enabled }}
-      host: {{ .Values.smtp.host }}
-      subject: {{ .Values.smtp.subject | quote }}
-      port: {{ .Values.smtp.port }}
-      from: {{ .Values.smtp.from }}
-      {{- if or .Values.smtp.username .Values.smtp.password }}
-      username: {{ .Values.smtp.username }}
-      password: {{ .Values.smtp.password }}
-      {{- end }}
-      {{- with .Values.smtp.properties }}
-      properties:
-        {{ toYaml . | nindent 8 | trim -}}
-      {{- end }}
+      {{- .Values.smtp | toYaml | nindent 6 }}
     {{- end }}
+    
     # SMTP configuration used to send notifications / alerts
     notifiers:
       email:

--- a/helm/tests/api/configmap_email_test.yaml
+++ b/helm/tests/api/configmap_email_test.yaml
@@ -36,7 +36,7 @@ tests:
           pattern: "password: TEST.password"
       - matchRegex:
           path: data.[gravitee.yml]
-          pattern: 'subject: "TEST.subject"'
+          pattern: "subject: TEST.subject"
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "starttls.enable: false"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -157,16 +157,16 @@ oidcAuth:
 #        - "ORGANIZATION:ADMIN"
 smtp:
   enabled: true
-  host: smtp.example.com
-  port: 25
-  from: info@example.com
-  username: info@example.com
-  password: example.com
-  subject: "[gravitee] %s"
-  properties:
-    auth: true
-    starttls.enable: false
-    #localhost: apim.example.com
+#  host: smtp.example.com
+#  port: 25
+#  from: info@example.com
+#  username: info@example.com
+#  password: example.com
+#  subject: "[gravitee] %s"
+#  properties:
+#    auth: true
+#    starttls.enable: false
+#    localhost: apim.example.com
 
 notifiers:
   smtp:


### PR DESCRIPTION
## Issues

https://gravitee.atlassian.net/browse/APIM-2733

## Description

Remove default smtp configuration.
This avoid helm subchart bug -> you can't nullify a subchart value