### PR TITLE
Refactor EmailNotifier to accept additional recipients

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/Recipient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/Recipient.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.model;
+
+public record Recipient(String type, String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.template;
+
+import freemarker.core.TemplateClassResolver;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+
+/**
+ * Implementation of {@link TemplateProcessor} using Freemarker.
+ */
+@Service
+public class FreemarkerTemplateProcessor implements TemplateProcessor {
+
+    @Override
+    public String processInlineTemplate(String template, Map<String, Object> params) throws TemplateProcessorException {
+        final freemarker.template.Configuration configuration = new freemarker.template.Configuration(
+            freemarker.template.Configuration.VERSION_2_3_22
+        );
+        configuration.setNewBuiltinClassResolver(TemplateClassResolver.SAFER_RESOLVER);
+
+        try {
+            Template freemarkerTemplate = new Template("", new StringReader(template), configuration);
+            return FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, params);
+        } catch (TemplateException | IOException e) {
+            throw new TemplateProcessorException(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/TemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/TemplateProcessor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.template;
+
+import java.util.Map;
+
+/**
+ * Interface of component handling Templates.
+ */
+public interface TemplateProcessor {
+    String processInlineTemplate(String template, Map<String, Object> params) throws TemplateProcessorException;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/TemplateProcessorException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/TemplateProcessorException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.template;
+
+public class TemplateProcessorException extends Exception {
+
+    public TemplateProcessorException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EmailNotification.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EmailNotification.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import lombok.Builder;
 
 /**
  * @author Azize Elamrani (azize.elamrani at graviteesource.com)
@@ -102,15 +103,14 @@ public class EmailNotification {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof EmailNotification)) return false;
-        EmailNotification that = (EmailNotification) o;
+        if (!(o instanceof EmailNotification that)) return false;
         return (
             Objects.equals(from, that.from) &&
             Objects.equals(fromName, that.fromName) &&
             Arrays.equals(to, that.to) &&
             Objects.equals(template, that.template) &&
             Objects.equals(params, that.params) &&
-            Objects.equals(bcc, that.bcc) &&
+            Arrays.equals(bcc, that.bcc) &&
             Objects.equals(copyToSender, that.copyToSender) &&
             Objects.equals(replyTo, that.replyTo)
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
@@ -42,33 +42,8 @@ public interface NotifierService {
         List<Recipient> additionalRecipients
     );
     void trigger(ExecutionContext executionContext, final PortalHook hook, Map<String, Object> params);
-    void triggerEmail(
-        ExecutionContext executionContext,
-        final ApplicationHook hook,
-        final String apiId,
-        Map<String, Object> params,
-        final String recipient
-    );
     List<NotifierEntity> list(NotificationReferenceType referenceType, String referenceId);
     Set<io.gravitee.rest.api.model.NotifierEntity> findAll();
     io.gravitee.rest.api.model.NotifierEntity findById(String notifier);
     String getSchema(String notifier);
-
-    /**
-     * Test if an email notification will be sent to the provided recipient
-     *
-     * @param executionContext
-     * @param hook the hook to test
-     * @param applicationId the notification related application identifier
-     * @param params the parameters used to customize template
-     * @param recipient the recipient to test
-     * @return if the recipient will received an email according to notification configuration, false otherwise
-     */
-    boolean hasEmailNotificationFor(
-        ExecutionContext executionContext,
-        final ApplicationHook hook,
-        final String applicationId,
-        Map<String, Object> params,
-        final String recipient
-    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service;
 
+import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.rest.api.model.notification.NotifierEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -33,6 +34,13 @@ import java.util.Set;
 public interface NotifierService {
     void trigger(ExecutionContext executionContext, final ApiHook hook, final String apiId, Map<String, Object> params);
     void trigger(ExecutionContext executionContext, final ApplicationHook hook, final String applicationId, Map<String, Object> params);
+    void trigger(
+        ExecutionContext executionContext,
+        final ApplicationHook hook,
+        final String applicationId,
+        Map<String, Object> params,
+        List<Recipient> additionalRecipients
+    );
     void trigger(ExecutionContext executionContext, final PortalHook hook, Map<String, Object> params);
     void triggerEmail(
         ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -66,7 +66,7 @@ public class EmailNotificationBuilder {
         return this;
     }
 
-    public EmailNotificationBuilder bcc(String[] bcc) {
+    public EmailNotificationBuilder bcc(String... bcc) {
         this.emailNotification.setBcc(bcc);
         return this;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
@@ -113,22 +113,6 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
 
     @Override
     @Async
-    public void triggerEmail(
-        final ExecutionContext executionContext,
-        final ApplicationHook hook,
-        final String appId,
-        Map<String, Object> params,
-        String recipient
-    ) {
-        if (!(recipient == null || recipient.isEmpty())) {
-            emailNotifierService.trigger(executionContext, hook, params, List.of(recipient));
-        } else {
-            LOGGER.debug("Recipient email is missing, ignore email trigger '{}' for application '{}'", hook, appId);
-        }
-    }
-
-    @Override
-    @Async
     public void trigger(
         final ExecutionContext executionContext,
         final ApplicationHook hook,
@@ -150,38 +134,6 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
     ) {
         triggerPortalNotifications(executionContext, hook, NotificationReferenceType.APPLICATION, applicationId, params);
         triggerGenericNotifications(executionContext, hook, NotificationReferenceType.APPLICATION, applicationId, params, recipients);
-    }
-
-    @Override
-    public boolean hasEmailNotificationFor(
-        final ExecutionContext executionContext,
-        final ApplicationHook hook,
-        final String applicationId,
-        Map<String, Object> params,
-        final String recipient
-    ) {
-        boolean result = false;
-        try {
-            for (GenericNotificationConfig genericNotificationConfig : genericNotificationConfigRepository.findByReferenceAndHook(
-                hook.name(),
-                NotificationReferenceType.APPLICATION,
-                applicationId
-            )) {
-                if (genericNotificationConfig.getNotifier().equals(DEFAULT_EMAIL_NOTIFIER_ID)) {
-                    List<String> mails = emailNotifierService.getMails(executionContext, genericNotificationConfig, params);
-                    result = mails != null && mails.contains(recipient);
-                }
-            }
-        } catch (TechnicalException e) {
-            LOGGER.error(
-                "Error looking for GenericNotificationConfig with {}/{}/{}",
-                hook,
-                NotificationReferenceType.APPLICATION,
-                applicationId,
-                e
-            );
-        }
-        return result;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/EmailNotifierService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/EmailNotifierService.java
@@ -26,19 +26,5 @@ import java.util.Map;
  * @author GraviteeSource Team
  */
 public interface EmailNotifierService {
-    void trigger(
-        ExecutionContext executionContext,
-        final Hook hook,
-        GenericNotificationConfig genericNotificationConfig,
-        final Map<String, Object> params
-    );
-
     void trigger(ExecutionContext executionContext, final Hook hook, final Map<String, Object> templateData, List<String> recipients);
-
-    @Deprecated
-    List<String> getMails(
-        ExecutionContext executionContext,
-        final GenericNotificationConfig genericNotificationConfig,
-        final Map<String, Object> params
-    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/EmailNotifierService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/EmailNotifierService.java
@@ -32,6 +32,10 @@ public interface EmailNotifierService {
         GenericNotificationConfig genericNotificationConfig,
         final Map<String, Object> params
     );
+
+    void trigger(ExecutionContext executionContext, final Hook hook, final Map<String, Object> templateData, List<String> recipients);
+
+    @Deprecated
     List<String> getMails(
         ExecutionContext executionContext,
         final GenericNotificationConfig genericNotificationConfig,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/CoreRulesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/CoreRulesTest.java
@@ -15,15 +15,9 @@
  */
 package architecture;
 
-import static com.tngtech.archunit.base.DescribedPredicate.not;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
-import static com.tngtech.archunit.lang.conditions.ArchConditions.haveNameMatching;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
-import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
-import com.tngtech.archunit.base.DescribedPredicate;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,6 +41,8 @@ public class CoreRulesTest extends AbstractApimArchitectureTest {
                     "java..",
                     "org.slf4j..",
                     "lombok..",
+                    // Api Definition can't be in core because it is required for the Gateway
+                    "io.gravitee.definition..",
                     // TODO: ideally, core should be independent from model.
                     "io.gravitee.rest.api.model..",
                     // Common and Exceptions are an accepted case of reusability

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
@@ -15,52 +15,26 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
-import freemarker.template.TemplateException;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
-import io.gravitee.repository.management.model.GenericNotificationConfig;
-import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
-import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.notification.ApiHook;
-import io.gravitee.rest.api.service.notification.ApplicationHook;
-import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
-import io.gravitee.rest.api.service.notification.NotificationTemplateService;
-import io.gravitee.rest.api.service.notification.PortalHook;
 import io.gravitee.rest.api.service.notifiers.impl.EmailNotifierServiceImpl;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -74,14 +48,11 @@ public class EmailNotifierServiceTest {
     @Mock
     private EmailService mockEmailService;
 
-    @Mock
-    private NotificationTemplateService notificationTemplateService;
-
     private EmailNotifierServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new EmailNotifierServiceImpl(mockEmailService, notificationTemplateService, new FreemarkerTemplateProcessor());
+        service = new EmailNotifierServiceImpl(mockEmailService, new FreemarkerTemplateProcessor());
     }
 
     @Nested
@@ -211,179 +182,5 @@ public class EmailNotifierServiceTest {
             service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, Map.of(), List.of("${inco"));
             verifyNoInteractions(mockEmailService);
         }
-    }
-
-    @Test
-    public void shouldNotSendEmailIfNoConfig() {
-        service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, (GenericNotificationConfig) null, null);
-        verify(mockEmailService, never()).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-
-        service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, new GenericNotificationConfig(), null);
-        verify(mockEmailService, never()).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("");
-        service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, cfg, null);
-        verify(mockEmailService, never()).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-    }
-
-    @Test
-    public void shouldNotSendEmailIfNoHook() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com");
-        service.trigger(GraviteeContext.getExecutionContext(), null, cfg, null);
-        verify(mockEmailService, never()).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-    }
-
-    @Test
-    public void shouldHaveATemplateForApiHooks() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com");
-        ApiEntity api = new ApiEntity();
-        api.setName("api-name");
-        PlanEntity plan = new PlanEntity();
-        plan.setId("plan-12345");
-        plan.setName("plan-name");
-        Map<String, Object> params = new HashMap<>();
-        params.put((NotificationParamsBuilder.PARAM_API), api);
-        params.put((NotificationParamsBuilder.PARAM_PLAN), plan);
-        for (ApiHook hook : ApiHook.values()) {
-            if (!ApiHook.MESSAGE.equals(hook)) {
-                reset(mockEmailService);
-                service.trigger(GraviteeContext.getExecutionContext(), hook, cfg, params);
-                verify(mockEmailService, times(1))
-                    .sendAsyncEmailNotification(
-                        eq(GraviteeContext.getExecutionContext()),
-                        argThat(notification ->
-                            notification.getTo() != null &&
-                            notification.getTo().length == 1 &&
-                            notification.getTo()[0].equals("test@mail.com")
-                        )
-                    );
-                verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-            }
-        }
-    }
-
-    @Test
-    public void shouldHaveATemplateForApplicationHooks() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com");
-        ApiEntity api = new ApiEntity();
-        api.setName("api-name");
-        PlanEntity plan = new PlanEntity();
-        plan.setName("plan-name");
-        Map<String, Object> params = new HashMap<>();
-        params.put((NotificationParamsBuilder.PARAM_API), api);
-        params.put((NotificationParamsBuilder.PARAM_PLAN), plan);
-        for (ApplicationHook hook : ApplicationHook.values()) {
-            reset(mockEmailService);
-            service.trigger(GraviteeContext.getExecutionContext(), hook, cfg, params);
-            verify(mockEmailService, times(1))
-                .sendAsyncEmailNotification(
-                    eq(GraviteeContext.getExecutionContext()),
-                    argThat(notification ->
-                        notification.getTo() != null && notification.getTo().length == 1 && notification.getTo()[0].equals("test@mail.com")
-                    )
-                );
-            verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        }
-    }
-
-    @Test
-    public void shouldHaveATemplateForPortalHooks() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com");
-        for (PortalHook hook : PortalHook.values()) {
-            if (!PortalHook.MESSAGE.equals(hook) && !PortalHook.GROUP_INVITATION.equals(hook)) {
-                reset(mockEmailService);
-                service.trigger(GraviteeContext.getExecutionContext(), hook, cfg, Collections.emptyMap());
-                verify(mockEmailService, times(1))
-                    .sendAsyncEmailNotification(
-                        eq(GraviteeContext.getExecutionContext()),
-                        argThat(notification ->
-                            notification.getTo() != null &&
-                            notification.getTo().length == 1 &&
-                            notification.getTo()[0].equals("test@mail.com")
-                        )
-                    );
-                verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-            }
-        }
-    }
-
-    @Test
-    public void shouldHaveATemplateForApplicationHooksWithFreemarker() throws TemplateException {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com, ${api.primaryOwner.email} ");
-        ApiEntity api = new ApiEntity();
-        api.setName("api-name");
-        UserEntity userEntity = new UserEntity();
-        userEntity.setEmail("primary@owner.com");
-        api.setPrimaryOwner(new PrimaryOwnerEntity(userEntity));
-        PlanEntity plan = new PlanEntity();
-        plan.setId("plan-id");
-        plan.setName("plan-name");
-        Map<String, Object> params = new HashMap<>();
-        params.put((NotificationParamsBuilder.PARAM_API), api);
-        params.put((NotificationParamsBuilder.PARAM_PLAN), plan);
-
-        when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), anyString(), any()))
-            .thenReturn("primary@owner.com");
-
-        for (ApplicationHook hook : ApplicationHook.values()) {
-            reset(mockEmailService);
-            service.trigger(GraviteeContext.getExecutionContext(), hook, cfg, params);
-            verify(mockEmailService, times(1))
-                .sendAsyncEmailNotification(
-                    eq(GraviteeContext.getExecutionContext()),
-                    argThat(notification ->
-                        notification.getTo() != null &&
-                        notification.getTo().length == 2 &&
-                        notification.getTo()[0].equals("test@mail.com") &&
-                        notification.getTo()[1].equals("primary@owner.com")
-                    )
-                );
-            verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
-        }
-    }
-
-    @Test
-    public void shouldHaveEmail() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        cfg.setConfig("test@mail.com");
-        ApiEntity api = new ApiEntity();
-        api.setName("api-name");
-        PlanEntity plan = new PlanEntity();
-        plan.setName("plan-name");
-        Map<String, Object> params = new HashMap<>();
-        params.put((NotificationParamsBuilder.PARAM_API), api);
-        params.put((NotificationParamsBuilder.PARAM_PLAN), plan);
-
-        List<String> mails = service.getMails(GraviteeContext.getExecutionContext(), cfg, params);
-        assertNotNull(mails);
-        assertFalse(mails.isEmpty());
-        assertThat(mails, CoreMatchers.hasItem(cfg.getConfig()));
-    }
-
-    @Test
-    public void shouldHaveEmptyEmailList() {
-        GenericNotificationConfig cfg = new GenericNotificationConfig();
-        Map<String, Object> params = new HashMap<>();
-        List<String> mails = service.getMails(GraviteeContext.getExecutionContext(), cfg, params);
-        assertNotNull(mails);
-        assertTrue(mails.isEmpty());
-    }
-
-    @Test
-    public void shouldHaveEmptyEmailList_NoConfig() {
-        Map<String, Object> params = new HashMap<>();
-        List<String> mails = service.getMails(GraviteeContext.getExecutionContext(), null, params);
-        assertNotNull(mails);
-        assertTrue(mails.isEmpty());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
@@ -15,39 +15,61 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import freemarker.template.TemplateException;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.notification.*;
+import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApplicationHook;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.notification.PortalHook;
 import io.gravitee.rest.api.service.notifiers.impl.EmailNotifierServiceImpl;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EmailNotifierServiceTest {
-
-    @InjectMocks
-    private EmailNotifierServiceImpl service = new EmailNotifierServiceImpl();
 
     @Mock
     private EmailService mockEmailService;
@@ -55,9 +77,145 @@ public class EmailNotifierServiceTest {
     @Mock
     private NotificationTemplateService notificationTemplateService;
 
+    private EmailNotifierServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EmailNotifierServiceImpl(mockEmailService, notificationTemplateService, new FreemarkerTemplateProcessor());
+    }
+
+    @Nested
+    class Trigger {
+
+        @Test
+        public void should_send_email_based_on_hook() {
+            // Given
+            var executionContext = new ExecutionContext(null, null);
+            var templateData = Map.<String, Object>of();
+            var recipientEmail = "recipient1@gravitee.io";
+
+            // When
+            service.trigger(executionContext, ApiHook.API_STARTED, templateData, List.of(recipientEmail));
+
+            // Then
+            verify(mockEmailService)
+                .sendAsyncEmailNotification(
+                    same(executionContext),
+                    eq(
+                        new EmailNotificationBuilder()
+                            .bcc(recipientEmail)
+                            .template(EmailNotificationBuilder.EmailTemplate.API_API_STARTED)
+                            .params(templateData)
+                            .build()
+                    )
+                );
+        }
+
+        @Test
+        public void should_send_email_using_templated_recipient() {
+            // Given
+            var executionContext = new ExecutionContext(null, null);
+            var templateData = Map.<String, Object>of(
+                "api",
+                ApiEntity.builder().primaryOwner(PrimaryOwnerEntity.builder().email("po@gravitee.io").build()).build()
+            );
+
+            // When
+            service.trigger(executionContext, ApiHook.API_STARTED, templateData, List.of("${api.primaryOwner.email}"));
+
+            // Then
+            verify(mockEmailService)
+                .sendAsyncEmailNotification(
+                    same(executionContext),
+                    eq(
+                        new EmailNotificationBuilder()
+                            .bcc("po@gravitee.io")
+                            .template(EmailNotificationBuilder.EmailTemplate.API_API_STARTED)
+                            .params(templateData)
+                            .build()
+                    )
+                );
+        }
+
+        @Test
+        public void should_send_email_to_several_recipients() {
+            // Given
+            var executionContext = new ExecutionContext(null, null);
+            var templateData = Map.<String, Object>of();
+            var recipientEmail1 = "recipient1@gravitee.io";
+            var recipientEmail2 = "recipient2@gravitee.io";
+
+            // When
+            service.trigger(executionContext, ApiHook.API_STARTED, templateData, List.of(recipientEmail1, recipientEmail2));
+
+            // Then
+            verify(mockEmailService)
+                .sendAsyncEmailNotification(
+                    same(executionContext),
+                    eq(
+                        new EmailNotificationBuilder()
+                            .bcc(recipientEmail2, recipientEmail1)
+                            .template(EmailNotificationBuilder.EmailTemplate.API_API_STARTED)
+                            .params(templateData)
+                            .build()
+                    )
+                );
+        }
+
+        @Test
+        public void should_remove_any_duplicate_in_recipients_before_sending_email() {
+            // Given
+            var executionContext = new ExecutionContext(null, null);
+            var templateData = Map.<String, Object>of(
+                "api",
+                ApiEntity.builder().primaryOwner(PrimaryOwnerEntity.builder().email("po@gravitee.io").build()).build()
+            );
+
+            // When
+            service.trigger(
+                executionContext,
+                ApiHook.API_STARTED,
+                templateData,
+                List.of(
+                    "recipient2@gravitee.io",
+                    "${api.primaryOwner.email}",
+                    "recipient1@gravitee.io",
+                    "recipient2@gravitee.io",
+                    "po@gravitee.io",
+                    "recipient1@gravitee.io"
+                )
+            );
+
+            // Then
+            verify(mockEmailService)
+                .sendAsyncEmailNotification(
+                    same(executionContext),
+                    eq(
+                        new EmailNotificationBuilder()
+                            .bcc("recipient2@gravitee.io", "po@gravitee.io", "recipient1@gravitee.io")
+                            .template(EmailNotificationBuilder.EmailTemplate.API_API_STARTED)
+                            .params(templateData)
+                            .build()
+                    )
+                );
+        }
+
+        @Test
+        public void should_do_nothing_when_no_hook_is_provided() {
+            service.trigger(GraviteeContext.getExecutionContext(), null, Map.of(), List.of());
+            verifyNoInteractions(mockEmailService);
+        }
+
+        @Test
+        public void should_do_nothing_when_templated_recipient_mal_formed() {
+            service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, Map.of(), List.of("${inco"));
+            verifyNoInteractions(mockEmailService);
+        }
+    }
+
     @Test
     public void shouldNotSendEmailIfNoConfig() {
-        service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, null, null);
+        service.trigger(GraviteeContext.getExecutionContext(), ApiHook.API_STARTED, (GenericNotificationConfig) null, null);
         verify(mockEmailService, never()).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
         verify(mockEmailService, never()).sendEmailNotification(eq(GraviteeContext.getExecutionContext()), any());
 


### PR DESCRIPTION
## Description

There was a specific case in SubscriptionService, where we sent ApplicationNotification using notification config (usually the primary owner). Still, the notification must also be sent to the subscriber when rejecting or accepting.

The current implementation was scattered. I suggest a simpler implementation (I could remove several methods). 

I've updated `EmailNotifierService.trigger` method to accept a list of recipients. This method supports templated recipients (which will be "decoded" using Freemarker) and removes duplicates in the recipient list.
Base on that SubscriptionService only have to give the subscriber's email to the additional recipients and the notifier service will do the job



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

