### PR TITLE
feat: add icon to copy the URL of entrypoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -21,7 +21,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { GioConfirmDialogModule, GioIconsModule, GioSaveBarModule, GioFormFocusInvalidModule } from '@gravitee/ui-particles-angular';
+import {
+  GioConfirmDialogModule,
+  GioIconsModule,
+  GioSaveBarModule,
+  GioFormFocusInvalidModule,
+  GioClipboardModule,
+} from '@gravitee/ui-particles-angular';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -54,6 +60,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioConfirmDialogModule,
     GioIconsModule,
     GioFormFocusInvalidModule,
+    GioClipboardModule,
   ],
 })
 export class ApiProxyEntrypointsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
@@ -22,9 +22,14 @@
       The URL location of your API. So if your URL is <strong>[{{ contextPathPrefix }}/myAPI]</strong>, then <strong>[/myAPI]</strong> is
       the context path.
     </div>
+
     <mat-form-field appearance="outline" class="form-card__context-path-field">
       <span matPrefix>{{ contextPathPrefix }}</span>
       <input matInput formControlName="contextPath" required />
+      <gio-clipboard-copy-icon
+        matSuffix
+        [contentToCopy]="contextPathPrefix + this.entrypointsForm.value.contextPath"
+      ></gio-clipboard-copy-icon>
       <mat-hint
         >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
         underscore.</mat-hint

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -71,6 +71,7 @@
           <mat-form-field class="virtual-host__table__path-field">
             <mat-label>Listening Path</mat-label>
             <input matInput [formControl]="element.controls.path" required />
+            <gio-clipboard-copy-icon matSuffix [contentToCopy]="element.value.host + element.value.path"></gio-clipboard-copy-icon>
             <mat-hint
               >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
               underscore.</mat-hint


### PR DESCRIPTION
Allow to get the URL for an entrypoint from the context path and virtual hosts screen

<img width="1219" alt="Screenshot 2023-09-08 at 19 10 57" src="https://github.com/gravitee-io/gravitee-api-management/assets/3619261/d528dd1a-d3cb-44cf-845f-4429a73ce098">
<img width="1219" alt="Screenshot 2023-09-08 at 19 10 49" src="https://github.com/gravitee-io/gravitee-api-management/assets/3619261/b96e7603-238f-4e9d-b120-9b24b5fa6e3d">

With context path: copies the context path prefix + the context path
With virtual host: copies the host + the path (I did not find a way to infer the scheme)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-czcjvuumid.chromatic.com)
<!-- Storybook placeholder end -->
