### PR TITLE
Fix - allow API_PUBLISHER only to manage subscription

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/application/baseApplication.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/application/baseApplication.fixture.ts
@@ -27,6 +27,7 @@ export function fakeBaseApplication(modifier?: Partial<BaseApplication>): BaseAp
       type: 'USER',
       displayName: 'Primary Owner',
     },
+    apiKeyMode: 'UNSPECIFIED',
   };
 
   return {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/application/baseApplication.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/application/baseApplication.ts
@@ -38,4 +38,8 @@ export interface BaseApplication {
    */
   type?: string;
   primaryOwner?: PrimaryOwner;
+  /**
+   * The API Key mode used for this application.
+   */
+  apiKeyMode: 'SHARED' | 'UNSPECIFIED' | 'EXCLUSIVE';
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/subscription.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/subscription.fixture.ts
@@ -35,6 +35,7 @@ export function fakeSubscription(modifier?: Partial<Subscription> | ((baseApi: S
         id: 'my-primary-owner',
         displayName: 'Primary Owner',
       },
+      apiKeyMode: 'UNSPECIFIED',
     },
     plan: {
       id: 'dee23b1e-34b1-4551-a23b-1e34b165516a',

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, Inject, OnInit } from '@angular/core';
-import { combineLatest, EMPTY, Observable, Subject } from 'rxjs';
+import { EMPTY, Observable, Subject } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { StateService, UIRouterGlobals } from '@uirouter/core';
 import { DatePipe } from '@angular/common';
@@ -35,8 +35,6 @@ import {
   ApiPortalSubscriptionTransferDialogResult,
 } from '../components/dialogs/transfer/api-portal-subscription-transfer-dialog.component';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
-import { ApplicationService } from '../../../../../services-ngx/application.service';
-import { ApiKeyMode } from '../../../../../entities/application/application';
 import {
   ApiPortalSubscriptionChangeEndDateDialogComponent,
   ApiPortalSubscriptionChangeEndDateDialogData,
@@ -116,7 +114,6 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
     @Inject('Constants') private readonly constants: Constants,
     private readonly ajsGlobals: UIRouterGlobals,
     private readonly apiSubscriptionService: ApiSubscriptionV2Service,
-    private readonly applicationService: ApplicationService,
     private datePipe: DatePipe,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
@@ -168,7 +165,8 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
             };
 
             if (this.subscription.plan.securityType === 'API_KEY' && this.subscription.status !== 'REJECTED') {
-              return combineLatest([this.applicationService.getById(subscription.application.id), this.getApiKeysList(1, 10)]);
+              this.hasSharedApiKeyMode = subscription.application.apiKeyMode === 'SHARED';
+              return this.getApiKeysList(1, 10);
             }
           }
           return EMPTY;
@@ -176,9 +174,6 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
         catchError((err) => {
           this.snackBarService.error(err.message); // If user is forbidden access to application getById
           return EMPTY;
-        }),
-        tap(([application, _]) => {
-          this.hasSharedApiKeyMode = application.api_key_mode === ApiKeyMode.SHARED;
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -3807,6 +3807,14 @@ components:
                     example: iOS
                 primaryOwner:
                     $ref: "#/components/schemas/PrimaryOwner"
+                apiKeyMode:
+                    type: string
+                    description: The API Key mode used for this application.
+                    example: UNSPECIFIED
+                    enum:
+                        - SHARED
+                        - EXCLUSIVE
+                        - UNSPECIFIED
         Member:
             type: object
             properties:


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-2824

## Description

The application get cannot be used in the api because a user does not necessarily have access to it. 
It is up to the api sub-resource to send the necessary. 

Application and API could be 2 separate parts in the console to avoid these errors. but in 10 years' , with the time lag we have here.


--

I hesitated to add a refactor commit to rename BaseApplication to BaseSubscriptionApplication. Because it's an application seen by the subscription and not an "application". I think this could be a problem when we add all "application" part to MAPIv2. 🤷‍♂️ 

--

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-howxkfyrwf.chromatic.com)
<!-- Storybook placeholder end -->
