### PR TITLE
fix: handle path mappings containing wildwards

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -211,8 +211,10 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
             pathMappingsNode
                 .elements()
                 .forEachRemaining(jsonNode -> {
-                    final String pathMapping = jsonNode.asText();
-                    api.getPathMappings().put(pathMapping, Pattern.compile(pathMapping.replaceAll(":\\w*", "[^\\/]*") + "/*"));
+                    String pathMapping = jsonNode.asText();
+                    String pathMappingRegex = pathMapping.replaceAll(":[^/]*", "[^/]*");
+                    Pattern pattern = Pattern.compile(pathMappingRegex);
+                    api.getPathMappings().put(pathMapping, pattern);
                 });
         }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -54,6 +54,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -150,6 +151,21 @@ public class ApiDeserializerTest extends AbstractTest {
 
         Set<HttpMethod> methods = rules.iterator().next().getMethods();
         assertEquals(2, methods.size());
+    }
+
+    @Test
+    public void definition_withWildcardInPathMapping() throws IOException {
+        Api api = load("/io/gravitee/definition/jackson/api-with-wildcard-in-path-mapping.json", Api.class);
+        assertNotNull(api.getPathMappings());
+        assertEquals(1, api.getPathMappings().size());
+        Pattern pattern = api.getPathMappings().get("/echo/:*test/.*");
+        assertNotNull(pattern);
+        assertEquals("/echo/[^/]*/.*", pattern.pattern());
+        assertFalse(pattern.matcher("/echo").matches());
+        assertFalse(pattern.matcher("/echo/").matches());
+        assertFalse(pattern.matcher("/echo/anything").matches());
+        assertTrue(pattern.matcher("/echo/anything/").matches());
+        assertTrue(pattern.matcher("/echo/anything/anything-else").matches());
     }
 
     @Test

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-with-wildcard-in-path-mapping.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-with-wildcard-in-path-mapping.json
@@ -1,0 +1,18 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:1234"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": true
+  },
+  "path_mappings": [
+    "/echo/:*test/.*"
+  ]
+}


### PR DESCRIPTION
When the API deserializer encountered a path mapping containing a regexp special character, it failed because the pattern might complain about dangling characters when compiling the resulting regular expression, which could lead to breaking the API list retrieval.

see https://gravitee.atlassian.net/browse/APIM-2611

Demonstration that it is still working is in the ticket ☝️ 

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uuwmkwowvn.chromatic.com)
<!-- Storybook placeholder end -->
