### PR TITLE
fix: create default alerts on API creation

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
@@ -130,7 +130,7 @@
                       </md-checkbox>
                     </md-input-container>
 
-                    <md-input-container clas="md-block" flex="50">
+                    <md-input-container clas="md-block" flex="50" ng-if="$ctrl.alert.template">
                       <md-checkbox
                         ng-model="$ctrl.apiByDefault"
                         ng-click="$event.stopPropagation()"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AlertService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AlertService.java
@@ -36,5 +36,6 @@ public interface AlertService {
     void delete(String alertId, String referenceId);
     AlertStatusEntity getStatus(ExecutionContext executionContext);
     Page<AlertEventEntity> findEvents(String alertId, AlertEventQuery eventQuery);
+    void createDefaults(ExecutionContext executionContext, AlertReferenceType referenceType, String referenceId);
     void applyDefaults(ExecutionContext executionContext, String alertId, AlertReferenceType referenceType);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -47,6 +47,8 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.AlertEvent;
+import io.gravitee.repository.management.model.AlertEventRule;
+import io.gravitee.repository.management.model.AlertEventType;
 import io.gravitee.repository.management.model.AlertTrigger;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.AlertEventQuery;
@@ -65,6 +67,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -411,6 +414,55 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             (int) alertEventsRepo.getPageElements(),
             alertEventsRepo.getTotalElements()
         );
+    }
+
+    private Set<AlertTriggerEntity> findByEvent(AlertEventType event) {
+        try {
+            LOGGER.debug("findByEvent: {}", event);
+            Set<AlertTriggerEntity> set = alertTriggerRepository
+                .findAll()
+                .stream()
+                .filter(alert ->
+                    alert.isTemplate() &&
+                    alert.getEventRules() != null &&
+                    alert.getEventRules().stream().map(AlertEventRule::getEvent).collect(Collectors.toList()).contains(event)
+                )
+                .map(alertTriggerConverter::toAlertTriggerEntity)
+                .sorted(Comparator.comparing(AlertTriggerEntity::getName))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+            LOGGER.debug("findByEvent : {} - DONE", set);
+            return set;
+        } catch (TechnicalException ex) {
+            LOGGER.error("An error occurs while trying to find alert triggers by event", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find alert triggers by event", ex);
+        }
+    }
+
+    @Override
+    public void createDefaults(ExecutionContext executionContext, AlertReferenceType referenceType, String referenceId) {
+        if (getStatus(executionContext).isEnabled()) {
+            Set<AlertTriggerEntity> defaultAlerts = findByEvent(AlertEventType.API_CREATE);
+
+            for (AlertTriggerEntity alert : defaultAlerts) {
+                AlertTrigger trigger = alertTriggerConverter.toAlertTrigger(alert);
+                AlertTriggerEntity triggerEntity = alertTriggerConverter.toAlertTriggerEntity(trigger);
+                triggerEntity.setId(UUID.toString(UUID.random()));
+                triggerEntity.setReferenceType(AlertReferenceType.API);
+                triggerEntity.setReferenceId(referenceId);
+                triggerEntity.setTemplate(false);
+                triggerEntity.setEnabled(true);
+                triggerEntity.setEventRules(null);
+                triggerEntity.setParentId(alert.getId());
+                triggerEntity.setCreatedAt(new Date());
+                triggerEntity.setUpdatedAt(trigger.getCreatedAt());
+
+                try {
+                    create(executionContext, alertTriggerConverter.toAlertTrigger(triggerEntity));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to create default alert", te);
+                }
+            }
+        }
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -660,6 +660,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             ApiEntity apiEntity = convert(executionContext, createdApi, primaryOwner, null);
             GenericApiEntity apiWithMetadata = apiMetadataService.fetchMetadataForApi(executionContext, apiEntity);
 
+            // Create default alerts
+            alertService.createDefaults(executionContext, AlertReferenceType.API, createdApi.getId());
+
             searchEngineService.index(executionContext, apiWithMetadata, false);
             return apiEntity;
         } catch (TechnicalException | IllegalStateException ex) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertService_CreateDefaultsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertService_CreateDefaultsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.alert.api.trigger.TriggerProvider;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.AlertTrigger;
+import io.gravitee.rest.api.model.alert.AlertReferenceType;
+import io.gravitee.rest.api.model.alert.NewAlertTriggerEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.exceptions.AlertUnavailableException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlertService_CreateDefaultsTest extends AlertServiceTest {
+
+    @Test(expected = TechnicalManagementException.class)
+    public void must_throw_TechnicalManagementException_when_create_defaults_alerts_for_an_API() throws TechnicalException {
+        when(parameterService.findAsBoolean(executionContext, Key.ALERT_ENABLED, ParameterReferenceType.ORGANIZATION)).thenReturn(true);
+        when(alertTriggerRepository.findAll()).thenThrow(new TechnicalException("An unexpected error has occurred"));
+
+        alertService.createDefaults(executionContext, AlertReferenceType.API, "apiId");
+    }
+
+    @Test
+    public void must_create_nothing_if_alerts_disabled() throws JsonProcessingException, TechnicalException {
+        when(parameterService.findAsBoolean(executionContext, Key.ALERT_ENABLED, ParameterReferenceType.ORGANIZATION)).thenReturn(false);
+
+        alertService.createDefaults(executionContext, AlertReferenceType.API, "apiId");
+        verify(alertTriggerRepository, times(0)).create(any());
+    }
+
+    @Test
+    public void must_create_defaults_alerts_for_an_API() throws JsonProcessingException, TechnicalException {
+        NewAlertTriggerEntity newAlertTriggerEntity1 = getNewAlertTriggerEntity(true);
+        NewAlertTriggerEntity newAlertTriggerEntity2 = getNewAlertTriggerEntity(false);
+        NewAlertTriggerEntity newAlertTriggerEntity3 = getNewAlertTriggerEntity(true);
+
+        Set<AlertTrigger> alertTriggers = Set.of(
+            getAlertTriggerFromNew(newAlertTriggerEntity1),
+            getAlertTriggerFromNew(newAlertTriggerEntity2),
+            getAlertTriggerFromNew(newAlertTriggerEntity3)
+        );
+
+        when(alertTriggerRepository.findAll()).thenReturn(alertTriggers);
+        when(alertTriggerProviderManager.findAll()).thenReturn(List.of(mock(TriggerProvider.class)));
+        when(parameterService.findAsBoolean(executionContext, Key.ALERT_ENABLED, ParameterReferenceType.ORGANIZATION)).thenReturn(true);
+        when(alertTriggerRepository.create(any())).thenReturn(getAlertTriggerFromNew(getNewAlertTriggerEntity()));
+
+        alertService.createDefaults(executionContext, AlertReferenceType.API, "apiId");
+
+        verify(alertTriggerRepository, times(2)).create(any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.MetadataFormat;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.NewApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -66,6 +67,7 @@ import io.gravitee.rest.api.service.PolicyService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.VirtualHostService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -241,6 +243,7 @@ public class ApiService_CreateTest {
         assertNotNull(apiEntity);
         assertEquals(API_NAME, apiEntity.getName());
         verify(searchEngineService, times(1)).index(eq(GraviteeContext.getExecutionContext()), any(), eq(false));
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test(expected = ApiAlreadyExistsException.class)
@@ -297,6 +300,7 @@ public class ApiService_CreateTest {
                 eq(null),
                 any()
             );
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -315,6 +319,7 @@ public class ApiService_CreateTest {
 
         verify(genericNotificationConfigService, times(1))
             .create(argThat(notifConfig -> notifConfig.getNotifier().equals(NotifierServiceImpl.DEFAULT_EMAIL_NOTIFIER_ID)));
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -339,6 +344,7 @@ public class ApiService_CreateTest {
                     newApiMetadataEntity.getName().equals(DefaultMetadataUpgrader.METADATA_EMAIL_SUPPORT_KEY)
                 )
             );
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -356,6 +362,7 @@ public class ApiService_CreateTest {
         apiService.create(GraviteeContext.getExecutionContext(), newApi, USER_NAME);
 
         verify(searchEngineService, times(1)).index(eq(GraviteeContext.getExecutionContext()), any(), eq(false));
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -379,6 +386,7 @@ public class ApiService_CreateTest {
                 new MembershipService.MembershipMember(USER_NAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
             );
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -397,6 +405,7 @@ public class ApiService_CreateTest {
         apiService.create(GraviteeContext.getExecutionContext(), newApi, USER_NAME);
 
         verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, apiFlows);
+        verify(alertService, times(1)).createDefaults(GraviteeContext.getExecutionContext(), AlertReferenceType.API, API_ID);
     }
 
     @Test
@@ -413,5 +422,6 @@ public class ApiService_CreateTest {
         ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
 
         assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
+        verify(alertService, times(1)).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.*;
@@ -131,6 +132,9 @@ public class ApiService_CreateWithDefinitionTest {
     @Mock
     private TagService tagService;
 
+    @Mock
+    private AlertService alertService;
+
     @AfterClass
     public static void cleanSecurityContextHolder() {
         // reset authentication to avoid side effect during test executions.
@@ -186,6 +190,7 @@ public class ApiService_CreateWithDefinitionTest {
         apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getLifecycleState().equals(LifecycleState.STARTED)));
+        verify(alertService, times(1)).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     @Test
@@ -219,6 +224,7 @@ public class ApiService_CreateWithDefinitionTest {
         apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getLifecycleState().equals(LifecycleState.STOPPED)));
+        verify(alertService, times(1)).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     @Test
@@ -251,6 +257,7 @@ public class ApiService_CreateWithDefinitionTest {
         apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getLifecycleState().equals(LifecycleState.STOPPED)));
+        verify(alertService, times(1)).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     @Test
@@ -276,6 +283,7 @@ public class ApiService_CreateWithDefinitionTest {
 
         assertThrows(TagNotFoundException.class, () -> apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition));
         verify(apiRepository, never()).create(any());
+        verify(alertService, never()).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     @Test
@@ -315,6 +323,7 @@ public class ApiService_CreateWithDefinitionTest {
             .checkTagsExist(Set.of("unit-tests"), GraviteeContext.getCurrentEnvironment(), TagReferenceType.ORGANIZATION);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getId().equals(definition.get("id").asText())));
+        verify(alertService, times(1)).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     @Test
@@ -339,6 +348,7 @@ public class ApiService_CreateWithDefinitionTest {
 
         assertThrows(TagNotAllowedException.class, () -> apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, USERNAME, definition));
         verify(apiRepository, never()).create(any());
+        verify(alertService, never()).createDefaults(any(ExecutionContext.class), eq(AlertReferenceType.API), any());
     }
 
     private JsonNode readDefinition(String resourcePath) throws Exception {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3010

## Description

Bug introduced in 2020, when merging 1.30.14 into 3.0.x branch.
This PR restores the `createDefaults` method and uses it at the end of the createAPI method.
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5571/console](https://pr.team-apim.gravitee.dev/5571/console)
      Portal: [https://pr.team-apim.gravitee.dev/5571/portal](https://pr.team-apim.gravitee.dev/5571/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5571/api/management](https://pr.team-apim.gravitee.dev/5571/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5571](https://pr.team-apim.gravitee.dev/5571)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5571](https://pr.gateway-v3.team-apim.gravitee.dev/5571)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zrerkudwdx.chromatic.com)
<!-- Storybook placeholder end -->
