### PR TITLE
Use medium executor for Gateway tests and improve script to find base branch

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-test-gateway.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-gateway.ts
@@ -45,7 +45,7 @@ cat tests-to-run
 # Run tests
 mvn --fail-fast -s ../${config.maven.settingsFile} test --no-transfer-progress -Dskip.validation=true -Dsurefire.excludesFile=/tmp/ignore_list`,
       }),
-      OpenJdkExecutor.create('small'),
+      OpenJdkExecutor.create('medium'),
       ['gravitee-apim-gateway/gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/'],
       {
         parallelism: 4,

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -296,7 +296,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -177,7 +177,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -263,7 +263,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -296,7 +296,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -263,7 +263,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -263,7 +263,7 @@ jobs:
   job-test-gateway:
     docker:
       - image: cimg/openjdk:17.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,42 @@ jobs:
                                 fi;
 
                                 if [ "x${CIRCLE_PULL_REQUEST}" == "x" ]; then
-                                  echo "No pull request -> stopping build"
+                                  echo "No opened pull request for this branch -> try to find the base branch with commits."
+                                  # Loop over the last 100 commits maximum and find the first commit that is on a branch matching `master` or `[0-9].[0-9].x`
+                                  MAX_COMMITS=100
+                                
+                                  # Define the pattern for matching branch names: master or [0-9].[0-9].x
+                                  PATTERN="master|[0-9]+\.[0-9]+\.x"
+                                
+                                  # Loop over the last $MAX_COMMITS commits
+                                  for (( i = 0; i < MAX_COMMITS; i++ )); do
+                                    # Get the commit hash
+                                    hash=$(git rev-parse HEAD~$i)
+                                  
+                                    # Get the branch name that contains the commit hash and matches the pattern
+                                    branch=$(git --no-pager branch --contains $hash | grep -oE $PATTERN || true)
+                                  
+                                    # If the branch name is not empty, then the matching branch has been found
+                                    if [ -n "$branch" ]; then
+                                      BASE_REF=$branch
+                                      echo "Base branch is $branch (common ancestor is commit: $hash)"
+                                      break
+                                    fi
+                                  done
+                                
+                                # else use the pull request info
+                                else
+                                  PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
+                                  BASE_REF=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL} | jq -r '.base.ref // "master"')
+                                fi;
+                              
+                                # if BASE_REF is empty just stop
+                                if [ "x${BASE_REF}" == "x" ]; then
+                                  echo "No base branch found, stopping"
                                   circleci step halt
                                 fi;
-
-                                PULL_REQUEST_URL=$(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//")
-                                BASE_REF=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" ${PULL_REQUEST_URL} | jq -r '.base.ref // "master"')
+                                
                                 echo "export GIT_BASE_BRANCH=${BASE_REF}" >> $BASH_ENV
-
                                 echo "The base branch is ${BASE_REF}"
 
             - node/install-packages:


### PR DESCRIPTION
## Issue

NA

## Description

### Medium executor for Gateway tests

When using a small executor the CPU is always at 100% and it can lead to flaky tests

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/1d7dcdd4-9ffc-41e1-b0ef-56f8a1e032cd)

### Improve the script used to find the base branch
 
The CI was not triggered if there is no opened PR because it is not able to find the base branch your branch has been created from. With the updated script, if there is no opened PR it will: walk through the git history (max 100 commits) and check if a commit is both on your branch and master (or a support branch). 
 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fyoqbmgyxc.chromatic.com)
<!-- Storybook placeholder end -->
