### PR TITLE
revert(console): remove debug on console lint

### DIFF
--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -165,7 +165,7 @@
     "build:prod": "webpack -c ./conf/webpack-dist.conf.js",
     "compile": "tsc",
     "lint": "npm run lint:eslint && npm run prettier",
-    "lint:eslint": "eslint --debug --ext .json,.ts ./src",
+    "lint:eslint": "eslint --ext .json,.ts ./src",
     "lint:eslint:fix": "eslint --ext .json,.ts ./src --fix",
     "lint:fix": "npm run lint:eslint:fix && npm run lint:license:fix && npm run prettier:fix",
     "lint:license": "license-check-and-add check -f license-check-config.json",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2640

## Description

I was experimenting speed improvements on console lint and the debug option as been committed and merged involuntarily on master 🙈  Here is a PR to remove it. Sorry for that

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

