### PR TITLE
fix(console): display 0 if api && application count equal 0

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -22,7 +22,7 @@
   <div class="home-overview__row">
     <mat-card class="home-overview__card flex">
       <div class="mat-subheading-1">Quick Summary</div>
-      <div *ngIf="apiNb && applicationNb; else loader" class="home-overview__card__list">
+      <div *ngIf="apiNb !== undefined && applicationNb !== undefined; else loader" class="home-overview__card__list">
         <div class="home-overview__card__list__row">
           <span class="home-overview__card__list__row__value">{{ apiNb }}</span>
           <span class="home-overview__card__list__row__label">Total APIs</span>


### PR DESCRIPTION
## Issue

n/a

## Description

Small fix to display 0 apis and 0 application instead of loading...

## Additional context
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/b83143ef-b007-4f12-9774-83915339aaa6)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-upltctcxkx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5455/console](https://pr.team-apim.gravitee.dev/5455/console)
      Portal: [https://pr.team-apim.gravitee.dev/5455/portal](https://pr.team-apim.gravitee.dev/5455/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5455/api/management](https://pr.team-apim.gravitee.dev/5455/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5455](https://pr.team-apim.gravitee.dev/5455)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5455](https://pr.gateway-v3.team-apim.gravitee.dev/5455)

<!-- Environment placeholder end -->
