### PR TITLE
test(ui): plans fix solution, looking for unique string

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -66,7 +66,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_name_field').type(`${planName}-APIKey`);
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} API Key`);
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.contains('selection rule').should('be.visible');
+    cy.contains('Propagate API Key').should('exist').scrollIntoView().should('be.visible');
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('Rate Limiting').should('be.visible');
     cy.contains('Quota').should('be.visible');
@@ -92,7 +92,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.get('[role="combobox"]').eq(4).type('Test');
     // ^ I can't find html element for this, this doesn't feel good but was best I could do as OAuth2 Resource a mandatory field
-    cy.contains('selection rule').should('be.visible');
+    cy.contains('OAuth2 resource').should('exist').scrollIntoView().should('be.visible');
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('Rate Limiting').should('be.visible');
     cy.contains('Quota').should('be.visible');
@@ -116,7 +116,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_name_field').type(`${planName}-JWT`);
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} JWT`);
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.contains('JWKS resolver').should('be.visible');
+    cy.contains('JWKS resolver').should('exist').scrollIntoView().should('be.visible');
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('Rate Limiting').should('be.visible');
     cy.contains('Quota').should('be.visible');


### PR DESCRIPTION
test(ui): plans test adding unique strings for step 2 plan creation

## Issue

#5454 #5449 

## Description

Instead of selection rule which was used while we were awaiting changes to some of these screens, it makes more sense to look for unique strings on this stage that signify the type of plan so, voila! 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

