### PR TITLE
Fix "Add member" feature for group admin

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/addMember.dialog.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/addMember.dialog.html
@@ -20,12 +20,7 @@
     <h4>Add members to {{$ctrl.group.name}}</h4>
     <div layout="row" layout-align="space-between center">
       <span>Choose an API role</span>
-      <md-select
-        ng-model="$ctrl.defaultApiRole"
-        aria-label="API Role"
-        class="md-no-underline"
-        ng-disabled="!$ctrl.canChangeDefaultApiRole()"
-      >
+      <md-select ng-model="$ctrl.defaultApiRole" aria-label="API Role" class="md-no-underline" ng-disabled="!$ctrl.canChangeDefaultApiRole">
         <md-option ng-repeat="role in $ctrl.apiRoles" ng-value="role.name" ng-disabled="$ctrl.isApiRoleDisabled(role)">
           {{role.name}}
         </md-option>
@@ -37,7 +32,7 @@
         ng-model="$ctrl.defaultApplicationRole"
         aria-label="Application Role"
         class="md-no-underline"
-        ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
       >
         <md-option ng-repeat="role in $ctrl.applicationRoles" ng-value="role.name" ng-disabled="role.system"> {{role.name}} </md-option>
       </md-select>

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -357,7 +357,7 @@ const GroupComponent: ng.IComponentOptions = {
       if (!this.group.max_invitation) {
         return false;
       }
-      const numberOfMembers = this.members ? this.members.length : 0;
+      const numberOfMembers = this.membersPage ? this.membersPage.page.total_elements : 0;
       const numberOfInvitations = this.invitations ? this.invitations.length : 0;
       const numberOfSlots = numberOfMembers + numberOfInvitations;
       return numberOfSlots >= this.group.max_invitation;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -97,6 +97,8 @@ const GroupComponent: ng.IComponentOptions = {
         this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'APPLICATION_CREATE') !== -1;
 
       this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
+      this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
+      this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;
 
       this.loadGroupApis();
     };
@@ -339,14 +341,6 @@ const GroupComponent: ng.IComponentOptions = {
 
     this.reset = () => {
       $state.reload();
-    };
-
-    this.canChangeDefaultApiRole = () => {
-      return this.isSuperAdmin || !this.group.lock_api_role;
-    };
-
-    this.canChangeDefaultApplicationRole = () => {
-      return this.isSuperAdmin || !this.group.lock_application_role;
     };
 
     this.canAddMembers = () => {

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -100,6 +100,12 @@ const GroupComponent: ng.IComponentOptions = {
       this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
       this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;
 
+      /*
+        It is written in the members list: "Enable email invitation and/or user search to allow the group administrator to add users."
+        It means that to add members, the group must be manageable (i.e. the current user is a group admin) and the group must have email invitation or system invitation enabled.
+       */
+      this.canAddMembers = this.isSuperAdmin || (this.group.manageable && (this.group.system_invitation || this.group.email_invitation));
+
       this.loadGroupApis();
     };
 
@@ -341,16 +347,6 @@ const GroupComponent: ng.IComponentOptions = {
 
     this.reset = () => {
       $state.reload();
-    };
-
-    this.canAddMembers = () => {
-      if (this.isSuperAdmin) {
-        return true;
-      } else if (this.group.manageable) {
-        return !this.isMaxInvitationReached();
-      } else {
-        return false;
-      }
     };
 
     this.isMaxInvitationReached = () => {

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -347,13 +347,20 @@ const GroupComponent: ng.IComponentOptions = {
       if (this.isSuperAdmin) {
         return true;
       } else if (this.group.manageable) {
-        const numberOfMembers = this.members ? this.members.length : 0;
-        const numberOfInvitations = this.invitations ? this.invitations.length : 0;
-        const numberOfSlots = numberOfMembers + numberOfInvitations;
-        return !this.group.max_invitation || numberOfSlots < this.group.max_invitation;
+        return !this.isMaxInvitationReached();
       } else {
         return false;
       }
+    };
+
+    this.isMaxInvitationReached = () => {
+      if (!this.group.max_invitation) {
+        return false;
+      }
+      const numberOfMembers = this.members ? this.members.length : 0;
+      const numberOfInvitations = this.invitations ? this.invitations.length : 0;
+      const numberOfSlots = numberOfMembers + numberOfInvitations;
+      return numberOfSlots >= this.group.max_invitation;
     };
 
     this.canSave = () => {

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -96,6 +96,8 @@ const GroupComponent: ng.IComponentOptions = {
       this.applicationByDefault =
         this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'APPLICATION_CREATE') !== -1;
 
+      this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
+
       this.loadGroupApis();
     };
 
@@ -340,15 +342,15 @@ const GroupComponent: ng.IComponentOptions = {
     };
 
     this.canChangeDefaultApiRole = () => {
-      return this.isSuperAdmin() || !this.group.lock_api_role;
+      return this.isSuperAdmin || !this.group.lock_api_role;
     };
 
     this.canChangeDefaultApplicationRole = () => {
-      return this.isSuperAdmin() || !this.group.lock_application_role;
+      return this.isSuperAdmin || !this.group.lock_application_role;
     };
 
     this.canAddMembers = () => {
-      if (this.isSuperAdmin()) {
+      if (this.isSuperAdmin) {
         return true;
       } else if (this.group.manageable) {
         const numberOfMembers = this.members ? this.members.length : 0;
@@ -358,10 +360,6 @@ const GroupComponent: ng.IComponentOptions = {
       } else {
         return false;
       }
-    };
-
-    this.isSuperAdmin = () => {
-      return UserService.isUserHasPermissions(['environment-group-u']);
     };
 
     this.canSave = () => {

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
@@ -48,7 +48,7 @@
             class="gv-input-number"
             ng-model="$ctrl.selectedApiRole"
             aria-label="Default API Role"
-            ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+            ng-disabled="!$ctrl.canChangeDefaultApiRole"
           >
             <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="role.system">{{role.name}} </md-option>
           </md-select>
@@ -60,7 +60,7 @@
             ng-model="$ctrl.selectedApplicationRole"
             class="gv-input-number"
             aria-label="Default Application Role"
-            ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+            ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
           >
             <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system">{{role.name}} </md-option>
           </md-select>
@@ -232,7 +232,7 @@
                         ng-model="member.roles['API']"
                         aria-label="API Role"
                         ng-change="$ctrl.updateRole(member)"
-                        ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+                        ng-disabled="!$ctrl.canChangeDefaultApiRole"
                       >
                         <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
                           >{{role.name}}</md-option
@@ -244,7 +244,7 @@
                         ng-model="member.roles['APPLICATION']"
                         aria-label="Application Role"
                         ng-change="$ctrl.updateRole(member)"
-                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
                       >
                         <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
                           >{{role.name}}</md-option
@@ -283,7 +283,7 @@
                           ng-model="invitation.api_role"
                           aria-label="API Role"
                           ng-change="$ctrl.updateInvitation(invitation)"
-                          ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+                          ng-disabled="!$ctrl.canChangeDefaultApiRole"
                         >
                           <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
                             >{{role.name}}</md-option
@@ -295,7 +295,7 @@
                           ng-model="invitation.application_role"
                           aria-label="Application Role"
                           ng-change="$ctrl.updateInvitation(invitation)"
-                          ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+                          ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
                         >
                           <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
                             >{{role.name}}</md-option

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
@@ -408,7 +408,7 @@
 
   <md-fab-actions>
     <md-button
-      ng-if="$ctrl.isSuperAdmin() || $ctrl.group.system_invitation"
+      ng-if="$ctrl.isSuperAdmin || $ctrl.group.system_invitation"
       class="md-fab md-success md-mini"
       ng-click="$ctrl.showAddMemberModal()"
       aria-label="Add member"
@@ -417,7 +417,7 @@
       <ng-md-icon icon="people"></ng-md-icon>
     </md-button>
     <md-button
-      ng-if="$ctrl.isSuperAdmin() || $ctrl.group.email_invitation"
+      ng-if="$ctrl.isSuperAdmin || $ctrl.group.email_invitation"
       class="md-fab md-success md-mini"
       ng-click="$ctrl.showInviteMemberModal()"
       aria-label="Invite member"
@@ -429,7 +429,7 @@
 </md-fab-speed-dial>
 
 <md-button
-  ng-if="!$ctrl.isSuperAdmin() && !($ctrl.group.system_invitation && $ctrl.group.email_invitation) && ($ctrl.group.system_invitation || $ctrl.group.email_invitation)"
+  ng-if="!$ctrl.isSuperAdmin && !($ctrl.group.system_invitation && $ctrl.group.email_invitation) && ($ctrl.group.system_invitation || $ctrl.group.email_invitation)"
   ng-click="$ctrl.group.system_invitation?$ctrl.showAddMemberModal(): $ctrl.showInviteMemberModal()"
   aria-label="Add member"
   class="md-fab md-fab-bottom-right md-fab-scrollable"

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
@@ -392,16 +392,23 @@
   </div>
 </div>
 
+<!--
+  To display the add member button, the user has to be a super admin or a group admin
+-->
 <md-fab-speed-dial
-  ng-if="$ctrl.canAddMembers() || ($ctrl.group.system_invitation && $ctrl.group.email_invitation)"
+  ng-if="$ctrl.canAddMembers"
   md-direction="left"
   md-open="false"
   class="md-scale md-fab-bottom-right md-fab-scrollable"
   ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}"
 >
   <md-fab-trigger>
-    <md-button aria-label="menu" class="md-fab md-success">
-      <md-tooltip md-direction="top" md-visible="false">Add member</md-tooltip>
+    <!-- The button is always displayed, but is disabled if the current user is a group admin and the maximum number of members has been reached -->
+    <md-button aria-label="menu" class="md-fab md-success" ng-disabled="!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached()">
+      <md-tooltip md-direction="top" md-visible="false"
+        >Add member{{!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached() ? " is not available because maximum number of members has been
+        reached" : ""}}</md-tooltip
+      >
       <ng-md-icon icon="add"></ng-md-icon>
     </md-button>
   </md-fab-trigger>
@@ -427,14 +434,3 @@
     </md-button>
   </md-fab-actions>
 </md-fab-speed-dial>
-
-<md-button
-  ng-if="!$ctrl.isSuperAdmin && !($ctrl.group.system_invitation && $ctrl.group.email_invitation) && ($ctrl.group.system_invitation || $ctrl.group.email_invitation)"
-  ng-click="$ctrl.group.system_invitation?$ctrl.showAddMemberModal(): $ctrl.showInviteMemberModal()"
-  aria-label="Add member"
-  class="md-fab md-fab-bottom-right md-fab-scrollable"
-  ng-class="{'gv-help-displayed': $ctrl.$rootScope.helpDisplayed}"
->
-  <md-tooltip md-direction="top" md-visible="false">Add member</md-tooltip>
-  <ng-md-icon icon="add"></ng-md-icon>
-</md-button>

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/inviteMember.dialog.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/inviteMember.dialog.html
@@ -25,7 +25,7 @@
           ng-model="$ctrl.group.api_role"
           aria-label="API Role"
           class="md-no-underline"
-          ng-disabled="!$ctrl.canChangeDefaultApiRole()"
+          ng-disabled="!$ctrl.canChangeDefaultApiRole"
         >
           <md-option ng-repeat="role in $ctrl.apiRoles" ng-value="role.name" ng-disabled="$ctrl.isApiRoleDisabled(role)">
             {{role.name}}
@@ -38,7 +38,7 @@
           ng-model="$ctrl.group.application_role"
           aria-label="Application Role"
           class="md-no-underline"
-          ng-disabled="!$ctrl.canChangeDefaultApplicationRole()"
+          ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
         >
           <md-option ng-repeat="role in $ctrl.applicationRoles" ng-value="role.name" ng-disabled="role.system"> {{role.name}} </md-option>
         </md-select>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2731

## Description

This PR improves a little bit the readability of the code and simplifies the rules about adding a member.

You can add a member if:
- you are a super admin (GROUP - UPDATE at environment Level)
- you are a group admin **and** at least one invitation mechanism is enabled (search a user or send a mail)

If the super admin defined a maximum number of members in the group, then this limitation is applied only to group admin. And if the limit is reached, the "Add member" button is just disabled with an explicit tooltip. (Instead of no button at all before)

![image](https://github.com/gravitee-io/gravitee-api-management/assets/13161768/99f40084-1f82-4725-80d0-c4f8eaf443d3)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uwgxyjzliq.chromatic.com)
<!-- Storybook placeholder end -->
