### PR TITLE
refactor: implement PrimaryOwnerDomainService

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
@@ -17,11 +17,17 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Group {
 
     public enum AuditEvent implements Audit.AuditEvent {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Membership.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Membership.java
@@ -16,6 +16,8 @@
 package io.gravitee.repository.management.model;
 
 import java.util.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -23,6 +25,8 @@ import java.util.*;
  * @author Florent CHAMFROY (forent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@AllArgsConstructor
 public class Membership {
 
     public enum AuditEvent implements Audit.ApiAuditEvent {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Role.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Role.java
@@ -17,11 +17,15 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@AllArgsConstructor
 public class Role {
 
     public enum AuditEvent implements Audit.AuditEvent {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/User.java
@@ -17,11 +17,21 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
 public class User {
 
     public enum AuditEvent implements Audit.AuditEvent {
@@ -108,8 +118,6 @@ public class User {
 
     private Boolean newsletterSubscribed;
 
-    public User() {}
-
     public User(User cloned) {
         this.id = cloned.id;
         this.organizationId = cloned.organizationId;
@@ -129,134 +137,6 @@ public class User {
         this.newsletterSubscribed = cloned.newsletterSubscribed;
     }
 
-    public String getOrganizationId() {
-        return organizationId;
-    }
-
-    public void setOrganizationId(String organizationId) {
-        this.organizationId = organizationId;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getFirstname() {
-        return firstname;
-    }
-
-    public void setFirstname(String firstname) {
-        this.firstname = firstname;
-    }
-
-    public String getLastname() {
-        return lastname;
-    }
-
-    public void setLastname(String lastname) {
-        this.lastname = lastname;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public String getPicture() {
-        return picture;
-    }
-
-    public void setPicture(String picture) {
-        this.picture = picture;
-    }
-
-    public String getSource() {
-        return source;
-    }
-
-    public void setSource(String source) {
-        this.source = source;
-    }
-
-    public String getSourceId() {
-        return sourceId;
-    }
-
-    public void setSourceId(String sourceId) {
-        this.sourceId = sourceId;
-    }
-
-    public Date getLastConnectionAt() {
-        return lastConnectionAt;
-    }
-
-    public void setLastConnectionAt(Date lastConnectionAt) {
-        this.lastConnectionAt = lastConnectionAt;
-    }
-
-    public UserStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(UserStatus status) {
-        this.status = status;
-    }
-
-    public long getLoginCount() {
-        return loginCount;
-    }
-
-    public void setLoginCount(long loginCount) {
-        this.loginCount = loginCount;
-    }
-
-    public Date getFirstConnectionAt() {
-        return firstConnectionAt;
-    }
-
-    public void setFirstConnectionAt(Date firstConnectionAt) {
-        this.firstConnectionAt = firstConnectionAt;
-    }
-
-    public Boolean getNewsletterSubscribed() {
-        return newsletterSubscribed;
-    }
-
-    public void setNewsletterSubscribed(Boolean newsletterSubscribed) {
-        this.newsletterSubscribed = newsletterSubscribed;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -272,17 +152,36 @@ public class User {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("User{");
-        sb.append("id='").append(id).append('\'');
-        sb.append(", organizationId='").append(organizationId).append('\'');
-        sb.append(", source='").append(source).append('\'');
-        sb.append(", sourceId='").append(sourceId).append('\'');
-        sb.append(", firstname='").append(firstname).append('\'');
-        sb.append(", lastname='").append(lastname).append('\'');
-        sb.append(", mail='").append(email).append('\'');
-        sb.append(", status='").append(status).append('\'');
-        sb.append(", loginCount='").append(loginCount).append('\'');
-        sb.append('}');
-        return sb.toString();
+        return (
+            "User{" +
+            "id='" +
+            id +
+            '\'' +
+            ", organizationId='" +
+            organizationId +
+            '\'' +
+            ", source='" +
+            source +
+            '\'' +
+            ", sourceId='" +
+            sourceId +
+            '\'' +
+            ", firstname='" +
+            firstname +
+            '\'' +
+            ", lastname='" +
+            lastname +
+            '\'' +
+            ", mail='" +
+            email +
+            '\'' +
+            ", status='" +
+            status +
+            '\'' +
+            ", loginCount='" +
+            loginCount +
+            '\'' +
+            '}'
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.spring;
 
-import io.gravitee.apim.infra.UsecaseSpringConfiguration;
-import io.gravitee.apim.infra.crud_service.CrudServiceSpringConfiguration;
+import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
@@ -31,13 +30,7 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @Import(
-    {
-        PluginConfiguration.class,
-        ServiceConfiguration.class,
-        IdentityProviderPluginConfiguration.class,
-        UsecaseSpringConfiguration.class,
-        CrudServiceSpringConfiguration.class,
-    }
+    { PluginConfiguration.class, ServiceConfiguration.class, IdentityProviderPluginConfiguration.class, UsecaseSpringConfiguration.class }
 )
 public class RestManagementConfiguration {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import fixtures.repository.ConnectionLogFixtures;
 import inmemory.ApplicationCrudServiceInMemory;
-import inmemory.InMemoryCrudService;
+import inmemory.InMemoryAlternative;
 import inmemory.LogCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLog;
@@ -90,7 +90,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
     public void tearDown() {
         GraviteeContext.cleanContext();
 
-        Stream.of(applicationStorageService, logStorageService, planStorageService).forEach(InMemoryCrudService::reset);
+        Stream.of(applicationStorageService, logStorageService, planStorageService).forEach(InMemoryAlternative::reset);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.spring;
 
 import static org.mockito.Mockito.mock;
 
-import io.gravitee.apim.infra.UsecaseSpringConfiguration;
+import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.node.api.license.NodeLicenseService;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.service.ApiDuplicatorService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiPrimaryOwnerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiPrimaryOwnerDomainService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+public interface ApiPrimaryOwnerDomainService {
+    PrimaryOwnerEntity getApiPrimaryOwner(ExecutionContext executionContext, String apiId) throws ApiPrimaryOwnerNotFoundException;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/ApiPrimaryOwnerNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/ApiPrimaryOwnerNotFoundException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiPrimaryOwnerNotFoundException extends RuntimeException {
+
+    private final String apiId;
+
+    public ApiPrimaryOwnerNotFoundException(String apiId) {
+        super("Primary owner not found for API [" + apiId + "]");
+        this.apiId = apiId;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/PrimaryOwnerEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/PrimaryOwnerEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.model;
+
+import lombok.Builder;
+
+@Builder
+public record PrimaryOwnerEntity(String id, String email, String displayName, String type) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.crud_service;
+
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface UserCrudService {
+    Optional<BaseUserEntity> findBaseUserById(String id);
+    Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds);
+    BaseUserEntity getBaseUser(String id);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.model;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class BaseUserEntity {
+
+    private String id;
+    private String organizationId;
+    private String firstname;
+    private String lastname;
+    private String email;
+    private Date createdAt;
+    private Date updatedAt;
+    /** The source when user is coming from an external system (LDAP, ...) */
+    private String source;
+    /** The user reference in the external source */
+    private String sourceId;
+
+    public String displayName() {
+        if (isNotBlank(firstname)) {
+            if (isNotBlank(lastname)) {
+                return firstname + ' ' + lastname;
+            }
+            return firstname;
+        } else if (isNotBlank(lastname)) {
+            return lastname;
+        } else if (isNotBlank(email) && !"memory".equals(source)) {
+            return email;
+        }
+        return sourceId;
+    }
+
+    private boolean isNotBlank(String s) {
+        return s != null && !s.isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.user;
+
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.crud_service.user.adapter.UserAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class UserCrudServiceImpl implements UserCrudService {
+
+    private final UserRepository userRepository;
+
+    public UserCrudServiceImpl(@Lazy UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public Optional<BaseUserEntity> findBaseUserById(String id) {
+        try {
+            log.debug("Find user [userId={}]", id);
+            Optional<User> optionalUser = userRepository.findById(id);
+            return optionalUser.map(UserAdapter::toBaseUserEntity);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find user using [userId={}]", id, ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
+    public Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds) {
+        try {
+            log.debug("Find users [userIds={}]", userIds);
+            return userRepository.findByIds(userIds).stream().map(UserAdapter::toBaseUserEntity).collect(Collectors.toSet());
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find user using [userIds={}]", userIds, ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
+    public BaseUserEntity getBaseUser(String id) {
+        try {
+            log.debug("Find user [userId={}]", id);
+            Optional<User> optionalUser = userRepository.findById(id);
+            return optionalUser.map(UserAdapter::toBaseUserEntity).orElseThrow(() -> new UserNotFoundException(id));
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to get user using [userId={}]", id, ex);
+            throw new TechnicalManagementException("An error occurs while trying to get user " + id, ex);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/adapter/UserAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/adapter/UserAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.user.adapter;
+
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.repository.management.model.User;
+
+public class UserAdapter {
+
+    private UserAdapter() {}
+
+    public static BaseUserEntity toBaseUserEntity(User user) {
+        if (user == null) {
+            return null;
+        }
+        var userEntity = new BaseUserEntity();
+
+        userEntity.setId(user.getId());
+        userEntity.setOrganizationId(user.getOrganizationId());
+        userEntity.setSource(user.getSource());
+        userEntity.setSourceId(user.getSourceId());
+        userEntity.setEmail(user.getEmail());
+        userEntity.setFirstname(user.getFirstname());
+        userEntity.setLastname(user.getLastname());
+        userEntity.setCreatedAt(user.getCreatedAt());
+        userEntity.setUpdatedAt(user.getUpdatedAt());
+
+        return userEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/PrimaryOwnerDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/PrimaryOwnerDomainServiceImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.membership;
+
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.api.RoleRepository;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.repository.management.model.MembershipReferenceType;
+import io.gravitee.repository.management.model.Role;
+import io.gravitee.repository.management.model.RoleReferenceType;
+import io.gravitee.repository.management.model.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class PrimaryOwnerDomainServiceImpl implements ApiPrimaryOwnerDomainService {
+
+    private final RoleRepository roleRepository;
+    private final MembershipRepository membershipRepository;
+    private final UserCrudService userCrudService;
+    private final GroupRepository groupRepository;
+
+    public PrimaryOwnerDomainServiceImpl(
+        @Lazy RoleRepository roleRepository,
+        @Lazy MembershipRepository membershipRepository,
+        UserCrudService userCrudService,
+        @Lazy GroupRepository groupRepository
+    ) {
+        this.roleRepository = roleRepository;
+        this.membershipRepository = membershipRepository;
+        this.userCrudService = userCrudService;
+        this.groupRepository = groupRepository;
+    }
+
+    @Override
+    public PrimaryOwnerEntity getApiPrimaryOwner(ExecutionContext executionContext, String apiId) throws ApiPrimaryOwnerNotFoundException {
+        return findPrimaryOwnerRole(executionContext.getOrganizationId())
+            .flatMap(role ->
+                findPrimaryOwnerMembership(apiId, role)
+                    .flatMap(membership ->
+                        switch (membership.getMemberType()) {
+                            case USER -> findUserPrimaryOwner(membership);
+                            case GROUP -> findGroupPrimaryOwner(membership, role.getId());
+                        }
+                    )
+            )
+            .orElseThrow(() -> new ApiPrimaryOwnerNotFoundException(apiId));
+    }
+
+    private Optional<Role> findPrimaryOwnerRole(String organizationId) {
+        try {
+            return roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                RoleScope.API,
+                SystemRole.PRIMARY_OWNER.name(),
+                organizationId,
+                RoleReferenceType.ORGANIZATION
+            );
+        } catch (TechnicalException e) {
+            log.error("An error occurs while trying to get primary owner role for [organizationId={}]", organizationId, e);
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private Optional<Membership> findPrimaryOwnerMembership(String apiId, Role role) {
+        try {
+            return membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API, apiId, role.getId()).stream().findFirst();
+        } catch (TechnicalException e) {
+            log.error("An error occurs while trying to get primary owner for [apiId={}]", apiId, e);
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private Optional<PrimaryOwnerEntity> findUserPrimaryOwner(Membership membership) {
+        return userCrudService
+            .findBaseUserById(membership.getMemberId())
+            .map(user ->
+                PrimaryOwnerEntity.builder().id(user.getId()).displayName(user.displayName()).email(user.getEmail()).type("USER").build()
+            );
+    }
+
+    private Optional<PrimaryOwnerEntity> findGroupPrimaryOwner(Membership membership, String primaryOwnerRoleId) {
+        try {
+            var group = groupRepository.findById(membership.getMemberId());
+            var user = findPrimaryOwnerGroupMember(membership.getMemberId(), primaryOwnerRoleId)
+                .flatMap(m -> userCrudService.findBaseUserById(m.getMemberId()));
+
+            if (user.isPresent() && group.isPresent()) {
+                return Optional.of(
+                    PrimaryOwnerEntity
+                        .builder()
+                        .id(group.get().getId())
+                        .displayName(group.get().getName())
+                        .type("GROUP")
+                        .email(user.get().getEmail())
+                        .build()
+                );
+            }
+            return Optional.empty();
+        } catch (TechnicalException e) {
+            log.error("An error occurs while trying to get group [groupId={}]", membership.getMemberId(), e);
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private Optional<Membership> findPrimaryOwnerGroupMember(String groupId, String primaryOwnerRoleId) {
+        try {
+            return membershipRepository
+                .findByReferenceAndRoleId(MembershipReferenceType.GROUP, groupId, primaryOwnerRoleId)
+                .stream()
+                .findFirst();
+        } catch (TechnicalException e) {
+            log.error("An error occurs while trying to get group member for [groupId={}]", groupId, e);
+            throw new TechnicalManagementException(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/InfraServiceSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/InfraServiceSpringConfiguration.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra.crud_service;
+package io.gravitee.apim.infra.spring;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(basePackages = { "io.gravitee.apim.infra.crud_service" })
-public class CrudServiceSpringConfiguration {}
+@ComponentScan(basePackages = { "io.gravitee.apim.infra" })
+public class InfraServiceSpringConfiguration {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra;
+package io.gravitee.apim.infra.spring;
 
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.log.crud_service.LogCrudService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.gravitee.apim.infra.spring.InfraServiceSpringConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.EventManagerImpl;
 import io.gravitee.common.util.DataEncryptor;
@@ -87,6 +88,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
         UpgraderConfiguration.class,
         InitializerConfiguration.class,
         ApiServicePluginConfiguration.class,
+        InfraServiceSpringConfiguration.class,
     }
 )
 public class ServiceConfiguration {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
@@ -26,6 +26,15 @@ import java.util.Map;
  * @author GraviteeSource Team
  */
 public interface PrimaryOwnerService {
+    /**
+     * Resolves the primary owner for the given API.
+     * @param executionContext the execution context
+     * @param apiId the API id
+     * @return The primary owner
+     * @throws TechnicalManagementException if an error occurs while resolving the primary owner
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
+     */
+    @Deprecated
     PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String apiId) throws TechnicalManagementException;
 
     /**
@@ -35,7 +44,10 @@ public interface PrimaryOwnerService {
      * @param executionContext the execution context
      * @param apiId the API id
      * @return the primary owner email
+     *
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
      */
+    @Deprecated
     String getPrimaryOwnerEmail(ExecutionContext executionContext, String apiId);
 
     PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String userId, PrimaryOwnerEntity currentPrimaryOwner);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/CrudServiceRulesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/CrudServiceRulesTest.java
@@ -58,20 +58,6 @@ public class CrudServiceRulesTest extends AbstractApimArchitectureTest {
     }
 
     /**
-     * CrudServices should only be accessed by Usecase
-     */
-    @Test
-    public void crud_services_only_be_accessed_by_usecase() {
-        classes()
-            .that()
-            .resideInAnyPackage(anyPackageThatContains(CORE_PACKAGE + ".(*)." + CRUD_SERVICE_PACKAGE))
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage(anyPackageThatContains(USECASE_PACKAGE))
-            .check(apimClassesWithoutTests());
-    }
-
-    /**
      * CrudServices should be independent: it must not depend on another CrudService
      */
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationCrudServiceInMemory.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class ApplicationCrudServiceInMemory implements ApplicationCrudService, InMemoryCrudService<BaseApplicationEntity> {
+public class ApplicationCrudServiceInMemory implements ApplicationCrudService, InMemoryAlternative<BaseApplicationEntity> {
 
     private final List<BaseApplicationEntity> storage = new ArrayList<>();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryAlternative.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryAlternative.java
@@ -17,7 +17,7 @@ package inmemory;
 
 import java.util.List;
 
-public interface InMemoryCrudService<T> {
+public interface InMemoryAlternative<T> {
     /**
      * Init the storage with the given items
      * @param items the items to store

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/LogCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/LogCrudServiceInMemory.java
@@ -25,7 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class LogCrudServiceInMemory implements LogCrudService, InMemoryCrudService<BaseConnectionLog> {
+public class LogCrudServiceInMemory implements LogCrudService, InMemoryAlternative<BaseConnectionLog> {
 
     private final List<BaseConnectionLog> storage = new ArrayList<>();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryCrudService<GenericPlanEntity> {
+public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlternative<GenericPlanEntity> {
 
     private final List<GenericPlanEntity> storage = new ArrayList<>();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PrimaryOwnerDomainServiceInMemory
+    implements ApiPrimaryOwnerDomainService, InMemoryAlternative<Map.Entry<String, PrimaryOwnerEntity>> {
+
+    Map<String, PrimaryOwnerEntity> storage = new HashMap<>();
+
+    @Override
+    public PrimaryOwnerEntity getApiPrimaryOwner(ExecutionContext executionContext, String apiId) throws ApiPrimaryOwnerNotFoundException {
+        PrimaryOwnerEntity primaryOwnerEntity = storage.get(apiId);
+        if (primaryOwnerEntity == null) {
+            throw new ApiPrimaryOwnerNotFoundException(apiId);
+        }
+        return primaryOwnerEntity;
+    }
+
+    @Override
+    public void initWith(List<Map.Entry<String, PrimaryOwnerEntity>> items) {
+        items.forEach(entry -> storage.put(entry.getKey(), entry.getValue()));
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Map.Entry<String, PrimaryOwnerEntity>> storage() {
+        return storage.entrySet().stream().toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlternative<BaseUserEntity> {
+
+    private final List<BaseUserEntity> storage = new ArrayList<>();
+
+    @Override
+    public Optional<BaseUserEntity> findBaseUserById(String userId) {
+        return storage.stream().filter(user -> userId.equals(user.getId())).findFirst();
+    }
+
+    @Override
+    public Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds) {
+        return storage.stream().filter(user -> userIds.contains(user.getId())).collect(Collectors.toSet());
+    }
+
+    @Override
+    public BaseUserEntity getBaseUser(String userId) {
+        return storage
+            .stream()
+            .filter(user -> userId.equals(user.getId()))
+            .findFirst()
+            .orElseThrow(() -> new UserNotFoundException(userId));
+    }
+
+    @Override
+    public void initWith(List<BaseUserEntity> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<BaseUserEntity> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/usecase/SearchConnectionLogUsecaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/usecase/SearchConnectionLogUsecaseTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import fixtures.repository.ConnectionLogFixtures;
 import inmemory.ApplicationCrudServiceInMemory;
-import inmemory.InMemoryCrudService;
+import inmemory.InMemoryAlternative;
 import inmemory.LogCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.apim.core.log.usecase.SearchConnectionLogUsecase.Request;
@@ -63,7 +63,7 @@ public class SearchConnectionLogUsecaseTest {
 
     @AfterEach
     void tearDown() {
-        Stream.of(logStorageService, planStorageService, applicationStorageService).forEach(InMemoryCrudService::reset);
+        Stream.of(logStorageService, planStorageService, applicationStorageService).forEach(InMemoryAlternative::reset);
 
         GraviteeContext.cleanContext();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/model/BaseUserEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/model/BaseUserEntityTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class BaseUserEntityTest {
+
+    @Nested
+    class DisplayName {
+
+        @Test
+        void should_return_display_name_when_user_has_firstname_and_lastname() {
+            var user = BaseUserEntity.builder().firstname("Jane").lastname("Doe").build();
+            assertThat(user.displayName()).isEqualTo("Jane Doe");
+        }
+
+        @Test
+        void should_return_display_name_when_user_has_only_firstname() {
+            var user = BaseUserEntity.builder().firstname("Jane").build();
+            assertThat(user.displayName()).isEqualTo("Jane");
+        }
+
+        @Test
+        void should_return_display_name_when_user_has_only_lastname() {
+            var user = BaseUserEntity.builder().lastname("Doe").build();
+            assertThat(user.displayName()).isEqualTo("Doe");
+        }
+
+        @Test
+        void should_return_email_when_user_coming_from_idp() {
+            var user = BaseUserEntity.builder().email("jane.doe@gravitee.io").source("google").build();
+            assertThat(user.displayName()).isEqualTo("jane.doe@gravitee.io");
+        }
+
+        @Test
+        void should_return_sourceId_when_user_coming_from_idp_without_email() {
+            var user = BaseUserEntity.builder().sourceId("google-user-id").source("google").build();
+            assertThat(user.displayName()).isEqualTo("google-user-id");
+        }
+
+        @Test
+        void should_return_sourceId_when_user_is_in_memory_user() {
+            var user = BaseUserEntity.builder().sourceId("source-id").source("memory").build();
+            assertThat(user.displayName()).isEqualTo("source-id");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.model.User;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class UserCrudServiceImplTest {
+
+    UserRepository userRepository;
+
+    UserCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+
+        service = new UserCrudServiceImpl(userRepository);
+    }
+
+    @Nested
+    class FindBaseUserById {
+
+        @Test
+        void should_find_user_and_adapt_it() throws TechnicalException {
+            // Given
+            when(userRepository.findById(any()))
+                .thenReturn(
+                    Optional.of(
+                        User
+                            .builder()
+                            .id("user-id")
+                            .organizationId("organization-id")
+                            .source("source")
+                            .sourceId("source-id")
+                            .email("jane.doe@gravitee.io")
+                            .firstname("Jane")
+                            .lastname("Doe")
+                            .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                            .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                            .build()
+                    )
+                );
+
+            // When
+            var user = service.findBaseUserById("userId");
+
+            // Then
+            assertThat(user)
+                .contains(
+                    BaseUserEntity
+                        .builder()
+                        .id("user-id")
+                        .organizationId("organization-id")
+                        .source("source")
+                        .sourceId("source-id")
+                        .email("jane.doe@gravitee.io")
+                        .firstname("Jane")
+                        .lastname("Doe")
+                        .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                        .build()
+                );
+        }
+
+        @Test
+        void should_return_empty_when_user_not_found() throws TechnicalException {
+            // Given
+            var userId = "user-id";
+            when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+            // When
+            var result = service.findBaseUserById(userId);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            var userId = "user-id";
+            when(userRepository.findById(any())).thenThrow(new TechnicalException("technical exception"));
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findBaseUserById(userId));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+    }
+
+    @Nested
+    class FindBaseUserByIds {
+
+        @Test
+        void should_find_users_and_adapt_them() throws TechnicalException {
+            // Given
+            when(userRepository.findByIds(any(List.class)))
+                .thenAnswer(invocation -> {
+                    List<String> ids = invocation.getArgument(0);
+                    return ids
+                        .stream()
+                        .map(id ->
+                            User
+                                .builder()
+                                .id(id)
+                                .organizationId("organization-id")
+                                .source("source-" + id)
+                                .sourceId("source-id-" + id)
+                                .email(id + "@gravitee.io")
+                                .firstname("Jane " + id)
+                                .lastname("Doe " + id)
+                                .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                                .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                                .build()
+                        )
+                        .collect(Collectors.toSet());
+                });
+
+            // When
+            var user = service.findBaseUsersByIds(List.of("1", "2"));
+
+            // Then
+            assertThat(user)
+                .hasSize(2)
+                .contains(
+                    BaseUserEntity
+                        .builder()
+                        .id("1")
+                        .organizationId("organization-id")
+                        .source("source-1")
+                        .sourceId("source-id-1")
+                        .email("1@gravitee.io")
+                        .firstname("Jane 1")
+                        .lastname("Doe 1")
+                        .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                        .build(),
+                    BaseUserEntity
+                        .builder()
+                        .id("2")
+                        .organizationId("organization-id")
+                        .source("source-2")
+                        .sourceId("source-id-2")
+                        .email("2@gravitee.io")
+                        .firstname("Jane 2")
+                        .lastname("Doe 2")
+                        .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                        .build()
+                );
+        }
+
+        @Test
+        void should_return_empty_when_user_not_found() throws TechnicalException {
+            // Given
+            var userId = "user-id";
+            when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+            // When
+            var result = service.findBaseUserById(userId);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            var userId = "user-id";
+            when(userRepository.findById(any())).thenThrow(new TechnicalException("technical exception"));
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findBaseUserById(userId));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+    }
+
+    @Nested
+    class GetBaseUser {
+
+        @Test
+        void should_find_user_and_adapt_id() throws TechnicalException {
+            // Given
+            when(userRepository.findById(any()))
+                .thenReturn(
+                    Optional.of(
+                        User
+                            .builder()
+                            .id("user-id")
+                            .organizationId("organization-id")
+                            .source("source")
+                            .sourceId("source-id")
+                            .email("jane.doe@gravitee.io")
+                            .firstname("Jane")
+                            .lastname("Doe")
+                            .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+                            .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+                            .build()
+                    )
+                );
+
+            // When
+            var user = service.getBaseUser("userId");
+
+            // Then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(user.getId()).isEqualTo("user-id");
+                softly.assertThat(user.getOrganizationId()).isEqualTo("organization-id");
+                softly.assertThat(user.getSource()).isEqualTo("source");
+                softly.assertThat(user.getSourceId()).isEqualTo("source-id");
+                softly.assertThat(user.getEmail()).isEqualTo("jane.doe@gravitee.io");
+                softly.assertThat(user.getFirstname()).isEqualTo("Jane");
+                softly.assertThat(user.getLastname()).isEqualTo("Doe");
+                softly.assertThat(user.getCreatedAt()).isEqualTo("2020-01-01T00:00:00Z");
+                softly.assertThat(user.getUpdatedAt()).isEqualTo("2020-01-02T00:00:00Z");
+            });
+        }
+
+        @Test
+        void should_throw_when_user_not_found() throws TechnicalException {
+            // Given
+            var userId = "user-id";
+            when(userRepository.findById(any())).thenReturn(Optional.empty());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getBaseUser(userId));
+
+            // Then
+            assertThat(throwable).isInstanceOf(UserNotFoundException.class).hasMessage("User [" + userId + "] cannot be found.");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.membership;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.domain_service.membership.PrimaryOwnerDomainServiceImpl;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.api.RoleRepository;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.repository.management.model.MembershipMemberType;
+import io.gravitee.repository.management.model.MembershipReferenceType;
+import io.gravitee.repository.management.model.Role;
+import io.gravitee.repository.management.model.RoleReferenceType;
+import io.gravitee.repository.management.model.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PrimaryOwnerDomainServiceImplTest {
+
+    public static final String PRIMARY_OWNER_ROLE_ID = "role-id";
+    UserCrudServiceInMemory userRepository;
+
+    @Mock
+    RoleRepository roleRepository;
+
+    @Mock
+    GroupRepository groupRepository;
+
+    @Mock
+    MembershipRepository membershipRepository;
+
+    PrimaryOwnerDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() throws TechnicalException {
+        userRepository = new UserCrudServiceInMemory();
+        service = new PrimaryOwnerDomainServiceImpl(roleRepository, membershipRepository, userRepository, groupRepository);
+
+        GraviteeContext.setCurrentOrganization("organization-id");
+
+        givenPrimaryRoleForOrganizationIs(
+            Role.builder().id(PRIMARY_OWNER_ROLE_ID).referenceId("organization-id").referenceType(RoleReferenceType.ORGANIZATION).build()
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(userRepository).forEach(UserCrudServiceInMemory::reset);
+        GraviteeContext.cleanContext();
+    }
+
+    @Nested
+    class GetApiPrimaryOwner {
+
+        @Test
+        @SneakyThrows
+        public void should_return_a_user_primary_owner_of_an_api() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.USER)
+                        .memberId("user-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+
+            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+
+            Assertions
+                .assertThat(result)
+                .isEqualTo(
+                    PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        public void should_return_a_group_primary_owner_of_an_api() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+            givenExistingGroup(List.of(Group.builder().id("group-id").name("Group name").build()));
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.GROUP)
+                        .memberId("group-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build(),
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.GROUP)
+                        .referenceId("group-id")
+                        .memberType(MembershipMemberType.USER)
+                        .memberId("user-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+
+            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+
+            Assertions
+                .assertThat(result)
+                .isEqualTo(
+                    PrimaryOwnerEntity
+                        .builder()
+                        .id("group-id")
+                        .displayName("Group name")
+                        .email("jane.doe@gravitee.io")
+                        .type("GROUP")
+                        .build()
+                );
+        }
+
+        @Test
+        public void should_return_no_user_primary_owner_found() {
+            givenExistingUsers(List.of());
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.USER)
+                        .memberId("user-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+
+            assertThat(throwable).isInstanceOf(ApiPrimaryOwnerNotFoundException.class);
+        }
+
+        @Test
+        public void should_throw_when_fail_to_get_primary_owner_role() {
+            // Given
+            givenRoleFailToBeFetched("technical exception");
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+
+        @Test
+        public void should_throw_when_fail_to_fetch_api_memberships() {
+            givenApiPrimaryOwnerMembershipFailToBeFetched("technical exception");
+
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+
+        @Test
+        public void should_throw_when_fail_to_fetch_group() {
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.GROUP)
+                        .memberId("group-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+            givenGroupFailToBeFetched("technical exception");
+
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+
+        @Test
+        public void should_throw_when_fail_to_fetch_group_members() {
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.GROUP)
+                        .memberId("group-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+            givenGroupMembershipFailToBeFetched("technical exception");
+
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+    }
+
+    private void givenPrimaryRoleForOrganizationIs(Role role) throws TechnicalException {
+        lenient()
+            .when(
+                roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                    RoleScope.API,
+                    SystemRole.PRIMARY_OWNER.name(),
+                    role.getReferenceId(),
+                    role.getReferenceType()
+                )
+            )
+            .thenReturn(Optional.of(role));
+    }
+
+    @SneakyThrows
+    private void givenRoleFailToBeFetched(String message) {
+        when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
+            .thenThrow(new TechnicalException(message));
+    }
+
+    @SneakyThrows
+    private void givenApiPrimaryOwnerMembershipFailToBeFetched(String message) {
+        when(membershipRepository.findByReferenceAndRoleId(eq(MembershipReferenceType.API), any(), any()))
+            .thenThrow(new TechnicalException(message));
+    }
+
+    @SneakyThrows
+    private void givenGroupMembershipFailToBeFetched(String message) {
+        when(membershipRepository.findByReferenceAndRoleId(eq(MembershipReferenceType.GROUP), any(), any()))
+            .thenThrow(new TechnicalException(message));
+    }
+
+    private void givenExistingUsers(List<BaseUserEntity> users) {
+        userRepository.initWith(users);
+    }
+
+    @SneakyThrows
+    private void givenExistingGroup(List<Group> groups) {
+        when(groupRepository.findById(any())).thenReturn(Optional.empty());
+
+        for (Group group : groups) {
+            when(groupRepository.findById(eq(group.getId())))
+                .thenAnswer(invocation -> Optional.of(Group.builder().id(invocation.getArgument(0)).name("Group name").build()));
+        }
+    }
+
+    @SneakyThrows
+    private void givenGroupFailToBeFetched(String message) {
+        when(groupRepository.findById(any())).thenThrow(new TechnicalException(message));
+    }
+
+    @SneakyThrows
+    private void givenExistingMemberships(List<Membership> memberships) {
+        when(membershipRepository.findByReferenceAndRoleId(any(), any(), any())).thenReturn(Set.of());
+
+        for (Membership m : memberships) {
+            when(membershipRepository.findByReferenceAndRoleId(m.getReferenceType(), m.getReferenceId(), m.getRoleId()))
+                .thenReturn(Set.of(m));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
@@ -36,7 +37,6 @@ import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.NoPrimaryOwnerGroupForUserException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import io.gravitee.rest.api.service.v4.impl.PrimaryOwnerServiceImpl;
 import java.util.Arrays;
@@ -82,6 +82,9 @@ public class ApiService_FindPrimaryOwnerTest {
     @Mock
     private RoleService roleService;
 
+    @Mock
+    private ApiPrimaryOwnerDomainService primaryOwnerDomainService;
+
     @Before
     public void before() {
         PrimaryOwnerService primaryOwnerService = new PrimaryOwnerServiceImpl(
@@ -89,7 +92,8 @@ public class ApiService_FindPrimaryOwnerTest {
             membershipService,
             groupService,
             parameterService,
-            roleService
+            roleService,
+            primaryOwnerDomainService
         );
         ReflectionTestUtils.setField(apiService, "primaryOwnerService", primaryOwnerService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
@@ -15,16 +15,22 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.rest.api.model.*;
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.GroupService;
@@ -33,9 +39,14 @@ import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,25 +77,22 @@ public class PrimaryOwnerServiceImplTest {
     @Mock
     private RoleService roleService;
 
+    @Mock
+    private ApiPrimaryOwnerDomainService primaryOwnerDomainService;
+
     private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("TEST", "TEST");
 
     @Before
     public void setUp() {
-        this.primaryOwnerService = new PrimaryOwnerServiceImpl(userService, membershipService, groupService, parameterService, roleService);
-    }
-
-    @Test
-    public void getPrimaryOwner_should_throw_PrimaryOwnerNotFoundException_if_no_membership_found() {
-        when(membershipService.getPrimaryOwner(EXECUTION_CONTEXT.getOrganizationId(), MembershipReferenceType.API, "my-api"))
-            .thenReturn(null);
-        PrimaryOwnerNotFoundException exception = assertThrows(
-            PrimaryOwnerNotFoundException.class,
-            () -> primaryOwnerService.getPrimaryOwner(EXECUTION_CONTEXT, "my-api")
-        );
-        assertEquals("Primary owner not found for API [my-api]", exception.getMessage());
-        assertEquals("primaryOwner.notFound", exception.getTechnicalCode());
-        assertEquals(500, exception.getHttpStatusCode());
-        assertEquals(Map.of("api", "my-api"), exception.getParameters());
+        this.primaryOwnerService =
+            new PrimaryOwnerServiceImpl(
+                userService,
+                membershipService,
+                groupService,
+                parameterService,
+                roleService,
+                primaryOwnerDomainService
+            );
     }
 
     @Test
@@ -127,98 +135,6 @@ public class PrimaryOwnerServiceImplTest {
         Map<String, PrimaryOwnerEntity> primaryOwners = primaryOwnerService.getPrimaryOwners(EXECUTION_CONTEXT, apiIds);
         assertNotNull(primaryOwners);
         assertEquals(3, primaryOwners.size());
-    }
-
-    @Test
-    public void getPrimaryOwner_should_return_group_primary_owner_with_email_of_po_user() {
-        final MembershipEntity groupMembership = primaryOwnerGroupMembership();
-        groupMembership.setMemberId("member-id");
-        when(membershipService.getPrimaryOwner(EXECUTION_CONTEXT.getOrganizationId(), MembershipReferenceType.API, "api"))
-            .thenReturn(groupMembership);
-
-        MemberEntity member = new MemberEntity();
-        member.setId("some-member");
-        member.setEmail("some-member@mail.com");
-        member.setRoles(List.of());
-
-        MemberEntity memberOther = new MemberEntity();
-        memberOther.setId("other-member");
-        memberOther.setEmail("other-member@mail.com");
-        memberOther.setRoles(List.of());
-
-        MemberEntity poMember = new MemberEntity();
-        poMember.setId("po-member");
-        poMember.setEmail("po-member@mail.com");
-        final RoleEntity role = new RoleEntity();
-        role.setScope(RoleScope.API);
-        role.setName(SystemRole.PRIMARY_OWNER.name());
-        poMember.setRoles(List.of(role));
-
-        when(membershipService.getMembersByReference(EXECUTION_CONTEXT, MembershipReferenceType.GROUP, groupMembership.getMemberId()))
-            .thenReturn(Set.of(member, memberOther, poMember));
-
-        final GroupEntity poGroup = primaryOwnerGroup();
-        when(groupService.findById(EXECUTION_CONTEXT, groupMembership.getMemberId())).thenReturn(poGroup);
-
-        final PrimaryOwnerEntity result = primaryOwnerService.getPrimaryOwner(EXECUTION_CONTEXT, "api");
-        assertThat(result.getId()).isEqualTo(poGroup.getId());
-        assertThat(result.getType()).isEqualTo("GROUP");
-        assertThat(result.getEmail()).isEqualTo("po-member@mail.com");
-    }
-
-    @Test
-    public void shouldReturnPrimaryOwnerEmailFromUser() {
-        final String apiId = "some-api";
-
-        when(
-            membershipService.getPrimaryOwner(
-                EXECUTION_CONTEXT.getOrganizationId(),
-                io.gravitee.rest.api.model.MembershipReferenceType.API,
-                apiId
-            )
-        )
-            .thenReturn(primaryOwnerUserMembership());
-
-        when(userService.findById(EXECUTION_CONTEXT, "some-user")).thenReturn(primaryOwnerUser());
-
-        String email = primaryOwnerService.getPrimaryOwnerEmail(EXECUTION_CONTEXT, apiId);
-
-        assertThat(email).isEqualTo("some-user@gravitee.test");
-    }
-
-    @Test
-    public void shouldReturnPrimaryOwnerEmailFromGroupMember() {
-        final String apiId = "some-api";
-
-        when(
-            membershipService.getPrimaryOwner(
-                EXECUTION_CONTEXT.getOrganizationId(),
-                io.gravitee.rest.api.model.MembershipReferenceType.API,
-                apiId
-            )
-        )
-            .thenReturn(primaryOwnerGroupMembership());
-
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), EXECUTION_CONTEXT.getOrganizationId()))
-            .thenReturn(apiPrimaryOwnerRole());
-
-        when(
-            membershipService.getMembersByReferenceAndRole(
-                EXECUTION_CONTEXT,
-                MembershipReferenceType.GROUP,
-                "some-group",
-                "role-api-primary-owner"
-            )
-        )
-            .thenReturn(primaryOwnerGroupMember());
-
-        when(groupService.findById(EXECUTION_CONTEXT, "some-group")).thenReturn(primaryOwnerGroup());
-
-        when(userService.findById(EXECUTION_CONTEXT, "some-member")).thenReturn(primaryOwnerUser());
-
-        String email = primaryOwnerService.getPrimaryOwnerEmail(EXECUTION_CONTEXT, apiId);
-
-        assertThat(email).isEqualTo("some-user@gravitee.test");
     }
 
     private static MembershipEntity primaryOwnerUserMembership() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2583

## Description

Rewrite of PrimaryOwnerService that finds the PO of an API (User or Group)
This new implementation does not rely on "legacy" services and should be used in any new code. 

We worked on that with @loriepisicchio and @ytvnr while working on "migrating" the Close Plan use-case. 


Two methods of the legacy service haven't migrated:
- `Map<String, PrimaryOwnerEntity> getPrimaryOwners(ExecutionContext executionContext, List<String> apiIds);`
- `PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String userId, PrimaryOwnerEntity currentPrimaryOwner);`

We didn't touch them as they are unnecessary for the Close Plan use-case. 
The first one can be done once merged (we wanted to spend time running some tests instead of working on this)
For the 2nd one, we were not sure about what it does 🙈



## Additional context

Run few tests:
- APIs list ✅ 
- Notifications ✅ 
- Documentation with EL ✅ 

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5172/console](https://pr.team-apim.gravitee.dev/5172/console)
      Portal: [https://pr.team-apim.gravitee.dev/5172/portal](https://pr.team-apim.gravitee.dev/5172/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5172/api/management](https://pr.team-apim.gravitee.dev/5172/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5172](https://pr.team-apim.gravitee.dev/5172)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5172](https://pr.gateway-v3.team-apim.gravitee.dev/5172)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-juvrmlzayr.chromatic.com)
<!-- Storybook placeholder end -->
