### PR TITLE
fix: improve context path validation

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/verifyApiPath.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/verifyApiPath.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class VerifyApiPathResponse {
+  ok: boolean;
+  reason?: string;
+}
+export class PathToVerify {
+  host?: string;
+  path: string;
+}

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.html
@@ -62,6 +62,9 @@
     </tr>
   </tbody>
 </table>
+<mat-error *ngIf="mainForm.hasError('listeners')">
+  Invalid paths{{ mainForm.getError('listeners') ? ': ' : '' }}{{ mainForm.getError('listeners') }}</mat-error
+>
 
 <button *ngIf="!isDisabled" class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">
   Add context-path

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.stories.ts
@@ -93,35 +93,3 @@ export const ReactiveForm: Story = {
     ],
   },
 };
-
-export const ReactiveFormValidationIgnoresExistingPaths: Story = {
-  render: (args) => {
-    const formControl = new FormControl(args.listeners);
-    formControl.valueChanges.subscribe((value) => {
-      action('Listeners')(value);
-    });
-    const pathsToIgnore = args.pathsToIgnore;
-
-    return {
-      template: `<gio-form-listeners-context-path [formControl]="formControl" [pathsToIgnore]="pathsToIgnore"></gio-form-listeners-context-path>`,
-      props: {
-        formControl,
-        pathsToIgnore,
-      },
-    };
-  },
-  args: {
-    listeners: [
-      {
-        path: '/api/my-api-1',
-      },
-      {
-        path: '/api/my-api-2',
-      },
-      {
-        path: '/api/my-api-3',
-      },
-    ],
-    pathsToIgnore: ['/api/my-api-1', '/api/my-api-2', '/api/my-api-3'],
-  },
-};

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.html
@@ -98,6 +98,9 @@
     </tr>
   </tbody>
 </table>
+<mat-error *ngIf="mainForm.hasError('listeners')">
+  Invalid paths{{ mainForm.getError('listeners') ? ': ' : '' }}{{ mainForm.getError('listeners') }}</mat-error
+>
 
 <button *ngIf="!isDisabled" class="gio-form-listeners__add-button" type="button" mat-stroked-button (click)="addEmptyListener()">
   Add context-path

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
@@ -105,6 +105,15 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
     setTimeout(() => subDomainControl.setErrors(null), 0);
     return inheritErrors;
   }
+
+  protected getValue(): PathV4[] {
+    return this.listenerFormArray?.controls.map((control) => {
+      return {
+        path: control.get('path').value,
+        host: combineSubDomainWithDomain(control.get('_hostSubDomain').value, control.get('_hostDomain').value),
+      };
+    });
+  }
 }
 
 const extractDomainToHost = (fullHost: string, domainRestrictions: string[] = []): { host: string; hostDomain: string } => {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -279,6 +279,7 @@ describe('ApiCreationV4Component', () => {
         expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
         expect(await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness)).toBeDefined();
+        expectVerifyContextPathGetRequest();
       });
     });
 
@@ -323,6 +324,7 @@ describe('ApiCreationV4Component', () => {
           { id: 'webhook', name: 'Webhook' },
         ]);
         expectApiGetPortalSettings();
+        expectVerifyContextPathGetRequest();
       });
 
       it('should not display context-path form for non http supportedListenerType', async () => {
@@ -362,6 +364,7 @@ describe('ApiCreationV4Component', () => {
         const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
         expect(await step21Harness.hasListenersForm()).toEqual(true);
         expect(await step21Harness.hasValidationDisabled()).toEqual(true);
+        expectVerifyContextPathGetRequest();
       });
 
       it('should not validate with bad path', async () => {
@@ -384,6 +387,7 @@ describe('ApiCreationV4Component', () => {
         const step22Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
         await step22Harness.fillPaths('bad-path');
         expect(await step22Harness.hasValidationDisabled()).toEqual(true);
+        expectVerifyContextPathGetRequest();
       });
 
       it('should configure paths', async () => {
@@ -482,6 +486,7 @@ describe('ApiCreationV4Component', () => {
 
         await step21Harness.fillVirtualHostsAndValidate({ host: '', path: '/api/my-api-3' });
         expect(await step21Harness.hasValidationDisabled()).toEqual(true);
+        expectVerifyContextPathGetRequest();
       });
 
       it('should configure virtual host', async () => {
@@ -1588,7 +1593,7 @@ describe('ApiCreationV4Component', () => {
   }
 
   function expectVerifyContextPathGetRequest() {
-    httpTestingController.match({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/verify`, method: 'POST' });
+    httpTestingController.match({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_verify/paths`, method: 'POST' });
   }
 
   function exceptEnvironmentGetRequest(environment: Environment) {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -30,13 +30,13 @@
         <gio-form-listeners-context-path
           *ngIf="!this.enableVirtualHost"
           [formControl]="pathsFormControl"
-          [pathsToIgnore]="apiExistingPaths"
+          [apiId]="apiId"
         ></gio-form-listeners-context-path>
 
         <gio-form-listeners-virtual-host
           *ngIf="this.enableVirtualHost"
           [formControl]="pathsFormControl"
-          [pathsToIgnore]="apiExistingPaths"
+          [apiId]="apiId"
           [domainRestrictions]="domainRestrictions"
         ></gio-form-listeners-virtual-host>
       </div>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -106,6 +106,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       await createComponent(ENV, API);
     });
 
+    afterEach(() => {
+      expectApiVerify();
+    });
+
     it('should show context paths only', async () => {
       const contextPath = await loader.getAllHarnesses(GioFormListenersContextPathHarness);
       expect(contextPath.length).toEqual(1);
@@ -146,6 +150,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
 
     beforeEach(async () => {
       await createComponent(ENV, API);
+    });
+
+    afterEach(() => {
+      expectApiVerify();
     });
 
     it('should show context paths', async () => {
@@ -223,6 +231,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       await createComponent(ENV, API);
     });
 
+    afterEach(() => {
+      expectApiVerify();
+    });
+
     it('should show virtual host', async () => {
       const harness = await loader.getHarness(GioFormListenersVirtualHostHarness);
       const listeners = await harness.getListenerRows();
@@ -292,6 +304,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
 
     beforeEach(async () => {
       await createComponent(ENV, API());
+    });
+
+    afterEach(() => {
+      expectApiVerify();
     });
 
     it('should show entrypoints list with action buttons', async () => {
@@ -446,6 +462,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       await createComponent(ENV, API);
     });
 
+    afterEach(() => {
+      expectApiVerify();
+    });
+
     it('should remove empty HTTP listener and attached context-path on save', async () => {
       const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiEntrypointsV4GeneralHarness);
 
@@ -489,6 +509,10 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       await createComponent(ENV, API);
     });
 
+    afterEach(() => {
+      expectApiVerify();
+    });
+
     it('should add the corresponding listener', async () => {
       const addListenerButton = await loader.getHarness(MatButtonHarness.with({ text: 'Add an entrypoint' }));
       expect(await addListenerButton.isDisabled()).toBeFalsy();
@@ -528,6 +552,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
 
     beforeEach(async () => {
       await createComponent(ENV, API);
+      expectApiVerify();
     });
 
     it('should disable add button if no listener type available', async () => {
@@ -597,6 +622,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
 
     beforeEach(async () => {
       await createComponent(ENV, API, undefined, ['api-definition-r']);
+      expectApiVerify();
     });
     it('should not show buttons that require permissions', async () => {
       // switch to virtual host mode/context path mode
@@ -644,7 +670,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
   }
 
   function expectApiVerify(): void {
-    httpTestingController.match({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/verify`, method: 'POST' });
+    httpTestingController.match({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_verify/paths`, method: 'POST' });
   }
 
   function expectGetEntrypoints(): void {

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -27,6 +27,7 @@ import {
   fakeCreateApiV4,
   fakeUpdateApiV4,
 } from '../entities/management-api-v2';
+import { PathToVerify } from '../entities/management-api-v2/api/verifyApiPath';
 
 describe('ApiV2Service', () => {
   let httpTestingController: HttpTestingController;
@@ -366,6 +367,25 @@ describe('ApiV2Service', () => {
       });
 
       expect(req.request.body).toEqual(transferOwnership);
+      req.flush(null);
+    });
+  });
+
+  describe('verify API path', () => {
+    it('should call the API', (done) => {
+      const apiId = 'apiId';
+      const paths: PathToVerify[] = [{ path: 'path', host: 'host' }];
+
+      apiV2Service.verifyPath(apiId, paths).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_verify/paths`,
+        method: 'POST',
+      });
+
+      expect(req.request.body).toEqual({ apiId, paths });
       req.flush(null);
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -15,7 +15,7 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable, BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
 
 import { Constants } from '../entities/Constants';
@@ -31,6 +31,7 @@ import {
   UpdateApi,
 } from '../entities/management-api-v2';
 import { ApiTransferOwnership } from '../entities/management-api-v2/api/apiTransferOwnership';
+import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 
 @Injectable({
   providedIn: 'root',
@@ -143,5 +144,9 @@ export class ApiV2Service {
 
   transferOwnership(api: string, ownership: ApiTransferOwnership): Observable<any> {
     return this.http.post(`${this.constants.env.v2BaseURL}/apis/${api}/_transfer-ownership`, ownership);
+  }
+
+  verifyPath(apiId: string, paths: PathToVerify[]): Observable<VerifyApiPathResponse> {
+    return this.http.post<VerifyApiPathResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/paths`, { apiId, paths });
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -145,6 +145,31 @@ paths:
                     $ref: "#/components/responses/ApisResponse"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/_verify/paths:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            parameters:
+                - $ref: "#/components/parameters/envIdParam"
+            tags:
+                - APIs
+            summary: Verify API paths
+            description: |-
+                Verify paths before creating or updating an API.<br>
+                This will check paths and hosts (depending on environment domain restrictions), and will check that path is not already used by other APIs in the environment.<br>
+                The result will indicate if the paths are OK, and give the reason of the failure if they are not (path contains invalid chars, path is already covered by another API,...)
+            operationId: verifyPaths
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/VerifyApiPaths"
+                required: true
+            responses:
+                "200":
+                    $ref: "#/components/responses/VerifyApiPathsResponse"
+                default:
+                    $ref: "#/components/responses/Error"
 
     /environments/{envId}/apis/{apiId}:
         parameters:
@@ -3231,6 +3256,15 @@ components:
                     format: int64
                     description: The total number of items.
 
+        PathToVerify:
+            type: object
+            properties:
+                host:
+                    type: string
+                path:
+                    type: string
+                    default: "/"
+
         PathV4:
             type: object
             properties:
@@ -4321,6 +4355,16 @@ components:
             title: "TcpListener"
             allOf:
                 - $ref: "#/components/schemas/BaseListener"
+        VerifyApiPaths:
+            title: "VerifyApiPaths"
+            properties:
+                apiId:
+                    type: string
+                paths:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PathToVerify"
+            required: [paths]
 
         ## API V2 specific schemas
         ApiEntrypoint:
@@ -5822,6 +5866,19 @@ components:
                     schema:
                         $ref: "#/components/schemas/Error"
 
+        VerifyApiPathsResponse:
+            description: Result of the API paths verification
+            content:
+                application/json:
+                    schema:
+                        title: "VerifyApiPathsResponse"
+                        properties:
+                            ok:
+                                type: boolean
+                                description: Indicates whether the paths are valid.
+                            reason:
+                                type: string
+                                description: An optional reason giving details about the result.
         # Analytics - Logs
         ApiLogsResponse:
             description: Page of API Logs

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.management.v2.rest.JerseySpringTest;
 import io.gravitee.rest.api.management.v2.rest.spring.ResourceContextConfiguration;
@@ -135,6 +136,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected ApiDuplicateService apiDuplicateService;
+
+    @Autowired
+    protected VerifyApiPathDomainService verifyApiPathDomainService;
 
     @BeforeEach
     public void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.spring;
 
 import static org.mockito.Mockito.mock;
 
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.node.api.license.NodeLicenseService;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -224,5 +225,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiDuplicateService apiDuplicateService() {
         return mock(ApiDuplicateService.class);
+    }
+
+    @Bean
+    public VerifyApiPathDomainService verifyApiPathDomainService() {
+        return mock(VerifyApiPathDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.api.model.Path;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+
+public interface VerifyApiPathDomainService {
+    List<Path> verifyApiPaths(ExecutionContext executionContext, String apiId, List<Path> paths);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Path.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Path.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import io.gravitee.apim.core.exception.InvalidPathException;
+import java.util.regex.Pattern;
+import lombok.Builder;
+import lombok.Data;
+import lombok.With;
+
+@Data
+@Builder
+@With
+public class Path {
+
+    private static final Pattern DUPLICATE_SLASH_REMOVER = Pattern.compile("[//]+");
+    private static final Pattern VALID_PATH = Pattern.compile("^[/.a-zA-Z0-9-_]*$");
+    private static final String URI_PATH_SEPARATOR = "/";
+    private static final char URI_PATH_SEPARATOR_CHAR = '/';
+
+    String host;
+    String path;
+
+    public boolean hasHost() {
+        return host != null && !host.isEmpty();
+    }
+
+    public Path sanitize() {
+        return this.withPath(sanitizePath(this.getPath()));
+    }
+
+    static String sanitizePath(String path) {
+        String sanitizedPath = path;
+        if (sanitizedPath == null || sanitizedPath.isEmpty()) {
+            sanitizedPath = URI_PATH_SEPARATOR;
+        }
+
+        if (!sanitizedPath.startsWith(URI_PATH_SEPARATOR)) {
+            sanitizedPath = URI_PATH_SEPARATOR + sanitizedPath;
+        }
+
+        if (sanitizedPath.lastIndexOf(URI_PATH_SEPARATOR_CHAR) != sanitizedPath.length() - 1) {
+            sanitizedPath += URI_PATH_SEPARATOR;
+        }
+
+        sanitizedPath = DUPLICATE_SLASH_REMOVER.matcher(sanitizedPath).replaceAll(URI_PATH_SEPARATOR);
+
+        if (!VALID_PATH.matcher(sanitizedPath).matches()) throw new InvalidPathException(sanitizedPath);
+        return sanitizedPath;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/InvalidPathException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/InvalidPathException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.exception;
+
+public class InvalidPathException extends RuntimeException {
+
+    public InvalidPathException(String message) {
+        super(message);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/VerifyApiPathDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/VerifyApiPathDomainServiceImpl.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.google.common.net.InternetDomainName;
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.model.Path;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.v4.exception.HttpListenerPathMissingException;
+import io.gravitee.rest.api.service.v4.exception.InvalidHostException;
+import io.gravitee.rest.api.service.v4.exception.PathAlreadyExistsException;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class VerifyApiPathDomainServiceImpl implements VerifyApiPathDomainService {
+
+    private final EnvironmentRepository environmentRepository;
+    private final ApiRepository apiRepository;
+    private final ObjectMapper objectMapper;
+
+    public VerifyApiPathDomainServiceImpl(
+        @Lazy final EnvironmentRepository environmentRepository,
+        @Lazy final ApiRepository apiRepository,
+        final ObjectMapper objectMapper
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.apiRepository = apiRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<Path> verifyApiPaths(ExecutionContext executionContext, String apiId, List<Path> paths) {
+        if (paths == null || paths.isEmpty()) {
+            throw new HttpListenerPathMissingException();
+        }
+        List<Path> sanitizedPaths = paths
+            .stream()
+            .map(path -> Path.builder().host(path.getHost()).path(path.getPath()).build().sanitize())
+            .toList();
+
+        List<Path> pathsWithDomain = validateAndSetDomain(executionContext.getEnvironmentId(), sanitizedPaths);
+
+        checkNoDuplicate(pathsWithDomain);
+
+        checkPathsAreAvailable(executionContext.getEnvironmentId(), apiId, pathsWithDomain);
+
+        return pathsWithDomain;
+    }
+
+    private void checkNoDuplicate(List<Path> paths) {
+        var set = new HashSet<>();
+        var duplicates = paths.stream().filter(n -> !set.add(n)).toList();
+
+        if (!duplicates.isEmpty()) {
+            throw new PathAlreadyExistsException(duplicates.get(0).toString());
+        }
+    }
+
+    private void checkPathsAreAvailable(String environmentId, String apiId, List<Path> paths) {
+        apiRepository
+            .search(
+                new ApiCriteria.Builder().environmentId(environmentId).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+            .filter(api -> !api.getId().equals(apiId))
+            .map(this::extractPaths)
+            .filter(extractedPaths -> extractedPaths != null && !extractedPaths.isEmpty())
+            .forEach(existingPaths -> {
+                // Extract all paths with a host
+                Map<String, List<String>> registeredPathWithHosts = existingPaths
+                    .stream()
+                    .filter(path -> !Strings.isNullOrEmpty(path.getHost()))
+                    .collect(Collectors.groupingBy(Path::getHost, Collectors.mapping(Path::getPath, Collectors.toList())));
+
+                // Check only paths with a host and compare to registered virtual hosts
+                if (!registeredPathWithHosts.isEmpty()) {
+                    paths
+                        .stream()
+                        .filter(path -> !Strings.isNullOrEmpty(path.getHost()))
+                        .forEach(path -> checkPathNotYetRegistered(path.getPath(), registeredPathWithHosts.get(path.getHost())));
+                }
+
+                // Extract all paths without host
+                List<String> registeredPathWithoutHost = existingPaths
+                    .stream()
+                    .filter(path -> Strings.isNullOrEmpty(path.getHost()))
+                    .map(Path::getPath)
+                    .collect(Collectors.toList());
+
+                // Then check remaining paths without a host and compare to registered paths without host
+                if (!registeredPathWithoutHost.isEmpty()) {
+                    paths
+                        .stream()
+                        .filter(path -> Strings.isNullOrEmpty(path.getHost()))
+                        .forEach(virtualHost -> checkPathNotYetRegistered(virtualHost.getPath(), registeredPathWithoutHost));
+                }
+            });
+    }
+
+    private List<Path> extractPaths(final Api api) {
+        if (api.getDefinition() != null) {
+            if (api.getDefinitionVersion() == DefinitionVersion.V4) {
+                try {
+                    io.gravitee.definition.model.v4.Api apiDefinition = objectMapper.readValue(
+                        api.getDefinition(),
+                        io.gravitee.definition.model.v4.Api.class
+                    );
+                    return apiDefinition
+                        .getListeners()
+                        .stream()
+                        .filter(listener -> listener instanceof HttpListener)
+                        .map(listener -> (HttpListener) listener)
+                        .flatMap(httpListener ->
+                            httpListener
+                                .getPaths()
+                                .stream()
+                                .map(path -> Path.builder().host(path.getHost()).path(path.getPath()).build().sanitize())
+                        )
+                        .collect(Collectors.toList());
+                } catch (IOException ioe) {
+                    log.error("Unexpected error while getting API definition", ioe);
+                }
+            } else {
+                try {
+                    io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
+                        api.getDefinition(),
+                        io.gravitee.definition.model.Api.class
+                    );
+                    return apiDefinition
+                        .getProxy()
+                        .getVirtualHosts()
+                        .stream()
+                        .map(virtualHost -> Path.builder().host(virtualHost.getHost()).path(virtualHost.getPath()).build().sanitize())
+                        .collect(Collectors.toList());
+                } catch (IOException ioe) {
+                    log.error("Unexpected error while getting API definition", ioe);
+                }
+            }
+        }
+        return null;
+    }
+
+    private void checkPathNotYetRegistered(final String path, final List<String> registeredPaths) {
+        boolean match =
+            registeredPaths != null &&
+            registeredPaths.stream().anyMatch(registeredPath -> path.startsWith(registeredPath) || registeredPath.startsWith(path));
+
+        if (match) {
+            throw new PathAlreadyExistsException(path);
+        }
+    }
+
+    private List<Path> validateAndSetDomain(String environmentId, List<Path> sanitizedPaths) {
+        try {
+            var env = environmentRepository.findById(environmentId).orElseThrow(() -> new EnvironmentNotFoundException(environmentId));
+
+            var domainRestrictions = env.getDomainRestrictions();
+            if (domainRestrictions != null && !domainRestrictions.isEmpty()) {
+                return sanitizedPaths
+                    .stream()
+                    .map(path -> {
+                        if (path.hasHost()) {
+                            checkDomainIsValid(path, domainRestrictions);
+                            return path;
+                        }
+
+                        return path.withHost(env.getDomainRestrictions().get(0));
+                    })
+                    .collect(Collectors.toList());
+            }
+
+            return sanitizedPaths;
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private void checkDomainIsValid(Path path, List<String> domainRestrictions) {
+        String hostWithoutPort = path.getHost().split(":")[0];
+        if (!isValidDomainOrSubDomain(hostWithoutPort, domainRestrictions)) {
+            throw new InvalidHostException(hostWithoutPort, domainRestrictions);
+        }
+    }
+
+    private boolean isValidDomainOrSubDomain(String domain, List<String> domainRestrictions) {
+        boolean isSubDomain = false;
+        if (domainRestrictions.isEmpty()) {
+            return true;
+        }
+        for (String domainRestriction : domainRestrictions) {
+            InternetDomainName domainIDN = InternetDomainName.from(domain);
+            InternetDomainName parentIDN = InternetDomainName.from(domainRestriction);
+
+            if (domainIDN.equals(parentIDN)) {
+                return true;
+            }
+            while (!isSubDomain && domainIDN.hasParent()) {
+                isSubDomain = parentIDN.equals(domainIDN);
+                domainIDN = domainIDN.parent();
+            }
+            if (isSubDomain) {
+                break;
+            }
+        }
+        return isSubDomain;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/InvalidPathException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/InvalidPathException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.util.Maps;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+public class InvalidPathException extends AbstractManagementException {
+
+    private final String path;
+
+    public InvalidPathException(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "path.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Maps.<String, String>builder().put("path", path).build();
+    }
+
+    @Override
+    public String getMessage() {
+        return "Path [" + path + "] is invalid";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/PathTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/PathTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PathTest {
+
+    public static Stream<Arguments> sanitizeParams() {
+        return Stream.of(
+            Arguments.of(null, "/"),
+            Arguments.of("", "/"),
+            Arguments.of("path", "/path/"),
+            Arguments.of("/path", "/path/"),
+            Arguments.of("path/", "/path/"),
+            Arguments.of("//path/", "/path/"),
+            Arguments.of("path//subpath", "/path/subpath/")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitizeParams")
+    void should_add_initial_slash(String input, String expected) {
+        assertThat(Path.sanitizePath(input)).isEqualTo(expected);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/VerifyApiPathDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/VerifyApiPathDomainServiceImplTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.model.Path;
+import io.gravitee.apim.core.exception.InvalidPathException;
+import io.gravitee.apim.infra.adapter.GraviteeJacksonMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Proxy;
+import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
+import io.gravitee.rest.api.service.v4.exception.InvalidHostException;
+import io.gravitee.rest.api.service.v4.exception.PathAlreadyExistsException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VerifyApiPathDomainServiceImplTest {
+
+    public static final String ENVIRONMENT_ID = "environment-id";
+
+    @Mock
+    ApiRepository apiRepository;
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    VerifyApiPathDomainServiceImpl service;
+    private ObjectMapper objectMapper;
+
+    public static Stream<Arguments> sanitizePathParams() {
+        return Stream.of(
+            Arguments.of(null, "/"),
+            Arguments.of("", "/"),
+            Arguments.of("path", "/path/"),
+            Arguments.of("/path", "/path/"),
+            Arguments.of("path/", "/path/"),
+            Arguments.of("//path/", "/path/")
+        );
+    }
+
+    public static Stream<Arguments> sanitizeHostParams() {
+        return Stream.of(
+            Arguments.of(null, "domain.com"),
+            Arguments.of("domain.com:123", "domain.com:123"),
+            Arguments.of("domain.net", "domain.net"),
+            Arguments.of("sub.domain.com", "sub.domain.com"),
+            Arguments.of("lower.sub.domain.net:443", "lower.sub.domain.net:443")
+        );
+    }
+
+    @BeforeEach
+    void setup() {
+        objectMapper = GraviteeJacksonMapper.getInstance();
+        service = new VerifyApiPathDomainServiceImpl(environmentRepository, apiRepository, objectMapper);
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void should_return_an_exception_if_environment_not_found() {
+        // Given no environment
+
+        Throwable throwable = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().build()))
+        );
+
+        assertThat(throwable).isInstanceOf(EnvironmentNotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitizePathParams")
+    public void should_sanitize_path(String path, String expectedPath) {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        var res = service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path(path).build()));
+        assertThat(res).hasSize(1);
+        assertThat(res.get(0).getPath()).isEqualTo(expectedPath);
+        assertThat(res.get(0).getHost()).isNull();
+    }
+
+    @Test
+    public void should_throw_exception_if_path_is_invalid() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("invalid+path").build()))
+        );
+
+        assertThat(throwable).isInstanceOf(InvalidPathException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("sanitizeHostParams")
+    public void should_set_domain_with_domain_restrictions(String host, String expectedHost) {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        var res = service.verifyApiPaths(
+            GraviteeContext.getExecutionContext(),
+            "api-id",
+            List.of(Path.builder().host(host).path("/path/").build())
+        );
+
+        assertThat(res).hasSize(1);
+        assertThat(res.get(0).getPath()).isEqualTo("/path/");
+        assertThat(res.get(0).getHost()).isEqualTo(expectedHost);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "wrong-domain.com", "not-same-domain:8082" })
+    public void should_throw_exception_if_domain_is_invalid(String host) {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                "api-id",
+                List.of(Path.builder().host(host).path("/path/").build())
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(InvalidHostException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_duplicate_paths() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                null,
+                List.of(Path.builder().path("/abc/").build(), Path.builder().path("/path/").build(), Path.builder().path("/path/").build())
+            )
+        );
+        assertThat(throwable).isInstanceOf(PathAlreadyExistsException.class);
+        assertThat(throwable.getMessage()).contains("/path");
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_covered_by_other_api_for_api_creation() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("", "/path/")))));
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), null, List.of(Path.builder().path("/path/").build()))
+        );
+        assertThat(throwable).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v2() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("", "/path/")))));
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/").build()))
+        );
+        assertThat(throwable).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v2_with_default_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/").build()))
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v2_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                "api-id",
+                List.of(Path.builder().host("domain.com").path("/path/").build())
+            )
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_ignore_path_used_by_same_api_v2_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(
+            ENVIRONMENT_ID,
+            Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api-id", List.of(Pair.of("domain.com", "/path/"))))
+        );
+
+        // Check should be ok if same path but different domain
+        var res = service.verifyApiPaths(
+            GraviteeContext.getExecutionContext(),
+            "api-id",
+            List.of(Path.builder().host("domain.com").path("/path/").build())
+        );
+        assertThat(res).hasSize(1);
+        assertThat(res.get(0).getPath()).isEqualTo("/path/");
+        assertThat(res.get(0).getHost()).isEqualTo("domain.com");
+    }
+
+    @Test
+    public void should_throw_exception_if_path_is_subpath_of_another_api_v2() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of());
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of(null, "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/subpath").build()))
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_is_subpath_of_another_api_v2_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                "api-id",
+                List.of(Path.builder().host("domain.com").path("/path/subpath").build())
+            )
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v4() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("", "/path/")))));
+
+        var throwable = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().host("").path("/path/").build()))
+        );
+        assertThat(throwable).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_ignore_path_already_used_by_same_api_v4() {
+        givenExistingEnvironment(ENVIRONMENT_ID, null);
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api-id", List.of(Pair.of("", "/path/")))));
+
+        var res = service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/").build()));
+        assertThat(res).hasSize(1);
+        assertThat(res.get(0).getPath()).isEqualTo("/path/");
+        assertThat(res.get(0).getHost()).isNullOrEmpty();
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v4_with_default_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/").build()))
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_already_used_by_api_v4_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                "api-id",
+                List.of(Path.builder().host("domain.com").path("/path/").build())
+            )
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_ignore_path_used_by_same_api_v4_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(
+            ENVIRONMENT_ID,
+            Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api-id", List.of(Pair.of("domain.com", "/path/"))))
+        );
+
+        // Check should be ok if same path but different domain
+        var res = service.verifyApiPaths(
+            GraviteeContext.getExecutionContext(),
+            "api-id",
+            List.of(Path.builder().host("domain.com").path("/path/").build())
+        );
+        assertThat(res).hasSize(1);
+        assertThat(res.get(0).getPath()).isEqualTo("/path/");
+        assertThat(res.get(0).getHost()).isEqualTo("domain.com");
+    }
+
+    @Test
+    public void should_throw_exception_if_path_is_subpath_of_another_api_v4() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of());
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of(null, "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(GraviteeContext.getExecutionContext(), "api-id", List.of(Path.builder().path("/path/subpath").build()))
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @Test
+    public void should_throw_exception_if_path_is_subpath_of_another_api_v4_with_host() {
+        givenExistingEnvironment(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
+
+        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
+
+        // If domain is not set, first domain of domain restriction is used
+        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
+            service.verifyApiPaths(
+                GraviteeContext.getExecutionContext(),
+                "api-id",
+                List.of(Path.builder().host("domain.com").path("/path/subpath").build())
+            )
+        );
+        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(PathAlreadyExistsException.class);
+    }
+
+    @SneakyThrows
+    private void givenExistingEnvironment(String environmentId, List<String> domainRestrictions) {
+        var env = new Environment();
+        env.setId(environmentId);
+        env.setDomainRestrictions(domainRestrictions);
+
+        lenient().when(environmentRepository.findById(any())).thenReturn(Optional.empty());
+        lenient().when(environmentRepository.findById(environmentId)).thenReturn(Optional.of(env));
+    }
+
+    private void givenExistingApis(String environmentId, Stream<Api> apis) {
+        lenient()
+            .when(
+                apiRepository.search(
+                    eq(new ApiCriteria.Builder().environmentId(environmentId).build()),
+                    eq(null),
+                    eq(new ApiFieldFilter.Builder().excludePicture().build())
+                )
+            )
+            .thenReturn(apis);
+    }
+
+    @SneakyThrows
+    private Api buildApiV2WithPaths(String environmentId, String apiId, List<Pair<String, String>> paths) {
+        io.gravitee.definition.model.Api apiDefV2 = new io.gravitee.definition.model.Api();
+        Proxy proxy = new Proxy();
+        proxy.setVirtualHosts(
+            paths
+                .stream()
+                .map(p -> {
+                    VirtualHost virtualHost = new VirtualHost();
+                    virtualHost.setHost(p.getLeft());
+                    virtualHost.setPath(p.getRight());
+                    return virtualHost;
+                })
+                .collect(Collectors.toList())
+        );
+        apiDefV2.setProxy(proxy);
+
+        Api api = new Api();
+        api.setId(apiId);
+        api.setEnvironmentId(environmentId);
+        api.setDefinitionVersion(DefinitionVersion.V2);
+        api.setDefinition(objectMapper.writeValueAsString(apiDefV2));
+        return api;
+    }
+
+    @SneakyThrows
+    private Api buildApiV4WithPaths(String environmentId, String apiId, List<Pair<String, String>> paths) {
+        io.gravitee.definition.model.v4.Api apiDefV4 = new io.gravitee.definition.model.v4.Api();
+
+        HttpListener listener = HttpListener
+            .builder()
+            .paths(
+                paths
+                    .stream()
+                    .map(p -> io.gravitee.definition.model.v4.listener.http.Path.builder().host(p.getLeft()).path(p.getRight()).build())
+                    .collect(Collectors.toList())
+            )
+            .build();
+        apiDefV4.setListeners(List.of(listener));
+        apiDefV4.setId(apiId);
+
+        Api api = new Api();
+        api.setId(apiId);
+        api.setEnvironmentId(environmentId);
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setDefinition(objectMapper.writeValueAsString(apiDefV4));
+        return api;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2295

## Description

In this PR, I have clean context path validation on front-end side, and remove useless check that contextPath must be at least 3 chars. I also split the contextPath validation so uniqueness of the path is check only in simple context path mode (not for virtual host)
I also migrate context path validation to management API V2 (I created a use case for that, just like we agreed during tech sprint), and use this new service in context path components for API V4

Other PRs will come to
- use same component for V2 and V4 edition
- remove existing API in MAPI V1
- clean useless code
- maybe use new domain service in API creation workflow to properly check paths before API creation

Other questions to answer:
- is path displayed in API list correct. There might be some issues specially when using virtual host.
- is it relevant or possible to disable virtual host mode when environment has domain restrictions ? Right now we can always disable virtual host mode on API V4 but it probably does not make sense when domain restrictions exist.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hzfhldmjou.chromatic.com)
<!-- Storybook placeholder end -->
