### PR TITLE
Fix Slack notification on failure

### DIFF
--- a/.circleci/ci/src/commands/cmd-notify-on-failure.ts
+++ b/.circleci/ci/src/commands/cmd-notify-on-failure.ts
@@ -18,7 +18,6 @@ import { ReusableCommand } from '@circleci/circleci-config-sdk/dist/src/lib/Comp
 import { config } from '../config';
 import { keeper } from '../orbs/keeper';
 import { slack } from '../orbs/slack';
-import { supportBranchPattern } from '../utils';
 
 export class NotifyOnFailureCommand {
   private static commandName = 'cmd-notify-on-failure';
@@ -34,7 +33,7 @@ export class NotifyOnFailureCommand {
       }),
       new reusable.ReusedCommand(slack.commands.notify, {
         channel: config.slack.channels.apiManagementTeamNotifications,
-        branch_pattern: `master,${supportBranchPattern}`,
+        branch_pattern: 'master,[0-9]+\\.[0-9]+\\.x', // Slack orb only supports POSIX regex. So we must use [0-9] instead of \d.
         event: 'fail',
         template: 'basic_fail_1',
       }),

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
 jobs:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-webui-install:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -54,7 +54,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
   cmd-create-docker-context:

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -62,7 +62,7 @@ commands:
           var-name: SLACK_ACCESS_TOKEN
       - slack/notify:
           channel: C02JENTV2AX
-          branch_pattern: master,\d+\.\d+\.x
+          branch_pattern: master,[0-9]+\.[0-9]+\.x
           event: fail
           template: basic_fail_1
 jobs:


### PR DESCRIPTION
## Issue

N/A

## Description

According to https://circleci.com/developer/orbs/orb/circleci/slack#jobs-on-hold, slack orb only accepts POSIX regex. So we must use `[0-9]` instead of `\d`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jusvqpwpum.chromatic.com)
<!-- Storybook placeholder end -->
