### PR TITLE
Console - continue notifications migration (part 6)

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -73,9 +73,6 @@ import { ApiPropertiesComponent } from './proxy/properties/api-properties.compon
 import { ApiRuntimeLogsMessagesComponent } from './runtime-logs-v4/runtime-logs-messages/api-runtime-logs-messages.component';
 import { ApiDocumentationV4Component } from './documentation-v4/api-documentation-v4.component';
 
-import { NotificationsComponent } from '../../components/notifications/notifications.component';
-import { Scope } from '../../entities/scope';
-import NotificationSettingsService from '../../services/notificationSettings.service';
 import { ApiService } from '../../services/api.service';
 import { GioEmptyComponent } from '../../shared/components/gio-empty/gio-empty.component';
 import { DocumentationQuery, DocumentationService } from '../../services/documentation.service';
@@ -827,9 +824,9 @@ export const states: Ng2StateDeclaration[] = [
     },
   },
   {
-    name: 'management.apis.notifications-ng',
+    name: 'management.apis.notifications',
     component: NotificationsListComponent,
-    url: '/notifications-ng',
+    url: '/notifications',
     data: {
       apiPermissions: {
         only: ['api-notification-r'],
@@ -843,71 +840,10 @@ export const states: Ng2StateDeclaration[] = [
   {
     name: 'management.apis.notification-details',
     component: NotificationDetailsComponent,
-    url: '/notifications-ng/:notificationId',
+    url: '/notifications/:notificationId',
     data: {
       apiPermissions: {
         only: ['api-notification-r', 'api-notification-c', 'api-notification-u'],
-      },
-      docs: {
-        page: 'management-api-notifications',
-      },
-      useAngularMaterial: true,
-    },
-  },
-  {
-    name: 'management.apis.notifications',
-    component: NotificationsComponent,
-    url: '/notifications',
-    data: {
-      apiPermissions: {
-        only: ['api-notification-r'],
-      },
-      useAngularMaterial: true,
-    },
-    resolve: [
-      {
-        token: 'resolvedHookScope',
-        resolveFn: () => {
-          return Scope.API;
-        },
-      },
-      {
-        token: 'resolvedHooks',
-        deps: ['NotificationSettingsService'],
-        resolveFn: (NotificationSettingsService: NotificationSettingsService) => {
-          return NotificationSettingsService.getHooks(Scope.API).then((response) => response.data);
-        },
-      },
-      {
-        token: 'resolvedNotifiers',
-        deps: ['NotificationSettingsService', '$stateParams'],
-        resolveFn: (NotificationSettingsService: NotificationSettingsService, $stateParams) => {
-          return NotificationSettingsService.getNotifiers(Scope.API, $stateParams.apiId).then((response) => response.data);
-        },
-      },
-      {
-        token: 'notificationSettings',
-        deps: ['NotificationSettingsService', '$stateParams'],
-        resolveFn: (NotificationSettingsService: NotificationSettingsService, $stateParams) => {
-          return NotificationSettingsService.getNotificationSettings(Scope.API, $stateParams.apiId).then((response) => response.data);
-        },
-      },
-      {
-        token: 'api',
-        deps: ['ApiService', '$stateParams'],
-        resolveFn: (ApiService: ApiService, $stateParams) => {
-          return ApiService.get($stateParams.apiId).then((response) => response.data);
-        },
-      },
-    ],
-  },
-  {
-    name: 'management.apis.notifications.notification',
-    component: NotificationsComponent,
-    url: '/:notificationId',
-    data: {
-      apiPermissions: {
-        only: ['api-notification-r'],
       },
       docs: {
         page: 'management-api-notifications',

--- a/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/notifications/notifications-list/notofication-details/notification-details.component.html
@@ -17,7 +17,7 @@
 -->
 <div>
   <div class="md-headline notifications-form__title" *ngIf="!isLoadingData">
-    <gio-go-back-button [ajsGo]="{ to: 'management.apis.notifications-ng' }"></gio-go-back-button>
+    <gio-go-back-button [ajsGo]="{ to: 'management.apis.notifications' }"></gio-go-back-button>
     Update <b>{{ notificationSettings.name }}</b>
     <span *ngIf="notifier" class="gio-badge-neutral">{{ notifier.name }}</span>
   </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2371

## Description

Last part of migrating notifications from angular.js to angular 2+, set correct routing

## Additional context

It's sixth part of notifications migration
<img width="1024" alt="Screenshot 2023-10-05 at 10 36 07 AM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/f36d7bdd-3946-43af-8700-ca64f01b8723">


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5474/console](https://pr.team-apim.gravitee.dev/5474/console)
      Portal: [https://pr.team-apim.gravitee.dev/5474/portal](https://pr.team-apim.gravitee.dev/5474/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5474/api/management](https://pr.team-apim.gravitee.dev/5474/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5474](https://pr.team-apim.gravitee.dev/5474)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5474](https://pr.gateway-v3.team-apim.gravitee.dev/5474)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rnmtrqozik.chromatic.com)
<!-- Storybook placeholder end -->
