### PR TITLE
publish env on demand url on GH pr description

### DIFF
--- a/.circleci/ci/src/jobs/job-publish-pr-env-urls.ts
+++ b/.circleci/ci/src/jobs/job-publish-pr-env-urls.ts
@@ -30,6 +30,8 @@ export class PublishPrEnvUrlsJob {
     dynamicConfig.addReusableCommand(notifyOnFailureCommand);
 
     return new Job(PublishPrEnvUrlsJob.jobName, NodeLtsExecutor.create('small'), [
+      new commands.Checkout(),
+      new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.githubApiToken,
         'var-name': 'GITHUB_TOKEN',

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -296,6 +296,9 @@ jobs:
       - image: cimg/node:16.10
     resource_class: small
     steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -248,6 +248,9 @@ jobs:
       - image: cimg/node:16.10
     resource_class: small
     steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -296,6 +296,9 @@ jobs:
       - image: cimg/node:16.10
     resource_class: small
     steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - keeper/env-export:
           secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
           var-name: GITHUB_TOKEN


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Today the environment on demand urls are not publish in the pull request description. Here is a pr to fix it

It has been tester here https://github.com/gravitee-io/gravitee-api-management/pull/5346

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gpehacxqyf.chromatic.com)
<!-- Storybook placeholder end -->
