### PR TITLE
fix: properly filter apis from admin context

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
@@ -78,7 +78,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
     @Test
     public void should_return_no_content_when_user_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of());
+        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getCurrentEnvironment())).thenReturn(Set.of());
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -101,7 +101,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
     @Test
     public void should_return_analytics_when_user_admin_and_application_analytics() {
-        when(applicationService.findIdsByUser(GraviteeContext.getExecutionContext(), null)).thenReturn(Set.of("app-1"));
+        when(applicationService.searchIds(eq(GraviteeContext.getExecutionContext()), any(), eq(null))).thenReturn(Set.of("app-1"));
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
@@ -133,7 +133,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
     @Test
     public void should_return_analytics_when_user_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of("api-1"));
+        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getCurrentEnvironment())).thenReturn(Set.of("api-1"));
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
@@ -71,6 +71,6 @@ public interface ApiAuthorizationService {
     );
 
     Set<String> findApiIdsByUserId(ExecutionContext executionContext, String userId, ApiQuery apiQuery);
-    Set<String> findIdsByEnvironment(final ExecutionContext executionContext);
+    Set<String> findIdsByEnvironment(final String environmentId);
     List<ApiCriteria> computeApiCriteriaForUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -178,11 +178,11 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
     }
 
     @Override
-    public Set<String> findIdsByEnvironment(ExecutionContext executionContext) {
-        if (isBlank(executionContext.getEnvironmentId())) {
+    public Set<String> findIdsByEnvironment(final String environmentId) {
+        if (isBlank(environmentId)) {
             return Set.of();
         }
-        final ApiCriteria.Builder builder = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
+        final ApiCriteria.Builder builder = new ApiCriteria.Builder().environmentId(environmentId);
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
         apiCriteriaList.add(builder.build());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -298,7 +298,7 @@ public class ApiAuthorizationServiceImplTest {
         apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").build());
 
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
-        final Set<String> apis = apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext());
+        final Set<String> apis = apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getCurrentEnvironment());
 
         assertThat(apis).hasSize(1);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-778
https://gravitee.atlassian.net/browse/CJ-779
https://gravitee.atlassian.net/browse/CJ-780


## Description

When retrieving analytics as an admin, the apis wasn't properly filtered and then all apis analytics for all orga/env was retrieved.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

