### PR TITLE
fix: keep period when changing page in runtime logs

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -30,13 +30,20 @@ export class ApiLogsV2Service {
     apiId: string,
     queryParam?: { page?: number; perPage?: number; from?: number; to?: number },
   ): Observable<ApiLogsResponse> {
+    let params = new HttpParams();
+    params = params.append('page', queryParam?.page ?? 1);
+    params = params.append('perPage', queryParam?.perPage ?? 10);
+
+    if (queryParam?.from) {
+      params = params.append('from', queryParam.from);
+    }
+
+    if (queryParam?.to) {
+      params = params.append('to', queryParam.to);
+    }
+
     return this.http.get<ApiLogsResponse>(`${this.constants.env.v2BaseURL}/apis/${apiId}/logs`, {
-      params: {
-        page: queryParam?.page ?? 1,
-        perPage: queryParam?.perPage ?? 10,
-        ...(!!queryParam?.from && { from: queryParam.from }),
-        ...(!!queryParam?.to && { to: queryParam.to }),
-      },
+      params,
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2474

## Description

Currently we are losing the periode when we navigate in runtime logs when there is a period selected.

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/30a86f0a-5b95-4437-9604-90873e39a970




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-toxymidzfs.chromatic.com)
<!-- Storybook placeholder end -->
