### PR TITLE
chore: exclude all transitive dependencies from runtime dep

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -73,6 +73,12 @@
             <version>${gravitee-alert-engine-connectors-ws.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.cockpit</groupId>
@@ -80,6 +86,12 @@
             <version>${gravitee-cockpit-connectors-ws.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.connector</groupId>
@@ -87,6 +99,12 @@
             <version>${gravitee-connector-http.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Entrypoints -->
@@ -95,6 +113,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-http-get</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -102,6 +126,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -109,6 +139,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -116,6 +152,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-webhook</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -123,6 +165,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-websocket</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -130,6 +178,12 @@
             <artifactId>gravitee-apim-plugin-entrypoint-http-proxy</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
 
@@ -139,6 +193,12 @@
             <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -146,6 +206,12 @@
             <artifactId>gravitee-apim-plugin-endpoint-kafka</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -153,6 +219,12 @@
             <artifactId>gravitee-apim-plugin-endpoint-mqtt5</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
         <dependency>
@@ -160,6 +232,12 @@
             <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
 
@@ -170,6 +248,12 @@
             <version>${gravitee-fetcher-bitbucket.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
@@ -177,6 +261,12 @@
             <version>${gravitee-fetcher-git.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
@@ -184,6 +274,12 @@
             <version>${gravitee-fetcher-github.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
@@ -191,6 +287,12 @@
             <version>${gravitee-fetcher-gitlab.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
@@ -198,6 +300,12 @@
             <version>${gravitee-fetcher-http.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Notifiers -->
@@ -207,6 +315,12 @@
             <version>${gravitee-notifier-email.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.notifier</groupId>
@@ -214,6 +328,12 @@
             <version>${gravitee-notifier-slack.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.notifier</groupId>
@@ -221,6 +341,12 @@
             <version>${gravitee-notifier-webhook.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Policies -->
@@ -230,6 +356,12 @@
             <version>${gravitee-policy-apikey.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -237,6 +369,12 @@
             <version>${gravitee-policy-assign-attributes.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -244,6 +382,12 @@
             <version>${gravitee-policy-assign-content.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -251,6 +395,12 @@
             <version>${gravitee-policy-cache.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -258,6 +408,12 @@
             <version>${gravitee-policy-callout-http.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -265,6 +421,12 @@
             <version>${gravitee-policy-dynamic-routing.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -272,6 +434,12 @@
             <version>${gravitee-policy-generate-http-signature.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -279,6 +447,12 @@
             <version>${gravitee-policy-generate-jwt.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -286,6 +460,12 @@
             <version>${gravitee-policy-groovy.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -293,6 +473,12 @@
             <version>${gravitee-policy-html-json.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -300,6 +486,12 @@
             <version>${gravitee-policy-http-signature.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -307,6 +499,12 @@
             <version>${gravitee-policy-ipfiltering.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -314,6 +512,12 @@
             <version>${gravitee-policy-json-threat-protection.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -321,6 +525,12 @@
             <version>${gravitee-policy-json-to-json.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -328,6 +538,12 @@
             <version>${gravitee-policy-json-validation.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -335,6 +551,12 @@
             <version>${gravitee-policy-json-xml.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -342,6 +564,12 @@
             <version>${gravitee-policy-jws.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -349,6 +577,12 @@
             <version>${gravitee-policy-jwt.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -356,6 +590,12 @@
             <version>${gravitee-policy-keyless.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -363,6 +603,12 @@
             <version>${gravitee-policy-latency.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -370,6 +616,12 @@
             <version>${gravitee-policy-metrics-reporter.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -377,6 +629,12 @@
             <version>${gravitee-policy-message-filtering.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -384,6 +642,12 @@
             <version>${gravitee-policy-mock.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -391,6 +655,12 @@
             <version>${gravitee-policy-oauth2.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -398,6 +668,12 @@
             <version>${gravitee-policy-openid-connect-userinfo.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -405,6 +681,12 @@
             <version>${gravitee-policy-override-http-method.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -412,6 +694,12 @@
             <version>${gravitee-policy-ratelimit.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -419,6 +707,12 @@
             <version>${gravitee-policy-ratelimit.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -426,6 +720,12 @@
             <version>${gravitee-policy-regex-threat-protection.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -433,6 +733,12 @@
             <version>${gravitee-policy-request-content-limit.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -440,6 +746,12 @@
             <version>${gravitee-policy-request-validation.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -447,6 +759,12 @@
             <version>${gravitee-policy-resource-filtering.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -454,6 +772,12 @@
             <version>${gravitee-policy-rest-to-soap.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -461,6 +785,12 @@
             <version>${gravitee-policy-retry.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -468,6 +798,12 @@
             <version>${gravitee-policy-role-based-access-control.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -475,6 +811,12 @@
             <version>${gravitee-policy-ratelimit.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -482,6 +824,12 @@
             <version>${gravitee-policy-ssl-enforcement.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -489,6 +837,12 @@
             <version>${gravitee-policy-traffic-shadowing.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -496,6 +850,12 @@
             <version>${gravitee-policy-transformheaders.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -503,6 +863,12 @@
             <version>${gravitee-policy-transformqueryparams.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -510,6 +876,12 @@
             <version>${gravitee-policy-url-rewriting.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -517,6 +889,12 @@
             <version>${gravitee-policy-xml-json.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -524,6 +902,12 @@
             <version>${gravitee-policy-xml-threat-protection.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -531,6 +915,12 @@
             <version>${gravitee-policy-xml-validation.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -538,6 +928,12 @@
             <version>${gravitee-policy-xslt.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Reporters -->
@@ -547,6 +943,12 @@
             <version>${gravitee-reporter-elasticsearch.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.reporter</groupId>
@@ -554,6 +956,12 @@
             <version>${gravitee-reporter-file.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.reporter</groupId>
@@ -561,6 +969,12 @@
             <version>${gravitee-reporter-tcp.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Repositories -->
@@ -570,6 +984,12 @@
             <version>${project.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>
@@ -577,6 +997,12 @@
             <version>${project.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
@@ -584,6 +1010,12 @@
             <version>${project.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
@@ -591,12 +1023,24 @@
             <version>${project.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-elasticsearch</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <type>zip</type>
         </dependency>
 
@@ -607,6 +1051,12 @@
             <version>${gravitee-resource-cache.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.resource</groupId>
@@ -614,6 +1064,12 @@
             <version>${gravitee-resource-oauth2-provider-am.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.resource</groupId>
@@ -621,6 +1077,12 @@
             <version>${gravitee-resource-oauth2-provider-generic.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Services -->
@@ -630,6 +1092,12 @@
             <version>${gravitee-service-discovery-consul.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -637,6 +1105,12 @@
             <version>${gravitee-policy-ratelimit.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Tracers -->
@@ -646,6 +1120,12 @@
             <version>${gravitee-tracer-jaeger.version}</version>
             <type>zip</type>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -698,6 +1178,12 @@
                     <version>${gravitee-connector-kafka.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <!-- Entrypoints -->
                 <dependency>
@@ -706,6 +1192,12 @@
                     <version>${gravitee-entrypoint-sse-advanced.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <!-- Endpoints -->
                 <dependency>
@@ -714,6 +1206,12 @@
                     <version>${gravitee-endpoint-kafka-advanced.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>
@@ -721,6 +1219,12 @@
                     <version>${gravitee-endpoint-mqtt5-advanced.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
 
                 <!-- Policies -->
@@ -730,6 +1234,12 @@
                     <version>${gravitee-policy-assign-metrics.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -737,6 +1247,12 @@
                     <version>${gravitee-policy-aws-lambda.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -744,6 +1260,12 @@
                     <version>${gravitee-policy-basic-authentication.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -751,6 +1273,12 @@
                     <version>${gravitee-policy-circuit-breaker.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -758,6 +1286,12 @@
                     <version>${gravitee-policy-custom-query-parameters-parser.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
@@ -767,8 +1301,8 @@
                     <scope>runtime</scope>
                     <exclusions>
                         <exclusion>
-                            <groupId>com.jayway.jsonpath</groupId>
-                            <artifactId>json-path</artifactId>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
                         </exclusion>
                     </exclusions>
                 </dependency>
@@ -778,6 +1312,12 @@
                     <version>${gravitee-policy-geoip-filtering.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -785,6 +1325,12 @@
                     <version>${gravitee-policy-javascript.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -792,6 +1338,12 @@
                     <version>${gravitee-policy-wssecurity-authentication.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -799,6 +1351,12 @@
                     <version>${gravitee-policy-interrupt.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <!-- Resources -->
                 <dependency>
@@ -807,6 +1365,12 @@
                     <version>${gravitee-resource-auth-provider-http.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.resource</groupId>
@@ -814,6 +1378,12 @@
                     <version>${gravitee-resource-auth-provider-inline.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.resource</groupId>
@@ -821,6 +1391,12 @@
                     <version>${gravitee-resource-auth-provider-ldap.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.resource</groupId>
@@ -828,6 +1404,12 @@
                     <version>${gravitee-resource-cache-redis.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.resource</groupId>
@@ -835,6 +1417,12 @@
                     <version>${gravitee-resource-oauth2-provider-keycloak.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
 
                 <!-- Services -->


### PR DESCRIPTION
## Issue

N/A

## Description

A bug (probably due to assembly plugin) is messing our lib/ext folder when building distribution.

Normally, we should only rely on provided and compile dependencies to add external libraries. But, even if we explicitly exclude runtime dependencies from this mechanism, the assembly plugin sometimes use a version from a runtime dependency, leading to downgrading some libs.

This commit exclude the transtives dependencies for runtime dep. We can do this since we use runtime deps only to know which plugins to add in the final distribution.


### Example - Content diff of the lib/ext folder of the gateway
On the left, before the fix, on the right, after
![image](https://github.com/gravitee-io/gravitee-api-management/assets/13161768/c0d0e150-9c8d-4592-8bbd-0b2d806d3777)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ggdvkkiocj.chromatic.com)
<!-- Storybook placeholder end -->
