### PR TITLE
fix: avoid having double slash at the beginning of the context path

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
@@ -18,7 +18,7 @@ import faker from '@faker-js/faker';
 
 describe('API creation workflow', () => {
   const apiVersion = `${faker.datatype.number({ min: 1, max: 9 })}.${faker.datatype.number({ min: 1, max: 9 })}`;
-  const apiPath = `/${faker.commerce.productName().replace(/ /g, '_')}`;
+  const apiPath = `${faker.commerce.productName().replace(/ /g, '_')}`;
   const apiName = faker.commerce.productName();
   let apiId: string;
 
@@ -93,7 +93,7 @@ describe('API creation workflow', () => {
     });
 
     it('should successfully connect to created API', function () {
-      cy.callGateway(`${apiPath}`).then((response) => {
+      cy.callGateway(`/${apiPath}`).then((response) => {
         expect(response.body.message).to.eq('Hello, World!'); // from wiremock
       });
     });


### PR DESCRIPTION
## Issue

N.A.

## Description

Fix failing E2E tests (context path should not start with double slash
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pkewybfpcl.chromatic.com)
<!-- Storybook placeholder end -->
