### PR TITLE
fix: use new path parameter processor at each call

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
@@ -137,8 +137,7 @@ public class RequestProcessorChainFactory extends ApiProcessorChainFactory {
         } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {
             final PathParametersExtractor extractor = new PathParametersExtractor(api);
             if (extractor.canExtractPathParams()) {
-                final PathParametersProcessor pathParametersProcessor = new PathParametersProcessor(extractor);
-                add(() -> pathParametersProcessor);
+                add(() -> new PathParametersProcessor(extractor));
             }
 
             if (api.getDefinition().getFlowMode() == null || api.getDefinition().getFlowMode() == FlowMode.DEFAULT) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/logback-test.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/logback-test.xml
@@ -26,7 +26,7 @@
         </encoder>
     </appender>
 
-    <logger name="io.gravitee" level="DEBUG" additivity="false">
+    <logger name="io.gravitee" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2819

## Description

Use new pathParameterProcessor at each call to avoid concurrency issue
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jdbyxpukye.chromatic.com)
<!-- Storybook placeholder end -->
