### PR TITLE
test(ui): plans JWT flaky fix

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -116,7 +116,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_name_field').type(`${planName}-JWT`);
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} JWT`);
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.contains('selection rule').scrollIntoView().should('be.visible');
+    cy.contains('JWKS resolver').should('be.visible');
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('Rate Limiting').should('be.visible');
     cy.contains('Quota').should('be.visible');


### PR DESCRIPTION
## Issue

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/26173/workflows/d20e68c6-a85e-46d2-a21e-eead80a393ee/jobs/467237

## Description

Couldn't get it to fail locally, initially patched this with #5278 but for whatever reason, cypress is no longer scrolling that text into view... So I changed the step to do basically the same thing closer to the top of the page that signifies it's a JWT plan. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wyuawkgfsg.chromatic.com)
<!-- Storybook placeholder end -->
