### PR TITLE
fix: allow usage if EL in endpoint for healthCheck

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -169,7 +169,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
     }
 
     protected URL createRequest(T endpoint, HealthCheckStep step) throws MalformedURLException {
-        URL targetURL = new URL(null, endpoint.getTarget());
+        URL targetURL = new URL(null, templateEngine.getValue(endpoint.getTarget(), String.class));
         logger.debug("Health-check step request{}", step.getRequest());
         if (step.getRequest().isFromRoot()) {
             targetURL = new URL(targetURL.getProtocol(), targetURL.getHost(), targetURL.getPort(), "/");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-418

## Description

Use template engine to parse EL in endpoints for the health-check service.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-epzgccyytv.chromatic.com)
<!-- Storybook placeholder end -->
