### PR TITLE
fix: remove the use of GraviteeContext to retrieve organization of an api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PrimaryOwnerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PrimaryOwnerAdapter.java
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.domain_service;
+package io.gravitee.apim.infra.adapter;
 
-import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
-import io.gravitee.rest.api.service.common.ExecutionContext;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
-public interface ApiPrimaryOwnerDomainService {
-    PrimaryOwnerEntity getApiPrimaryOwner(final String organizationId, String apiId) throws ApiPrimaryOwnerNotFoundException;
+@Mapper
+public interface PrimaryOwnerAdapter {
+    PrimaryOwnerAdapter INSTANCE = Mappers.getMapper(PrimaryOwnerAdapter.class);
+
+    PrimaryOwnerEntity fromRestEntity(io.gravitee.rest.api.model.PrimaryOwnerEntity primaryOwnerEntity);
+
+    io.gravitee.rest.api.model.PrimaryOwnerEntity toRestEntity(PrimaryOwnerEntity primaryOwnerEntity);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/PrimaryOwnerDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/PrimaryOwnerDomainServiceImpl.java
@@ -59,8 +59,8 @@ public class PrimaryOwnerDomainServiceImpl implements ApiPrimaryOwnerDomainServi
     }
 
     @Override
-    public PrimaryOwnerEntity getApiPrimaryOwner(ExecutionContext executionContext, String apiId) throws ApiPrimaryOwnerNotFoundException {
-        return findPrimaryOwnerRole(executionContext.getOrganizationId())
+    public PrimaryOwnerEntity getApiPrimaryOwner(final String organizationId, String apiId) throws ApiPrimaryOwnerNotFoundException {
+        return findPrimaryOwnerRole(organizationId)
             .flatMap(role ->
                 findPrimaryOwnerMembership(apiId, role)
                     .flatMap(membership ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -739,7 +739,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     private PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, Api api) throws TechnicalManagementException {
-        return primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+        return primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -1429,7 +1429,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
     }
 
     private RoleEntity mapApiPrimaryOwnerRoleToGroupRole(ExecutionContext executionContext, String apiId, String groupId, RoleEntity role) {
-        PrimaryOwnerEntity apiPrimaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, apiId);
+        PrimaryOwnerEntity apiPrimaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), apiId);
         if (apiPrimaryOwner.getId().equals(groupId)) {
             return role;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializer.java
@@ -188,7 +188,7 @@ public class SearchIndexInitializer implements Initializer {
         Indexable indexable;
         PrimaryOwnerEntity primaryOwner = null;
         try {
-            primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+            primaryOwner = primaryOwnerService.getPrimaryOwner(organizationId, api.getId());
         } catch (PrimaryOwnerNotFoundException e) {
             LOGGER.warn("Failed to retrieve API primary owner, API will we indexed without his primary owner", e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgrader.java
@@ -256,7 +256,7 @@ public class PlansDataFixUpgrader implements Upgrader {
     }
 
     protected void sendEmailToApiOwner(ExecutionContext executionContext, Api api, List<Plan> createdPlans, List<Plan> closedPlans) {
-        getApiOwnerEmail(executionContext, api)
+        getApiOwnerEmail(executionContext.getOrganizationId(), api)
             .ifPresent(apiOwnerEmail -> {
                 log.debug("Sending report email to api {} owner", api.getId());
                 emailService.sendAsyncEmailNotification(
@@ -270,8 +270,8 @@ public class PlansDataFixUpgrader implements Upgrader {
             });
     }
 
-    private Optional<String> getApiOwnerEmail(ExecutionContext executionContext, Api api) {
-        return Optional.ofNullable(primaryOwnerService.getPrimaryOwner(executionContext, api.getId()).getEmail());
+    private Optional<String> getApiOwnerEmail(String organizationId, Api api) {
+        return Optional.ofNullable(primaryOwnerService.getPrimaryOwner(organizationId, api.getId()).getEmail());
     }
 
     private void logWarningHeaderBlock() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
@@ -28,27 +28,27 @@ import java.util.Map;
 public interface PrimaryOwnerService {
     /**
      * Resolves the primary owner for the given API.
-     * @param executionContext the execution context
+     * @param organizationId the organization id
      * @param apiId the API id
      * @return The primary owner
      * @throws TechnicalManagementException if an error occurs while resolving the primary owner
-     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(String, String)} instead
      */
     @Deprecated
-    PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String apiId) throws TechnicalManagementException;
+    PrimaryOwnerEntity getPrimaryOwner(String organizationId, String apiId) throws TechnicalManagementException;
 
     /**
      * Resolves the primary owner email for the given API.
      * If the primary owner is a user, the email is returned.
      * If the primary owner is a group, the email of the member entitled as an API primary owner is returned.
-     * @param executionContext the execution context
+     * @param organizationId the organization id
      * @param apiId the API id
      * @return the primary owner email
      *
-     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(ExecutionContext, String)} instead
+     * @deprecated use {@link io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService#getApiPrimaryOwner(String, String)} instead
      */
     @Deprecated
-    String getPrimaryOwnerEmail(ExecutionContext executionContext, String apiId);
+    String getPrimaryOwnerEmail(String organizationId, String apiId);
 
     PrimaryOwnerEntity getPrimaryOwner(ExecutionContext executionContext, String userId, PrimaryOwnerEntity currentPrimaryOwner);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -520,7 +520,10 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
             return apiRepository
                 .search(queryToCriteria(executionContext, apiQuery).groups(poGroupIds).build(), null, ApiFieldFilter.allFields())
                 .filter(api -> {
-                    PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+                    PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(
+                        executionContext.getOrganizationId(),
+                        api.getId()
+                    );
                     /*
                      * If one of the groups where the user has the API Primary Owner Role
                      * is the actual Primary Owner of the API, grant permission

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiGroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiGroupServiceImpl.java
@@ -165,7 +165,7 @@ public class ApiGroupServiceImpl implements ApiGroupService {
         GroupEntity memberGroup = groupService.findById(executionContext, groupId);
         String groupDefaultApiRoleName = memberGroup.getRoles() == null ? null : memberGroup.getRoles().get(RoleScope.API);
 
-        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
 
         /*
          * If the group is not primary owner and the API, return the default group role for the API scope

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -95,14 +95,14 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     @Override
     public ApiEntity findById(final ExecutionContext executionContext, final String apiId) {
         final Api api = this.findV4RepositoryApiById(executionContext, apiId);
-        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
         return apiMapper.toEntity(executionContext, api, primaryOwner, null, true);
     }
 
     @Override
     public GenericApiEntity findGenericById(final ExecutionContext executionContext, final String apiId) {
         final Api api = this.findRepositoryApiById(executionContext, apiId);
-        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
         final List<CategoryEntity> categories = categoryService.findAll(executionContext.getEnvironmentId());
         return genericApiMapper.toGenericApi(executionContext, api, primaryOwner, categories);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -145,7 +145,7 @@ public class ApiStateServiceImpl implements ApiStateService {
 
         this.deployApi(executionContext, authenticatedUser, apiDeploymentEntity, api);
 
-        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
+        PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
         final GenericApiEntity deployedApi = genericApiMapper.toGenericApi(api, primaryOwner);
         GenericApiEntity apiWithMetadata = apiMetadataService.fetchMetadataForApi(executionContext, deployedApi);
 
@@ -249,7 +249,10 @@ public class ApiStateServiceImpl implements ApiStateService {
             api.setUpdatedAt(new Date());
             api.setLifecycleState(lifecycleState);
             Api updateApi = apiRepository.update(api);
-            ApiEntity apiEntity = apiMapper.toEntity(updateApi, primaryOwnerService.getPrimaryOwner(executionContext, api.getId()));
+            ApiEntity apiEntity = apiMapper.toEntity(
+                updateApi,
+                primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId())
+            );
             // Audit
             auditService.createApiAuditLog(
                 executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
@@ -179,7 +179,7 @@ public class ApiTemplateServiceImpl implements ApiTemplateService {
             if (supportEmail.isBlank()) {
                 decodedMetadata.put(
                     METADATA_EMAIL_SUPPORT_KEY,
-                    primaryOwnerService.getPrimaryOwnerEmail(executionContext, genericApiModel.getId())
+                    primaryOwnerService.getPrimaryOwnerEmail(executionContext.getOrganizationId(), genericApiModel.getId())
                 );
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImpl.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.api.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -77,24 +78,23 @@ public class PrimaryOwnerServiceImpl extends TransactionalService implements Pri
     }
 
     @Override
-    public PrimaryOwnerEntity getPrimaryOwner(final ExecutionContext executionContext, final String apiId)
-        throws TechnicalManagementException {
+    public PrimaryOwnerEntity getPrimaryOwner(final String organizationId, final String apiId) throws TechnicalManagementException {
         try {
             io.gravitee.apim.core.membership.model.PrimaryOwnerEntity po = primaryOwnerDomainService.getApiPrimaryOwner(
-                executionContext,
+                organizationId,
                 apiId
             );
-            return PrimaryOwnerEntity.builder().id(po.id()).type(po.type()).displayName(po.displayName()).email(po.email()).build();
+            return PrimaryOwnerAdapter.INSTANCE.toRestEntity(po);
         } catch (ApiPrimaryOwnerNotFoundException e) {
             throw new PrimaryOwnerNotFoundException(e.getApiId());
         }
     }
 
     @Override
-    public String getPrimaryOwnerEmail(ExecutionContext executionContext, String apiId) {
+    public String getPrimaryOwnerEmail(final String organizationId, String apiId) {
         try {
             io.gravitee.apim.core.membership.model.PrimaryOwnerEntity po = primaryOwnerDomainService.getApiPrimaryOwner(
-                executionContext,
+                organizationId,
                 apiId
             );
             return po.email();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -43,7 +43,6 @@ import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
@@ -29,7 +29,7 @@ public class PrimaryOwnerDomainServiceInMemory
     Map<String, PrimaryOwnerEntity> storage = new HashMap<>();
 
     @Override
-    public PrimaryOwnerEntity getApiPrimaryOwner(ExecutionContext executionContext, String apiId) throws ApiPrimaryOwnerNotFoundException {
+    public PrimaryOwnerEntity getApiPrimaryOwner(String organizationId, String apiId) throws ApiPrimaryOwnerNotFoundException {
         PrimaryOwnerEntity primaryOwnerEntity = storage.get(apiId);
         if (primaryOwnerEntity == null) {
             throw new ApiPrimaryOwnerNotFoundException(apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
@@ -77,8 +77,6 @@ public class PrimaryOwnerDomainServiceImplTest {
         userRepository = new UserCrudServiceInMemory();
         service = new PrimaryOwnerDomainServiceImpl(roleRepository, membershipRepository, userRepository, groupRepository);
 
-        GraviteeContext.setCurrentOrganization("organization-id");
-
         givenPrimaryRoleForOrganizationIs(
             Role.builder().id(PRIMARY_OWNER_ROLE_ID).referenceId("organization-id").referenceType(RoleReferenceType.ORGANIZATION).build()
         );
@@ -112,7 +110,7 @@ public class PrimaryOwnerDomainServiceImplTest {
                 )
             );
 
-            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+            var result = service.getApiPrimaryOwner("organization-id", "api-id");
 
             Assertions
                 .assertThat(result)
@@ -149,7 +147,7 @@ public class PrimaryOwnerDomainServiceImplTest {
                 )
             );
 
-            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+            var result = service.getApiPrimaryOwner("organization-id", "api-id");
 
             Assertions
                 .assertThat(result)
@@ -181,7 +179,7 @@ public class PrimaryOwnerDomainServiceImplTest {
                 )
             );
 
-            var result = service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id");
+            var result = service.getApiPrimaryOwner("organization-id", "api-id");
 
             Assertions
                 .assertThat(result)
@@ -204,7 +202,7 @@ public class PrimaryOwnerDomainServiceImplTest {
                 )
             );
 
-            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner("organization-id", "api-id"));
 
             assertThat(throwable).isInstanceOf(ApiPrimaryOwnerNotFoundException.class);
         }
@@ -215,7 +213,7 @@ public class PrimaryOwnerDomainServiceImplTest {
             givenRoleFailToBeFetched("technical exception");
 
             // When
-            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner("organization-id", "api-id"));
 
             // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
@@ -225,7 +223,7 @@ public class PrimaryOwnerDomainServiceImplTest {
         public void should_throw_when_fail_to_fetch_api_memberships() {
             givenApiPrimaryOwnerMembershipFailToBeFetched("technical exception");
 
-            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner("organization-id", "api-id"));
 
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }
@@ -246,7 +244,7 @@ public class PrimaryOwnerDomainServiceImplTest {
             );
             givenGroupFailToBeFetched("technical exception");
 
-            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner("organization-id", "api-id"));
 
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }
@@ -267,7 +265,7 @@ public class PrimaryOwnerDomainServiceImplTest {
             );
             givenGroupMembershipFailToBeFetched("technical exception");
 
-            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(GraviteeContext.getExecutionContext(), "api-id"));
+            Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner("organization-id", "api-id"));
 
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlansDataFixUpgraderTest.java
@@ -243,11 +243,12 @@ public class PlansDataFixUpgraderTest {
         Api api = new Api();
         api.setId("my-api-id");
 
-        when(primaryOwnerService.getPrimaryOwner(GraviteeContext.getExecutionContext(), "my-api-id")).thenReturn(new PrimaryOwnerEntity());
+        when(primaryOwnerService.getPrimaryOwner(GraviteeContext.getCurrentOrganization(), "my-api-id"))
+            .thenReturn(new PrimaryOwnerEntity());
 
         upgrader.sendEmailToApiOwner(GraviteeContext.getExecutionContext(), api, Collections.emptyList(), Collections.emptyList());
 
-        verify(primaryOwnerService, times(1)).getPrimaryOwner(GraviteeContext.getExecutionContext(), "my-api-id");
+        verify(primaryOwnerService, times(1)).getPrimaryOwner(GraviteeContext.getCurrentOrganization(), "my-api-id");
     }
 
     @Test
@@ -257,7 +258,7 @@ public class PlansDataFixUpgraderTest {
 
         PrimaryOwnerEntity primaryOwner = new PrimaryOwnerEntity();
         primaryOwner.setEmail("primary-owner-email");
-        when(primaryOwnerService.getPrimaryOwner(GraviteeContext.getExecutionContext(), "my-api-id")).thenReturn(primaryOwner);
+        when(primaryOwnerService.getPrimaryOwner(GraviteeContext.getCurrentOrganization(), "my-api-id")).thenReturn(primaryOwner);
 
         List<Plan> createdPlans = new ArrayList<>();
         List<Plan> closedPlans = new ArrayList<>();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-778
https://gravitee.atlassian.net/browse/CJ-779
https://gravitee.atlassian.net/browse/CJ-780

## Description

Remove the use of GraviteeContext to retrieve organization of an pain and use the environementId from the API itself

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mnoutlkpsy.chromatic.com)
<!-- Storybook placeholder end -->
