### PR TITLE
fix: accept wide logo on portal

### DIFF
--- a/gravitee-apim-portal-webui/src/app/app.component.css
+++ b/gravitee-apim-portal-webui/src/app/app.component.css
@@ -123,7 +123,7 @@
 
 .layout__header__container {
   display: grid;
-  grid-template-columns: 75px 1fr auto;
+  grid-template-columns: 250px 1fr auto;
   grid-gap: 0.5rem;
   padding: var(--gv-theme-layout--pt) var(--gv-theme-layout--pr) var(--gv-theme-layout--pb) var(--gv-theme-layout--pl);
 }
@@ -132,7 +132,7 @@
   background-image: var(--gv-theme-logo);
   background-size: contain;
   background-repeat: no-repeat;
-  background-position: center;
+  background-position-y: center;
   height: var(--gv-theme-layout-header--h);
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3054

## Description

Change CSS to accept large logos on Portal.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5254/console](https://pr.team-apim.gravitee.dev/5254/console)
      Portal: [https://pr.team-apim.gravitee.dev/5254/portal](https://pr.team-apim.gravitee.dev/5254/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5254/api/management](https://pr.team-apim.gravitee.dev/5254/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5254](https://pr.team-apim.gravitee.dev/5254)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5254](https://pr.gateway-v3.team-apim.gravitee.dev/5254)

<!-- Environment placeholder end -->
