### PR TITLE
Console - continue notifications migration (part 3)

### DIFF
--- a/gravitee-apim-console-webui/src/entities/notification/notificationSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notificationSettings.fixture.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NotificationSettings } from './notificationSettings';
+
+export function fakeNotificationSettings(attributes?: Partial<NotificationSettings>): NotificationSettings {
+  const defaultValue: NotificationSettings = {
+    id: 'f7889b1c-2b4c-435d-889b-1c2b4c235da9',
+    name: 'test tes test',
+    referenceType: 'API',
+    referenceId: 'f1ddf4b5-c23a-33a7-87bf-28ec0a1d9db9',
+    notifier: 'default-email',
+    hooks: [],
+    useSystemProxy: false,
+    config_type: 'GENERIC',
+  };
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
@@ -18,7 +18,13 @@
 
 <div class="title">
   <h1>Notifications</h1>
-  <button mat-raised-button color="primary" aria-label="add-notification" [disabled]="true">
+  <button
+    *gioPermission="{ anyOf: ['api-notification-c'] }"
+    mat-raised-button
+    color="primary"
+    aria-label="add-notification"
+    [disabled]="true"
+  >
     <mat-icon>add</mat-icon>
     Add notification
   </button>
@@ -41,6 +47,26 @@
         <a [uiSref]="'management.apis.notifications-ng.details'" [uiParams]="{ notificationId: element.id || element.configType }">
           {{ element.name }}
         </a>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef id="actions" width="1%"></th>
+      <td mat-cell *matCellDef="let element">
+        <div class="notifications-list__table__actions">
+          <ng-container *ngIf="element.id">
+            <button
+              *gioPermission="{ anyOf: ['api-notification-d'] }"
+              mat-icon-button
+              (click)="deleteNotification(element.name, element.id)"
+              aria-label="Delete notification"
+              id="deleteNotification"
+              matTooltip="Delete notification"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </ng-container>
+        </div>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.module.ts
@@ -22,6 +22,8 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { UIRouterModule } from '@uirouter/angular';
 import { HttpClientModule } from '@angular/common/http';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { NotificationsListComponent } from './notifications-list.component';
 
@@ -42,6 +44,8 @@ import { GioTableWrapperModule } from '../../../../shared/components/gio-table-w
     MatTooltipModule,
     UIRouterModule,
     HttpClientModule,
+    MatDialogModule,
+    MatSnackBarModule,
   ],
 })
 export class NotificationsListModule {}

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { NotificationSettingsService } from './notification-settings.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+
+describe('NotificationSettings', () => {
+  let httpTestingController: HttpTestingController;
+  let notificationSettingsService: NotificationSettingsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    notificationSettingsService = TestBed.inject<NotificationSettingsService>(NotificationSettingsService);
+  });
+
+  describe('delete', () => {
+    it('should call the API', (done) => {
+      notificationSettingsService.delete('123', '456').subscribe(() => done());
+
+      httpTestingController
+        .expectOne({
+          method: 'DELETE',
+          url: `${CONSTANTS_TESTING.org.baseURL}/environments/DEFAULT/apis/123/notificationsettings/456`,
+        })
+        .flush(null);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
@@ -29,4 +29,8 @@ export class NotificationSettingsService {
   getNotificationSettings(apiId: string): Observable<NotificationSettings[]> {
     return this.http.get<NotificationSettings[]>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings`);
   }
+
+  delete(apiId: string, id: string): Observable<NotificationSettings[]> {
+    return this.http.delete<NotificationSettings[]>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings/${id}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2371

## Description

Continue migrating notifications from angular.js to angular 2+, creating a feature to delete selected notification

## Additional context

It's third part of notifications migration
Screenshot
<img width="1285" alt="Screenshot 2023-09-14 at 3 28 47 PM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/ad6ab615-4db2-418a-93cc-960516c5677e">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ehtiqowvuv.chromatic.com)
<!-- Storybook placeholder end -->
