### PR TITLE
Do not remove attached media when renaming an API Doc Page

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -317,8 +317,11 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 : withUpdatePage.getAccessControls()
         );
 
-        List<PageMedia> pageMediaList = convertMediaEntity(updatePageEntity.getAttachedMedia());
-        page.setAttachedMedia(pageMediaList != null ? pageMediaList : withUpdatePage.getAttachedMedia());
+        page.setAttachedMedia(
+            updatePageEntity.getAttachedMedia() != null
+                ? convertMediaEntity(updatePageEntity.getAttachedMedia())
+                : withUpdatePage.getAttachedMedia()
+        );
         page.setParentId(
             updatePageEntity.getParentId() != null
                 ? updatePageEntity.getParentId().isEmpty() ? null : updatePageEntity.getParentId()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2855
https://github.com/gravitee-io/issues/issues/9285

## Description

Do not remove attached media when renaming an API Doc Page
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cilzslwgef.chromatic.com)
<!-- Storybook placeholder end -->
