### PR TITLE
test: improve UserServiceTest by forcing no auth

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -73,6 +73,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * @author Azize Elamrani (azize dot elamrani at gmail dot com)
@@ -1061,6 +1064,18 @@ public class UserServiceTest {
         )
             .thenReturn(mock(MetadataPage.class));
 
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(final Authentication authentication) {}
+            }
+        );
+
         userService.resetPassword(GraviteeContext.getExecutionContext(), USER_NAME);
 
         verify(user, never()).setPassword(null);
@@ -1089,6 +1104,18 @@ public class UserServiceTest {
         )
             .thenReturn(mdPage);
 
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(final Authentication authentication) {}
+            }
+        );
+
         userService.resetPassword(GraviteeContext.getExecutionContext(), USER_NAME);
 
         verify(user, never()).setPassword(null);
@@ -1113,6 +1140,18 @@ public class UserServiceTest {
             )
         )
             .thenReturn(mdPage);
+
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(final Authentication authentication) {}
+            }
+        );
 
         userService.resetPassword(GraviteeContext.getExecutionContext(), USER_NAME);
 


### PR DESCRIPTION
## Issue

N/A
## Description

Fix UserService tests by settings the right security context so the failing tests work again.

## Additional information
This pb has been discovered with parallelization of unit tests. It has been fixed in 4.0.x, but not applied on other branches.
A fix has been made for master, but the fixed tests don't test the exact same use cases.

Maybe there won't have conflicts when merging in master, but need to change this commit: f0104110