### PR TITLE
fix(logs): manage field nullity during log search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtils.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JsonNodeUtils {
+
+    public static String asTextOrNull(JsonNode jsonNode) {
+        return jsonNode != null ? jsonNode.asText() : null;
+    }
+
+    public static int asIntOr(JsonNode jsonNode, int defaultValue) {
+        return jsonNode != null ? jsonNode.asInt() : defaultValue;
+    }
+
+    public static boolean asBooleanOrFalse(JsonNode jsonNode) {
+        return jsonNode != null && jsonNode.asBoolean();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogResponseAdapter.java
@@ -15,12 +15,18 @@
  */
 package io.gravitee.repository.elasticsearch.v4.log.adapter.connection;
 
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asBooleanOrFalse;
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asIntOr;
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asTextOrNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.elasticsearch.utils.JsonNodeUtils;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
 import java.util.List;
+import java.util.Optional;
 
 public class SearchConnectionLogResponseAdapter {
 
@@ -42,15 +48,15 @@ public class SearchConnectionLogResponseAdapter {
         return ConnectionLog
             .builder()
             .requestId(json.get("request-id").asText())
-            .timestamp(json.get("@timestamp").asText())
-            .applicationId(json.get("application-id").asText())
-            .apiId(json.get("api-id").asText())
-            .planId(json.get("plan-id").asText())
-            .clientIdentifier(json.get("client-identifier").asText())
-            .transactionId(json.get("transaction-id").asText())
-            .method(HttpMethod.get(json.get("http-method").asInt()))
-            .status(json.get("status").asInt())
-            .requestEnded(json.get("request-ended").asBoolean())
+            .timestamp(asTextOrNull(json.get("@timestamp")))
+            .applicationId(asTextOrNull(json.get("application-id")))
+            .apiId(asTextOrNull(json.get("api-id")))
+            .planId(asTextOrNull(json.get("plan-id")))
+            .clientIdentifier(asTextOrNull(json.get("client-identifier")))
+            .transactionId(asTextOrNull(json.get("transaction-id")))
+            .method(HttpMethod.get(asIntOr(json.get("http-method"), 0)))
+            .status(asIntOr(json.get("status"), 0))
+            .requestEnded(asBooleanOrFalse(json.get("request-ended")))
             .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/message/SearchMessageLogResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/message/SearchMessageLogResponseAdapter.java
@@ -15,8 +15,11 @@
  */
 package io.gravitee.repository.elasticsearch.v4.log.adapter.message;
 
+import static io.gravitee.repository.elasticsearch.utils.JsonNodeUtils.asTextOrNull;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.elasticsearch.utils.JsonNodeUtils;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.message.MessageLog;
 import java.util.List;
@@ -44,20 +47,20 @@ public class SearchMessageLogResponseAdapter {
         final JsonNode messageJson = json.get("message");
         return MessageLog
             .builder()
-            .apiId(json.get("api-id").asText())
-            .requestId(json.get("request-id").asText())
-            .timestamp(json.get("@timestamp").asText())
-            .clientIdentifier(json.get("client-identifier").asText())
-            .correlationId(json.get("correlation-id").asText())
-            .operation(json.get("operation").asText())
-            .connectorId(json.get("connector-id").asText())
-            .connectorType(json.get("connector-type").asText())
+            .apiId(asTextOrNull(json.get("api-id")))
+            .requestId(asTextOrNull(json.get("request-id")))
+            .timestamp(asTextOrNull(json.get("@timestamp")))
+            .clientIdentifier(asTextOrNull(json.get("client-identifier")))
+            .correlationId(asTextOrNull(json.get("correlation-id")))
+            .operation(asTextOrNull(json.get("operation")))
+            .connectorId(asTextOrNull(json.get("connector-id")))
+            .connectorType(asTextOrNull(json.get("connector-type")))
             .message(
                 MessageLog.Message
                     .builder()
-                    .id(messageJson.get("id").asText())
+                    .id(asTextOrNull(messageJson.get("id")))
                     .isError(messageJson.get("isError") != null && messageJson.get("isError").asBoolean())
-                    .payload(messageJson.get("payload").asText())
+                    .payload(asTextOrNull(messageJson.get("payload")))
                     .headers(
                         messageJson
                             .get("headers")
@@ -69,8 +72,8 @@ public class SearchMessageLogResponseAdapter {
                                     entry ->
                                         StreamSupport
                                             .stream(entry.getValue().spliterator(), false)
-                                            .map(JsonNode::asText)
-                                            .collect(Collectors.toList())
+                                            .map(JsonNodeUtils::asTextOrNull)
+                                            .toList()
                                 )
                             )
                     )
@@ -79,7 +82,7 @@ public class SearchMessageLogResponseAdapter {
                             .get("metadata")
                             .properties()
                             .stream()
-                            .collect(Collectors.toMap(Map.Entry::getKey, value -> value.getValue().asText()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, value -> asTextOrNull(value.getValue())))
                     )
                     .build()
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtilsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/JsonNodeUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JsonNodeUtilsTest {
+
+    @Test
+    void should_get_field_as_text() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", "value");
+        assertThat(JsonNodeUtils.asTextOrNull(jsonNode.get("key"))).isEqualTo("value");
+    }
+
+    @Test
+    void should_get_null_text() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", "value");
+        assertThat(JsonNodeUtils.asTextOrNull(jsonNode.get("absent-key"))).isNull();
+    }
+
+    @Test
+    void should_get_field_as_int() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", 1);
+        assertThat(JsonNodeUtils.asIntOr(jsonNode.get("key"), -1)).isOne();
+    }
+
+    @Test
+    void should_get_default_int() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", 1);
+        assertThat(JsonNodeUtils.asIntOr(jsonNode.get("absent-key"), -1)).isEqualTo(-1);
+    }
+
+    @Test
+    void should_get_field_as_boolean() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", true);
+        assertThat(JsonNodeUtils.asBooleanOrFalse(jsonNode.get("key"))).isTrue();
+    }
+
+    @Test
+    void should_get_false() {
+        final JsonNode jsonNode = JsonNodeFactory.instance.objectNode().put("key", true);
+        assertThat(JsonNodeUtils.asBooleanOrFalse(jsonNode.get("absent-key"))).isFalse();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/usecase/log/SearchConnectionLogUsecase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/usecase/log/SearchConnectionLogUsecase.java
@@ -37,6 +37,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class SearchConnectionLogUsecase {
 
+    static final String UNKNOWN = "Unknown";
     private final ConnectionLogCrudService connectionLogCrudService;
     private final PlanCrudService planCrudService;
     private final ApplicationCrudService applicationCrudService;
@@ -72,7 +73,7 @@ public class SearchConnectionLogUsecase {
             .requestId(connectionLog.getRequestId())
             .timestamp(connectionLog.getTimestamp())
             .application(getApplicationEntity(executionContext, connectionLog.getApplicationId()))
-            .clientIdentifier(connectionLog.getClientIdentifier())
+            .clientIdentifier(connectionLog.getClientIdentifier() != null ? connectionLog.getClientIdentifier() : UNKNOWN)
             .method(connectionLog.getMethod())
             .plan(getPlanInfo(connectionLog.getPlanId()))
             .requestEnded(connectionLog.isRequestEnded())
@@ -82,10 +83,11 @@ public class SearchConnectionLogUsecase {
     }
 
     private GenericPlanEntity getPlanInfo(String planId) {
+        final BasePlanEntity unknownPlan = BasePlanEntity.builder().id(planId).name(UNKNOWN).build();
         try {
-            return planCrudService.findById(planId);
+            return planId != null ? planCrudService.findById(planId) : unknownPlan;
         } catch (PlanNotFoundException | TechnicalManagementException e) {
-            return BasePlanEntity.builder().id(planId).name("Unknown plan").build();
+            return unknownPlan;
         }
     }
 
@@ -93,7 +95,7 @@ public class SearchConnectionLogUsecase {
         try {
             return applicationCrudService.findById(executionContext, applicationId);
         } catch (ApplicationNotFoundException | TechnicalManagementException e) {
-            return BaseApplicationEntity.builder().id(applicationId).name("Unknown application").build();
+            return BaseApplicationEntity.builder().id(applicationId).name(UNKNOWN).build();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
@@ -18,6 +18,7 @@ package inmemory;
 import io.gravitee.apim.crud_service.plan.PlanCrudService;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +29,9 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryCrudSer
 
     @Override
     public GenericPlanEntity findById(String planId) {
+        if (planId == null) {
+            throw new TechnicalManagementException("planId should not be null");
+        }
         return storage
             .stream()
             .filter(plan -> planId.equals(plan.getId()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/usecase/log/SearchConnectionLogUsecaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/usecase/log/SearchConnectionLogUsecaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.usecase.log;
 
+import static io.gravitee.apim.usecase.log.SearchConnectionLogUsecase.UNKNOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -157,7 +158,19 @@ public class SearchConnectionLogUsecaseTest {
         var result = usecase.execute(GraviteeContext.getExecutionContext(), new Request(API_ID, USER_ID));
         assertThat(result.data())
             .extracting(ConnectionLogModel::getPlan)
-            .isEqualTo(List.of(BasePlanEntity.builder().id(unknownPlan).name("Unknown plan").build()));
+            .isEqualTo(List.of(BasePlanEntity.builder().id(unknownPlan).name(UNKNOWN).build()));
+    }
+
+    @Test
+    void should_return_api_connection_logs_with_only_available_info() {
+        logStorageService.initWith(
+            List.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(null).clientIdentifier(null).applicationId("1").build())
+        );
+
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new Request(API_ID, USER_ID));
+        assertThat(result.data())
+            .extracting(ConnectionLogModel::getPlan)
+            .isEqualTo(List.of(BasePlanEntity.builder().id(null).name(UNKNOWN).build()));
     }
 
     @Test
@@ -169,6 +182,6 @@ public class SearchConnectionLogUsecaseTest {
         var result = usecase.execute(GraviteeContext.getExecutionContext(), new Request(API_ID, USER_ID));
         assertThat(result.data())
             .extracting(ConnectionLogModel::getApplication)
-            .isEqualTo(List.of(BaseApplicationEntity.builder().id(unknownApp).name("Unknown application").build()));
+            .isEqualTo(List.of(BaseApplicationEntity.builder().id(unknownApp).name(UNKNOWN).build()));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2796

## Description

For some request, like Unauthorized ones, me miss some fields in the log entry in elastic search. We have to check nullity to avoid NPE

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mqfomwiheq.chromatic.com)
<!-- Storybook placeholder end -->
