### PR TITLE
fix: load rest-api-v2 spring configuration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -37,7 +37,15 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({ VertxConfiguration.class, RestManagementConfiguration.class, RestPortalConfiguration.class, NodeCertificatesConfiguration.class })
+@Import(
+    {
+        VertxConfiguration.class,
+        RestManagementConfiguration.class,
+        io.gravitee.rest.api.management.v2.rest.spring.RestManagementConfiguration.class,
+        RestPortalConfiguration.class,
+        NodeCertificatesConfiguration.class,
+    }
+)
 public class StandaloneConfiguration {
 
     @Bean


### PR DESCRIPTION
## Description

RestManagementConfiguration for the rest-api v2 was not loaded.
Unfortunately, I've added new imports for the Api Logs lately, specifically for the v2 and those services were not loaded 🙈 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-idlrqoqdrs.chromatic.com)
<!-- Storybook placeholder end -->
