### PR TITLE
fix: resolve client call url using X-Forwarded headers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/bootstrap/ManagementUIBootstrapResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/bootstrap/ManagementUIBootstrapResource.java
@@ -35,6 +35,10 @@ import java.net.URI;
 import java.net.URL;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -73,25 +77,19 @@ public class ManagementUIBootstrapResource {
                 )
                 .build();
         }
-        try {
-            URL defaultBaseUrl = new URL(
-                httpServletRequest.getScheme(),
-                httpServletRequest.getServerName(),
-                httpServletRequest.getServerPort(),
-                contextPath.toString()
-            );
-            return Response
-                .ok(
-                    ManagementUIBootstrapEntity
-                        .builder()
-                        .organizationId(GraviteeContext.getDefaultOrganization())
-                        .baseURL(defaultBaseUrl.toExternalForm())
-                        .build()
-                )
-                .build();
-        } catch (MalformedURLException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
-        }
+
+        ServerHttpRequest request = new ServletServerHttpRequest(httpServletRequest);
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpRequest(request).replacePath(contextPath.toString()).build();
+
+        return Response
+            .ok(
+                ManagementUIBootstrapEntity
+                    .builder()
+                    .organizationId(GraviteeContext.getDefaultOrganization())
+                    .baseURL(uriComponents.toUriString())
+                    .build()
+            )
+            .build();
     }
 
     private static URI sanitizeContextPath(final HttpServletRequest httpServletRequest) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/bootstrap/PortalUIBootstrapResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/bootstrap/PortalUIBootstrapResource.java
@@ -36,6 +36,10 @@ import java.net.URI;
 import java.net.URL;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -79,25 +83,17 @@ public class PortalUIBootstrapResource {
                 .build();
         }
 
-        try {
-            URL defaultBaseUrl = new URL(
-                httpServletRequest.getScheme(),
-                httpServletRequest.getServerName(),
-                httpServletRequest.getServerPort(),
-                contextPath.toString()
-            );
-            return Response
-                .ok(
-                    PortalUIBootstrapEntity
-                        .builder()
-                        .organizationId(GraviteeContext.getDefaultOrganization())
-                        .environmentId(GraviteeContext.getDefaultEnvironment())
-                        .baseURL(defaultBaseUrl.toExternalForm())
-                        .build()
-                )
-                .build();
-        } catch (MalformedURLException e) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
-        }
+        ServerHttpRequest request = new ServletServerHttpRequest(httpServletRequest);
+        UriComponents uriComponents = UriComponentsBuilder.fromHttpRequest(request).replacePath(contextPath.toString()).build();
+        return Response
+            .ok(
+                PortalUIBootstrapEntity
+                    .builder()
+                    .organizationId(GraviteeContext.getDefaultOrganization())
+                    .environmentId(GraviteeContext.getDefaultEnvironment())
+                    .baseURL(uriComponents.toUriString())
+                    .build()
+            )
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -61,6 +61,7 @@ http:
 #    management:
 #      enabled: true
 #      entrypoint: ${http.api.entrypoint}management
+#      proxyPath: ${http.api.management.entrypoint}
 #      cors:
 # Allows to configure the header Access-Control-Allow-Origin (default value: *)
 # '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.
@@ -76,6 +77,7 @@ http:
 #    portal:
 #      enabled: true
 #      entrypoint: ${http.api.entrypoint}portal
+#      proxyPath: ${http.api.portal.entrypoint}
 #      cors:
 # Allows to configure the header Access-Control-Allow-Origin (default value: *)
 # '*' is a valid value but is considered as a security risk as it will be opened to cross origin requests from anywhere.

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -96,10 +96,6 @@ data:
       {{- end }}
 
     console:
-      api:
-        url: "https://{{index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}"
-      ui:
-        url: "https://{{index .Values.ui.ingress.hosts 0 }}{{ regexFind "/[a-zA-Z]+" .Values.ui.ingress.path }}"
       {{- if (((.Values.ui).analytics).pendo).enabled }}
       analytics:
         {{ toYaml .Values.ui.analytics | indent 8 | trim -}}
@@ -194,8 +190,10 @@ data:
         entrypoint: {{ .Values.api.http.api.entrypoint }}
         management:
           entrypoint: ${http.api.entrypoint}management
+          proxyPath: {{ .Values.api.ingress.management.path }}
         portal:
           entrypoint: ${http.api.entrypoint}portal
+          proxyPath: {{ .Values.api.ingress.portal.path }}
     {{- end }}
 
     analytics:


### PR DESCRIPTION

## Description

When deploying the mapi behind a proxy as we do using nginx ingress controler, the original client request needs to be resolved using X-Forwarded-* header to make sure we return a correct default baseUrl for the mapi.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5531/console](https://pr.team-apim.gravitee.dev/5531/console)
      Portal: [https://pr.team-apim.gravitee.dev/5531/portal](https://pr.team-apim.gravitee.dev/5531/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5531/api/management](https://pr.team-apim.gravitee.dev/5531/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5531](https://pr.team-apim.gravitee.dev/5531)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5531](https://pr.gateway-v3.team-apim.gravitee.dev/5531)

<!-- Environment placeholder end -->
