### PR TITLE
fix: do not remove pathInfo method

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -203,6 +203,12 @@ public abstract class AbstractRequest implements MutableRequest {
     }
 
     @Override
+    public MutableRequest pathInfo(String pathInfo) {
+        this.pathInfo = pathInfo;
+        return this;
+    }
+
+    @Override
     public MutableRequest transactionId(String transactionId) {
         this.transactionId = transactionId;
         return this;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/MutableRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/MutableRequest.java
@@ -31,6 +31,14 @@ public interface MutableRequest extends Request, OnMessagesInterceptor {
     MutableRequest contextPath(final String contextPath);
 
     /**
+     * Allow setting path info.
+     *
+     * @param pathInfo the path info to set.
+     * @return {@link MutableRequest}.
+     */
+    MutableRequest pathInfo(final String pathInfo);
+
+    /**
      * Allow setting transaction id.
      *
      * @param transactionId the transaction identifier to set.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2821

## Description

The reactor engine set the pathInfo in the request when handling subscriptions.
This reverts a part of commit d411f354f58cacf0db0dc45d1022599a7ef586ff.

