### PR TITLE
refactor: use new primaryowner domain service 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
@@ -26,6 +26,15 @@ import java.util.Map;
  * @author GraviteeSource Team
  */
 public interface PrimaryOwnerService {
+    /**
+     * Resolves the primary owner for the given API.
+     * @param executionContext the execution context
+     * @param apiId the API id
+     * @return The primary owner
+     * @throws TechnicalManagementException if an error occurs while resolving the primary owner
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
+     */
+    @Deprecated
     PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String apiId) throws TechnicalManagementException;
 
     /**
@@ -35,7 +44,10 @@ public interface PrimaryOwnerService {
      * @param executionContext the execution context
      * @param apiId the API id
      * @return the primary owner email
+     *
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
      */
+    @Deprecated
     String getPrimaryOwnerEmail(ExecutionContext executionContext, String apiId);
 
     PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String userId, PrimaryOwnerEntity currentPrimaryOwner);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
@@ -165,6 +165,30 @@ public class PrimaryOwnerDomainServiceImplTest {
         }
 
         @Test
+        @SneakyThrows
+        public void should_return_a_group_primary_owner_with_no_email_when_group_has_no_users() {
+            givenExistingGroup(List.of(Group.builder().id("group-id").name("Group name").build()));
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(MembershipReferenceType.API)
+                        .referenceId("api-id")
+                        .memberType(MembershipMemberType.GROUP)
+                        .memberId("group-id")
+                        .roleId(PRIMARY_OWNER_ROLE_ID)
+                        .build()
+                )
+            );
+
+            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+
+            Assertions
+                .assertThat(result)
+                .isEqualTo(PrimaryOwnerEntity.builder().id("group-id").displayName("Group name").type("GROUP").build());
+        }
+
+        @Test
         public void should_return_no_user_primary_owner_found() {
             givenExistingUsers(List.of());
             givenExistingMemberships(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
@@ -36,7 +37,6 @@ import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.NoPrimaryOwnerGroupForUserException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import io.gravitee.rest.api.service.v4.impl.PrimaryOwnerServiceImpl;
 import java.util.Arrays;
@@ -82,6 +82,9 @@ public class ApiService_FindPrimaryOwnerTest {
     @Mock
     private RoleService roleService;
 
+    @Mock
+    private ApiPrimaryOwnerDomainService primaryOwnerDomainService;
+
     @Before
     public void before() {
         PrimaryOwnerService primaryOwnerService = new PrimaryOwnerServiceImpl(
@@ -89,7 +92,8 @@ public class ApiService_FindPrimaryOwnerTest {
             membershipService,
             groupService,
             parameterService,
-            roleService
+            roleService,
+            primaryOwnerDomainService
         );
         ReflectionTestUtils.setField(apiService, "primaryOwnerService", primaryOwnerService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
@@ -15,16 +15,22 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.rest.api.model.*;
+import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.GroupService;
@@ -33,9 +39,14 @@ import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,25 +77,22 @@ public class PrimaryOwnerServiceImplTest {
     @Mock
     private RoleService roleService;
 
+    @Mock
+    private ApiPrimaryOwnerDomainService primaryOwnerDomainService;
+
     private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("TEST", "TEST");
 
     @Before
     public void setUp() {
-        this.primaryOwnerService = new PrimaryOwnerServiceImpl(userService, membershipService, groupService, parameterService, roleService);
-    }
-
-    @Test
-    public void getPrimaryOwner_should_throw_PrimaryOwnerNotFoundException_if_no_membership_found() {
-        when(membershipService.getPrimaryOwner(EXECUTION_CONTEXT.getOrganizationId(), MembershipReferenceType.API, "my-api"))
-            .thenReturn(null);
-        PrimaryOwnerNotFoundException exception = assertThrows(
-            PrimaryOwnerNotFoundException.class,
-            () -> primaryOwnerService.getPrimaryOwner(EXECUTION_CONTEXT, "my-api")
-        );
-        assertEquals("Primary owner not found for API [my-api]", exception.getMessage());
-        assertEquals("primaryOwner.notFound", exception.getTechnicalCode());
-        assertEquals(500, exception.getHttpStatusCode());
-        assertEquals(Map.of("api", "my-api"), exception.getParameters());
+        this.primaryOwnerService =
+            new PrimaryOwnerServiceImpl(
+                userService,
+                membershipService,
+                groupService,
+                parameterService,
+                roleService,
+                primaryOwnerDomainService
+            );
     }
 
     @Test
@@ -127,98 +135,6 @@ public class PrimaryOwnerServiceImplTest {
         Map<String, PrimaryOwnerEntity> primaryOwners = primaryOwnerService.getPrimaryOwners(EXECUTION_CONTEXT, apiIds);
         assertNotNull(primaryOwners);
         assertEquals(3, primaryOwners.size());
-    }
-
-    @Test
-    public void getPrimaryOwner_should_return_group_primary_owner_with_email_of_po_user() {
-        final MembershipEntity groupMembership = primaryOwnerGroupMembership();
-        groupMembership.setMemberId("member-id");
-        when(membershipService.getPrimaryOwner(EXECUTION_CONTEXT.getOrganizationId(), MembershipReferenceType.API, "api"))
-            .thenReturn(groupMembership);
-
-        MemberEntity member = new MemberEntity();
-        member.setId("some-member");
-        member.setEmail("some-member@mail.com");
-        member.setRoles(List.of());
-
-        MemberEntity memberOther = new MemberEntity();
-        memberOther.setId("other-member");
-        memberOther.setEmail("other-member@mail.com");
-        memberOther.setRoles(List.of());
-
-        MemberEntity poMember = new MemberEntity();
-        poMember.setId("po-member");
-        poMember.setEmail("po-member@mail.com");
-        final RoleEntity role = new RoleEntity();
-        role.setScope(RoleScope.API);
-        role.setName(SystemRole.PRIMARY_OWNER.name());
-        poMember.setRoles(List.of(role));
-
-        when(membershipService.getMembersByReference(EXECUTION_CONTEXT, MembershipReferenceType.GROUP, groupMembership.getMemberId()))
-            .thenReturn(Set.of(member, memberOther, poMember));
-
-        final GroupEntity poGroup = primaryOwnerGroup();
-        when(groupService.findById(EXECUTION_CONTEXT, groupMembership.getMemberId())).thenReturn(poGroup);
-
-        final PrimaryOwnerEntity result = primaryOwnerService.getPrimaryOwner(EXECUTION_CONTEXT, "api");
-        assertThat(result.getId()).isEqualTo(poGroup.getId());
-        assertThat(result.getType()).isEqualTo("GROUP");
-        assertThat(result.getEmail()).isEqualTo("po-member@mail.com");
-    }
-
-    @Test
-    public void shouldReturnPrimaryOwnerEmailFromUser() {
-        final String apiId = "some-api";
-
-        when(
-            membershipService.getPrimaryOwner(
-                EXECUTION_CONTEXT.getOrganizationId(),
-                io.gravitee.rest.api.model.MembershipReferenceType.API,
-                apiId
-            )
-        )
-            .thenReturn(primaryOwnerUserMembership());
-
-        when(userService.findById(EXECUTION_CONTEXT, "some-user")).thenReturn(primaryOwnerUser());
-
-        String email = primaryOwnerService.getPrimaryOwnerEmail(EXECUTION_CONTEXT, apiId);
-
-        assertThat(email).isEqualTo("some-user@gravitee.test");
-    }
-
-    @Test
-    public void shouldReturnPrimaryOwnerEmailFromGroupMember() {
-        final String apiId = "some-api";
-
-        when(
-            membershipService.getPrimaryOwner(
-                EXECUTION_CONTEXT.getOrganizationId(),
-                io.gravitee.rest.api.model.MembershipReferenceType.API,
-                apiId
-            )
-        )
-            .thenReturn(primaryOwnerGroupMembership());
-
-        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), EXECUTION_CONTEXT.getOrganizationId()))
-            .thenReturn(apiPrimaryOwnerRole());
-
-        when(
-            membershipService.getMembersByReferenceAndRole(
-                EXECUTION_CONTEXT,
-                MembershipReferenceType.GROUP,
-                "some-group",
-                "role-api-primary-owner"
-            )
-        )
-            .thenReturn(primaryOwnerGroupMember());
-
-        when(groupService.findById(EXECUTION_CONTEXT, "some-group")).thenReturn(primaryOwnerGroup());
-
-        when(userService.findById(EXECUTION_CONTEXT, "some-member")).thenReturn(primaryOwnerUser());
-
-        String email = primaryOwnerService.getPrimaryOwnerEmail(EXECUTION_CONTEXT, apiId);
-
-        assertThat(email).isEqualTo("some-user@gravitee.test");
     }
 
     private static MembershipEntity primaryOwnerUserMembership() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2583


## Description

Use new PrimaryOwnerDomainService in existing code.

## Additional context

Our initial implementation was throwing an exception when an API is owned by a group that has no user (and thus, no email).
But when importing an API, we only create the group but not any attached user. In this case, the PrimaryOwner entity returned should simply not have any email address.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kctjovhhwe.chromatic.com)
<!-- Storybook placeholder end -->
