### PR TITLE
Console - Start to migrate endpoints configuration to mapiv2

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
@@ -87,7 +87,7 @@ export function fakeBaseApi(modifier?: Partial<BaseApi> | ((baseApi: BaseApi) =>
 
 export function fakeApiV1(modifier?: Partial<ApiV1> | ((baseApi: ApiV1) => ApiV1)): ApiV1 {
   const base: ApiV1 = {
-    ...fakeBaseApi(modifier),
+    ...fakeBaseApi(),
     definitionVersion: 'V1',
     environmentId: 'my-environment',
     entrypoints: [
@@ -156,7 +156,7 @@ export function fakeApiV1(modifier?: Partial<ApiV1> | ((baseApi: ApiV1) => ApiV1
 
 export function fakeApiV2(modifier?: Partial<ApiV2> | ((baseApi: ApiV2) => ApiV2)): ApiV2 {
   const base: ApiV2 = {
-    ...fakeBaseApi(modifier),
+    ...fakeBaseApi(),
     definitionVersion: 'V2',
     entrypoints: [
       {
@@ -265,7 +265,7 @@ export function fakeApiV2(modifier?: Partial<ApiV2> | ((baseApi: ApiV2) => ApiV2
 
 export function fakeApiV4(modifier?: Partial<ApiV4> | ((baseApi: ApiV4) => ApiV4)): ApiV4 {
   const base: ApiV4 = {
-    ...fakeBaseApi({ ...modifier }),
+    ...fakeBaseApi(),
     definitionVersion: 'V4',
     type: 'MESSAGE',
     listeners: [

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v2/endpointGroupV2.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v2/endpointGroupV2.ts
@@ -19,6 +19,7 @@ import { HttpClientSslOptions } from './httpClientSslOptions';
 import { HttpProxy } from './httpProxy';
 import { HttpClientOptions } from './httpClientOptions';
 import { EndpointDiscoveryService } from './endpointDiscoveryService';
+import { HttpHeader } from './httpHeader';
 
 import { LoadBalancer } from '../loadBalancer';
 
@@ -40,4 +41,5 @@ export interface EndpointGroupV2 {
   httpProxy?: HttpProxy;
   httpClientOptions?: HttpClientOptions;
   httpClientSslOptions?: HttpClientSslOptions;
+  headers?: HttpHeader[];
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
@@ -15,4 +15,116 @@
     limitations under the License.
 
 -->
-🚧🚧🚧
+<ng-container *ngIf="httpConfigFormGroup" [formGroup]="httpConfigFormGroup">
+  <ng-container formGroupName="httpClientOptions">
+    <h2>HTTP Options</h2>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>HTTP Protocol version</mat-label>
+      <mat-select formControlName="version">
+        <mat-option *ngFor="let version of httpVersions" [value]="version.value">{{ version.label }}</mat-option>
+      </mat-select>
+      <mat-hint>HTTP protocol version to use</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Connect timeout</mat-label>
+      <input matInput formControlName="connectTimeout" type="number" />
+      <mat-hint>Maximum time to connect to the remote host. (in milliseconds)</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Read timeout</mat-label>
+      <input matInput formControlName="readTimeout" type="number" />
+      <mat-hint>Maximum time to complete the request, including response. (in milliseconds)</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Idle timeout</mat-label>
+      <input matInput formControlName="idleTimeout" type="number" />
+      <mat-hint>Maximum time a connection will timeout and be closed if no data is received within the timeout. (in milliseconds)</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Max Concurrent Connections</mat-label>
+      <input matInput formControlName="maxConcurrentConnections" type="number" />
+      <mat-hint>Maximum pool size for connections.</mat-hint>
+    </mat-form-field>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Allow h2c Clear Text Upgrade</gio-form-label>
+      If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly
+      (with prior knowledge)
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="clearTextUpgrade"
+        aria-label="Allow h2c Clear Text Upgrade"
+        name="clearTextUpgrade"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Enable keep-alive</gio-form-label>
+      Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.
+      <mat-slide-toggle gioFormSlideToggle formControlName="keepAlive" aria-label="Enable keep-alive" name="keepAlive"></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Enable HTTP pipelining</gio-form-label>
+      When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="pipelining"
+        aria-label="Enable HTTP pipelining"
+        name="pipelining"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Follow HTTP redirects</gio-form-label>
+      When the client receives a status code in the range 3xx, it follows the redirection provided by the Location response header
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="followRedirects"
+        aria-label="Follow HTTP redirects"
+        name="followRedirects"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Enable compression (gzip, deflate)</gio-form-label>
+      The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed
+      response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote
+      server.
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="useCompression"
+        aria-label="Enable compression (gzip, deflate)"
+        name="useCompression"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Propagate client Accept-Encoding header (no decompression if any)</gio-form-label>
+      The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway
+      will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to
+      apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. DO NOT
+      activate this option if you plan to play with body responses.
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="propagateClientAcceptEncoding"
+        aria-label="Propagate client Accept-Encoding header (no decompression if any)"
+        name="propagateClientAcceptEncoding"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+  </ng-container>
+
+  <h2>HTTP Headers</h2>
+  🚧
+
+  <h2>Proxy Options</h2>
+  🚧
+
+  <h2>SSL Options</h2>
+  🚧
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+🚧🚧🚧

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
@@ -124,8 +124,58 @@
     <gio-form-headers [headerFieldMapper]="{ keyName: 'name', valueName: 'value' }" formControlName="headers"></gio-form-headers>
   </div>
 
-  <h2>Proxy Options</h2>
-  🚧
+  <div class="proxyOptions" formGroupName="httpProxy">
+    <h2>Proxy Options</h2>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Use proxy</gio-form-label>
+      Use proxy for client connections
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="enabled"
+        aria-label="Use proxy for client connections"
+        name="enabled"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <gio-form-slide-toggle class="endpointHttpConfig__formField">
+      <gio-form-label>Use system proxy</gio-form-label>
+      Use proxy configured at system level
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="useSystemProxy"
+        aria-label="Use proxy configured at system level"
+        name="useSystemProxy"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Proxy Type</mat-label>
+      <mat-select formControlName="type">
+        <mat-option *ngFor="let type of proxyTypes" [value]="type.value">{{ type.label }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Proxy host</mat-label>
+      <input matInput formControlName="host" />
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Proxy port</mat-label>
+      <input matInput formControlName="port" type="number" />
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Proxy username</mat-label>
+      <input matInput formControlName="username" />
+    </mat-form-field>
+
+    <mat-form-field class="endpointHttpConfig__formField">
+      <mat-label>Proxy password</mat-label>
+      <input matInput formControlName="password" type="password" />
+    </mat-form-field>
+  </div>
 
   <h2>SSL Options</h2>
   🚧

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.html
@@ -16,7 +16,7 @@
 
 -->
 <ng-container *ngIf="httpConfigFormGroup" [formGroup]="httpConfigFormGroup">
-  <ng-container formGroupName="httpClientOptions">
+  <div class="httpClientOptions" formGroupName="httpClientOptions">
     <h2>HTTP Options</h2>
 
     <mat-form-field class="endpointHttpConfig__formField">
@@ -117,10 +117,12 @@
         name="propagateClientAcceptEncoding"
       ></mat-slide-toggle>
     </gio-form-slide-toggle>
-  </ng-container>
+  </div>
 
-  <h2>HTTP Headers</h2>
-  🚧
+  <div class="headers">
+    <h2>HTTP Headers</h2>
+    <gio-form-headers [headerFieldMapper]="{ keyName: 'name', valueName: 'value' }" formControlName="headers"></gio-form-headers>
+  </div>
 
   <h2>Proxy Options</h2>
   🚧

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
@@ -1,3 +1,6 @@
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 
+.endpointHttpConfig__formField {
+  width: 100%;
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
@@ -6,6 +6,7 @@
 }
 
 .httpClientOptions,
-.headers {
+.headers,
+.proxyOptions {
   padding-bottom: 24px;
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
@@ -1,0 +1,3 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.scss
@@ -4,3 +4,8 @@
 .endpointHttpConfig__formField {
   width: 100%;
 }
+
+.httpClientOptions,
+.headers {
+  padding-bottom: 24px;
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
@@ -25,6 +25,7 @@ import { EndpointHttpConfigModule } from './endpoint-http-config.module';
 import { EndpointHttpConfigHarness } from './endpoint-http-config.harness';
 
 import { GioHttpTestingModule } from '../../../../../../shared/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 describe('ApiPropertiesComponent', () => {
   let fixture: ComponentFixture<EndpointHttpConfigComponent>;
@@ -34,7 +35,7 @@ describe('ApiPropertiesComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioHttpTestingModule, EndpointHttpConfigModule],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, EndpointHttpConfigModule, MatIconTestingModule],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {
@@ -76,17 +77,20 @@ describe('ApiPropertiesComponent', () => {
     const values = await endpointHttpConfigHarness.getHttpConfigValues();
 
     expect(values).toEqual({
-      clearTextUpgrade: true,
-      connectTimeout: 1000,
-      followRedirects: true,
-      idleTimeout: 1000,
-      keepAlive: true,
-      maxConcurrentConnections: 1000,
-      pipelining: true,
-      propagateClientAcceptEncoding: false,
-      readTimeout: 1000,
-      useCompression: true,
-      version: 'HTTP/2',
+      httpClientOptions: {
+        clearTextUpgrade: true,
+        connectTimeout: 1000,
+        followRedirects: true,
+        idleTimeout: 1000,
+        keepAlive: true,
+        maxConcurrentConnections: 1000,
+        pipelining: true,
+        propagateClientAcceptEncoding: false,
+        readTimeout: 1000,
+        useCompression: true,
+        version: 'HTTP/2',
+      },
+      headers: [],
     });
   });
 
@@ -100,17 +104,20 @@ describe('ApiPropertiesComponent', () => {
     expect(await clearTextUpgrade.isDisabled()).toEqual(true);
 
     expect(await endpointHttpConfigHarness.getHttpConfigValues()).toEqual({
-      clearTextUpgrade: false,
-      connectTimeout: 1000,
-      followRedirects: true,
-      idleTimeout: 1000,
-      keepAlive: true,
-      maxConcurrentConnections: 1000,
-      pipelining: true,
-      propagateClientAcceptEncoding: false,
-      readTimeout: 1000,
-      useCompression: true,
-      version: 'HTTP/1.1',
+      httpClientOptions: {
+        clearTextUpgrade: false,
+        connectTimeout: 1000,
+        followRedirects: true,
+        idleTimeout: 1000,
+        keepAlive: true,
+        maxConcurrentConnections: 1000,
+        pipelining: true,
+        propagateClientAcceptEncoding: false,
+        readTimeout: 1000,
+        useCompression: true,
+        version: 'HTTP/1.1',
+      },
+      headers: [],
     });
   });
 
@@ -124,17 +131,48 @@ describe('ApiPropertiesComponent', () => {
     await propagateClientAcceptEncoding.toggle();
 
     expect(await endpointHttpConfigHarness.getHttpConfigValues()).toEqual({
-      clearTextUpgrade: true,
-      connectTimeout: 1000,
-      followRedirects: true,
-      idleTimeout: 1000,
-      keepAlive: true,
-      maxConcurrentConnections: 1000,
-      pipelining: true,
-      propagateClientAcceptEncoding: true,
-      readTimeout: 1000,
-      useCompression: false,
-      version: 'HTTP/2',
+      httpClientOptions: {
+        clearTextUpgrade: true,
+        connectTimeout: 1000,
+        followRedirects: true,
+        idleTimeout: 1000,
+        keepAlive: true,
+        maxConcurrentConnections: 1000,
+        pipelining: true,
+        propagateClientAcceptEncoding: true,
+        readTimeout: 1000,
+        useCompression: false,
+        version: 'HTTP/2',
+      },
+      headers: [],
+    });
+  });
+
+  it('should add headers', async () => {
+    const httpFormHeaders = await endpointHttpConfigHarness.getHttpFormHeaders();
+
+    await httpFormHeaders.addHeader({ key: 'key1', value: 'value1' });
+
+    expect(await endpointHttpConfigHarness.getHttpConfigValues()).toEqual({
+      httpClientOptions: {
+        clearTextUpgrade: true,
+        connectTimeout: 1000,
+        followRedirects: true,
+        idleTimeout: 1000,
+        keepAlive: true,
+        maxConcurrentConnections: 1000,
+        pipelining: true,
+        propagateClientAcceptEncoding: false,
+        readTimeout: 1000,
+        useCompression: true,
+        version: 'HTTP/2',
+      },
+      headers: [
+        {
+          name: 'key1',
+          value: 'value1',
+        },
+      ],
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+
+import { EndpointHttpConfigComponent } from './endpoint-http-config.component';
+import { EndpointHttpConfigModule } from './endpoint-http-config.module';
+import { GioHttpTestingModule } from '../../../../../../shared/testing';
+
+describe('ApiPropertiesComponent', () => {
+  let fixture: ComponentFixture<EndpointHttpConfigComponent>;
+  let component: EndpointHttpConfigComponent;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, EndpointHttpConfigModule],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(EndpointHttpConfigComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should work', async () => {
+    expect(component).toBeTruthy();
+    expect(loader).toBeTruthy();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
@@ -19,19 +19,22 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { EndpointHttpConfigComponent } from './endpoint-http-config.component';
 import { EndpointHttpConfigModule } from './endpoint-http-config.module';
 import { EndpointHttpConfigHarness } from './endpoint-http-config.harness';
 
 import { GioHttpTestingModule } from '../../../../../../shared/testing';
-import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { EndpointGroupV2 } from '../../../../../../entities/management-api-v2';
 
 describe('ApiPropertiesComponent', () => {
   let fixture: ComponentFixture<EndpointHttpConfigComponent>;
   let component: EndpointHttpConfigComponent;
   let httpTestingController: HttpTestingController;
   let endpointHttpConfigHarness: EndpointHttpConfigHarness;
+
+  let initialEndpointGroupV2: EndpointGroupV2;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -48,24 +51,32 @@ describe('ApiPropertiesComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     component = fixture.componentInstance;
 
-    component.httpConfigFormGroup = EndpointHttpConfigComponent.getHttpConfigFormGroup(
-      {
-        httpClientOptions: {
-          version: 'HTTP_2',
-          connectTimeout: 1000,
-          readTimeout: 1000,
-          idleTimeout: 1000,
-          maxConcurrentConnections: 1000,
-          keepAlive: true,
-          pipelining: true,
-          useCompression: true,
-          followRedirects: true,
-          propagateClientAcceptEncoding: true,
-          clearTextUpgrade: true,
-        },
+    initialEndpointGroupV2 = {
+      httpClientOptions: {
+        version: 'HTTP_2',
+        connectTimeout: 1000,
+        readTimeout: 1000,
+        idleTimeout: 1000,
+        maxConcurrentConnections: 1000,
+        keepAlive: true,
+        pipelining: true,
+        useCompression: true,
+        followRedirects: true,
+        propagateClientAcceptEncoding: true,
+        clearTextUpgrade: true,
       },
-      false,
-    );
+      httpProxy: {
+        enabled: true,
+        useSystemProxy: false,
+        type: 'HTTP',
+        host: 'host',
+        port: 1000,
+        username: 'username',
+        password: 'password',
+      },
+    };
+    component.httpConfigFormGroup = EndpointHttpConfigComponent.getHttpConfigFormGroup(initialEndpointGroupV2, false);
+    fixture.detectChanges();
     endpointHttpConfigHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, EndpointHttpConfigHarness);
   });
 
@@ -88,9 +99,10 @@ describe('ApiPropertiesComponent', () => {
         propagateClientAcceptEncoding: false,
         readTimeout: 1000,
         useCompression: true,
-        version: 'HTTP/2',
+        version: 'HTTP_2',
       },
       headers: [],
+      httpProxy: initialEndpointGroupV2.httpProxy,
     });
   });
 
@@ -115,9 +127,10 @@ describe('ApiPropertiesComponent', () => {
         propagateClientAcceptEncoding: false,
         readTimeout: 1000,
         useCompression: true,
-        version: 'HTTP/1.1',
+        version: 'HTTP_1_1',
       },
       headers: [],
+      httpProxy: initialEndpointGroupV2.httpProxy,
     });
   });
 
@@ -142,9 +155,10 @@ describe('ApiPropertiesComponent', () => {
         propagateClientAcceptEncoding: true,
         readTimeout: 1000,
         useCompression: false,
-        version: 'HTTP/2',
+        version: 'HTTP_2',
       },
       headers: [],
+      httpProxy: initialEndpointGroupV2.httpProxy,
     });
   });
 
@@ -165,7 +179,7 @@ describe('ApiPropertiesComponent', () => {
         propagateClientAcceptEncoding: false,
         readTimeout: 1000,
         useCompression: true,
-        version: 'HTTP/2',
+        version: 'HTTP_2',
       },
       headers: [
         {
@@ -173,6 +187,7 @@ describe('ApiPropertiesComponent', () => {
           value: 'value1',
         },
       ],
+      httpProxy: initialEndpointGroupV2.httpProxy,
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
@@ -19,7 +19,7 @@ import { Subject } from 'rxjs';
 import { FormControl, FormGroup } from '@angular/forms';
 import { filter, startWith, takeUntil } from 'rxjs/operators';
 
-import { EndpointGroupV2, ProtocolVersion } from '../../../../../../entities/management-api-v2';
+import { EndpointGroupV2, HttpHeader, ProtocolVersion } from '../../../../../../entities/management-api-v2';
 
 export interface EndpointHttpConfigValue {
   httpClientOptions: {
@@ -35,6 +35,7 @@ export interface EndpointHttpConfigValue {
     propagateClientAcceptEncoding?: boolean;
     clearTextUpgrade?: boolean;
   };
+  headers: HttpHeader[];
 }
 
 @Component({
@@ -93,6 +94,7 @@ export class EndpointHttpConfigComponent implements OnInit, OnDestroy {
 
     return new FormGroup({
       httpClientOptions,
+      headers: new FormControl(endpointGroup.headers ?? []),
     });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
@@ -14,8 +14,28 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
+import { FormControl, FormGroup } from '@angular/forms';
+import { filter, startWith, takeUntil } from 'rxjs/operators';
+
+import { EndpointGroupV2, ProtocolVersion } from '../../../../../../entities/management-api-v2';
+
+export interface EndpointHttpConfigValue {
+  httpClientOptions: {
+    version: ProtocolVersion;
+    connectTimeout: number;
+    readTimeout: number;
+    idleTimeout: number;
+    maxConcurrentConnections: number;
+    keepAlive: boolean;
+    pipelining: boolean;
+    useCompression: boolean;
+    followRedirects: boolean;
+    propagateClientAcceptEncoding?: boolean;
+    clearTextUpgrade?: boolean;
+  };
+}
 
 @Component({
   selector: 'endpoint-http-config',
@@ -23,11 +43,126 @@ import { Subject } from 'rxjs';
   styles: [require('./endpoint-http-config.component.scss')],
 })
 export class EndpointHttpConfigComponent implements OnInit, OnDestroy {
+  public static getHttpConfigFormGroup(endpointGroup: EndpointGroupV2, isReadonly: boolean): FormGroup {
+    const httpClientOptions = new FormGroup({
+      version: new FormControl({
+        value: endpointGroup.httpClientOptions?.version,
+        disabled: isReadonly,
+      }),
+      connectTimeout: new FormControl({
+        value: endpointGroup.httpClientOptions?.connectTimeout,
+        disabled: isReadonly,
+      }),
+      readTimeout: new FormControl({
+        value: endpointGroup.httpClientOptions?.readTimeout,
+        disabled: isReadonly,
+      }),
+      idleTimeout: new FormControl({
+        value: endpointGroup.httpClientOptions?.idleTimeout,
+        disabled: isReadonly,
+      }),
+      maxConcurrentConnections: new FormControl({
+        value: endpointGroup.httpClientOptions?.maxConcurrentConnections,
+        disabled: isReadonly,
+      }),
+      keepAlive: new FormControl({
+        value: endpointGroup.httpClientOptions?.keepAlive,
+        disabled: isReadonly,
+      }),
+      pipelining: new FormControl({
+        value: endpointGroup.httpClientOptions?.pipelining,
+        disabled: isReadonly,
+      }),
+      useCompression: new FormControl({
+        value: endpointGroup.httpClientOptions?.useCompression,
+        disabled: isReadonly,
+      }),
+      followRedirects: new FormControl({
+        value: endpointGroup.httpClientOptions?.followRedirects,
+        disabled: isReadonly,
+      }),
+      propagateClientAcceptEncoding: new FormControl({
+        value: endpointGroup.httpClientOptions?.propagateClientAcceptEncoding,
+        disabled: isReadonly,
+      }),
+      clearTextUpgrade: new FormControl({
+        value: endpointGroup.httpClientOptions?.clearTextUpgrade,
+        disabled: isReadonly,
+      }),
+    });
+
+    return new FormGroup({
+      httpClientOptions,
+    });
+  }
+
+  public static getHttpConfigValue(httpConfigFormGroup: FormGroup): EndpointHttpConfigValue {
+    return httpConfigFormGroup.getRawValue();
+  }
+
+  @Input()
+  public httpConfigFormGroup: FormGroup;
+
+  public httpVersions: { label: string; value: ProtocolVersion }[] = [
+    {
+      label: 'HTTP/1.1',
+      value: 'HTTP_1_1',
+    },
+    {
+      label: 'HTTP/2',
+      value: 'HTTP_2',
+    },
+  ];
+
   private unsubscribe$ = new Subject<boolean>();
 
-  constructor() {}
+  ngOnInit(): void {
+    if (!this.httpConfigFormGroup) {
+      throw new Error('httpConfigFormGroup input is required');
+    }
 
-  ngOnInit(): void {}
+    const httpClientOptions = this.httpConfigFormGroup.get('httpClientOptions');
+
+    httpClientOptions
+      .get('version')
+      .valueChanges.pipe(
+        startWith(httpClientOptions.get('version').value),
+        // Only if version is not disabled
+        filter(() => !httpClientOptions.get('version').disabled),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe((value) => {
+        const isHttp2 = value === 'HTTP_2';
+        if (isHttp2) {
+          httpClientOptions.get('clearTextUpgrade').enable();
+        } else {
+          if (httpClientOptions.get('clearTextUpgrade').value === true) {
+            httpClientOptions.get('clearTextUpgrade').setValue(false);
+          }
+          httpClientOptions.get('clearTextUpgrade').disable();
+        }
+      });
+
+    httpClientOptions
+      .get('useCompression')
+      .valueChanges.pipe(
+        startWith(httpClientOptions.get('useCompression').value),
+        // Only if useCompression is not disabled
+        filter(() => !httpClientOptions.get('useCompression').disabled),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe((value) => {
+        const useCompression = !!value;
+        if (useCompression) {
+          if (httpClientOptions.get('propagateClientAcceptEncoding').value === true) {
+            httpClientOptions.get('propagateClientAcceptEncoding').setValue(false);
+          }
+          httpClientOptions.get('propagateClientAcceptEncoding').disable();
+        } else {
+          httpClientOptions.get('propagateClientAcceptEncoding').enable();
+        }
+      });
+  }
 
   ngOnDestroy() {
     this.unsubscribe$.next(true);

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Component({
+  selector: 'endpoint-http-config',
+  template: require('./endpoint-http-config.component.html'),
+  styles: [require('./endpoint-http-config.component.scss')],
+})
+export class EndpointHttpConfigComponent implements OnInit, OnDestroy {
+  private unsubscribe$ = new Subject<boolean>();
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.harness.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { keyBy, mapValues } from 'lodash';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { EndpointHttpConfigValue } from './endpoint-http-config.component';
+
+const formControlNameList = [
+  'version',
+  'connectTimeout',
+  'readTimeout',
+  'idleTimeout',
+  'maxConcurrentConnections',
+  'keepAlive',
+  'pipelining',
+  'useCompression',
+  'followRedirects',
+  'propagateClientAcceptEncoding',
+  'clearTextUpgrade',
+];
+
+const matSelectControlNameList = ['version'];
+const matSlideToggleControlNameList = [
+  'keepAlive',
+  'pipelining',
+  'useCompression',
+  'followRedirects',
+  'propagateClientAcceptEncoding',
+  'clearTextUpgrade',
+];
+const matInputControlNameList = ['connectTimeout', 'readTimeout', 'idleTimeout', 'maxConcurrentConnections'];
+
+export class EndpointHttpConfigHarness extends ComponentHarness {
+  static hostSelector = 'endpoint-http-config';
+
+  async getMatSelect(formControlName: string): Promise<MatSelectHarness> {
+    return this.locatorForOptional(MatSelectHarness.with({ selector: `[formControlName="${formControlName}"]` }))();
+  }
+
+  async getMatSlideToggle(formControlName: string): Promise<MatSlideToggleHarness> {
+    return this.locatorForOptional(MatSlideToggleHarness.with({ selector: `[formControlName="${formControlName}"]` }))();
+  }
+
+  async getMatInput(formControlName: string): Promise<MatInputHarness> {
+    return this.locatorForOptional(MatInputHarness.with({ selector: `[formControlName="${formControlName}"]` }))();
+  }
+
+  async getHttpConfigValues(): Promise<EndpointHttpConfigValue> {
+    const keyValues = await parallel(() =>
+      formControlNameList.map(async (formControlName) => {
+        let value = null;
+        if (matSelectControlNameList.includes(formControlName)) {
+          value = await this.getMatSelect(formControlName).then((matSelect) => matSelect?.getValueText());
+        }
+        if (matSlideToggleControlNameList.includes(formControlName)) {
+          value = await this.getMatSlideToggle(formControlName).then((matSlideToggle) => matSlideToggle?.isChecked());
+        }
+        if (matInputControlNameList.includes(formControlName)) {
+          value = await this.getMatInput(formControlName)
+            .then((matInput) => matInput?.getValue())
+            .then((v) => (Number(v) ? Number(v) : v));
+        }
+
+        return {
+          key: formControlName,
+          value,
+        };
+      }),
+    );
+
+    return mapValues(keyBy(keyValues, 'key'), 'value') as EndpointHttpConfigValue;
+  }
+
+  async setHttpVersion(versionLabel: string): Promise<void> {
+    const matSelect = await this.getMatSelect('version');
+
+    if (await matSelect.isDisabled()) {
+      throw new Error('Http version is disabled');
+    }
+
+    await matSelect.clickOptions({ text: versionLabel });
+  }
+
+  async setEnableCompression(enable: boolean): Promise<void> {
+    const matSlideToggle = await this.getMatSlideToggle('useCompression');
+
+    if (await matSlideToggle.isDisabled()) {
+      throw new Error('Use compression is disabled');
+    }
+
+    if ((await matSlideToggle.isChecked()) !== enable) {
+      await matSlideToggle.toggle();
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
@@ -15,7 +15,7 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+import { GioFormHeadersModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -36,6 +36,7 @@ import { EndpointHttpConfigComponent } from './endpoint-http-config.component';
     MatSlideToggleModule,
 
     GioFormSlideToggleModule,
+    GioFormHeadersModule,
   ],
   declarations: [EndpointHttpConfigComponent],
   exports: [EndpointHttpConfigComponent],

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
+
+import { EndpointHttpConfigComponent } from './endpoint-http-config.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [EndpointHttpConfigComponent],
+  exports: [EndpointHttpConfigComponent],
+})
+export class EndpointHttpConfigModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/endpoint-http-config/endpoint-http-config.module.ts
@@ -15,12 +15,28 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { EndpointHttpConfigComponent } from './endpoint-http-config.component';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+
+    MatFormFieldModule,
+    MatSelectModule,
+    MatInputModule,
+    MatSlideToggleModule,
+
+    GioFormSlideToggleModule,
+  ],
   declarations: [EndpointHttpConfigComponent],
   exports: [EndpointHttpConfigComponent],
 })

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.html
@@ -1,0 +1,98 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h3>Trust store</h3>
+<div class="form" [formGroup]="internalFormGroup">
+  <mat-form-field class="field">
+    <mat-label>Type</mat-label>
+    <mat-select formControlName="type">
+      <mat-option *ngFor="let type of types" [value]="type.value">{{ type.label }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <ng-container [ngSwitch]="internalFormGroup.get('type').value">
+    <ng-container *ngSwitchCase="'JKS'">
+      <mat-form-field class="field">
+        <mat-label>Password</mat-label>
+        <input matInput formControlName="jksPassword" type="password" name="jksPassword" autocomplete="off" required />
+        <mat-hint>Key store password</mat-hint>
+        <mat-error *ngIf="internalFormGroup.get('jksPassword').hasError('required')"> Password is required </mat-error>
+      </mat-form-field>
+
+      <div class="pathOrContent">
+        <mat-form-field class="field">
+          <mat-label>Path</mat-label>
+          <input matInput formControlName="jksPath" name="jksPath" autocomplete="off" />
+          <mat-hint>Path to the trust store file</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('jksPath').hasError('pathOrContentRequired')"> Path or content is required </mat-error>
+        </mat-form-field>
+
+        <mat-form-field class="field">
+          <mat-label>Content</mat-label>
+          <textarea matInput formControlName="jksContent" rows="1" name="jksContent"></textarea>
+          <mat-hint>Binary content as Base64</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('jksContent').hasError('pathOrContentRequired')"> Path or content is required </mat-error>
+        </mat-form-field>
+      </div>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="'PKCS12'">
+      <mat-form-field class="field">
+        <mat-label>Password</mat-label>
+        <input matInput formControlName="pkcs12Password" type="password" name="pkcs12Password" autocomplete="off" required />
+        <mat-hint>Key store password</mat-hint>
+        <mat-error *ngIf="internalFormGroup.get('pkcs12Password').hasError('required')"> Password is required </mat-error>
+      </mat-form-field>
+
+      <div class="pathOrContent">
+        <mat-form-field class="field">
+          <mat-label>Path</mat-label>
+          <input matInput formControlName="pkcs12Path" name="pkcs12Path" autocomplete="off" />
+          <mat-hint>Path to the trust store file</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('pkcs12Path').hasError('pathOrContentRequired')"> Path or content is required </mat-error>
+        </mat-form-field>
+
+        <mat-form-field class="field">
+          <mat-label>Content</mat-label>
+          <textarea matInput formControlName="pkcs12Content" rows="1" name="pkcs12Content"></textarea>
+          <mat-hint>Binary content as Base64</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('pkcs12Content').hasError('pathOrContentRequired')">
+            Path or content is required
+          </mat-error>
+        </mat-form-field>
+      </div>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="'PEM'">
+      <div class="pathOrContent">
+        <mat-form-field class="field">
+          <mat-label>Path</mat-label>
+          <input matInput formControlName="pemPath" name="pemPath" autocomplete="off" />
+          <mat-hint>Path to the trust store file</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('pemPath').hasError('pathOrContentRequired')"> Path or content is required </mat-error>
+        </mat-form-field>
+
+        <mat-form-field class="field">
+          <mat-label>Content</mat-label>
+          <textarea matInput formControlName="pemContent" rows="1" name="pemContent"></textarea>
+          <mat-hint>Binary content as Base64</mat-hint>
+          <mat-error *ngIf="internalFormGroup.get('pemContent').hasError('pathOrContentRequired')"> Path or content is required </mat-error>
+        </mat-form-field>
+      </div>
+    </ng-container>
+  </ng-container>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.scss
@@ -1,0 +1,18 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.form {
+  display: flex;
+  flex-direction: column;
+
+  .field {
+    flex: 1 1 auto;
+  }
+
+  .pathOrContent {
+    display: flex;
+    flex-direction: row;
+    flex: 1 1 auto;
+    gap: 16px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { ControlContainer, ReactiveFormsModule } from '@angular/forms';
+
+import { SslTrustStoreFormComponent } from './ssl-truststore-form.component';
+import { SslTrustStoreFormModule } from './ssl-truststore-form.module';
+import { SslTrustStoreFormHarness } from './ssl-truststore-form.harness';
+
+import { GioHttpTestingModule } from '../../../../../../shared/testing';
+
+describe('SslTrustStoreFormComponent', () => {
+  let fixture: ComponentFixture<SslTrustStoreFormComponent>;
+  let component: SslTrustStoreFormComponent;
+  let httpTestingController: HttpTestingController;
+  let sslTrustStoreFormHarness: SslTrustStoreFormHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule, NoopAnimationsModule, GioHttpTestingModule, SslTrustStoreFormModule, MatIconTestingModule],
+      providers: [
+        {
+          provide: ControlContainer,
+          useValue: {},
+        },
+      ],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SslTrustStoreFormComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+    sslTrustStoreFormHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SslTrustStoreFormHarness);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should init with value', async () => {
+    component.writeValue({
+      type: 'PEM',
+      path: 'path',
+      content: 'content',
+    });
+
+    const values = await sslTrustStoreFormHarness.getValues();
+    expect(values).toEqual({
+      type: 'PEM',
+      content: 'content',
+      path: 'path',
+    });
+  });
+
+  it('should set JKS TrustStore', async () => {
+    await sslTrustStoreFormHarness.setJksTrustStore({
+      password: 'password',
+      path: 'path',
+      content: 'content',
+      type: 'JKS',
+    });
+
+    const values = await sslTrustStoreFormHarness.getValues();
+    expect(values).toEqual({
+      type: 'JKS',
+      content: 'content',
+      password: 'password',
+      path: 'path',
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.component.ts
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Input, OnDestroy, OnInit, forwardRef } from '@angular/core';
+import {
+  AbstractControl,
+  ControlContainer,
+  ControlValueAccessor,
+  FormControl,
+  FormGroup,
+  NG_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  Validator,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { Subject } from 'rxjs';
+import { isEmpty } from 'lodash';
+import { filter, take, map, takeUntil } from 'rxjs/operators';
+
+import { JKSTrustStore, PEMTrustStore, PKCS12TrustStore, TrustStore } from '../../../../../../entities/management-api-v2';
+
+type InternalFormValue = {
+  type: TrustStore['type'];
+  jksPath?: string;
+  jksContent?: string;
+  jksPassword?: string;
+  pkcs12Path?: string;
+  pkcs12Content?: string;
+  pkcs12Password?: string;
+  pemPath?: string;
+  pemContent?: string;
+};
+
+export const TRUSTSTORE_TYPE_LABELS: { label: string; value: TrustStore['type'] }[] = [
+  {
+    label: 'None',
+    value: 'NONE',
+  },
+  {
+    label: 'Java Trust Store (.jks)',
+    value: 'JKS',
+  },
+  {
+    label: 'PKCS#12 (.p12) / PFX (.pfx)',
+    value: 'PKCS12',
+  },
+  {
+    label: 'PEM (.pem)',
+    value: 'PEM',
+  },
+];
+
+@Component({
+  selector: 'ssl-truststore-form',
+  template: require('./ssl-truststore-form.component.html'),
+  styles: [require('./ssl-truststore-form.component.scss')],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: forwardRef(() => SslTrustStoreFormComponent),
+    },
+    {
+      provide: NG_VALIDATORS,
+      useExisting: forwardRef(() => SslTrustStoreFormComponent),
+      multi: true,
+    },
+  ],
+})
+export class SslTrustStoreFormComponent implements OnInit, OnDestroy, ControlValueAccessor, Validator {
+  private unsubscribe$ = new Subject<boolean>();
+
+  private _onChange: (value: TrustStore) => void = () => ({});
+
+  private _onTouched: () => void = () => ({});
+
+  @Input() formControlName!: string;
+  @Input() formGroupName!: string;
+
+  public types = TRUSTSTORE_TYPE_LABELS;
+
+  public internalFormGroup = new FormGroup({
+    // Base fields
+    type: new FormControl('NONE'),
+
+    // JKS fields
+    jksPath: new FormControl(),
+    jksContent: new FormControl(),
+    jksPassword: new FormControl(),
+
+    // PKCS12 fields
+    pkcs12Path: new FormControl(),
+    pkcs12Content: new FormControl(),
+    pkcs12Password: new FormControl(),
+
+    // PEM fields
+    pemPath: new FormControl(),
+    pemContent: new FormControl(),
+  });
+  public isDisabled = false;
+
+  constructor(private controlContainer: ControlContainer) {}
+
+  ngOnInit(): void {
+    this.internalFormGroup
+      .get('type')
+      .valueChanges.pipe(takeUntil(this.unsubscribe$))
+      .subscribe((type) => {
+        // Clear all validators
+        this.internalFormGroup.clearValidators();
+        this.internalFormGroup.get('jksPassword').clearValidators();
+        this.internalFormGroup.get('pkcs12Password').clearValidators();
+
+        switch (type) {
+          case 'JKS': {
+            this.internalFormGroup.get('jksPassword').setValidators([Validators.required]);
+            this.internalFormGroup.setValidators([pathOrContentRequired('jksPath', 'jksContent')]);
+            break;
+          }
+          case 'PKCS12': {
+            this.internalFormGroup.get('pkcs12Password').setValidators([Validators.required]);
+            this.internalFormGroup.setValidators([pathOrContentRequired('pkcs12Path', 'pkcs12Content')]);
+            break;
+          }
+          case 'PEM': {
+            this.internalFormGroup.setValidators([pathOrContentRequired('pemPath', 'pemContent')]);
+            break;
+          }
+        }
+
+        // Update validators
+        this.internalFormGroup.get('jksPassword').updateValueAndValidity();
+        this.internalFormGroup.get('pkcs12Password').updateValueAndValidity();
+        this.internalFormGroup.updateValueAndValidity();
+      });
+
+    this.internalFormGroup.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((value) => {
+      this._onChange(internalFormValueToTrustStore(value));
+    });
+
+    this.internalFormGroup.statusChanges
+      .pipe(
+        map(() => this.internalFormGroup?.touched),
+        filter((touched) => touched === true && this.isDisabled === false),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this._onTouched();
+      });
+
+    // If parent form control is touched, mark all internal fields as touched
+    const parentFormControl = this.controlContainer?.control?.get(this.formControlName);
+    if (parentFormControl) {
+      parentFormControl.statusChanges
+        .pipe(
+          map(() => parentFormControl?.touched),
+          filter((touched) => touched === true && this.isDisabled === false),
+          take(1),
+          takeUntil(this.unsubscribe$),
+        )
+        .subscribe(() => {
+          this.internalFormGroup.markAllAsTouched();
+        });
+    }
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  registerOnChange(fn: (value: TrustStore) => void): void {
+    this._onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+    isDisabled ? this.internalFormGroup.disable() : this.internalFormGroup.enable();
+  }
+
+  validate(_: AbstractControl): ValidationErrors | null {
+    return this.internalFormGroup.valid
+      ? null
+      : {
+          invalidTrustStore: true,
+        };
+  }
+
+  writeValue(value: TrustStore): void {
+    this.internalFormGroup.reset(trustStoreTypeToInternalFormValue(value));
+  }
+}
+
+const pathOrContentRequired: (pathControlName: string, contentControlName: string) => ValidatorFn = (
+  pathControlName: string,
+  contentControlName: string,
+) => {
+  return (formGroup: FormGroup): ValidationErrors | null => {
+    const pathControl = formGroup.get(pathControlName);
+    const contentControl = formGroup.get(contentControlName);
+
+    if (isEmpty(pathControl.value) && isEmpty(contentControl.value)) {
+      pathControl.setErrors({ pathOrContentRequired: true }, { emitEvent: false });
+      contentControl.setErrors({ pathOrContentRequired: true }, { emitEvent: false });
+      return { pathOrContentRequired: true };
+    }
+
+    pathControl.setErrors(null, { emitEvent: false });
+    contentControl.setErrors(null, { emitEvent: false });
+    return null;
+  };
+};
+
+const trustStoreTypeToInternalFormValue: (trustStore?: TrustStore) => InternalFormValue = (trustStore) => {
+  switch (trustStore?.type) {
+    case 'JKS': {
+      const jksTrustStore = trustStore as JKSTrustStore;
+      return {
+        type: trustStore.type,
+        jksPath: jksTrustStore.path,
+        jksContent: jksTrustStore.content,
+        jksPassword: jksTrustStore.password,
+      };
+    }
+    case 'PKCS12': {
+      const pkcs12TrustStore = trustStore as PKCS12TrustStore;
+      return {
+        type: trustStore.type,
+        pkcs12Path: pkcs12TrustStore.path,
+        pkcs12Content: pkcs12TrustStore.content,
+        pkcs12Password: pkcs12TrustStore.password,
+      };
+    }
+    case 'PEM': {
+      const pemTrustStore = trustStore as PEMTrustStore;
+      return {
+        type: trustStore.type,
+        pemPath: pemTrustStore.path,
+        pemContent: pemTrustStore.content,
+      };
+    }
+    default: {
+      return {
+        type: 'NONE',
+      };
+    }
+  }
+};
+
+const internalFormValueToTrustStore: (internalFormValue: InternalFormValue) => TrustStore = (internalFormValue) => {
+  switch (internalFormValue.type) {
+    case 'JKS':
+      return {
+        type: internalFormValue.type,
+        path: internalFormValue.jksPath,
+        content: internalFormValue.jksContent,
+        password: internalFormValue.jksPassword,
+      };
+    case 'PKCS12':
+      return {
+        type: internalFormValue.type,
+        path: internalFormValue.pkcs12Path,
+        content: internalFormValue.pkcs12Content,
+        password: internalFormValue.pkcs12Password,
+      };
+    case 'PEM':
+      return {
+        type: internalFormValue.type,
+        path: internalFormValue.pemPath,
+        content: internalFormValue.pemContent,
+      };
+    default:
+      return {
+        type: internalFormValue.type,
+      };
+  }
+};

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.harness.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { keyBy } from 'lodash';
+
+import { TRUSTSTORE_TYPE_LABELS } from './ssl-truststore-form.component';
+
+import { JKSTrustStore, TrustStore } from '../../../../../../entities/management-api-v2';
+
+const TRUSTSTORE_TYPE_LABELS_TO_KEY = keyBy(TRUSTSTORE_TYPE_LABELS, 'value');
+
+export class SslTrustStoreFormHarness extends ComponentHarness {
+  static hostSelector = 'ssl-truststore-form';
+
+  protected getInputHarness = (formControlName: string) =>
+    this.locatorFor(MatInputHarness.with({ selector: `[formControlName="${formControlName}"]` }))();
+
+  protected getType = () => this.locatorFor(MatSelectHarness.with({ selector: `[formControlName="type"]` }))();
+
+  async setJksTrustStore(jks: JKSTrustStore) {
+    const type = await this.getType();
+    await type.clickOptions({ text: TRUSTSTORE_TYPE_LABELS_TO_KEY['JKS'].label });
+
+    const passwordInput = await this.getInputHarness('jksPassword');
+    await passwordInput.setValue(jks.password);
+
+    if (jks.path) {
+      const pathInput = await this.getInputHarness('jksPath');
+      await pathInput.setValue(jks.path);
+    }
+
+    if (jks.content) {
+      const contentInput = await this.getInputHarness('jksContent');
+      await contentInput.setValue(jks.content);
+    }
+  }
+
+  async getValues(): Promise<TrustStore> {
+    const type = await this.getType();
+    const typeValue = await type.getValueText();
+
+    switch (typeValue) {
+      case TRUSTSTORE_TYPE_LABELS_TO_KEY['JKS'].label: {
+        const passwordInput = await this.getInputHarness('jksPassword');
+        const password = await passwordInput.getValue();
+        const pathInput = await this.getInputHarness('jksPath');
+        const path = await pathInput.getValue();
+        const contentInput = await this.getInputHarness('jksContent');
+        const content = await contentInput.getValue();
+        return {
+          type: TRUSTSTORE_TYPE_LABELS_TO_KEY['JKS'].value,
+          password,
+          path,
+          content,
+        };
+      }
+      case TRUSTSTORE_TYPE_LABELS_TO_KEY['PEM'].label: {
+        const pemPathInput = await this.getInputHarness('pemPath');
+        const pemPath = await pemPathInput.getValue();
+        const pemContentInput = await this.getInputHarness('pemContent');
+        const pemContent = await pemContentInput.getValue();
+        return {
+          type: TRUSTSTORE_TYPE_LABELS_TO_KEY['PEM'].value,
+          path: pemPath,
+          content: pemContent,
+        };
+      }
+      case TRUSTSTORE_TYPE_LABELS_TO_KEY['PKCS12'].label: {
+        const pkcs12PasswordInput = await this.getInputHarness('pkcs12Password');
+        const pkcs12Password = await pkcs12PasswordInput.getValue();
+        const pkcs12PathInput = await this.getInputHarness('pkcs12Path');
+        const pkcs12Path = await pkcs12PathInput.getValue();
+        const pkcs12ContentInput = await this.getInputHarness('pkcs12Content');
+        const pkcs12Content = await pkcs12ContentInput.getValue();
+        return {
+          type: TRUSTSTORE_TYPE_LABELS_TO_KEY['PKCS12'].value,
+          password: pkcs12Password,
+          path: pkcs12Path,
+          content: pkcs12Content,
+        };
+      }
+      case TRUSTSTORE_TYPE_LABELS_TO_KEY['NONE'].label: {
+        return {
+          type: TRUSTSTORE_TYPE_LABELS_TO_KEY['NONE'].value,
+        };
+      }
+      default:
+        throw new Error(`Unknown type ${typeValue}`);
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/components/ssl-truststore-form/ssl-truststore-form.module.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+
+import { SslTrustStoreFormComponent } from './ssl-truststore-form.component';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, MatFormFieldModule, MatSelectModule, MatInputModule],
+  declarations: [SslTrustStoreFormComponent],
+  exports: [SslTrustStoreFormComponent],
+})
+export class SslTrustStoreFormModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/api-proxy-groups.module.ts
@@ -39,6 +39,7 @@ import { ApiProxyGroupServiceDiscoveryComponent } from './edit/service-discovery
 import { ApiProxyGroupEndpointModule } from './endpoint/api-proxy-group-endpoint.module';
 
 import { GioGoBackButtonModule } from '../../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
+import { EndpointHttpConfigModule } from '../components/endpoint-http-config/endpoint-http-config.module';
 
 @NgModule({
   declarations: [
@@ -68,6 +69,7 @@ import { GioGoBackButtonModule } from '../../../../../shared/components/gio-go-b
 
     ApiProxyGroupEndpointModule,
     GioFormJsonSchemaModule,
+    EndpointHttpConfigModule,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2795

## Description

Start migrating this part of the config to Angular.
This PR starts building some hidden components (without touching the existing page).
For now the forms are very vertical but I'll see at the end to reduce the height with a "final UI touch". 

📓  Note MAPIV2 : The json schema is no longer used for this configuration part . That's why it's changed to a page with a full form. MAPIV2 use openApi to validate this config payload.

HTTP Options: 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/9eab9c8a-db41-4d7d-b98e-4e3318e2232b)

Header & Proxy
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/25244000-18c7-45b3-b0d9-cfe8bc678386)




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wuucbaicgl.chromatic.com)
<!-- Storybook placeholder end -->
