### PR TITLE
Console - add date time picker instead of only date for subscription date field

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -22,6 +22,8 @@
         "@angular/upgrade": "13.3.12",
         "@asciidoctor/core": "^2.2.4",
         "@asyncapi/web-component": "1.0.0-next.47",
+        "@danielmoncada/angular-datetime-picker": "^16.0.1",
+        "@danielmoncada/angular-datetime-picker-moment-adapter": "^3.0.1",
         "@fontsource/libre-franklin": "4.4.5",
         "@gravitee/ui-analytics": "7.29.3",
         "@gravitee/ui-components": "3.44.0",
@@ -4327,6 +4329,33 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@danielmoncada/angular-datetime-picker": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@danielmoncada/angular-datetime-picker/-/angular-datetime-picker-16.0.1.tgz",
+      "integrity": "sha512-HvpGYYdeGpnLQtBc0yyQ3QBiS/2rpUbJiCy7Lempk0jVEvUaW1ICPgL40ss+FlMP+R/3pZHzLxrSA9cr1H2N8A==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "@angular/common": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "@angular/core": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@danielmoncada/angular-datetime-picker-moment-adapter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@danielmoncada/angular-datetime-picker-moment-adapter/-/angular-datetime-picker-moment-adapter-3.0.1.tgz",
+      "integrity": "sha512-A4mWzCHU8u1s0c12bfMMKtauUM3Md+kbXhWV8LDEUyS9bBuZvpaj6dimDyyAC0ztJ+c/iz8jI41OgX6GhbCS3Q==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "@angular/common": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "@angular/core": "^13.0.3 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "moment": "^2.29.1"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -39758,6 +39787,22 @@
       "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
       "dev": true,
       "requires": {}
+    },
+    "@danielmoncada/angular-datetime-picker": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@danielmoncada/angular-datetime-picker/-/angular-datetime-picker-16.0.1.tgz",
+      "integrity": "sha512-HvpGYYdeGpnLQtBc0yyQ3QBiS/2rpUbJiCy7Lempk0jVEvUaW1ICPgL40ss+FlMP+R/3pZHzLxrSA9cr1H2N8A==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@danielmoncada/angular-datetime-picker-moment-adapter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@danielmoncada/angular-datetime-picker-moment-adapter/-/angular-datetime-picker-moment-adapter-3.0.1.tgz",
+      "integrity": "sha512-A4mWzCHU8u1s0c12bfMMKtauUM3Md+kbXhWV8LDEUyS9bBuZvpaj6dimDyyAC0ztJ+c/iz8jI41OgX6GhbCS3Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.6",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -16,6 +16,8 @@
     "@angular/upgrade": "13.3.12",
     "@asciidoctor/core": "^2.2.4",
     "@asyncapi/web-component": "1.0.0-next.47",
+    "@danielmoncada/angular-datetime-picker": "^16.0.1",
+    "@danielmoncada/angular-datetime-picker-moment-adapter": "^3.0.1",
     "@fontsource/libre-franklin": "4.4.5",
     "@gravitee/ui-analytics": "7.29.3",
     "@gravitee/ui-components": "3.44.0",

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/api-portal-subscriptions.module.ts
@@ -37,9 +37,9 @@ import {
   GioIconsModule,
   GioLoaderModule,
 } from '@gravitee/ui-particles-angular';
-import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { OWL_MOMENT_DATE_TIME_ADAPTER_OPTIONS, OwlMomentDateTimeModule } from '@danielmoncada/angular-datetime-picker-moment-adapter';
+import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 
 import { ApiPortalSubscriptionCreationDialogComponent } from './components/dialogs/creation/api-portal-subscription-creation-dialog.component';
 import { ApiPortalSubscriptionTransferDialogComponent } from './components/dialogs/transfer/api-portal-subscription-transfer-dialog.component';
@@ -79,11 +79,9 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatAutocompleteModule,
     MatButtonModule,
     MatCardModule,
-    MatDatepickerModule,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
-    MatMomentDateModule,
     MatOptionModule,
     MatSelectModule,
     MatSnackBarModule,
@@ -91,7 +89,8 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatTableModule,
     MatTooltipModule,
     MatButtonToggleModule,
-    MatMomentDateModule,
+    OwlDateTimeModule,
+    OwlMomentDateTimeModule,
 
     GioAvatarModule,
     GioClipboardModule,
@@ -102,6 +101,15 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioPermissionModule,
     GioTableWrapperModule,
   ],
-  providers: [DatePipe, { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],
+  providers: [
+    DatePipe,
+    {
+      provide: OWL_MOMENT_DATE_TIME_ADAPTER_OPTIONS,
+      useValue: {
+        useUtc: true,
+        parseStrict: false,
+      },
+    },
+  ],
 })
 export class ApiPortalSubscriptionsModule {}

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
@@ -24,14 +24,14 @@
         Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this API.
       </div>
       <div *ngIf="data.securityType === 'API_KEY'">All API Keys after the new end date will be revoked.</div>
-      <mat-form-field class="change-end-date__datepicker">
-        <mat-label>Choose a date</mat-label>
-        <input matInput [min]="minDate" [matDatepicker]="picker" formControlName="endDate" />
-        <mat-datepicker-toggle matSuffix [for]="picker">
-          <mat-icon matDatepickerToggleIcon svgIcon="gio:calendar"></mat-icon>
-        </mat-datepicker-toggle>
-        <mat-datepicker #picker></mat-datepicker>
-        <mat-hint>MM/DD/YYYY</mat-hint>
+      <mat-form-field>
+        <mat-label>Validation end date (optional)</mat-label>
+        <input matInput [owlDateTime]="endDate" [min]="minDate" formControlName="endDate" />
+        <mat-icon [owlDateTimeTrigger]="endDate" matSuffix svgIcon="gio:calendar"></mat-icon>
+        <owl-date-time #endDate></owl-date-time>
+        <mat-error *ngIf="form.get('endDate').hasError('owlDateTimeMin')">
+          Date Time value must be after {{ minDate | date : 'medium' }}
+        </mat-error>
       </mat-form-field>
     </div>
   </mat-dialog-content>

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.html
@@ -20,14 +20,20 @@
 
   <mat-dialog-content class="expire-api-key__dialog-content">
     <div class="expire-api-key__content">
-      <mat-form-field appearance="outline">
-        <mat-label>Choose a date</mat-label>
-        <div class="expire-api-key__datepicker">
-          <input matInput [min]="minDate" [matDatepicker]="picker" formControlName="expirationDate" />
-          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
-          <mat-datepicker #picker></mat-datepicker>
-        </div>
-        <mat-hint>MM/DD/YYYY</mat-hint>
+      <mat-form-field>
+        <mat-label>Expire date</mat-label>
+        <input
+          matInput
+          [owlDateTime]="expirationDate"
+          [owlDateTimeTrigger]="expirationDate"
+          [min]="minDate"
+          formControlName="expirationDate"
+        />
+        <mat-icon [owlDateTimeTrigger]="expirationDate" matSuffix svgIcon="gio:calendar"></mat-icon>
+        <owl-date-time #expirationDate></owl-date-time>
+        <mat-error *ngIf="form.get('expirationDate').hasError('owlDateTimeMin')">
+          Date Time value must be after {{ minDate | date : 'medium' }}
+        </mat-error>
       </mat-form-field>
     </div>
   </mat-dialog-content>

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
@@ -21,20 +21,26 @@
     <div class="validate-subscription__content">
       <div class="validate-subscription__content__row">
         <mat-form-field>
-          <mat-label>Enter a date range</mat-label>
-          <mat-date-range-input formGroupName="range" [rangePicker]="picker" [min]="minDate">
-            <input matStartDate formControlName="start" placeholder="Start date" />
-            <input matEndDate formControlName="end" placeholder="End date" />
-          </mat-date-range-input>
-          <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
-          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-          <mat-date-range-picker #picker></mat-date-range-picker>
+          <mat-label>Validation period (optional)</mat-label>
+          <input
+            matInput
+            [owlDateTime]="dateTimeRange"
+            [owlDateTimeTrigger]="dateTimeRange"
+            [selectMode]="'range'"
+            [min]="minDate"
+            formControlName="dateTimeRange"
+          />
+          <mat-icon [owlDateTimeTrigger]="dateTimeRange" matSuffix svgIcon="gio:calendar"></mat-icon>
+          <owl-date-time #dateTimeRange></owl-date-time>
+          <mat-error *ngIf="form.get('dateTimeRange').hasError('owlDateTimeMin')">
+            Date Time value must be after {{ minDate | date : 'medium' }}
+          </mat-error>
         </mat-form-field>
       </div>
       <div class="validate-subscription__content__row">
         <mat-form-field appearance="outline" class="validate-subscription__content__message">
           <input id="subscription-message" type="text" matInput formControlName="message" maxlength="50" />
-          <mat-label>If necessary, add a message</mat-label>
+          <mat-label>Message (optional)</mat-label>
         </mat-form-field>
       </div>
       <div class="validate-subscription__content__row" *ngIf="data.canUseCustomApiKey && !data.sharedApiKeyMode">

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.ts
@@ -50,19 +50,18 @@ export class ApiPortalSubscriptionValidateDialogComponent implements OnInit {
     this.minDate = new Date();
 
     this.form = new FormGroup({
-      range: new FormGroup({
-        start: new FormControl(undefined),
-        end: new FormControl(undefined),
-      }),
+      dateTimeRange: new FormControl(),
       message: new FormControl(''),
       apiKey: new FormControl(''),
     });
   }
 
   onClose() {
+    const [start, end] = this.form.getRawValue()?.dateTimeRange ?? [undefined, undefined];
+
     this.dialogRef.close({
-      start: this.form.getRawValue().range.start,
-      end: this.form.getRawValue().range.end,
+      start: start ?? undefined,
+      end: end ?? undefined,
       message: this.form.getRawValue().message,
       customApiKey: this.form.getRawValue().apiKey,
     });

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.scss
@@ -12,9 +12,6 @@
   flex-direction: column;
   gap: 24px;
 
-  &__nav {
-    padding-bottom: 36px;
-  }
   &__row {
     display: flex;
     border-bottom: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.spec.ts
@@ -23,7 +23,6 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatRadioGroupHarness } from '@angular/material/radio/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { MatDatepickerInputHarness, MatDateRangeInputHarness } from '@angular/material/datepicker/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { set } from 'lodash';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
@@ -420,14 +419,13 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       );
       expect(await changeEndDateDialog.getTitleText()).toEqual('Change the subscription end date');
 
-      const datepicker = await changeEndDateDialog.getHarness(MatDatepickerInputHarness);
+      const datepicker = await changeEndDateDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="endDate"]' }));
       expect(await datepicker.getValue()).toEqual('');
 
       const changeEndDateBtn = await changeEndDateDialog.getHarness(MatButtonHarness.with({ text: 'Change end date' }));
 
       expect(await changeEndDateBtn.isDisabled()).toEqual(true);
-      await datepicker.openCalendar();
-      await datepicker.setValue('01/01/2080');
+      await datepicker.setValue('01/01/2080, 12:00 AM');
 
       expect(await changeEndDateBtn.isDisabled()).toEqual(false);
       await changeEndDateBtn.click();
@@ -472,14 +470,13 @@ describe('ApiPortalSubscriptionEditComponent', () => {
         MatDialogHarness.with({ selector: '#changeEndDateDialog' }),
       );
 
-      const datepicker = await changeEndDateDialog.getHarness(MatDatepickerInputHarness);
-      expect(await datepicker.getValue()).toEqual(endingAt.toLocaleDateString());
+      const datepicker = await changeEndDateDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="endDate"]' }));
+      expect(await datepicker.getValue()).toEqual('1/1/2080 12:00 AM');
 
       const changeEndDateBtn = await changeEndDateDialog.getHarness(MatButtonHarness.with({ text: 'Change end date' }));
 
       expect(await changeEndDateBtn.isDisabled()).toEqual(true);
-      await datepicker.openCalendar();
-      await datepicker.setValue('01/02/2080');
+      await datepicker.setValue('01/02/2080, 12:00 AM');
 
       expect(await changeEndDateBtn.isDisabled()).toEqual(false);
       await changeEndDateBtn.click();
@@ -613,11 +610,10 @@ describe('ApiPortalSubscriptionEditComponent', () => {
         MatDialogHarness.with({ selector: '#validateSubscriptionDialog' }),
       );
 
-      const datePicker = await validateDialog.getHarness(MatDateRangeInputHarness);
+      const datePicker = await validateDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="dateTimeRange"]' }));
+
       expect(await datePicker.getValue()).toEqual('');
-      await datePicker.openCalendar();
-      await datePicker.getStartInput().then((startInput) => startInput.setValue('01/01/2080'));
-      await datePicker.getEndInput().then((endInput) => endInput.setValue('01/02/2080'));
+      await datePicker.setValue('1/1/2080 12:00 AM - 1/2/2080 12:00 AM');
 
       const message = await validateDialog.getHarness(MatInputHarness.with({ selector: '#subscription-message' }));
       expect(await message.getValue()).toEqual('');
@@ -985,14 +981,13 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       );
       expect(await expireApiKeyDialog.getTitleText()).toEqual(`Change your API Key's expiration date`);
 
-      const datepicker = await expireApiKeyDialog.getHarness(MatDatepickerInputHarness);
+      const datepicker = await expireApiKeyDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="expirationDate"]' }));
       expect(await datepicker.getValue()).toEqual('');
 
       const expireApiKeyBtn = await expireApiKeyDialog.getHarness(MatButtonHarness.with({ text: 'Change expiration date' }));
 
       expect(await expireApiKeyBtn.isDisabled()).toEqual(true);
-      await datepicker.openCalendar();
-      await datepicker.setValue('01/01/2080');
+      await datepicker.setValue('01/01/2080, 12:00 AM');
 
       expect(await expireApiKeyBtn.isDisabled()).toEqual(false);
       await expireApiKeyBtn.click();
@@ -1021,14 +1016,13 @@ describe('ApiPortalSubscriptionEditComponent', () => {
         MatDialogHarness.with({ selector: '#expireApiKeyDialog' }),
       );
 
-      const datepicker = await expireApiKeyDialog.getHarness(MatDatepickerInputHarness);
-      expect(await datepicker.getValue()).toEqual(endingAt.toLocaleDateString());
+      const datepicker = await expireApiKeyDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="expirationDate"]' }));
+      expect(await datepicker.getValue()).toEqual('1/1/2080 12:00 AM');
 
       const expireApiKeyBtn = await expireApiKeyDialog.getHarness(MatButtonHarness.with({ text: 'Change expiration date' }));
 
       expect(await expireApiKeyBtn.isDisabled()).toEqual(true);
-      await datepicker.openCalendar();
-      await datepicker.setValue('01/02/2080');
+      await datepicker.setValue('01/02/2080, 12:00 AM');
 
       expect(await expireApiKeyBtn.isDisabled()).toEqual(false);
       await expireApiKeyBtn.click();

--- a/gravitee-apim-console-webui/src/scss/gio-global-style.scss
+++ b/gravitee-apim-console-webui/src/scss/gio-global-style.scss
@@ -4,6 +4,8 @@
 
 @import './gio-description-list';
 
+@import '@danielmoncada/angular-datetime-picker/assets/style/picker.min';
+
 $background: map.get(gio.$mat-theme, background);
 
 .gio-snack-bar-success {


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-2828 



## Description
add date time picker instead of only date for subscription date field
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/e7342f69-c614-4177-a782-c30795931e31)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nnvsqlhpal.chromatic.com)
<!-- Storybook placeholder end -->
