### PR TITLE
fix useSystemProxy for health-check

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
@@ -97,7 +97,7 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
         HttpProxy proxy = endpoint.getHttpProxy();
         if (proxy != null && proxy.isEnabled()) {
             ProxyOptions proxyOptions = null;
-            if (proxy.isUseSystemProxy() && this.systemProxyOptions != null) {
+            if (proxy.isUseSystemProxy()) {
                 proxyOptions = this.systemProxyOptions;
             } else {
                 proxyOptions =


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2838

## Description

When using system proxy for HealthCheck, we don't want to fallback on the proxy options of the endpoint if no system proxy is configured.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgvyhalosa.chromatic.com)
<!-- Storybook placeholder end -->
