### PR TITLE
fix: minor bugs with group admin

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -96,6 +96,7 @@ const GroupComponent: ng.IComponentOptions = {
       this.applicationByDefault =
         this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'APPLICATION_CREATE') !== -1;
 
+      this.currentUserId = UserService.currentUser.id;
       this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
       this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
       this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.html
@@ -224,6 +224,7 @@
                         ng-false-value="''"
                         ng-change="$ctrl.updateRole(member)"
                         aria-label="Administrator of this group"
+                        ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
                       >
                       </md-checkbox>
                     </td>
@@ -253,7 +254,7 @@
                     </td>
                     <td md-cell ng-click="$event.stopPropagation()">
                       <div layout="row" layout-align="end center">
-                        <span ng-if="$ctrl.group.manageable">
+                        <span ng-if="$ctrl.isSuperAdmin || ($ctrl.group.manageable && $ctrl.currentUserId !== member.id)">
                           <md-tooltip md-direction="top">delete</md-tooltip>
                           <ng-md-icon icon="delete" ng-click="$ctrl.removeUser($event, member)" aria-label="delete-user"></ng-md-icon>
                         </span>

--- a/gravitee-apim-console-webui/src/management/configuration/groups/groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/groups.component.ts
@@ -37,6 +37,10 @@ const GroupsComponent: ng.IComponentOptions = {
     'ngInject';
     this.$rootScope = $rootScope;
 
+    this.$onInit = () => {
+      this.canRemoveGroup = UserService.isUserHasPermissions(['environment-group-d']);
+    };
+
     this.create = () => {
       $state.go('management.settings.groups.create');
     };

--- a/gravitee-apim-console-webui/src/management/configuration/groups/groups.html
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/groups.html
@@ -44,7 +44,7 @@
                 <ng-md-icon ng-if="$ctrl.hasEvent(group, 'APPLICATION_CREATE')" icon="done"></ng-md-icon>
               </td>
               <td md-cell ng-click="$event.stopPropagation()" layout="row" style="padding: 10px 0">
-                <span ng-if="group.manageable && !group.primary_owner">
+                <span ng-if="group.manageable && !group.primary_owner && $ctrl.canRemoveGroup">
                   <md-tooltip md-direction="top">Delete</md-tooltip>
                   <ng-md-icon
                     icon="delete"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2731

## Description

Fixing minor bugs found by @ThibaudAV in his review:

- User group admin shouldn't be able to remove itself
- User group admin shouldn't be able to update members (role and groupAdmin status) if System invitation is disabled
- User group admin have remove icon on group list. Only a user with environment-group-delete permission could do it.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jkzyjusxqx.chromatic.com)
<!-- Storybook placeholder end -->
