### PR TITLE
Console - continue notifications migration (part 4)

### DIFF
--- a/gravitee-apim-console-webui/src/entities/notification/newNotificationSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/newNotificationSettings.ts
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
+export interface NewNotificationSettings {
   name: string;
+  notifier: string;
+  config_type: string;
+  hooks: string[];
   referenceType: string;
   referenceId: string;
-  notifier: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
 }

--- a/gravitee-apim-console-webui/src/entities/notification/notifier.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notifier.fixture.ts
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
+import { Notifier } from './notifier';
+
+export function fakeNotifier(attributes?: Partial<Notifier>): Notifier {
+  const defaultValue: Notifier = {
+    id: 'test id',
+    name: 'test name',
+  };
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
 }

--- a/gravitee-apim-console-webui/src/entities/notification/notifier.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notifier.ts
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
+export interface Notifier {
   id?: string;
+  type?: string;
   name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,3 +15,28 @@
     limitations under the License.
 
 -->
+
+<h2 mat-dialog-title class="title">New notification</h2>
+
+<form autocomplete="off" [formGroup]="notificationForm" (ngSubmit)="onSubmit()">
+  <mat-dialog-content>
+    <div class="form">
+      <mat-form-field>
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" required />
+        <mat-error *ngIf="notificationForm.get('name').hasError('required')">Name is required.</mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Notifier</mat-label>
+        <mat-select formControlName="notifier">
+          <mat-option *ngFor="let notifier of notifierList" [value]="notifier.id">{{ notifier.name }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button mat-button [mat-dialog-close]="">Cancel</button>
+    <button mat-button [disabled]="notificationForm.invalid" color="primary" type="submit">Create</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.scss
@@ -1,0 +1,8 @@
+.form {
+  display: flex;
+  flex-direction: column;
+
+  mat-form-field {
+    flex: 1 1 auto;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.component.ts
@@ -13,11 +13,53 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { Notifier } from '../../../../entities/notification/notifier';
+import { NewNotificationSettings } from '../../../../entities/notification/newNotificationSettings';
+import { NotificationSettings } from '../../../../entities/notification/notificationSettings';
+import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+
+export interface NotificationsAddNotificationDialogData {
+  notifier: Notifier[];
+}
+
+export type NotificationsAddNotificationDialogResult = NewNotificationSettings;
 
 @Component({
   selector: 'notifications-add-notification-dialog',
   template: require('./notifications-add-notification-dialog.component.html'),
   styles: [require('./notifications-add-notification-dialog.component.scss')],
 })
-export class NotificationsAddNotificationDialogComponent {}
+export class NotificationsAddNotificationDialogComponent {
+  notificationForm: FormGroup;
+  notifierList: Notifier[];
+  notificationTemplate: NotificationSettings[];
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) dialogData: NotificationsAddNotificationDialogData,
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    public dialogRef: MatDialogRef<NotificationsAddNotificationDialogData, NotificationsAddNotificationDialogResult>,
+  ) {
+    this.notifierList = dialogData.notifier;
+    this.notificationForm = new FormGroup({
+      name: new FormControl(null, [Validators.required]),
+      notifier: new FormControl(this.notifierList[0].id, [Validators.required]),
+    });
+  }
+
+  onSubmit() {
+    const { name, notifier } = this.notificationForm.getRawValue();
+
+    this.dialogRef.close({
+      name,
+      notifier,
+      config_type: 'GENERIC',
+      hooks: [],
+      referenceType: 'API',
+      referenceId: this.ajsStateParams.apiId,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-add-notification-dialog/notifications-add-notification-dialog.module.ts
@@ -15,12 +15,28 @@
  */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { NotificationsAddNotificationDialogComponent } from './notifications-add-notification-dialog.component';
 
 @NgModule({
   declarations: [NotificationsAddNotificationDialogComponent],
   exports: [NotificationsAddNotificationDialogComponent],
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatOptionModule,
+    MatSelectModule,
+    ReactiveFormsModule,
+  ],
 })
 export class NotificationsAddNotificationDialogModule {}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
@@ -22,8 +22,8 @@
     *gioPermission="{ anyOf: ['api-notification-c'] }"
     mat-raised-button
     color="primary"
-    aria-label="add-notification"
-    [disabled]="true"
+    aria-label="Add notification"
+    (click)="addNotification()"
   >
     <mat-icon>add</mat-icon>
     Add notification

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.module.ts
@@ -29,6 +29,7 @@ import { NotificationsListComponent } from './notifications-list.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { NotificationsAddNotificationDialogModule } from '../notifications-add-notification-dialog/notifications-add-notification-dialog.module';
 
 @NgModule({
   declarations: [NotificationsListComponent],
@@ -46,6 +47,7 @@ import { GioTableWrapperModule } from '../../../../shared/components/gio-table-w
     HttpClientModule,
     MatDialogModule,
     MatSnackBarModule,
+    NotificationsAddNotificationDialogModule,
   ],
 })
 export class NotificationsListModule {}

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
@@ -19,6 +19,8 @@ import { TestBed } from '@angular/core/testing';
 import { NotificationSettingsService } from './notification-settings.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { fakeNotifier } from '../entities/notification/notifier.fixture';
+import { fakeNotificationSettings } from '../entities/notification/notificationSettings.fixture';
 
 describe('NotificationSettings', () => {
   let httpTestingController: HttpTestingController;
@@ -43,6 +45,57 @@ describe('NotificationSettings', () => {
           url: `${CONSTANTS_TESTING.org.baseURL}/environments/DEFAULT/apis/123/notificationsettings/456`,
         })
         .flush(null);
+    });
+  });
+
+  describe('get notifiers', () => {
+    it('should call the API', (done) => {
+      const notifier = [fakeNotifier({ id: 'notifier-a', name: 'Notifier A' })];
+
+      notificationSettingsService.getNotifiers('123').subscribe(() => done());
+
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.org.baseURL}/environments/DEFAULT/apis/123/notifiers`,
+        })
+        .flush(notifier);
+    });
+  });
+
+  describe('get notification settings', () => {
+    it('should call the API', (done) => {
+      const notificationSettings = [fakeNotificationSettings({ name: 'Test name', id: 'test id' })];
+
+      notificationSettingsService.getNotificationSettings('123').subscribe(() => done());
+
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.org.baseURL}/environments/DEFAULT/apis/123/notificationsettings`,
+        })
+        .flush(notificationSettings);
+    });
+  });
+
+  describe('create', () => {
+    it('should call the API', (done) => {
+      const fakeNewNotificationSettings = {
+        name: 'test name',
+        notifier: 'test notifier',
+        config_type: 'test config_type',
+        hooks: [],
+        referenceType: 'test reference_type',
+        referenceId: 'test reference_id',
+      };
+
+      notificationSettingsService.create('123', fakeNewNotificationSettings).subscribe(() => done());
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/environments/DEFAULT/apis/123/notificationsettings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body).toEqual(fakeNewNotificationSettings);
+
+      req.flush(fakeNewNotificationSettings);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
@@ -19,6 +19,8 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
 import { NotificationSettings } from '../entities/notification/notificationSettings';
+import { Notifier } from '../entities/notification/notifier';
+import { NewNotificationSettings } from '../entities/notification/newNotificationSettings';
 
 @Injectable({
   providedIn: 'root',
@@ -32,5 +34,13 @@ export class NotificationSettingsService {
 
   delete(apiId: string, id: string): Observable<NotificationSettings[]> {
     return this.http.delete<NotificationSettings[]>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings/${id}`);
+  }
+
+  getNotifiers(apiId: string): Observable<Notifier[]> {
+    return this.http.get<Notifier[]>(`${this.constants.env.baseURL}/apis/${apiId}/notifiers`);
+  }
+
+  create(apiId, notificationConfig: NewNotificationSettings): Observable<NewNotificationSettings> {
+    return this.http.post<NewNotificationSettings>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings`, notificationConfig);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2371

## Description

Continue migrating notifications from angular.js to angular 2+, creating a feature to add new notification

## Additional context

It's fourth part of notifications migration
Screenshot
<img width="682" alt="Screenshot 2023-09-19 at 12 19 30 PM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/ffd27f42-d788-4c56-b40d-c76c4dce95de">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nlakjbsyqq.chromatic.com)
<!-- Storybook placeholder end -->
