### PR TITLE
fix(docker): prevent $uri replacement in nginx configuration

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONSOLE_BASE_HREF "/"

--- a/gravitee-apim-console-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-console-webui/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/gravitee-apim-console-webui/docker/config/default.conf
+++ b/gravitee-apim-console-webui/docker/config/default.conf
@@ -23,7 +23,7 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
     location / {
-        try_files ${DOLLAR}uri ${DOLLAR}uri/ =404;
+        try_files $uri $uri/ =404;
         root /usr/share/nginx/html;
         sub_filter '<base href="/"' '<base href="$CONSOLE_BASE_HREF"';
         sub_filter_once on;

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"

--- a/gravitee-apim-portal-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx-noconfd:1.25
+FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -22,7 +22,7 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
     location / {
-        try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html =404;
+        try_files $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;
         sub_filter '<base href="/"' '<base href="$PORTAL_BASE_HREF"';
         sub_filter_once on;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2527

## Description

Prevent $uri replacement in nginx configuration.
Environment variables that need to be replaced are now specified in the run.sh of the nginx-noconfd docker image
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5198/console](https://pr.team-apim.gravitee.dev/5198/console)
      Portal: [https://pr.team-apim.gravitee.dev/5198/portal](https://pr.team-apim.gravitee.dev/5198/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5198/api/management](https://pr.team-apim.gravitee.dev/5198/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5198](https://pr.team-apim.gravitee.dev/5198)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5198](https://pr.gateway-v3.team-apim.gravitee.dev/5198)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pxoeoifbwi.chromatic.com)
<!-- Storybook placeholder end -->
