### PR TITLE
improve API V2 import with members

### DIFF
--- a/gravitee-apim-e2e/api-test/src/mapi-v2/apis/import/api-import.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/mapi-v2/apis/import/api-import.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, describe, expect, test } from '@jest/globals';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { APIsApi as APIsApiV2 } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { forManagementAsApiUser, forManagementV2AsAdminUser } from '@gravitee/utils/configuration';
+import { ApiImportEntity, ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { succeed } from '@lib/jest-utils';
+import { ApiEntity, ApiEntityStateEnum } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
+import { Visibility } from '@gravitee/management-webclient-sdk/src/lib/models/Visibility';
+import { ApiLifecycleState } from '@gravitee/management-webclient-sdk/src/lib/models/ApiLifecycleState';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const apisResourceApiUser = new APIsApi(forManagementAsApiUser());
+const v2ApisResourceAsAdmin = new APIsApiV2(forManagementV2AsAdminUser());
+
+describe('API - Imports', () => {
+  describe('API definition import', () => {
+    let apiToImport: ApiImportEntity = ApisFaker.apiImport();
+    let importedApi: ApiEntity;
+
+    test('should import API from definition', async () => {
+      delete apiToImport['groups'];
+
+      importedApi = await succeed(
+        apisResourceApiUser.importApiDefinitionRaw({
+          orgId,
+          envId,
+          body: apiToImport,
+        }),
+      );
+
+      expect(importedApi.state).toBe(ApiEntityStateEnum.STOPPED);
+      expect(importedApi.visibility).toBe(Visibility.PRIVATE);
+      expect(importedApi.lifecycle_state).toBe(ApiLifecycleState.CREATED);
+
+      let foundApi = await succeed(
+        v2ApisResourceAsAdmin.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+
+      expect(foundApi).toBeTruthy();
+      expect(foundApi.id).toBe(importedApi.id);
+      expect(foundApi.state).toBe(ApiEntityStateEnum.STOPPED);
+      expect(foundApi.visibility).toBe(Visibility.PRIVATE);
+      expect(foundApi.lifecycleState).toBe(ApiLifecycleState.CREATED);
+      expect(foundApi.groups).toHaveLength(0);
+    });
+
+    afterAll(async () => {
+      if (importedApi) {
+        await apisResourceApiUser.deleteApi({
+          envId,
+          orgId,
+          api: importedApi.id,
+        });
+      }
+    });
+  });
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
@@ -64,4 +64,7 @@ public interface RoleRepository extends FindAllRepository<Role> {
         throws TechnicalException;
 
     Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) throws TechnicalException;
+
+    Role findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, RoleReferenceType referenceType)
+        throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
@@ -174,6 +174,12 @@ public class MongoRoleRepository implements RoleRepository {
     }
 
     @Override
+    public Role findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, RoleReferenceType referenceType)
+        throws TechnicalException {
+        return this.map(internalRoleRepo.findByIdAndReferenceIdAndReferenceType(roleId, referenceId, referenceType.name()));
+    }
+
+    @Override
     public Set<Role> findByScopeAndReferenceIdAndReferenceType(RoleScope scope, String referenceId, RoleReferenceType referenceType)
         throws TechnicalException {
         LOGGER.debug("Find role by scope and ref [{}, {}, {}]", scope, referenceId, referenceType);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/role/RoleMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/role/RoleMongoRepository.java
@@ -36,4 +36,7 @@ public interface RoleMongoRepository extends MongoRepository<RoleMongo, String> 
 
     @Query("{ 'referenceId': ?0, 'referenceType': ?1 }")
     List<RoleMongo> findByReferenceIdAndReferenceType(String referenceId, String referenceType);
+
+    @Query("{ '_id' : ?0, 'referenceId' : ?1, 'referenceType': ?2 }")
+    RoleMongo findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, String referenceType);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RoleRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/RoleRepositoryTest.java
@@ -15,12 +15,9 @@
  */
 package io.gravitee.repository.management;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Role;
 import io.gravitee.repository.management.model.RoleReferenceType;
 import io.gravitee.repository.management.model.RoleScope;
@@ -29,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 
 public class RoleRepositoryTest extends AbstractManagementRepositoryTest {
@@ -142,7 +140,7 @@ public class RoleRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void shouldFindById() throws Exception {
-        Optional<Role> role = roleRepository.findById("API_find_by_scope_1");
+        Optional<Role> role = roleRepository.findById("an_api_organisation_role");
         assertTrue("role not found", role.isPresent());
         assertEquals("invalid name", "find by scope 1", role.get().getName());
         assertEquals("invalid description", "role description", role.get().getDescription());
@@ -168,5 +166,37 @@ public class RoleRepositoryTest extends AbstractManagementRepositoryTest {
     public void shouldNotUpdateNull() throws Exception {
         roleRepository.update(null);
         fail("A null role should not be updated");
+    }
+
+    @Test
+    public void shouldFindByIdAndOrganisationId() throws TechnicalException {
+        Role role = roleRepository.findByIdAndReferenceIdAndReferenceType("an_api_organisation_role", REFERENCE_ID, REFERENCE_TYPE);
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(role).isNotNull();
+            soft.assertThat(RoleScope.API).isEqualTo(role.getScope());
+            soft.assertThat(REFERENCE_TYPE).isEqualTo(role.getReferenceType());
+        });
+    }
+
+    @Test
+    public void shouldNotFindByIdAndOrganisationIdWhenOrganisationIdIsWrong() throws TechnicalException {
+        Role role = roleRepository.findByIdAndReferenceIdAndReferenceType("an_api_organisation_role", "dummy", REFERENCE_TYPE);
+        assertNull(role);
+    }
+
+    @Test
+    public void shouldNotFindByIdAndOrganisationIdWhenRoleIdIsWrong() throws TechnicalException {
+        Role role = roleRepository.findByIdAndReferenceIdAndReferenceType("dummy", REFERENCE_ID, REFERENCE_TYPE);
+        assertNull(role);
+    }
+
+    @Test
+    public void shouldNotFindByIdAndOrganisationIdWhenReferenceTypeIsWrong() throws TechnicalException {
+        Role role = roleRepository.findByIdAndReferenceIdAndReferenceType(
+            "API_find_by_id_and_org_id",
+            REFERENCE_ID,
+            RoleReferenceType.ENVIRONMENT
+        );
+        assertNull(role);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/role-tests/roles.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/role-tests/roles.json
@@ -17,7 +17,7 @@
     "permissions": [1,2,3]
   },
   {
-    "id": "API_find_by_scope_1",
+    "id": "an_api_organisation_role",
     "name": "find by scope 1",
     "referenceId": "DEFAULT",
     "referenceType": "ORGANIZATION",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
@@ -45,6 +45,7 @@ public interface RoleService {
     void delete(ExecutionContext executionContext, String roleId);
     List<RoleEntity> findAllByOrganization(String organizationId);
     RoleEntity findById(String roleId);
+    RoleEntity findByIdAndOrganizationId(String roleId, String organizationId);
     List<RoleEntity> findByScope(RoleScope scope, String organizationId);
     Optional<RoleEntity> findByScopeAndName(RoleScope scope, String name, String organizationId);
     List<RoleEntity> findDefaultRoleByScopes(String organizationId, RoleScope... scopes);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -319,6 +319,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 }
                 importedApi.getGroups().add(group.getId());
             }
+        } else {
+            importedApi.setGroups(Collections.emptySet());
         }
 
         // Views & Categories

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -101,6 +101,18 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
     }
 
     @Override
+    public RoleEntity findByIdAndOrganizationId(String roleId, String organizationId) {
+        try {
+            return this.convert(
+                    roleRepository.findByIdAndReferenceIdAndReferenceType(roleId, organizationId, RoleReferenceType.ORGANIZATION)
+                );
+        } catch (TechnicalException ex) {
+            LOGGER.error("An error occurs while trying to find roles by id and organizationId", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find roles by id and organizationId", ex);
+        }
+    }
+
+    @Override
     public List<RoleEntity> findAllByOrganization(String organizationId) {
         try {
             LOGGER.debug("Find all Roles");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -70,6 +70,8 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
     private static final String API_ID = "id-api";
     private static final String SOURCE = "source";
+    private static final String PO_ROLE_ID = "API_PRIMARY_OWNER";
+    private static final String OWNER_ROLE_ID = "API_OWNER";
 
     @InjectMocks
     protected ApiDuplicatorServiceImpl apiDuplicatorService;
@@ -163,11 +165,23 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return poRoleEntity;
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return ownerRoleEntity;
+                }
+                return null;
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -217,7 +231,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_PRIMARY_OWNER"
+                PO_ROLE_ID
             );
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
@@ -226,7 +240,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
         verify(apiService, times(1)).update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any());
         verify(apiService, never()).create(eq(GraviteeContext.getExecutionContext()), any(), any());
@@ -242,11 +256,23 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
+        poRole.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
 
         RoleEntity ownerRole = new RoleEntity();
-        ownerRole.setId("API_OWNER");
+        ownerRole.setId(OWNER_ROLE_ID);
+        ownerRole.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return poRole;
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return ownerRole;
+                }
+                return null;
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -287,7 +313,8 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         MemberEntity po = new MemberEntity();
@@ -312,7 +339,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_PRIMARY_OWNER"
+                PO_ROLE_ID
             );
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
@@ -321,7 +348,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
         verify(apiService, times(1)).update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any());
         verify(apiService, never()).create(eq(GraviteeContext.getExecutionContext()), any(), any());
@@ -336,10 +363,10 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
 
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
         when(userService.findById(GraviteeContext.getExecutionContext(), user.getId())).thenReturn(user);
@@ -375,10 +402,10 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         UserEntity user = new UserEntity();
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
 
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
         when(userService.findById(GraviteeContext.getExecutionContext(), user.getId())).thenReturn(user);
@@ -416,7 +443,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -455,7 +482,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
 
         mockApiIdRecalculation();
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2605

## Description

Improve API V2 import:

1. there is a difference between v2 and V4 APIs. Today when a user try to import a V2 API, the groups attribute is null by default which breaks the display on the frontend side.


https://github.com/gravitee-io/gravitee-api-management/assets/25704259/528788e3-1f6c-4562-ae58-a10998d12980

2. Ensure that users cannot import V2 APIs with member roles associated with an organization different from the one into which we intend to import the API. 

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/ed97a3df-f6d4-44a6-af7a-2914635993b2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ctvkoqphxw.chromatic.com)
<!-- Storybook placeholder end -->
