### PR TITLE
chore: bump gravitee-plugin and gravitee-node to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.2.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>4.0.0</gravitee-node.version>
+        <gravitee-node.version>4.3.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>2.0.1</gravitee-plugin.version>
+        <gravitee-plugin.version>2.0.3</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>


### PR DESCRIPTION
Without this, the latest version of gravitee-reporter-elasticsearch won't start

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bzjqwsihpb.chromatic.com)
<!-- Storybook placeholder end -->
