### PR TITLE
test: added tests for creation and modification of flows in Policy St…

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-create-and-modify-flow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/policy-studio/ui-ps-create-and-modify-flow.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
+import { ApiType, ApiV4, HttpListener } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
+
+const envId = 'DEFAULT';
+import PolicyStudio from 'ui-test/support/PageObjects/Apis/PolicyStudio';
+import faker from '@faker-js/faker';
+
+describe('Create and modify a flow in Policy Studio', () => {
+  let v4api: ApiV4;
+  const httpListener: HttpListener = MAPIV2ApisFaker.newHttpListener();
+  const apiPath: string = httpListener.paths[0].path;
+  const flowName = faker.lorem.words(3);
+
+  before(() => {
+    cy.log('Create v4 API');
+    cy.request({
+      method: 'POST',
+      url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis`,
+      auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
+      body: MAPIV2ApisFaker.newApi({
+        type: ApiType.PROXY,
+        listeners: [httpListener],
+        endpointGroups: [MAPIV2ApisFaker.newHttpEndpointGroup()],
+      }),
+    }).then((response) => {
+      expect(response.status).to.eq(201);
+      v4api = response.body;
+
+      cy.log('Create a plan with a flow');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/plans`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+        body: MAPIV2PlansFaker.newPlanV4(),
+      })
+        .then((response) => {
+          expect(response.status).to.eq(201);
+          return response.body.id;
+        })
+        .then((planId) => {
+          cy.log('Publish Plan');
+          cy.request({
+            method: 'POST',
+            url: `${Cypress.env('managementApi')}/management/v2/environments/DEFAULT/apis/${v4api.id}/plans/${planId}/_publish`,
+            auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+          }).then((response) => {
+            expect(response.status).to.eq(200);
+          });
+        });
+
+      cy.log('Deploy API');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/deployments`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+      }).then((response) => {
+        expect(response.status).to.eq(202);
+      });
+
+      cy.log('Start API');
+      cy.request({
+        method: 'POST',
+        url: `${Cypress.env('managementApi')}/management/v2/environments/${envId}/apis/${v4api.id}/_start`,
+        auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
+      }).then((response) => {
+        expect(response.status).to.eq(204);
+      });
+    });
+  });
+
+  beforeEach(() => {
+    cy.loginInAPIM(API_PUBLISHER_USER.username, API_PUBLISHER_USER.password);
+  });
+
+  after(() => {
+    cy.clearCookie('Auth-Graviteeio-APIM');
+    cy.teardownV4Api(v4api.id);
+  });
+
+  describe('Verify that flows can be created and modified in Policy Studio', () => {
+    const headerKey = `x-${faker.lorem.word()}`;
+    const headerValue = faker.lorem.word();
+    const flowPath = faker.lorem.word();
+
+    it('should create a common flow using the "+" icon', () => {
+      PolicyStudio.openPolicyStudio(v4api.id)
+        .addCommonFlow()
+        .enterName(flowName)
+        .clickOnCreateButton()
+        .addResponsePhasePolicy()
+        .choosePolicy('Transform Headers')
+        .addOrUpdateHeaders(headerKey, headerValue)
+        .clickOnAddPolicyButton()
+        .clickOnSaveButton()
+        .deployApiUsingUi();
+    });
+
+    it('should show newly added header when calling Gateway', { retries: 20 }, () => {
+      cy.wait(500); // wait for the API to be deployed
+      cy.callGateway(apiPath)
+        .its('headers')
+        .should((responseHeader) => {
+          expect(responseHeader).to.have.property(headerKey, headerValue);
+        });
+    });
+
+    it('should edit flow details of a common flow using pen icon', () => {
+      PolicyStudio.openPolicyStudio(v4api.id)
+        .editFlowDetails(flowName)
+        .setPath(flowPath)
+        .clickOnSaveButtonInDialog()
+        .clickOnSaveButton()
+        .deployApiUsingUi();
+    });
+
+    it('should not have added header anymore when calling Gateway as before', { retries: 20 }, () => {
+      cy.wait(500); // wait for the API to be deployed
+      cy.callGateway(apiPath)
+        .its('headers')
+        .should((responseHeader) => {
+          expect(responseHeader).to.not.have.property(headerKey);
+        });
+    });
+
+    it('should have header when calling Gateway with updated path', () => {
+      cy.callGateway(`${apiPath}/${flowPath}`)
+        .its('headers')
+        .should((responseHeader) => {
+          expect(responseHeader).to.have.property(headerKey, headerValue);
+        });
+    });
+  });
+});

--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default class PolicyStudio {
+  static openPolicyStudio(apiId: string) {
+    cy.visit(`/#!/environments/default/apis/${apiId}/policy-studio`);
+    cy.url().should('include', '/policy-studio');
+    cy.contains('.list__flowsGroup__header__label', 'Common flows', { timeout: 60000 });
+    return new PolicyStudio();
+  }
+  addCommonFlow() {
+    cy.contains('.list__flowsGroup__header', 'Common flows').find('button').click();
+    return this;
+  }
+
+  clickOnSaveButton() {
+    cy.contains('button', 'Save').click();
+    return this;
+  }
+
+  clickOnSaveButtonInDialog() {
+    cy.get('[role="dialog"]').contains('button', 'Save').click();
+    return this;
+  }
+
+  deployApiUsingUi(deployLabel?: string) {
+    cy.contains('button', 'Deploy API')
+      .click()
+      .then(() => {
+        if (deployLabel) {
+          cy.get('input').click().type(deployLabel);
+        }
+      });
+    cy.contains('button', /^Deploy$/).click();
+    cy.contains('API successfully deployed');
+  }
+
+  enterName(flowName: string) {
+    cy.get('[formcontrolname="name"]').click().clear().type(flowName);
+    return this;
+  }
+
+  clickOnCreateButton() {
+    cy.contains('button', 'Create').click();
+    return this;
+  }
+
+  addResponsePhasePolicy() {
+    cy.contains('gio-ps-flow-details-phase', 'Response phase').find('button').first().click();
+    return this;
+  }
+
+  choosePolicy(policyName: string) {
+    cy.contains('.policiesCatalog__list__policy', policyName).find('button').click();
+    return this;
+  }
+
+  addOrUpdateHeaders(key: string, value: string) {
+    cy.get('textarea[formcontrolname="key"]').click().clear().type(key);
+    cy.get('textarea[formcontrolname="value"]').first().click().clear().type(value);
+    return this;
+  }
+
+  clickOnAddPolicyButton() {
+    cy.contains('button', 'Add policy').click();
+    return this;
+  }
+
+  editFlowDetails(flowName: string) {
+    cy.contains('.list__flowsGroup__flow__name', flowName, { timeout: 60000 }).should('be.visible').click();
+    cy.get('.header__configBtn__edit').click();
+    return this;
+  }
+
+  setPath(flowPath: string) {
+    cy.get('[formcontrolname="path"]').click().clear().type(flowPath);
+    return this;
+  }
+}


### PR DESCRIPTION
…udio

APIM-2375

## Description
Adding test to verify that a user can create and modify flows in Policy Studio. 

This set of tests uses a relatively new approach of writing tests. It relies on Page Objects that include a bit more actions with the purpose that tests are more readably by hiding the technical details in the Page Objects.  

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dyjhebtkcg.chromatic.com)
<!-- Storybook placeholder end -->
