### PR TITLE
test: adjusting cypress login test to migrated Home screen

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
@@ -25,9 +25,6 @@ describe('Login Feature', () => {
 
   it(`should launch the login page`, () => {
     cy.url().should('contain', 'login');
-  });
-
-  it(`should have login page elements`, () => {
     cy.get('.title').should('be.visible');
     cy.get('.title').contains('Sign In');
   });
@@ -37,6 +34,10 @@ describe('Login Feature', () => {
     cy.get('#input_1').type(ADMIN_USER.password);
 
     cy.get('.btn').click();
-    cy.contains('Home board');
+    cy.url().should('contain', '/home/overview');
+    cy.contains('Overview').should('be.visible');
+    cy.contains('APIs health-check').should('be.visible');
+    cy.contains('My tasks').should('be.visible');
+    cy.contains('h2', 'API Events').should('be.visible');
   });
 });


### PR DESCRIPTION
## Issue

Home/Dashboard screen was migrated to Angular and one change, the removal of the string 'Home' from that page, broke one of the login test in Cypress. 

## Description

This quick fix adjusts the login test to the newly migrated Home/Dashboard screen.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xvfzhhojzr.chromatic.com)
<!-- Storybook placeholder end -->
