### PR TITLE
[4.1.x] Upgrade `gravitee-bom` to have the latest Vertx and Netty versions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DuplicateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DuplicateApiTest.java
@@ -61,11 +61,12 @@ public class ApiResource_DuplicateApiTest extends ApiResourceTest {
         assertThat(error.getMessage()).isEqualTo("Api [" + API + "] cannot be found.");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] {arguments}")
     @CsvSource(
         delimiterString = "|",
+        useHeadersInDisplayName = true,
         textBlock = """
-        # API_DEFINITION[READ] |  ENVIRONMENT_API[CREATE]
+        API_DEFINITION[READ] |  ENVIRONMENT_API[CREATE]
         false                  |  false
         true                   |  false
         false                  |  true

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
-        <vertx.version>4.4.4</vertx.version>
+        <vertx.version>4.4.6</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>6.0.3</gravitee-bom.version>
+        <gravitee-bom.version>6.0.15</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.1.0</gravitee-cockpit-api.version>
         <gravitee-common.version>3.3.3</gravitee-common.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2984
https://gravitee.atlassian.net/browse/APIM-2986
https://gravitee.atlassian.net/browse/APIM-2994

## Description

Upgrade gravitee-bom to have the latest Vertx and Netty versions 

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pdjzwsdtkr.chromatic.com)
<!-- Storybook placeholder end -->
