### PR TITLE
improve API V2 import with members 

### DIFF
--- a/gravitee-apim-e2e/api-test/src/mapi-v2/apis/import/api-import.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/mapi-v2/apis/import/api-import.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, describe, expect, test } from '@jest/globals';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { APIsApi as APIsApiV2 } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { forManagementAsApiUser, forManagementV2AsAdminUser } from '@gravitee/utils/configuration';
+import { ApiImportEntity, ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { succeed } from '@lib/jest-utils';
+import { ApiEntity, ApiEntityStateEnum } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
+import { Visibility } from '@gravitee/management-webclient-sdk/src/lib/models/Visibility';
+import { ApiLifecycleState } from '@gravitee/management-webclient-sdk/src/lib/models/ApiLifecycleState';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const apisResourceApiUser = new APIsApi(forManagementAsApiUser());
+const v2ApisResourceAsAdmin = new APIsApiV2(forManagementV2AsAdminUser());
+
+describe('API - Imports', () => {
+  describe('API definition import', () => {
+    let apiToImport: ApiImportEntity = ApisFaker.apiImport();
+    let importedApi: ApiEntity;
+
+    test('should import API with management V1 and get it from management V2', async () => {
+      delete apiToImport['groups'];
+
+      importedApi = await succeed(
+        apisResourceApiUser.importApiDefinitionRaw({
+          orgId,
+          envId,
+          body: apiToImport,
+        }),
+      );
+
+      expect(importedApi.state).toBe(ApiEntityStateEnum.STOPPED);
+      expect(importedApi.visibility).toBe(Visibility.PRIVATE);
+      expect(importedApi.lifecycle_state).toBe(ApiLifecycleState.CREATED);
+
+      let foundApi = await succeed(
+        v2ApisResourceAsAdmin.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+
+      expect(foundApi).toBeTruthy();
+      expect(foundApi.id).toBe(importedApi.id);
+      expect(foundApi.state).toBe(ApiEntityStateEnum.STOPPED);
+      expect(foundApi.visibility).toBe(Visibility.PRIVATE);
+      expect(foundApi.lifecycleState).toBe(ApiLifecycleState.CREATED);
+      expect(foundApi.groups).toHaveLength(0);
+    });
+
+    afterAll(async () => {
+      if (importedApi) {
+        await v2ApisResourceAsAdmin.deleteApi({
+          envId,
+          apiId: importedApi.id,
+        });
+      }
+    });
+  });
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
@@ -64,4 +64,7 @@ public interface RoleRepository extends FindAllRepository<Role> {
         throws TechnicalException;
 
     Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) throws TechnicalException;
+
+    Optional<Role> findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, RoleReferenceType referenceType)
+        throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
@@ -168,14 +168,18 @@ public class MongoRoleRepository implements RoleRepository {
     }
 
     @Override
-    public Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) throws TechnicalException {
+    public Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) {
         final List<RoleMongo> roles = internalRoleRepo.findByReferenceIdAndReferenceType(referenceId, referenceType.name());
         return roles.stream().map(this::map).collect(Collectors.toSet());
     }
 
     @Override
-    public Set<Role> findByScopeAndReferenceIdAndReferenceType(RoleScope scope, String referenceId, RoleReferenceType referenceType)
-        throws TechnicalException {
+    public Optional<Role> findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, RoleReferenceType referenceType) {
+        return Optional.ofNullable(map(internalRoleRepo.findByIdAndReferenceIdAndReferenceType(roleId, referenceId, referenceType.name())));
+    }
+
+    @Override
+    public Set<Role> findByScopeAndReferenceIdAndReferenceType(RoleScope scope, String referenceId, RoleReferenceType referenceType) {
         LOGGER.debug("Find role by scope and ref [{}, {}, {}]", scope, referenceId, referenceType);
 
         final Set<RoleMongo> roles = internalRoleRepo.findByScopeAndReferenceIdAndReferenceType(

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/role/RoleMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/role/RoleMongoRepository.java
@@ -36,4 +36,7 @@ public interface RoleMongoRepository extends MongoRepository<RoleMongo, String> 
 
     @Query("{ 'referenceId': ?0, 'referenceType': ?1 }")
     List<RoleMongo> findByReferenceIdAndReferenceType(String referenceId, String referenceType);
+
+    @Query("{ '_id' : ?0, 'referenceId' : ?1, 'referenceType': ?2 }")
+    RoleMongo findByIdAndReferenceIdAndReferenceType(String roleId, String referenceId, String referenceType);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/role-tests/roles.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/role-tests/roles.json
@@ -17,7 +17,7 @@
     "permissions": [1,2,3]
   },
   {
-    "id": "API_find_by_scope_1",
+    "id": "an_api_organisation_role",
     "name": "find by scope 1",
     "referenceId": "DEFAULT",
     "referenceType": "ORGANIZATION",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
@@ -45,6 +45,7 @@ public interface RoleService {
     void delete(ExecutionContext executionContext, String roleId);
     List<RoleEntity> findAllByOrganization(String organizationId);
     RoleEntity findById(String roleId);
+    Optional<RoleEntity> findByIdAndOrganizationId(String roleId, String organizationId);
     List<RoleEntity> findByScope(RoleScope scope, String organizationId);
     Optional<RoleEntity> findByScopeAndName(RoleScope scope, String name, String organizationId);
     List<RoleEntity> findDefaultRoleByScopes(String organizationId, RoleScope... scopes);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -319,6 +319,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 }
                 importedApi.getGroups().add(group.getId());
             }
+        } else {
+            importedApi.setGroups(Collections.emptySet());
         }
 
         // Views & Categories

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -407,7 +407,21 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 MemberToImport memberToImport = objectMapper.readValue(memberNode.toString(), MemberToImport.class);
                 boolean presentWithSameRole = isPresentWithSameRole(membersAlreadyPresent, memberToImport);
 
-                List<String> roleIdsToImport = getRoleIdsToImport(executionContext, memberToImport);
+                List<String> roleIdsToImport = getRoleIdsToImport(executionContext, memberToImport)
+                    .stream()
+                    .filter(roleId -> {
+                        var role = roleService.findByIdAndOrganizationId(roleId, executionContext.getOrganizationId());
+                        var isValidRole = role.isPresent() && RoleScope.API.equals(role.get().getScope());
+                        if (!isValidRole) {
+                            LOGGER.warn(
+                                "Role {} does not exist in organization {} or is not an API role",
+                                roleId,
+                                executionContext.getOrganizationId()
+                            );
+                        }
+                        return isValidRole;
+                    })
+                    .toList();
                 addOrUpdateMembers(
                     executionContext,
                     apiEntity.getId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -101,6 +101,18 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
     }
 
     @Override
+    public Optional<RoleEntity> findByIdAndOrganizationId(String roleId, String organizationId) {
+        try {
+            return roleRepository
+                .findByIdAndReferenceIdAndReferenceType(roleId, organizationId, RoleReferenceType.ORGANIZATION)
+                .map(this::convert);
+        } catch (TechnicalException ex) {
+            LOGGER.error("An error occurs while trying to find roles by id and organizationId", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find roles by id and organizationId", ex);
+        }
+    }
+
+    @Override
     public List<RoleEntity> findAllByOrganization(String organizationId) {
         try {
             LOGGER.debug("Find all Roles");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -31,16 +31,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
-import io.gravitee.rest.api.model.MemberEntity;
-import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.PlanEntity;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
-import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.ApiIdsCalculatorService;
@@ -63,10 +56,7 @@ import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,6 +81,8 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
     private static final String API_ID = "id-api";
     private static final String SOURCE = "source";
+    private static final String PO_ROLE_ID = "API_PRIMARY_OWNER";
+    private static final String OWNER_ROLE_ID = "API_OWNER";
 
     @InjectMocks
     protected ApiDuplicatorServiceImpl apiDuplicatorService;
@@ -166,7 +158,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
     }
 
     @Test
-    public void shouldCreateImportApiWithMembersAndPages() throws IOException, TechnicalException {
+    public void shouldCreateImportApiWithMembersAndPages() throws IOException {
         URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.definition+members+pages.json");
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
         ApiEntity apiEntity = new ApiEntity();
@@ -176,12 +168,25 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         when(apiService.createWithApiDefinition(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(apiEntity);
         when(userService.findBySource(eq(GraviteeContext.getExecutionContext()), anyString(), anyString(), eq(false)))
             .thenReturn(new UserEntity());
+
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRoleEntity);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRoleEntity);
+                }
+                return Optional.empty();
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -227,12 +232,12 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
     }
 
     @Test
-    public void shouldCreateImportApiWithMembers() throws IOException, TechnicalException {
+    public void shouldCreateImportApiWithMembers() throws IOException {
         URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.definition+members.json");
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
         ApiEntity apiEntity = new ApiEntity();
@@ -253,11 +258,23 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRoleEntity);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRoleEntity);
+                }
+                return Optional.empty();
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -291,13 +308,13 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
         verify(membershipService, never()).transferApiOwnership(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
     }
 
     @Test
-    public void shouldCreateImportApiWithPages() throws IOException, TechnicalException {
+    public void shouldCreateImportApiWithPages() throws IOException {
         URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.definition+pages.json");
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
         ApiEntity apiEntity = new ApiEntity();
@@ -511,7 +528,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
     }
 
     @Test
-    public void shouldCreateImportApiEvenIfMemberRoleIsInvalid() throws IOException, TechnicalException {
+    public void shouldCreateImportApiEvenIfMemberRoleIsInvalid() throws IOException {
         URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.definition+members.json");
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
         ApiEntity apiEntity = new ApiEntity();
@@ -530,11 +547,23 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRoleEntity);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRoleEntity);
+                }
+                return Optional.empty();
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -552,7 +581,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             )
         )
             .thenThrow(new RoleNotFoundException("API_OWNER Not found"));
@@ -647,5 +676,70 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 })
             );
         verify(pageService, times(1)).createAsideFolder(eq(GraviteeContext.getExecutionContext()), eq(apiId));
+    }
+
+    @Test
+    public void shouldImportApiWithoutMembersWrongRoles() throws IOException {
+        URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.definition+members.json");
+        String toBeImport = Resources.toString(url, Charsets.UTF_8);
+        ApiEntity apiEntity = new ApiEntity();
+        Api api = new Api();
+        api.setId(API_ID);
+        apiEntity.setId(API_ID);
+        when(apiService.createWithApiDefinition(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(apiEntity);
+
+        UserEntity admin = new UserEntity();
+        admin.setId("admin");
+        admin.setSource(SOURCE);
+        admin.setSourceId("ref-admin");
+        UserEntity user = new UserEntity();
+        user.setId("user");
+        user.setSource(SOURCE);
+        user.setSourceId("ref-user");
+        when(userService.findBySource(GraviteeContext.getExecutionContext(), user.getSource(), user.getSourceId(), false)).thenReturn(user);
+        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
+
+        RoleEntity poRoleEntity = new RoleEntity();
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
+
+        RoleEntity ownerRoleEntity = new RoleEntity();
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.ENVIRONMENT);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRoleEntity);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRoleEntity);
+                }
+                return Optional.empty();
+            });
+
+        MemberEntity po = new MemberEntity();
+        po.setId("admin");
+        po.setReferenceId(API_ID);
+        po.setReferenceType(MembershipReferenceType.API);
+        po.setRoles(Arrays.asList(poRoleEntity));
+        po.setType(MembershipMemberType.USER);
+        MemberEntity owner = new MemberEntity();
+        owner.setId("user");
+        owner.setReferenceId(API_ID);
+        owner.setReferenceType(MembershipReferenceType.API);
+        owner.setType(MembershipMemberType.USER);
+        owner.setRoles(Arrays.asList(ownerRoleEntity));
+        when(membershipService.getMembersByReference(eq(GraviteeContext.getExecutionContext()), any(), any()))
+            .thenReturn(Collections.singleton(po));
+
+        when(apiIdsCalculatorService.recalculateApiDefinitionIds(any(), any())).then(AdditionalAnswers.returnsSecondArg());
+
+        apiDuplicatorService.createWithImportedDefinition(GraviteeContext.getExecutionContext(), toBeImport);
+
+        verify(apiService, times(1)).createWithApiDefinition(eq(GraviteeContext.getExecutionContext()), any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any(), any(), any(), any());
+        verify(membershipService, never()).transferApiOwnership(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -70,6 +70,8 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
     private static final String API_ID = "id-api";
     private static final String SOURCE = "source";
+    private static final String PO_ROLE_ID = "API_PRIMARY_OWNER";
+    private static final String OWNER_ROLE_ID = "API_OWNER";
 
     @InjectMocks
     protected ApiDuplicatorServiceImpl apiDuplicatorService;
@@ -163,11 +165,23 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
+        ownerRoleEntity.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRoleEntity);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRoleEntity);
+                }
+                return Optional.empty();
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -217,7 +231,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_PRIMARY_OWNER"
+                PO_ROLE_ID
             );
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
@@ -226,7 +240,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
         verify(apiService, times(1)).update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any());
         verify(apiService, never()).create(eq(GraviteeContext.getExecutionContext()), any(), any());
@@ -242,11 +256,23 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
+        poRole.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
 
         RoleEntity ownerRole = new RoleEntity();
-        ownerRole.setId("API_OWNER");
+        ownerRole.setId(OWNER_ROLE_ID);
+        ownerRole.setScope(RoleScope.API);
+
+        when(roleService.findByIdAndOrganizationId(anyString(), eq(GraviteeContext.getExecutionContext().getOrganizationId())))
+            .thenAnswer(invocationOnMock -> {
+                if (PO_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(poRole);
+                } else if (OWNER_ROLE_ID.equals(invocationOnMock.getArgument(0))) {
+                    return Optional.of(ownerRole);
+                }
+                return Optional.empty();
+            });
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -287,7 +313,8 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
+        poRoleEntity.setScope(RoleScope.API);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
 
         MemberEntity po = new MemberEntity();
@@ -312,7 +339,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_PRIMARY_OWNER"
+                PO_ROLE_ID
             );
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
@@ -321,7 +348,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
                 API_ID,
                 MembershipMemberType.USER,
                 user.getId(),
-                "API_OWNER"
+                OWNER_ROLE_ID
             );
         verify(apiService, times(1)).update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any());
         verify(apiService, never()).create(eq(GraviteeContext.getExecutionContext()), any(), any());
@@ -336,10 +363,10 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
 
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
 
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
         when(userService.findById(GraviteeContext.getExecutionContext(), user.getId())).thenReturn(user);
@@ -375,10 +402,10 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         UserEntity user = new UserEntity();
         ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
         RoleEntity poRoleEntity = new RoleEntity();
-        poRoleEntity.setId("API_PRIMARY_OWNER");
+        poRoleEntity.setId(PO_ROLE_ID);
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
         RoleEntity ownerRoleEntity = new RoleEntity();
-        ownerRoleEntity.setId("API_OWNER");
+        ownerRoleEntity.setId(OWNER_ROLE_ID);
 
         when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
         when(userService.findById(GraviteeContext.getExecutionContext(), user.getId())).thenReturn(user);
@@ -416,7 +443,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -455,7 +482,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(PO_ROLE_ID);
 
         mockApiIdRecalculation();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_FindByIdAndOrganizationId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_FindByIdAndOrganizationId.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.RoleRepository;
+import io.gravitee.repository.management.model.Role;
+import io.gravitee.repository.management.model.RoleReferenceType;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class RoleService_FindByIdAndOrganizationId {
+
+    private static final String ROLE_ID = "my-role";
+    private static final String ORGANIZATION_ID = "DEFAULT";
+
+    @InjectMocks
+    private RoleServiceImpl roleService = new RoleServiceImpl();
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @BeforeEach
+    public void setUp() {
+        GraviteeContext.getCurrentRoles().clear();
+    }
+
+    @Test
+    public void should_not_find_role() throws TechnicalException {
+        when(roleRepository.findByIdAndReferenceIdAndReferenceType(ROLE_ID, ORGANIZATION_ID, RoleReferenceType.ORGANIZATION))
+            .thenReturn(Optional.empty());
+
+        assertThat(roleService.findByIdAndOrganizationId(ROLE_ID, ORGANIZATION_ID)).isEmpty();
+    }
+
+    @Test
+    public void should_find_role() throws TechnicalException {
+        var role = new Role();
+        role.setId(ROLE_ID);
+
+        when(roleRepository.findByIdAndReferenceIdAndReferenceType(ROLE_ID, ORGANIZATION_ID, RoleReferenceType.ORGANIZATION))
+            .thenReturn(Optional.of(role));
+        assertThat(roleService.findByIdAndOrganizationId(ROLE_ID, ORGANIZATION_ID)).isNotNull();
+    }
+
+    @Test
+    public void should_throw_exception() throws TechnicalException {
+        when(roleRepository.findByIdAndReferenceIdAndReferenceType(ROLE_ID, ORGANIZATION_ID, RoleReferenceType.ORGANIZATION))
+            .thenThrow(new TechnicalException());
+
+        assertThrows(TechnicalManagementException.class, () -> roleService.findByIdAndOrganizationId(ROLE_ID, ORGANIZATION_ID));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2605

## Description

Improve API V2 import:

1. there is a difference between v2 and V4 APIs. Today when a user try to import a V2 API, the groups attribute is null by default which breaks the display on the frontend side.


https://github.com/gravitee-io/gravitee-api-management/assets/25704259/528788e3-1f6c-4562-ae58-a10998d12980

2. Ensure that users cannot import V2 APIs with member roles associated with an organization different from the one into which we intend to import the API. 

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/ed97a3df-f6d4-44a6-af7a-2914635993b2
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vloukjkfhm.chromatic.com)
<!-- Storybook placeholder end -->
