### PR TITLE
fix(sync): order subscriptions during incremental sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppender.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +79,10 @@ public class ApiKeyAppender {
             } else {
                 criteriaBuilder.includeRevoked(true);
             }
-            List<io.gravitee.repository.management.model.ApiKey> bySubscriptions = apiKeyRepository.findByCriteria(criteriaBuilder.build());
+            List<io.gravitee.repository.management.model.ApiKey> bySubscriptions = apiKeyRepository.findByCriteria(
+                criteriaBuilder.build(),
+                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
+            );
             return bySubscriptions
                 .stream()
                 .flatMap(apiKey ->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -25,7 +25,10 @@ import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.mapper.SubscriptionMapper;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -80,7 +83,7 @@ public class SubscriptionAppender {
 
         try {
             return subscriptionRepository
-                .search(criteriaBuilder.build())
+                .search(criteriaBuilder.build(), new SortableBuilder().field("updatedAt").order(Order.ASC).build())
                 .stream()
                 .map(subscription -> {
                     Subscription subscriptionConverted = subscriptionMapper.to(subscription);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppenderTest.java
@@ -93,7 +93,7 @@ class ApiKeyAppenderTest {
         e1.setSubscriptions(List.of("subscription1"));
         ApiKey e2 = new ApiKey();
         e2.setSubscriptions(List.of("subscription1"));
-        when(apiKeyRepository.findByCriteria(any())).thenReturn(List.of(e1, e2));
+        when(apiKeyRepository.findByCriteria(any(), any())).thenReturn(List.of(e1, e2));
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable
             .builder()
             .apiId("api2")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -90,7 +90,7 @@ class SubscriptionAppenderTest {
         io.gravitee.repository.management.model.Subscription subscription2 = new io.gravitee.repository.management.model.Subscription();
         subscription2.setId("sub2");
         subscription2.setApi("api1");
-        when(subscriptionRepository.search(any())).thenReturn(List.of(subscription1, subscription2));
+        when(subscriptionRepository.search(any(), any())).thenReturn(List.of(subscription1, subscription2));
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable
             .builder()
             .apiId("api2")


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2745

## Description

During incremental sync, accepted subscriptions have to be cached after all other kind of subscriptions.
By doing this, we avoid an accepted subscription to be removed from cache by a closed one, sharing the same key (appId, clientId, planId).