### PR TITLE
Console - continue notifications migration (part 5)

### DIFF
--- a/gravitee-apim-console-webui/src/entities/notification/hooks.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/hooks.fixture.ts
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
+import { Hooks } from './hooks';
+
+export function fakeHooks(attributes?: Partial<Hooks>): Hooks {
+  const defaultValue: Hooks = {
+    id: 'test_id',
+    label: 'test label',
+    description: 'test description',
+    scope: 'test SCOPE',
+    category: 'TEST CATEGORY',
+  };
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
 }

--- a/gravitee-apim-console-webui/src/entities/notification/hooks.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/hooks.ts
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
+export interface Hooks {
+  id: string;
+  label: string;
+  description: string;
+  scope: string;
+  category: string;
 }

--- a/gravitee-apim-console-webui/src/entities/notification/notifier.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notifier.fixture.ts
@@ -18,6 +18,7 @@ import { Notifier } from './notifier';
 export function fakeNotifier(attributes?: Partial<Notifier>): Notifier {
   const defaultValue: Notifier = {
     id: 'test id',
+    type: 'test type',
     name: 'test name',
   };
   return {

--- a/gravitee-apim-console-webui/src/entities/notification/notifier.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notifier.ts
@@ -16,5 +16,5 @@
 export interface Notifier {
   id?: string;
   type?: string;
-  name: string;
+  name?: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -38,6 +38,7 @@ import { NotificationsListModule } from './notifications/notifications-list/noti
 import { ApiCreationV2Module } from './creation-v2/api-creation-v2.module';
 import { ApiCreationGetStartedModule } from './creation-get-started/api-creation-get-started.module';
 import { ApiCreationV4Module } from './creation-v4/api-creation-v4.module';
+import { NotificationDetailsModule } from './notifications/notifications-list/notofication-details/notification-details.module';
 
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
 import { GioEmptyModule } from '../../shared/components/gio-empty/gio-empty.module';
@@ -89,6 +90,7 @@ graviteeManagementModule.run(apiPermissionHook);
     ApiEndpointsModule,
     ApiAuditModule,
     NotificationsListModule,
+    NotificationDetailsModule,
     GioPolicyStudioRoutingModule.withRouting({ stateNamePrefix: 'management.apis.policy-studio-v2' }),
     SpecificJsonSchemaTypeModule,
     DocumentationModule,

--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -833,16 +833,22 @@ export const states: Ng2StateDeclaration[] = [
       apiPermissions: {
         only: ['api-notification-r'],
       },
+      docs: {
+        page: 'management-api-notifications',
+      },
       useAngularMaterial: true,
     },
   },
   {
-    name: 'management.apis.notifications-ng.details',
+    name: 'management.apis.notification-details',
     component: NotificationDetailsComponent,
-    url: '/:notificationId',
+    url: '/notifications-ng/:notificationId',
     data: {
       apiPermissions: {
-        only: ['api-notification-r'],
+        only: ['api-notification-r', 'api-notification-c', 'api-notification-u'],
+      },
+      docs: {
+        page: 'management-api-notifications',
       },
       useAngularMaterial: true,
     },

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.html
@@ -44,9 +44,16 @@
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef id="name">Name</th>
       <td mat-cell *matCellDef="let element">
-        <a [uiSref]="'management.apis.notifications-ng.details'" [uiParams]="{ notificationId: element.id || element.configType }">
+        <a [uiSref]="'management.apis.notification-details'" [uiParams]="{ notificationId: element.id || element.configType }">
           {{ element.name }}
         </a>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="notifier">
+      <th mat-header-cell *matHeaderCellDef id="notifier">Notifier</th>
+      <td mat-cell *matCellDef="let element">
+        <span class="gio-badge-neutral" *ngIf="element.notifierName">{{ element.notifierName }}</span>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.spec.ts
@@ -102,16 +102,20 @@ describe('NotificationsListComponent', () => {
       expect(await table.getCellTextByIndex()).toEqual([['Loading...']]);
 
       const notifications = [fakeNotificationSettings({ name: 'Test name' })];
-      expectApiGetNotificationList(notifications);
-      expectApiGetNotifiers([]);
+      const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
 
-      expect(await table.getCellTextByIndex()).toEqual([['Test name', '']]);
+      expectApiGetNotificationList(notifications);
+      expectApiGetNotifiers(notifier);
+
+      expect(await table.getCellTextByIndex()).toEqual([['Test name', 'Notifier A', '']]);
     });
 
     it('should delete the notification', async () => {
       const table = [fakeNotificationSettings({ name: 'Test name', id: 'test id' })];
+      const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
+
       expectApiGetNotificationList(table);
-      expectApiGetNotifiers([]);
+      expectApiGetNotifiers(notifier);
 
       const button = await loader.getHarness(MatButtonHarness.with({ selector: `[aria-label="Delete notification"]` }));
       await button.click();
@@ -128,7 +132,7 @@ describe('NotificationsListComponent', () => {
     it('should add the notification', async () => {
       const table = [fakeNotificationSettings({ name: 'Test name', id: 'test id' })];
       expectApiGetNotificationList(table);
-      const notifier = [fakeNotifier({ id: 'notifier-a', name: 'Notifier A' })];
+      const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
       expectApiGetNotifiers(notifier);
 
       const button = await loader.getHarness(MatButtonHarness.with({ selector: `[aria-label="Add notification"]` }));
@@ -154,7 +158,7 @@ describe('NotificationsListComponent', () => {
         config_type: 'GENERIC',
         hooks: [],
         name: 'Test notification',
-        notifier: 'notifier-a',
+        notifier: 'default-email',
         referenceId: 'apiId',
         referenceType: 'API',
       });

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notifications-list.component.ts
@@ -36,6 +36,7 @@ type NotificationSettingsTable = {
   name: string;
   id: string;
   configType: string;
+  notifierName?: string;
 };
 
 @Component({
@@ -47,7 +48,7 @@ export class NotificationsListComponent implements OnInit {
   public notificationsSettingsTable: NotificationSettingsTable[] = [];
   public notifiersGroup: Notifier[] = [];
   public isLoadingData = true;
-  public displayedColumns = ['name', 'actions'];
+  public displayedColumns = ['name', 'notifier', 'actions'];
   public notificationUnpaginatedLength = 0;
   public filteredNotificationsSettingsTable = [];
 
@@ -64,22 +65,24 @@ export class NotificationsListComponent implements OnInit {
     this.isLoadingData = true;
     this.filteredNotificationsSettingsTable = [];
     combineLatest([
-      this.notificationSettingsService.getNotificationSettings(this.ajsStateParams.apiId),
+      this.notificationSettingsService.getAll(this.ajsStateParams.apiId),
       this.notificationSettingsService.getNotifiers(this.ajsStateParams.apiId),
     ])
       .pipe(
         tap(([notificationsList, notifiers]) => {
+          this.notifiersGroup = notifiers;
+
           this.notificationsSettingsTable = notificationsList.map((notificationSettings) => {
             return {
               id: notificationSettings.id,
               configType: notificationSettings.config_type,
               name: notificationSettings.name,
+              notifier: notificationSettings.notifier || 'none',
+              notifierName: this.setNotifierName(notificationSettings),
             };
           });
           this.filteredNotificationsSettingsTable = this.notificationsSettingsTable;
           this.notificationUnpaginatedLength = this.filteredNotificationsSettingsTable.length;
-
-          this.notifiersGroup = notifiers;
         }),
         takeUntil(this.unsubscribe$),
       )
@@ -152,5 +155,11 @@ export class NotificationsListComponent implements OnInit {
         takeUntil(this.unsubscribe$),
       )
       .subscribe(() => this.ngOnInit());
+  }
+
+  setNotifierName(element) {
+    if (element.id) {
+      return this.notifiersGroup.find((i) => i.id === element.notifier).name;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.html
@@ -15,4 +15,31 @@
     limitations under the License.
 
 -->
-🚧 Notification detail component 🚧
+<div>
+  <div class="md-headline notifications-form__title" *ngIf="!isLoadingData">
+    <gio-go-back-button [ajsGo]="{ to: 'management.apis.notifications-ng' }"></gio-go-back-button>
+    Update <b>{{ notificationSettings.name }}</b>
+    <span *ngIf="notifier" class="gio-badge-neutral">{{ notifier.name }}</span>
+  </div>
+  <form autocomplete="off" gioFormFocusInvalid [formGroup]="notificationForm" (ngSubmit)="onSubmit()" *ngIf="!isLoadingData">
+    <mat-card>
+      <mat-form-field class="notifications-form__email">
+        <mat-label>Email list</mat-label>
+        <input matInput formControlName="notifier" />
+        <mat-hint>Use space, ',' or ';' to separate emails. EL supported.</mat-hint>
+      </mat-form-field>
+      <h3>Event subscribed</h3>
+
+      <div *ngFor="let category of categoriesHooksVM" class="notifications-hooks-categories">
+        <h6>{{ category.name }}</h6>
+        <div class="checkbox-container">
+          <mat-checkbox *ngFor="let singleHook of category.hooks" [formControlName]="singleHook.id" class="checkbox-container__checkbox">
+            <b>{{ singleHook.label }}</b
+            ><br />{{ singleHook.description }}
+          </mat-checkbox>
+        </div>
+      </div>
+    </mat-card>
+    <gio-save-bar [form]="notificationForm" [formInitialValues]="formInitialValues"></gio-save-bar>
+  </form>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.scss
@@ -1,0 +1,36 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.checkbox-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.checkbox-container__checkbox {
+  flex-basis: calc(50% - 8px);
+  margin: 4px;
+}
+
+.notifications-form__email {
+  width: 100%;
+}
+
+.notifications-form__title {
+  margin-bottom: 16px;
+}
+
+.notifications-hooks-categories {
+  margin-bottom: 20px;
+
+  h6 {
+    margin: 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { UIRouterModule } from '@uirouter/angular';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { NotificationDetailsComponent } from './notification-details.component';
+import { NotificationDetailsModule } from './notification-details.module';
+
+import { User } from '../../../../../entities/user';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../shared/testing';
+import { GioUiRouterTestingModule } from '../../../../../shared/testing/gio-uirouter-testing-module';
+import { AjsRootScope, CurrentUserService, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
+import { fakeHooks } from '../../../../../entities/notification/hooks.fixture';
+import { fakeNotificationSettings } from '../../../../../entities/notification/notificationSettings.fixture';
+import { Notifier } from '../../../../../entities/notification/notifier';
+import { fakeNotifier } from '../../../../../entities/notification/notifier.fixture';
+import { NotificationSettings } from '../../../../../entities/notification/notificationSettings';
+import { Hooks } from '../../../../../entities/notification/hooks';
+
+describe('NotificationDetailsComponent', () => {
+  let fixture: ComponentFixture<NotificationDetailsComponent>;
+  const API_ID = 'apiId';
+  const NOTIFICATION_ID = 'f7889b1c-2b4c-435d-889b-1c2b4c235da9';
+  const currentUser = new User();
+  currentUser.userPermissions = ['api-notification-u', 'api-notification-d', 'api-notification-c'];
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        GioHttpTestingModule,
+        GioUiRouterTestingModule,
+        NotificationDetailsModule,
+        MatIconTestingModule,
+        UIRouterModule.forRoot({
+          useHash: true,
+        }),
+      ],
+      providers: [
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID, notificationId: NOTIFICATION_ID } },
+        { provide: AjsRootScope, useValue: null },
+        { provide: CurrentUserService, useValue: { currentUser } },
+      ],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+          isTabbable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(NotificationDetailsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should display all checkboxes', async () => {
+    const hooks = [fakeHooks()];
+    const notifications = [fakeNotificationSettings({ name: 'Test name' })];
+    const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
+
+    expectApiGetHooks(hooks);
+    expectApiGetNotifiers(notifier);
+    expectApiGetSingleNotificationList(notifications);
+
+    const groupCheckbox = await loader.getAllHarnesses(MatCheckboxHarness);
+    expect(groupCheckbox.length).toEqual(1);
+
+    const testCheckbox = await loader.getHarness(MatCheckboxHarness.with({ selector: `[ng-reflect-name="test_id"]` }));
+    expect(await testCheckbox.isChecked()).toEqual(false);
+  });
+
+  it('should update a checkbox', async () => {
+    const hooks = [fakeHooks()];
+    const notifications = [fakeNotificationSettings({ name: 'Test name' })];
+    const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
+
+    expectApiGetHooks(hooks);
+    expectApiGetNotifiers(notifier);
+    expectApiGetSingleNotificationList(notifications);
+
+    const testCheckbox = await loader.getHarness(MatCheckboxHarness.with({ selector: `[ng-reflect-name="test_id"]` }));
+    expect(await testCheckbox.isChecked()).toEqual(false);
+
+    await testCheckbox.check();
+
+    expect(await testCheckbox.isChecked()).toEqual(true);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+
+    await saveBar.clickSubmit();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${NOTIFICATION_ID}`);
+
+    expect(req.request.method).toEqual('PUT');
+    expect(req.request.body).toEqual({
+      id: 'f7889b1c-2b4c-435d-889b-1c2b4c235da9',
+      name: 'Test name',
+      referenceType: 'API',
+      referenceId: 'f1ddf4b5-c23a-33a7-87bf-28ec0a1d9db9',
+      notifier: 'default-email',
+      hooks: ['test_id'],
+      useSystemProxy: false,
+      config_type: 'GENERIC',
+      config: null,
+    });
+  });
+
+  it('should update an email', async () => {
+    const hooks = [fakeHooks()];
+    const notifications = [fakeNotificationSettings({ name: 'Test name' })];
+    const notifier = [fakeNotifier({ id: 'default-email', name: 'Notifier A', type: 'Notifier-type' })];
+
+    expectApiGetHooks(hooks);
+    expectApiGetNotifiers(notifier);
+    expectApiGetSingleNotificationList(notifications);
+
+    const notifierInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=notifier]' }));
+    await notifierInput.setValue('test@email.test');
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+
+    await saveBar.clickSubmit();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${NOTIFICATION_ID}`);
+
+    expect(req.request.method).toEqual('PUT');
+    expect(req.request.body).toEqual({
+      id: 'f7889b1c-2b4c-435d-889b-1c2b4c235da9',
+      name: 'Test name',
+      referenceType: 'API',
+      referenceId: 'f1ddf4b5-c23a-33a7-87bf-28ec0a1d9db9',
+      notifier: 'default-email',
+      hooks: ['notifier'],
+      useSystemProxy: false,
+      config_type: 'GENERIC',
+      config: 'test@email.test',
+    });
+  });
+
+  function expectApiGetHooks(hooks: Hooks[]) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/hooks`,
+        method: 'GET',
+      })
+      .flush(hooks);
+    fixture.detectChanges();
+  }
+
+  function expectApiGetNotifiers(notifier: Notifier[]) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notifiers`,
+        method: 'GET',
+      })
+      .flush(notifier);
+    fixture.detectChanges();
+  }
+
+  function expectApiGetSingleNotificationList(notifactionSettings: NotificationSettings[]) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings`,
+        method: 'GET',
+      })
+      .flush(notifactionSettings);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.ts
@@ -13,11 +13,107 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, Subject } from 'rxjs';
+import { groupBy, map } from 'lodash';
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
+import { NotificationSettingsService } from '../../../../../services-ngx/notification-settings.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { NotificationSettings } from '../../../../../entities/notification/notificationSettings';
+import { Notifier } from '../../../../../entities/notification/notifier';
+import { Hooks } from '../../../../../entities/notification/hooks';
+
+type CategoriesHooksVM = {
+  name: string;
+  hooks: (Hooks & { checked: boolean })[];
+}[];
 
 @Component({
   selector: 'notifications-details',
   template: require('./notification-details.component.html'),
   styles: [require('./notification-details.component.scss')],
 })
-export class NotificationDetailsComponent {}
+export class NotificationDetailsComponent implements OnInit, OnDestroy {
+  public isLoadingData = true;
+  public categoriesHooksVM: CategoriesHooksVM;
+  public notificationSettings: NotificationSettings;
+  public formInitialValues: unknown;
+  public notifier: Notifier;
+  notificationForm: FormGroup;
+
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  constructor(
+    private readonly notificationSettingsService: NotificationSettingsService,
+    private readonly snackBarService: SnackBarService,
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+  ) {}
+
+  public ngOnInit() {
+    this.isLoadingData = true;
+    combineLatest([
+      this.notificationSettingsService.getHooks(),
+      this.notificationSettingsService.getSingleNotificationSetting(this.ajsStateParams.apiId, this.ajsStateParams.notificationId),
+      this.notificationSettingsService.getNotifiers(this.ajsStateParams.apiId),
+    ])
+      .pipe(
+        tap(([hooks, notificationSettings, notifiers]) => {
+          this.notificationSettings = notificationSettings;
+          this.notificationForm = new FormGroup({
+            notifier: new FormControl(this.notificationSettings.config),
+          });
+
+          const hooksChecked: (Hooks & { checked: boolean })[] = hooks.map((hook) => ({
+            ...hook,
+            checked: notificationSettings.hooks.includes(hook.id),
+          }));
+
+          hooksChecked.map((item) => {
+            this.notificationForm.addControl(`${item.id}`, new FormControl(item.checked));
+          });
+
+          const categories = groupBy(hooksChecked, 'category');
+          this.categoriesHooksVM = map(categories, (hooks, k) => ({
+            name: k,
+            hooks: hooks,
+          }));
+          this.notifier = notifiers.find((i) => i.id === this.notificationSettings.notifier);
+          this.formInitialValues = this.notificationForm.getRawValue();
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => {
+        this.isLoadingData = false;
+      });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onSubmit() {
+    if (this.notificationForm.invalid) {
+      return;
+    }
+
+    const notificationSettingsValue = {
+      ...this.notificationSettings,
+      hooks: Object.keys(
+        Object.fromEntries(Object.entries(this.notificationForm.getRawValue()).filter(([key, value]) => value && key !== 'config')),
+      ),
+      config: this.notificationForm.controls.notifier.value,
+    };
+
+    this.notificationSettingsService
+      .update(this.ajsStateParams.apiId, this.ajsStateParams.notificationId, notificationSettingsValue)
+      .pipe(
+        tap(() => this.snackBarService.success('Notification settings successfully saved!')),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(() => this.ngOnInit());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.module.ts
@@ -15,12 +15,35 @@
  */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { GioFormFocusInvalidModule, GioFormHeadersModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatInputModule } from '@angular/material/input';
+import { MatCardModule } from '@angular/material/card';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { NotificationDetailsComponent } from './notification-details.component';
+
+import { GioPermissionModule } from '../../../../../shared/components/gio-permission/gio-permission.module';
+import { GioGoBackButtonModule } from '../../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
 
 @NgModule({
   declarations: [NotificationDetailsComponent],
   exports: [NotificationDetailsComponent],
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    GioPermissionModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioSaveBarModule,
+    GioFormHeadersModule,
+    GioFormFocusInvalidModule,
+    GioGoBackButtonModule,
+    ReactiveFormsModule,
+    MatCheckboxModule,
+    MatInputModule,
+    MatCardModule,
+    MatSnackBarModule,
+  ],
 })
 export class NotificationDetailsModule {}

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.spec.ts
@@ -67,7 +67,7 @@ describe('NotificationSettings', () => {
     it('should call the API', (done) => {
       const notificationSettings = [fakeNotificationSettings({ name: 'Test name', id: 'test id' })];
 
-      notificationSettingsService.getNotificationSettings('123').subscribe(() => done());
+      notificationSettingsService.getAll('123').subscribe(() => done());
 
       httpTestingController
         .expectOne({

--- a/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/notification-settings.service.ts
@@ -16,11 +16,13 @@
 import { Inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { Constants } from '../entities/Constants';
 import { NotificationSettings } from '../entities/notification/notificationSettings';
 import { Notifier } from '../entities/notification/notifier';
 import { NewNotificationSettings } from '../entities/notification/newNotificationSettings';
+import { Hooks } from '../entities/notification/hooks';
 
 @Injectable({
   providedIn: 'root',
@@ -28,8 +30,16 @@ import { NewNotificationSettings } from '../entities/notification/newNotificatio
 export class NotificationSettingsService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
-  getNotificationSettings(apiId: string): Observable<NotificationSettings[]> {
+  getAll(apiId: string): Observable<NotificationSettings[]> {
     return this.http.get<NotificationSettings[]>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings`);
+  }
+
+  getSingleNotificationSetting(apiId: string, selectedId: string): Observable<NotificationSettings> {
+    return this.http.get<NotificationSettings[]>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings`).pipe(
+      map((notifications: NotificationSettings[]) => {
+        return notifications.find((notification) => notification.id === selectedId) || notifications[0];
+      }),
+    );
   }
 
   delete(apiId: string, id: string): Observable<NotificationSettings[]> {
@@ -40,7 +50,18 @@ export class NotificationSettingsService {
     return this.http.get<Notifier[]>(`${this.constants.env.baseURL}/apis/${apiId}/notifiers`);
   }
 
-  create(apiId, notificationConfig: NewNotificationSettings): Observable<NewNotificationSettings> {
+  create(apiId: string, notificationConfig: NewNotificationSettings): Observable<NewNotificationSettings> {
     return this.http.post<NewNotificationSettings>(`${this.constants.env.baseURL}/apis/${apiId}/notificationsettings`, notificationConfig);
+  }
+
+  update(apiId: string, notificationId: string, notificationConfig: NotificationSettings): Observable<NotificationSettings> {
+    return this.http.put<NotificationSettings>(
+      `${this.constants.env.baseURL}/apis/${apiId}/notificationsettings/${notificationId}`,
+      notificationConfig,
+    );
+  }
+
+  getHooks(): Observable<Hooks[]> {
+    return this.http.get<Hooks[]>(`${this.constants.env.baseURL}/apis/hooks`);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2371

## Description

Continue migrating notifications from angular.js to angular 2+, creating a feature to access notification settings


## Additional context

It's fifth part of notifications migration
<img width="958" alt="Screenshot 2023-10-02 at 2 32 45 PM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/1b1e32eb-f87f-442b-a5ea-240c2670e956">


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5403/console](https://pr.team-apim.gravitee.dev/5403/console)
      Portal: [https://pr.team-apim.gravitee.dev/5403/portal](https://pr.team-apim.gravitee.dev/5403/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5403/api/management](https://pr.team-apim.gravitee.dev/5403/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5403](https://pr.team-apim.gravitee.dev/5403)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5403](https://pr.gateway-v3.team-apim.gravitee.dev/5403)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nlqeolywyz.chromatic.com)
<!-- Storybook placeholder end -->
