### PR TITLE
fix: do not send email notification when email address is empty string

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
@@ -162,12 +162,12 @@ public class EmailServiceImpl extends TransactionalService implements EmailServi
                     mailMessage.setTo(emailNotification.getTo());
                 }
 
-                if (emailNotification.isCopyToSender() && sender != null) {
-                    mailMessage.setBcc(sender);
-                }
-
                 if (emailNotification.getBcc() != null && emailNotification.getBcc().length > 0) {
                     mailMessage.setBcc(emailNotification.getBcc());
+                }
+
+                if (emailNotification.isCopyToSender() && sender != null) {
+                    mailMessage.addBcc(sender);
                 }
 
                 mailMessage.setSubject(format(mailParameters.get(EMAIL_SUBJECT), emailSubject));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/EmailNotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/EmailNotifierServiceImpl.java
@@ -17,17 +17,16 @@ package io.gravitee.rest.api.service.notifiers.impl;
 
 import io.gravitee.apim.infra.template.TemplateProcessor;
 import io.gravitee.apim.infra.template.TemplateProcessorException;
-import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.notification.Hook;
-import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.notifiers.EmailNotifierService;
-import java.util.*;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -108,6 +107,6 @@ public class EmailNotifierServiceImpl implements EmailNotifierService {
                     })
             );
 
-        return collect.filter(Optional::isPresent).map(Optional::get).collect(Collectors.toSet());
+        return collect.filter(s -> s.isPresent() && !s.get().isEmpty()).map(Optional::get).collect(Collectors.toSet());
     }
 }


### PR DESCRIPTION
## Description

When the PrimaryOwner of an API or APPLICATION has an empty value for
its email, we should not trigger a notification to this empty address.

This was breaking importing a basic API using GKO.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hcqlykstqx.chromatic.com)
<!-- Storybook placeholder end -->
