### PR TITLE
fix(console): make api-key expire not required

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.html
@@ -22,13 +22,7 @@
     <div class="expire-api-key__content">
       <mat-form-field>
         <mat-label>Expire date</mat-label>
-        <input
-          matInput
-          [owlDateTime]="expirationDate"
-          [owlDateTimeTrigger]="expirationDate"
-          [min]="minDate"
-          formControlName="expirationDate"
-        />
+        <input matInput [owlDateTime]="expirationDate" [min]="minDate" formControlName="expirationDate" />
         <mat-icon [owlDateTimeTrigger]="expirationDate" matSuffix svgIcon="gio:calendar"></mat-icon>
         <owl-date-time #expirationDate></owl-date-time>
         <mat-error *ngIf="form.get('expirationDate').hasError('owlDateTimeMin')">

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 
 export interface ApiPortalSubscriptionExpireApiKeyDialogData {
   expirationDate: Date;
@@ -46,7 +46,7 @@ export class ApiPortalSubscriptionExpireApiKeyDialogComponent implements OnInit 
   ngOnInit() {
     this.minDate = new Date();
     this.form = new FormGroup({
-      expirationDate: new FormControl(this.expirationDate, [Validators.required]),
+      expirationDate: new FormControl(this.expirationDate),
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2739

## Description

Confusion on my side between "subscription end date" and" apiKey expiration". the both should be removable.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hefrzkeytx.chromatic.com)
<!-- Storybook placeholder end -->
