### PR TITLE
test(ui): fixing flaky plans test with scrollIntoView

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -116,7 +116,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_name_field').type(`${planName}-JWT`);
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} JWT`);
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.contains('selection rule').should('be.visible');
+    cy.contains('selection rule').scrollIntoView().should('be.visible');
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('Rate Limiting').should('be.visible');
     cy.contains('Quota').should('be.visible');


### PR DESCRIPTION
## Issue

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/25423/workflows/d0e0364f-9255-4401-9be0-9f8362fb3282/jobs/452929

## Description

Very simple change, adding scrollIntoView for 'resource filtering' wording. There was a change on this screen and for whatever reason, Cypress was failing to read the whole page and this seems to have fixed the issue. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rolhzmigzx.chromatic.com)
<!-- Storybook placeholder end -->
