### PR TITLE
Console -  Remove use of ng-annotate-loader 

### DIFF
--- a/gravitee-apim-console-webui/.eslintrc.js
+++ b/gravitee-apim-console-webui/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
     'angular/controller-name': 'error',
     'angular/module-setter': 'error',
     'angular/log': 'error',
-    'angular/di': 'error',
     'angular/on-watch': 'error',
     'angular/no-service-method': 'off',
     'angular/module-getter': 'off',

--- a/gravitee-apim-console-webui/.storybook/main.ts
+++ b/gravitee-apim-console-webui/.storybook/main.ts
@@ -60,17 +60,7 @@ module.exports = {
       {
         test: /\.ts$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ng-annotate-loader',
-            options: {
-              ngAnnotate: 'ng-annotate-patched',
-              es6: true,
-              explicitOnly: false,
-            },
-          },
-          'ts-loader',
-        ],
+        use: ['ts-loader'],
       },
       {
         test: /\.mjs$/,

--- a/gravitee-apim-console-webui/conf/webpack-dist.conf.js
+++ b/gravitee-apim-console-webui/conf/webpack-dist.conf.js
@@ -53,17 +53,7 @@ module.exports = {
       {
         test: /\.ts$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ng-annotate-loader',
-            options: {
-              ngAnnotate: 'ng-annotate-patched',
-              es6: true,
-              explicitOnly: false,
-            },
-          },
-          'ts-loader?transpileOnly=true',
-        ],
+        use: ['ts-loader?transpileOnly=true'],
       },
       {
         test: /\.mjs$/,

--- a/gravitee-apim-console-webui/conf/webpack-dist.conf.js
+++ b/gravitee-apim-console-webui/conf/webpack-dist.conf.js
@@ -91,13 +91,6 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-      moment: 'moment',
-      tinycolor: 'tinycolor2',
-      Highcharts: 'highcharts',
-    }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '..', 'src', 'index.html'),
     }),

--- a/gravitee-apim-console-webui/conf/webpack.conf.js
+++ b/gravitee-apim-console-webui/conf/webpack.conf.js
@@ -50,17 +50,7 @@ module.exports = {
       {
         test: /\.ts$/,
         exclude: /node_modules/,
-        use: [
-          {
-            loader: 'ng-annotate-loader',
-            options: {
-              ngAnnotate: 'ng-annotate-patched',
-              es6: true,
-              explicitOnly: false,
-            },
-          },
-          'ts-loader',
-        ],
+        use: ['ts-loader'],
       },
       {
         test: /\.mjs$/,

--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -149,8 +149,6 @@
         "jest-preset-angular": "11.1.0",
         "license-check-and-add": "4.0.3",
         "mini-css-extract-plugin": "1.6.2",
-        "ng-annotate-loader": "0.7.0",
-        "ng-annotate-patched": "1.14.0",
         "prettier": "2.8.4",
         "sass": "1.49.0",
         "sass-loader": "10.2.1",
@@ -11694,15 +11692,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/alter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha512-Wuss6JIZ6h4j2+NgU2t+9mSwS7gBSZJbU4Dg8xETguAD2veJUSuCrvTIiC78QgZE7/zX7h6OnXw2PiiCBirEGw==",
-      "dev": true,
-      "dependencies": {
-        "stable": "~0.1.3"
-      }
-    },
     "node_modules/amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -14520,15 +14509,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -26718,174 +26698,6 @@
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
       "dev": true
     },
-    "node_modules/ng-annotate": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-1.2.1.tgz",
-      "integrity": "sha512-L52Tn+Id4hLENVT73WGqC/bmSlDOG1FnGBF/W/UfXlym2W4vCwZnKVM04UbweZmZNKTNyffxfZsD9xLYshrBTQ==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "~2.6.4",
-        "alter": "~0.2.0",
-        "convert-source-map": "~1.1.2",
-        "optimist": "~0.6.1",
-        "ordered-ast-traverse": "~1.1.1",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "source-map": "~0.5.3",
-        "stable": "~0.1.5",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2"
-      },
-      "bin": {
-        "ng-annotate": "build/es5/ng-annotate"
-      }
-    },
-    "node_modules/ng-annotate-loader": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ng-annotate-loader/-/ng-annotate-loader-0.7.0.tgz",
-      "integrity": "sha512-pvW5jwoUFcsUwAF3jHAc5hnU9bNTggg7YES5rMmv4WvhEsn/p2zEMmwXQOYCvDlwZpRNb7XDnaXHs0cT9qvhNg==",
-      "dev": true,
-      "dependencies": {
-        "clone": "^2.1.1",
-        "loader-utils": "1.1.0",
-        "ng-annotate": "1.2.1",
-        "normalize-path": "2.0.1",
-        "source-map": "0.5.6"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/big.js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/loader-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-      "integrity": "sha512-gkD9aSEG9UGglyPcDJqY9YBTUtCLKaBK6ihD2VP1d1X60lTfFspNZNulGBBbUZLkPygy4LySYHyxBpq+VhjObQ==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/normalize-path": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-      "integrity": "sha512-jxWwhoRh27+8aiYjkOl0pPfGPvYr2Y6iMC71HUtSGz2BwSvxlxjv8o0bNF28ex6zY02Yn2FJLWFOpEkZGWFo3A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ng-annotate-loader/node_modules/source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ng-annotate-patched": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ng-annotate-patched/-/ng-annotate-patched-1.14.0.tgz",
-      "integrity": "sha512-iq23drG3ogkpfdo092iyyKWZest5i22dMGmdHILJ35K1oFAg0k3X+nz/BFRztfcRs3Ng37zuxew5CD1flj3jlg==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0",
-        "commander": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "convert-source-map": "^1.7.0",
-        "source-map": "^0.6.1"
-      },
-      "bin": {
-        "ng-annotate-patched": "ng-annotate"
-      }
-    },
-    "node_modules/ng-annotate-patched/node_modules/acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ng-annotate-patched/node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ng-annotate-patched/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ng-annotate/node_modules/acorn": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz",
-      "integrity": "sha512-aINieSoQYX0C9uQqJGeC8mnO1T6onBTmtCdxHel6ZP/nBu4mpC03EoDtQUzAAAlUXluWjIvVV9vCuMhmOdRDXQ==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ng-annotate/node_modules/convert-source-map": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-      "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
-      "dev": true
-    },
-    "node_modules/ng-annotate/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ng-file-upload": {
       "version": "12.2.13",
       "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
@@ -27933,31 +27745,6 @@
         "json-pointer": "0.6.2"
       }
     },
-    "node_modules/optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true
-    },
-    "node_modules/optimist/node_modules/wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -28079,21 +27866,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ordered-ast-traverse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
-      "integrity": "sha512-/VDCNFrMUftwD04zNwMMXUY5+5IN0tQKbElSC1v6f53ueZMuRKzZmR5HxTC5TQnwLVY1FH3KbulWc0DXZ5kBnQ==",
-      "dev": true,
-      "dependencies": {
-        "ordered-esprima-props": "~1.1.0"
-      }
-    },
-    "node_modules/ordered-esprima-props": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz",
-      "integrity": "sha512-RVQ/gx+EZY/txtizlzn4OY4Rto8vhM2HasczvmP1SJYBW6GD9vLfqx/7vgKEAFK2C9ynzz/evBArFyp3HAVmTg==",
-      "dev": true
     },
     "node_modules/orderedmap": {
       "version": "2.1.1",
@@ -32096,18 +31868,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-fmt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha512-9a3zTDDh9LXbTR37qBhACWIQ/mP/ry5xtmbE98BJM8GR02sanCkfMzp7AdCTqYhkBZggK/w7hJtc8Pb9nmo16A==",
-      "dev": true
-    },
-    "node_modules/simple-is": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha512-GJXhv3r5vdj5tGWO+rcrWgjU2azLB+fb7Ehh3SmZpXE0o4KrrFLti0w4mdDCbR29X/z0Ls20ApjZitlpAXhAeg==",
-      "dev": true
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -32984,18 +32744,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/stringmap": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha512-mR1LEHDw6TsHa+LwJeeBc9ZqZqEOm7bHidgxMmDg8HB/rbA1HhDeT08gS67CCCG/xrgIfQx5tW42pd8vFpLUow==",
-      "dev": true
-    },
-    "node_modules/stringset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha512-km3jeiRpmySChl1oLiBE2ESdG5k/4+6tjENVL6BB3mdmKBiUikI5ks4paad2WAKsxzpNiBqBBbXCC12QqlpLWA==",
-      "dev": true
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -33918,12 +33666,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/tryor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha512-2+ilNA00DGvbUYYbRrm3ux+snbo7I6uPXMw8I4p/QMl7HUOWBBZFbk+Mpr8/IAPDQE+LQ8vOdlI6xEzjc+e/BQ==",
-      "dev": true
     },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
@@ -45384,15 +45126,6 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "requires": {}
     },
-    "alter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-      "integrity": "sha512-Wuss6JIZ6h4j2+NgU2t+9mSwS7gBSZJbU4Dg8xETguAD2veJUSuCrvTIiC78QgZE7/zX7h6OnXw2PiiCBirEGw==",
-      "dev": true,
-      "requires": {
-        "stable": "~0.1.3"
-      }
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -47574,12 +47307,6 @@
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "dev": true
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -56860,135 +56587,6 @@
       "integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
       "dev": true
     },
-    "ng-annotate": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-1.2.1.tgz",
-      "integrity": "sha512-L52Tn+Id4hLENVT73WGqC/bmSlDOG1FnGBF/W/UfXlym2W4vCwZnKVM04UbweZmZNKTNyffxfZsD9xLYshrBTQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "~2.6.4",
-        "alter": "~0.2.0",
-        "convert-source-map": "~1.1.2",
-        "optimist": "~0.6.1",
-        "ordered-ast-traverse": "~1.1.1",
-        "simple-fmt": "~0.1.0",
-        "simple-is": "~0.2.0",
-        "source-map": "~0.5.3",
-        "stable": "~0.1.5",
-        "stringmap": "~0.2.2",
-        "stringset": "~0.2.1",
-        "tryor": "~0.1.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "2.6.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz",
-          "integrity": "sha512-aINieSoQYX0C9uQqJGeC8mnO1T6onBTmtCdxHel6ZP/nBu4mpC03EoDtQUzAAAlUXluWjIvVV9vCuMhmOdRDXQ==",
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-          "integrity": "sha512-Y8L5rp6jo+g9VEPgvqNfEopjTR4OTYct8lXlS8iVQdmnjDvbdbzYe9rjtFCB9egC86JoNCU61WRY+ScjkZpnIg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
-      }
-    },
-    "ng-annotate-loader": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ng-annotate-loader/-/ng-annotate-loader-0.7.0.tgz",
-      "integrity": "sha512-pvW5jwoUFcsUwAF3jHAc5hnU9bNTggg7YES5rMmv4WvhEsn/p2zEMmwXQOYCvDlwZpRNb7XDnaXHs0cT9qvhNg==",
-      "dev": true,
-      "requires": {
-        "clone": "^2.1.1",
-        "loader-utils": "1.1.0",
-        "ng-annotate": "1.2.1",
-        "normalize-path": "2.0.1",
-        "source-map": "0.5.6"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha512-gkD9aSEG9UGglyPcDJqY9YBTUtCLKaBK6ihD2VP1d1X60lTfFspNZNulGBBbUZLkPygy4LySYHyxBpq+VhjObQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
-          }
-        },
-        "normalize-path": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-          "integrity": "sha512-jxWwhoRh27+8aiYjkOl0pPfGPvYr2Y6iMC71HUtSGz2BwSvxlxjv8o0bNF28ex6zY02Yn2FJLWFOpEkZGWFo3A==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
-          "dev": true
-        }
-      }
-    },
-    "ng-annotate-patched": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/ng-annotate-patched/-/ng-annotate-patched-1.14.0.tgz",
-      "integrity": "sha512-iq23drG3ogkpfdo092iyyKWZest5i22dMGmdHILJ35K1oFAg0k3X+nz/BFRztfcRs3Ng37zuxew5CD1flj3jlg==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0",
-        "commander": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
-        "convert-source-map": "^1.7.0",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-          "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
-          "dev": true
-        },
-        "acorn-walk": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "ng-file-upload": {
       "version": "12.2.13",
       "resolved": "https://registry.npmjs.org/ng-file-upload/-/ng-file-upload-12.2.13.tgz",
@@ -57821,30 +57419,6 @@
         "json-pointer": "0.6.2"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -57934,21 +57508,6 @@
           }
         }
       }
-    },
-    "ordered-ast-traverse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
-      "integrity": "sha512-/VDCNFrMUftwD04zNwMMXUY5+5IN0tQKbElSC1v6f53ueZMuRKzZmR5HxTC5TQnwLVY1FH3KbulWc0DXZ5kBnQ==",
-      "dev": true,
-      "requires": {
-        "ordered-esprima-props": "~1.1.0"
-      }
-    },
-    "ordered-esprima-props": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz",
-      "integrity": "sha512-RVQ/gx+EZY/txtizlzn4OY4Rto8vhM2HasczvmP1SJYBW6GD9vLfqx/7vgKEAFK2C9ynzz/evBArFyp3HAVmTg==",
-      "dev": true
     },
     "orderedmap": {
       "version": "2.1.1",
@@ -61014,18 +60573,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "simple-fmt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-      "integrity": "sha512-9a3zTDDh9LXbTR37qBhACWIQ/mP/ry5xtmbE98BJM8GR02sanCkfMzp7AdCTqYhkBZggK/w7hJtc8Pb9nmo16A==",
-      "dev": true
-    },
-    "simple-is": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-      "integrity": "sha512-GJXhv3r5vdj5tGWO+rcrWgjU2azLB+fb7Ehh3SmZpXE0o4KrrFLti0w4mdDCbR29X/z0Ls20ApjZitlpAXhAeg==",
-      "dev": true
-    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -61747,18 +61294,6 @@
         "es-abstract": "^1.20.4"
       }
     },
-    "stringmap": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-      "integrity": "sha512-mR1LEHDw6TsHa+LwJeeBc9ZqZqEOm7bHidgxMmDg8HB/rbA1HhDeT08gS67CCCG/xrgIfQx5tW42pd8vFpLUow==",
-      "dev": true
-    },
-    "stringset": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-      "integrity": "sha512-km3jeiRpmySChl1oLiBE2ESdG5k/4+6tjENVL6BB3mdmKBiUikI5ks4paad2WAKsxzpNiBqBBbXCC12QqlpLWA==",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -62469,12 +62004,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
-    },
-    "tryor": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-      "integrity": "sha512-2+ilNA00DGvbUYYbRrm3ux+snbo7I6uPXMw8I4p/QMl7HUOWBBZFbk+Mpr8/IAPDQE+LQ8vOdlI6xEzjc+e/BQ==",
       "dev": true
     },
     "ts-dedent": {

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -143,8 +143,6 @@
     "jest-preset-angular": "11.1.0",
     "license-check-and-add": "4.0.3",
     "mini-css-extract-plugin": "1.6.2",
-    "ng-annotate-loader": "0.7.0",
-    "ng-annotate-patched": "1.14.0",
     "prettier": "2.8.4",
     "sass": "1.49.0",
     "sass-loader": "10.2.1",

--- a/gravitee-apim-console-webui/src/authentication/authentication.config.ts
+++ b/gravitee-apim-console-webui/src/authentication/authentication.config.ts
@@ -16,9 +16,8 @@
 
 import { AuthProvider } from 'satellizer';
 
-/* @ngInject */
 function authenticationConfig($authProvider: AuthProvider) {
   $authProvider.withCredentials = true;
 }
-
+authenticationConfig.$inject = ['$authProvider'];
 export default authenticationConfig;

--- a/gravitee-apim-console-webui/src/components/alerts/activity/alerts-activity.controller.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/activity/alerts-activity.controller.ts
@@ -17,11 +17,10 @@ class AlertsActivityController {
   private hasConfiguredAlerts: boolean;
   private hasAlertingPlugin: boolean;
 
-  /* @ngInject */
   constructor(private configuredAlerts, private alertingStatus) {
     this.hasConfiguredAlerts = configuredAlerts?.length > 0;
     this.hasAlertingPlugin = alertingStatus?.available_plugins > 0;
   }
 }
-
+AlertsActivityController.$inject = ['configuredAlerts', 'alertingStatus'];
 export default AlertsActivityController;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ajs.ts
@@ -31,163 +31,171 @@ const AlertComponentAjs: ng.IComponentOptions = {
     resolvedApi: '<',
   },
   template: require('./alert.html'),
-  /* @ngInject */
-  controller: function (
-    Constants: any,
-    $scope: IScope,
-    AlertService: AlertService,
-    NotificationService: NotificationService,
-    UserService: UserService,
-    $state,
-    $mdDialog,
-  ) {
-    this.$onInit = () => {
-      this.tabs = ['general', 'notifications', 'history'];
-      this.severities = ['INFO', 'WARNING', 'CRITICAL'];
-      const indexOfTab = this.tabs.indexOf($state.params.tab);
-      this.selectedTab = indexOfTab > -1 ? indexOfTab : 0;
-      this.currentTab = this.tabs[this.selectedTab];
+  controller: [
+    'Constants',
+    '$scope',
+    'AlertService',
+    'NotificationService',
+    'UserService',
+    '$state',
+    '$mdDialog',
+    function (
+      Constants: any,
+      $scope: IScope,
+      AlertService: AlertService,
+      NotificationService: NotificationService,
+      UserService: UserService,
+      $state,
+      $mdDialog,
+    ) {
+      this.$onInit = () => {
+        this.tabs = ['general', 'notifications', 'history'];
+        this.severities = ['INFO', 'WARNING', 'CRITICAL'];
+        const indexOfTab = this.tabs.indexOf($state.params.tab);
+        this.selectedTab = indexOfTab > -1 ? indexOfTab : 0;
+        this.currentTab = this.tabs[this.selectedTab];
 
-      let referenceId;
-      let referenceType;
+        let referenceId;
+        let referenceType;
 
-      if ($state.params.apiId) {
-        referenceType = Scope.API;
-        referenceId = $state.params.apiId;
-        this.groups = ['API metrics', 'Health-check'];
-        this.titlePrefix = this.resolvedApi.data.name;
-      } else if ($state.params.applicationId) {
-        referenceType = Scope.APPLICATION;
-        referenceId = $state.params.applicationId;
-        this.groups = ['Application'];
-        this.titlePrefix = ($scope.$parent as any).$resolve.resolvedApplication.data.name;
-      } else {
-        referenceType = Scope.ENVIRONMENT;
-        this.groups = ['Node', 'API metrics', 'Health-check'];
-        this.titlePrefix = 'Platform';
-      }
+        if ($state.params.apiId) {
+          referenceType = Scope.API;
+          referenceId = $state.params.apiId;
+          this.groups = ['API metrics', 'Health-check'];
+          this.titlePrefix = this.resolvedApi.data.name;
+        } else if ($state.params.applicationId) {
+          referenceType = Scope.APPLICATION;
+          referenceId = $state.params.applicationId;
+          this.groups = ['Application'];
+          this.titlePrefix = ($scope.$parent as any).$resolve.resolvedApplication.data.name;
+        } else {
+          referenceType = Scope.ENVIRONMENT;
+          this.groups = ['Node', 'API metrics', 'Health-check'];
+          this.titlePrefix = 'Platform';
+        }
 
-      this.rules = Rule.findByScope(referenceType);
-      this.updateMode = $state.params.alertId !== undefined;
+        this.rules = Rule.findByScope(referenceType);
+        this.updateMode = $state.params.alertId !== undefined;
 
-      if (!this.updateMode) {
-        this.alert = new Alert('New alert', 'INFO', undefined, undefined, undefined, referenceType, referenceId);
-        this.alerts.push(this.alert);
-      } else {
-        this.alert = _.find(this.alerts, { id: $state.params.alertId }) || this.alerts[0];
-        this.alert.type = (this.alert.source + '@' + this.alert.type).toUpperCase();
-        this.alert.reference_type = referenceType;
-      }
+        if (!this.updateMode) {
+          this.alert = new Alert('New alert', 'INFO', undefined, undefined, undefined, referenceType, referenceId);
+          this.alerts.push(this.alert);
+        } else {
+          this.alert = _.find(this.alerts, { id: $state.params.alertId }) || this.alerts[0];
+          this.alert.type = (this.alert.source + '@' + this.alert.type).toUpperCase();
+          this.alert.reference_type = referenceType;
+        }
 
-      this.template = this.alert.template || false;
-      this.apiByDefault = this.alert.event_rules && this.alert.event_rules.findIndex((rule) => rule.event === 'API_CREATE') !== -1;
-      this.initialAlert = _.cloneDeep(this.alert);
-    };
+        this.template = this.alert.template || false;
+        this.apiByDefault = this.alert.event_rules && this.alert.event_rules.findIndex((rule) => rule.event === 'API_CREATE') !== -1;
+        this.initialAlert = _.cloneDeep(this.alert);
+      };
 
-    this.selectTab = (idx: number) => {
-      this.selectedTab = idx;
-      this.currentTab = this.tabs[this.selectedTab];
-      // $state.transitionTo("^.alert", {alertId: this.alert.id, tab: this.currentTab}, {notify: false});
-    };
+      this.selectTab = (idx: number) => {
+        this.selectedTab = idx;
+        this.currentTab = this.tabs[this.selectedTab];
+        // $state.transitionTo("^.alert", {alertId: this.alert.id, tab: this.currentTab}, {notify: false});
+      };
 
-    this.$onDestroy = () => {
-      if (!this.updateMode) {
-        this.alerts.pop();
-      }
-    };
+      this.$onDestroy = () => {
+        if (!this.updateMode) {
+          this.alerts.pop();
+        }
+      };
 
-    this.save = (alert: Alert) => {
-      if (this.apiByDefault) {
-        alert.event_rules = [{ event: 'API_CREATE' }];
-      } else {
-        delete alert.event_rules;
-      }
+      this.save = (alert: Alert) => {
+        if (this.apiByDefault) {
+          alert.event_rules = [{ event: 'API_CREATE' }];
+        } else {
+          delete alert.event_rules;
+        }
 
-      let service;
-      alert.type = alert.type.split('@')[1];
-      if (this.updateMode) {
-        service = AlertService.update(alert);
-      } else {
-        service = AlertService.create(alert);
-      }
-      return service.then((response) => {
-        this.formAlert.$setPristine();
-        NotificationService.show('Alert has been saved successfully');
-        const alert = response.data;
-        $state.go('^.alert', { alertId: alert.id }, { reload: true });
-        return alert;
-      });
-    };
+        let service;
+        alert.type = alert.type.split('@')[1];
+        if (this.updateMode) {
+          service = AlertService.update(alert);
+        } else {
+          service = AlertService.create(alert);
+        }
+        return service.then((response) => {
+          this.formAlert.$setPristine();
+          NotificationService.show('Alert has been saved successfully');
+          const alert = response.data;
+          $state.go('^.alert', { alertId: alert.id }, { reload: true });
+          return alert;
+        });
+      };
 
-    this.delete = () => {
-      if (this.alert.id) {
-        $mdDialog
-          .show(
-            $mdDialog.confirm({
-              title: 'Warning',
-              textContent: 'Are you sure you want to remove this alert?',
-              ok: 'OK',
-              cancel: 'Cancel',
-            }),
-          )
-          .then(() => {
-            AlertService.delete(this.alert).then(() => {
-              NotificationService.show('Alert deleted with success');
-              this.backToAlerts();
+      this.delete = () => {
+        if (this.alert.id) {
+          $mdDialog
+            .show(
+              $mdDialog.confirm({
+                title: 'Warning',
+                textContent: 'Are you sure you want to remove this alert?',
+                ok: 'OK',
+                cancel: 'Cancel',
+              }),
+            )
+            .then(() => {
+              AlertService.delete(this.alert).then(() => {
+                NotificationService.show('Alert deleted with success');
+                this.backToAlerts();
+              });
             });
-          });
-      } else {
-        this.backToAlerts();
-      }
-    };
+        } else {
+          this.backToAlerts();
+        }
+      };
 
-    this.reset = () => {
-      this.alert = _.cloneDeep(this.initialAlert);
-      this.formAlert.$setPristine();
-    };
+      this.reset = () => {
+        this.alert = _.cloneDeep(this.initialAlert);
+        this.formAlert.$setPristine();
+      };
 
-    this.associateToApis = () => {
-      AlertService.associate(this.alert, 'api').then(() => {
-        $state.reload();
-        NotificationService.show("Alert '" + this.alert.name + "' has been associated to all APIs");
-      });
-    };
+      this.associateToApis = () => {
+        AlertService.associate(this.alert, 'api').then(() => {
+          $state.reload();
+          NotificationService.show("Alert '" + this.alert.name + "' has been associated to all APIs");
+        });
+      };
 
-    this.onRuleChange = () => {
-      const rule: Rule = _.find(this.rules, (rule) => rule.source + '@' + rule.type === this.alert.type);
-      this.alert.source = rule.source;
-      if (this.alert.filters) {
-        this.alert.filters.length = 0;
-      }
-      this.alert.description = rule.description;
-      // Template is a feature only available at platform level
-      this.template = this.alert.reference_type === 2 && (rule.category === 'API metrics' || rule.category === 'Health-check');
-    };
+      this.onRuleChange = () => {
+        const rule: Rule = _.find(this.rules, (rule) => rule.source + '@' + rule.type === this.alert.type);
+        this.alert.source = rule.source;
+        if (this.alert.filters) {
+          this.alert.filters.length = 0;
+        }
+        this.alert.description = rule.description;
+        // Template is a feature only available at platform level
+        this.template = this.alert.reference_type === 2 && (rule.category === 'API metrics' || rule.category === 'Health-check');
+      };
 
-    this.backToAlerts = () => {
-      if ($state.params.apiId) {
-        $state.go('management.apis.alerts.list', { apiId: $state.params.apiId });
-      } else if ($state.params.applicationId) {
-        $state.go('management.applications.application.alerts.list', { applicationId: $state.params.applicationId });
-      } else {
-        $state.go('management.alerts.list');
-      }
-    };
+      this.backToAlerts = () => {
+        if ($state.params.apiId) {
+          $state.go('management.apis.alerts.list', { apiId: $state.params.apiId });
+        } else if ($state.params.applicationId) {
+          $state.go('management.applications.application.alerts.list', { applicationId: $state.params.applicationId });
+        } else {
+          $state.go('management.alerts.list');
+        }
+      };
 
-    this.hasPermissionForCurrentScope = (permission: string): boolean => {
-      let scope = 'environment';
-      if ($state.params.apiId) {
-        scope = 'api';
-      } else if ($state.params.applicationId) {
-        scope = 'application';
-      }
-      return UserService.isUserHasPermissions([`${scope}-${permission}`]);
-    };
+      this.hasPermissionForCurrentScope = (permission: string): boolean => {
+        let scope = 'environment';
+        if ($state.params.apiId) {
+          scope = 'api';
+        } else if ($state.params.applicationId) {
+          scope = 'application';
+        }
+        return UserService.isUserHasPermissions([`${scope}-${permission}`]);
+      };
 
-    this.isReadonly = (): boolean => {
-      return this.mode === 'detail' && !this.hasPermissionForCurrentScope('alert-u');
-    };
-  },
+      this.isReadonly = (): boolean => {
+        return this.mode === 'detail' && !this.hasPermissionForCurrentScope('alert-u');
+      };
+    },
+  ],
 };
 
 export default AlertComponentAjs;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/history/alert-history.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/history/alert-history.component.ts
@@ -24,31 +24,33 @@ const AlertHistoryComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./alert-history.html'),
-  /* @ngInject */
-  controller: function (AlertService: AlertService) {
-    this.query = {
-      limit: 10,
-      page: 1,
-    };
+  controller: [
+    'AlertService',
+    function (AlertService: AlertService) {
+      this.query = {
+        limit: 10,
+        page: 1,
+      };
 
-    this.$onInit = () => {
-      AlertService.listAlertEvents(this.alert).then((response) => {
-        this.events = response.data;
-      });
-    };
+      this.$onInit = () => {
+        AlertService.listAlertEvents(this.alert).then((response) => {
+          this.events = response.data;
+        });
+      };
 
-    this.search = () => {
-      AlertService.listAlertEvents(this.alert, {
-        from: this.lastFrom,
-        to: this.lastTo,
-        page: this.query.page - 1,
-        size: this.query.limit,
-      }).then((response) => {
-        this.events = response.data;
-        this.$scope.eventsFetchData = false;
-      });
-    };
-  },
+      this.search = () => {
+        AlertService.listAlertEvents(this.alert, {
+          from: this.lastFrom,
+          to: this.lastTo,
+          page: this.query.page - 1,
+          size: this.query.limit,
+        }).then((response) => {
+          this.events = response.data;
+          this.$scope.eventsFetchData = false;
+        });
+      };
+    },
+  ],
 };
 
 export default AlertHistoryComponent;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.ts
@@ -26,47 +26,50 @@ const AlertNotificationComponent: ng.IComponentOptions = {
     parent: '^gvAlertNotifications',
   },
   template: require('./alert-notification.html'),
-  /* @ngInject */
-  controller: function (NotificationService: NotificationService, NotifierService: NotifierService) {
-    this.notifierJsonSchemaForm = ['*'];
+  controller: [
+    'NotificationService',
+    'NotifierService',
+    function (NotificationService: NotificationService, NotifierService: NotifierService) {
+      this.notifierJsonSchemaForm = ['*'];
 
-    this.$onInit = () => {
-      if (this.notification.type) {
+      this.$onInit = () => {
+        if (this.notification.type) {
+          this.reloadNotifierSchema();
+        }
+      };
+
+      this.onNotifierChange = () => {
+        this.notification.configuration = {};
         this.reloadNotifierSchema();
-      }
-    };
+      };
 
-    this.onNotifierChange = () => {
-      this.notification.configuration = {};
-      this.reloadNotifierSchema();
-    };
-
-    this.reloadNotifierSchema = () => {
-      NotifierService.getSchema(this.notification.type).then(
-        ({ data }) => {
-          this.notifierJsonSchema = { ...data, readonly: this.isReadonly };
-          return {
-            schema: data,
-          };
-        },
-        (response) => {
-          if (response.status === 404) {
-            this.notifierJsonSchema = {};
+      this.reloadNotifierSchema = () => {
+        NotifierService.getSchema(this.notification.type).then(
+          ({ data }) => {
+            this.notifierJsonSchema = { ...data, readonly: this.isReadonly };
             return {
-              schema: {},
+              schema: data,
             };
-          } else {
-            // todo manage errors
-            NotificationService.showError('Unexpected error while loading notifier schema for ' + this.notifier.type);
-          }
-        },
-      );
-    };
+          },
+          (response) => {
+            if (response.status === 404) {
+              this.notifierJsonSchema = {};
+              return {
+                schema: {},
+              };
+            } else {
+              // todo manage errors
+              NotificationService.showError('Unexpected error while loading notifier schema for ' + this.notifier.type);
+            }
+          },
+        );
+      };
 
-    this.remove = () => {
-      this.onNotificationRemove();
-    };
-  },
+      this.remove = () => {
+        this.onNotificationRemove();
+      };
+    },
+  ],
 };
 
 export default AlertNotificationComponent;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notifications.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notifications.ts
@@ -22,7 +22,6 @@ const AlertNotificationsComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./alert-notifications.html'),
-  /* @ngInject */
   controller: function () {
     this.addNotification = () => {
       if (this.alert.notifications === undefined) {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.component.ts
@@ -25,7 +25,6 @@ const AlertTriggerConditionCompareComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-condition-compare.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.metrics = _.filter(

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
@@ -25,34 +25,37 @@ const AlertTriggerConditionStringComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-condition-string.html'),
-  /* @ngInject */
-  controller: function ($injector, $state) {
-    this.$onInit = () => {
-      // Get the metric field according to the condition property
-      const metric = _.find(this.metrics as Metrics[], (metric) => metric.key === this.condition.property);
+  controller: [
+    '$injector',
+    '$state',
+    function ($injector, $state) {
+      this.$onInit = () => {
+        // Get the metric field according to the condition property
+        const metric = _.find(this.metrics as Metrics[], (metric) => metric.key === this.condition.property);
 
-      if (metric.loader) {
-        let referenceId;
-        let referenceType;
+        if (metric.loader) {
+          let referenceId;
+          let referenceType;
 
-        if ($state.params.apiId) {
-          referenceType = Scope.API;
-          referenceId = $state.params.apiId;
-        } else if ($state.params.applicationId) {
-          referenceType = Scope.APPLICATION;
-          referenceId = $state.params.applicationId;
-        } else {
-          referenceType = Scope.ENVIRONMENT;
+          if ($state.params.apiId) {
+            referenceType = Scope.API;
+            referenceId = $state.params.apiId;
+          } else if ($state.params.applicationId) {
+            referenceType = Scope.APPLICATION;
+            referenceId = $state.params.applicationId;
+          } else {
+            referenceType = Scope.ENVIRONMENT;
+          }
+
+          this.values = metric.loader(referenceType, referenceId, $injector);
         }
+      };
 
-        this.values = metric.loader(referenceType, referenceId, $injector);
-      }
-    };
-
-    this.displaySelect = () => {
-      return this.values !== undefined && (this.condition.operator === 'EQUALS' || this.condition.operator === 'NOT_EQUALS');
-    };
-  },
+      this.displaySelect = () => {
+        return this.values !== undefined && (this.condition.operator === 'EQUALS' || this.condition.operator === 'NOT_EQUALS');
+      };
+    },
+  ],
 };
 
 export default AlertTriggerConditionStringComponent;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.component.ts
@@ -19,7 +19,6 @@ const AlertTriggerConditionThresholdRangeComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-condition-threshold-range.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       /*

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.component.ts
@@ -28,7 +28,6 @@ const AlertTriggerProjectionComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-projection.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // Metrics are depending on the source of the trigger

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.component.ts
@@ -21,7 +21,6 @@ const AlertTriggerProjectionsComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-projections.html'),
-  /* @ngInject */
   controller: function () {
     this.addProjection = () => {
       if (this.condition.projections === undefined) {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-api-hc-endpoint-status-changed.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-api-hc-endpoint-status-changed.component.ts
@@ -19,7 +19,6 @@ const AlertTriggerApiHealthCheckEndpointStatusChangedComponent: ng.IComponentOpt
     alert: '<',
   },
   template: require('./trigger-api-hc-endpoint-status-changed.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // New alert, initialize it with the condition model

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-application-quota.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-application-quota.component.ts
@@ -24,7 +24,6 @@ const AlertTriggerApplicationQuotaComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-application-quota.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.metrics = [ApiMetrics.QUOTA_COUNTER];

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.component.ts
@@ -25,7 +25,6 @@ const AlertTriggerConditionComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-condition.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.onMetricsChange(false);

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-dampening.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-dampening.component.ts
@@ -23,7 +23,6 @@ const AlertTriggerDampeningComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-dampening.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.modes = DampeningMode.MODES;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.component.ts
@@ -26,7 +26,6 @@ const AlertTriggerFilterComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-filter.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // Metrics are depending on the source of the trigger

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.component.ts
@@ -20,7 +20,6 @@ const AlertTriggerFiltersComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-filters.html'),
-  /* @ngInject */
   controller: function () {
     this.addFilter = () => {
       if (this.alert.filters === undefined) {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-aggregation.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-aggregation.component.ts
@@ -25,7 +25,6 @@ const AlertTriggerMetricsAggregationComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-metrics-aggregation.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.metrics = Rule.findByScopeAndType(this.alert.reference_type, this.alert.type).metrics;

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-rate.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-rate.component.ts
@@ -25,7 +25,6 @@ const AlertTriggerMetricsRateComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-metrics-rate.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.metrics = Metrics.filterByScope(

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-simple-condition.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-simple-condition.component.ts
@@ -25,7 +25,6 @@ const AlertTriggerMetricsSimpleConditionComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-metrics-simple-condition.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.metrics = Metrics.filterByScope(

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-missing-data.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-missing-data.component.ts
@@ -22,7 +22,6 @@ const AlertTriggerMissingDataComponent: ng.IComponentOptions = {
     parent: '^alertComponentAjs',
   },
   template: require('./trigger-missing-data.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // New alert, initialize it with the condition model

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-node-healthcheck.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-node-healthcheck.component.ts
@@ -19,7 +19,6 @@ const AlertTriggerNodeHealthcheckComponent: ng.IComponentOptions = {
     alert: '<',
   },
   template: require('./trigger-node-healthcheck.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // New alert, initialize it with the condition model

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-node-lifecycle-changed.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-node-lifecycle-changed.component.ts
@@ -19,7 +19,6 @@ const AlertTriggerNodeLifecycleChangedComponent: ng.IComponentOptions = {
     alert: '<',
   },
   template: require('./trigger-node-lifecycle-changed.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       // New alert, initialize it with the condition model

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.component.ts
@@ -22,7 +22,6 @@ const AlertTriggerWindowComponent: ng.IComponentOptions = {
     isReadonly: '<',
   },
   template: require('./trigger-window.html'),
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       this.timeUnits = DurationTimeUnit.TIME_UNITS;

--- a/gravitee-apim-console-webui/src/components/alerts/alertTabs/alert-tabs-component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alertTabs/alert-tabs-component.ts
@@ -21,7 +21,6 @@ class AlertTabsController {
   private selectedIndex: number;
   private canViewAlerts: boolean;
 
-  /* @ngInject */
   constructor(private $state: StateService, private UserService: UserService, private Constants) {}
 
   $onInit() {
@@ -31,5 +30,5 @@ class AlertTabsController {
     this.selectedIndex = candidateIndex > -1 ? candidateIndex : 0;
   }
 }
-
+AlertTabsController.$inject = ['$state', 'UserService', 'Constants'];
 export default AlertTabsController;

--- a/gravitee-apim-console-webui/src/components/alerts/alerts.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alerts.component.ajs.ts
@@ -25,104 +25,111 @@ const AlertsComponentAjs: ng.IComponentOptions = {
     alerts: '<',
   },
   template: require('./alerts.html'),
-  /* @ngInject */
-  controller: function (
-    $stateParams,
-    $state: StateService,
-    AlertService: AlertService,
-    NotificationService: NotificationService,
-    UserService: UserService,
-    $mdDialog,
-  ) {
-    this.alerts = this.alerts ?? [];
-    this.goTo = (suffixState: string, alertId: string) => {
-      if ($stateParams.apiId) {
-        $state.go('management.apis.alerts.' + suffixState, { apiId: $stateParams.apiId, alertId: alertId });
-      } else if ($stateParams.applicationId) {
-        $state.go('management.applications.application.alerts.' + suffixState, {
-          applicationId: $stateParams.applicationId,
-          alertId: alertId,
-        });
-      } else {
-        if (suffixState === 'editalert') {
-          $state.go('management.editalert', { alertId: alertId });
+  controller: [
+    '$stateParams',
+    '$state',
+    'AlertService',
+    'NotificationService',
+    'UserService',
+    '$mdDialog',
+    function (
+      $stateParams,
+      $state: StateService,
+      AlertService: AlertService,
+      NotificationService: NotificationService,
+      UserService: UserService,
+      $mdDialog,
+    ) {
+      this.alerts = this.alerts ?? [];
+      this.goTo = (suffixState: string, alertId: string) => {
+        if ($stateParams.apiId) {
+          $state.go('management.apis.alerts.' + suffixState, { apiId: $stateParams.apiId, alertId: alertId });
+        } else if ($stateParams.applicationId) {
+          $state.go('management.applications.application.alerts.' + suffixState, {
+            applicationId: $stateParams.applicationId,
+            alertId: alertId,
+          });
         } else {
-          $state.go('management.alertnew');
-        }
-      }
-    };
-
-    this.delete = (alert: Alert) => {
-      this.enhanceAlert(alert);
-      $mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: `Are you sure you want to delete the alert '${alert.name}'?`,
-            msg: '',
-            confirmButton: 'Delete',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            AlertService.delete(alert).then(() => {
-              NotificationService.show("Alert '" + alert.name + "' has been deleted");
-              $state.go($state.current, {}, { reload: true });
-            });
+          if (suffixState === 'editalert') {
+            $state.go('management.editalert', { alertId: alertId });
+          } else {
+            $state.go('management.alertnew');
           }
-        });
-    };
+        }
+      };
 
-    this.update = (alert: Alert) => {
-      this.enhanceAlert(alert);
-      AlertService.update(alert)
-        .then(() => {
-          NotificationService.show('Alert saved with success');
-        })
-        .finally(() => {
-          $state.go($state.current, {}, { reload: true });
-        });
-    };
+      this.delete = (alert: Alert) => {
+        this.enhanceAlert(alert);
+        $mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../../components/dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: `Are you sure you want to delete the alert '${alert.name}'?`,
+              msg: '',
+              confirmButton: 'Delete',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              AlertService.delete(alert).then(() => {
+                NotificationService.show("Alert '" + alert.name + "' has been deleted");
+                $state.go($state.current, {}, { reload: true });
+              });
+            }
+          });
+      };
 
-    this.toggleEnable = (alert: Alert) => {
-      alert.enabled = !alert.enabled;
-      this.update(alert);
-    };
+      this.update = (alert: Alert) => {
+        this.enhanceAlert(alert);
+        AlertService.update(alert)
+          .then(() => {
+            NotificationService.show('Alert saved with success');
+          })
+          .finally(() => {
+            $state.go($state.current, {}, { reload: true });
+          });
+      };
 
-    this.enhanceAlert = (alert: Alert) => {
-      if ($stateParams.apiId) {
-        alert.reference_type = Scope.API;
-      } else if ($stateParams.applicationId) {
-        alert.reference_type = Scope.APPLICATION;
-      } else {
-        alert.reference_type = Scope.ENVIRONMENT;
-      }
-    };
+      this.toggleEnable = (alert: Alert) => {
+        alert.enabled = !alert.enabled;
+        this.update(alert);
+      };
 
-    this.getSeverityColor = (alert: Alert) => {
-      switch (alert.severity) {
-        case 'INFO':
-          return '#54a3ff';
-        case 'WARNING':
-          return '#FF950D';
-        case 'CRITICAL':
-          return '#d73a49';
-      }
-    };
+      this.enhanceAlert = (alert: Alert) => {
+        if ($stateParams.apiId) {
+          alert.reference_type = Scope.API;
+        } else if ($stateParams.applicationId) {
+          alert.reference_type = Scope.APPLICATION;
+        } else {
+          alert.reference_type = Scope.ENVIRONMENT;
+        }
+      };
 
-    this.hasPermissionForCurrentScope = (permission: string): boolean => {
-      let scope = 'environment';
-      if ($stateParams.apiId) {
-        scope = 'api';
-      } else if ($stateParams.applicationId) {
-        scope = 'application';
-      }
-      return UserService.isUserHasPermissions([`${scope}-${permission}`]);
-    };
-  },
+      this.getSeverityColor = (alert: Alert) => {
+        switch (alert.severity) {
+          case 'INFO':
+            return '#54a3ff';
+          case 'WARNING':
+            return '#FF950D';
+          case 'CRITICAL':
+            return '#d73a49';
+        }
+      };
+
+      this.hasPermissionForCurrentScope = (permission: string): boolean => {
+        let scope = 'environment';
+        if ($stateParams.apiId) {
+          scope = 'api';
+        } else if ($stateParams.applicationId) {
+          scope = 'application';
+        }
+        return UserService.isUserHasPermissions([`${scope}-${permission}`]);
+      };
+    },
+  ],
 };
 
 export default AlertsComponentAjs;

--- a/gravitee-apim-console-webui/src/components/alerts/dashboard/alerts-dashboard.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/dashboard/alerts-dashboard.component.ts
@@ -42,7 +42,6 @@ class AlertsDashboardComponent implements ng.IComponentController {
   private series: IPromise<unknown>;
   private options: any;
 
-  /* @ngInject */
   constructor(
     private $scope: IScope,
     private AlertService: AlertService,
@@ -185,5 +184,5 @@ const AlertDashBoardComponent: ng.IComponentOptions = {
   },
   controller: AlertsDashboardComponent,
 };
-
+AlertsDashboardComponent.$inject = ['$scope', 'AlertService', 'UserService', '$state', 'Constants'];
 export default AlertDashBoardComponent;

--- a/gravitee-apim-console-webui/src/components/audit/audit.component.ts
+++ b/gravitee-apim-console-webui/src/components/audit/audit.component.ts
@@ -25,79 +25,81 @@ const AuditComponent: ng.IComponentOptions = {
     applications: '<',
     events: '<',
   },
-  /* @ngInject */
-  controller: function (AuditService: AuditService) {
-    this.$onInit = () => {
-      this.events = _.map(this.events, (ev: string) => {
-        return ev.toUpperCase();
-      });
-      this.query = new AuditQuery();
-      this.onPaginate = this.onPaginate.bind(this);
-      AuditService.list(null, this.api).then((response) => this.handleAuditResponseData(response.data));
-      this.queryLogType = 'all';
-    };
-
-    this.handleAuditResponseData = (responseData) => {
-      this.auditLogs = responseData.content;
-      this.metadata = responseData.metadata;
-      this.enhanceAuditLogs(this.auditLogs);
-      this.query.page = responseData.pageNumber;
-      this.result = {
-        size: responseData.pageElements,
-        total: responseData.totalElements,
+  controller: [
+    'AuditService',
+    function (AuditService: AuditService) {
+      this.$onInit = () => {
+        this.events = _.map(this.events, (ev: string) => {
+          return ev.toUpperCase();
+        });
+        this.query = new AuditQuery();
+        this.onPaginate = this.onPaginate.bind(this);
+        AuditService.list(null, this.api).then((response) => this.handleAuditResponseData(response.data));
+        this.queryLogType = 'all';
       };
-    };
 
-    this.enhanceAuditLogs = (auditLogs) => {
-      _.forEach(auditLogs, (log) => {
-        log.prettyPatch = JSON.stringify(JSON.parse(log.patch), null, '  ');
-        log.displayPatch = false;
-        log.displayProperties = false;
-      });
-    };
+      this.handleAuditResponseData = (responseData) => {
+        this.auditLogs = responseData.content;
+        this.metadata = responseData.metadata;
+        this.enhanceAuditLogs(this.auditLogs);
+        this.query.page = responseData.pageNumber;
+        this.result = {
+          size: responseData.pageElements,
+          total: responseData.totalElements,
+        };
+      };
 
-    this.onPaginate = () => {
-      AuditService.list(this.query, this.api).then((response) => {
-        this.handleAuditResponseData(response.data);
-      });
-    };
+      this.enhanceAuditLogs = (auditLogs) => {
+        _.forEach(auditLogs, (log) => {
+          log.prettyPatch = JSON.stringify(JSON.parse(log.patch), null, '  ');
+          log.displayPatch = false;
+          log.displayProperties = false;
+        });
+      };
 
-    this.getNameByReference = (ref: { type: string; id: string }) => {
-      if (this.metadata[ref.type + ':' + ref.id + ':name']) {
-        return this.metadata[ref.type + ':' + ref.id + ':name'];
-      }
-      return ref.id;
-    };
+      this.onPaginate = () => {
+        AuditService.list(this.query, this.api).then((response) => {
+          this.handleAuditResponseData(response.data);
+        });
+      };
 
-    this.getDisplayableProperties = (properties) => {
-      return _.mapValues(properties, (v, k) => this.metadata[k + ':' + v + ':name']);
-    };
+      this.getNameByReference = (ref: { type: string; id: string }) => {
+        if (this.metadata[ref.type + ':' + ref.id + ':name']) {
+          return this.metadata[ref.type + ':' + ref.id + ':name'];
+        }
+        return ref.id;
+      };
 
-    this.onOrgEnvFilterChange = () => {
-      if (this.queryLogType === 'env') {
-        this.query.orgLog = false;
-        this.query.envLog = true;
-      } else if (this.queryLogType === 'org') {
-        this.query.orgLog = true;
-        this.query.envLog = false;
-      } else {
-        this.query.orgLog = false;
-        this.query.envLog = false;
-      }
-    };
+      this.getDisplayableProperties = (properties) => {
+        return _.mapValues(properties, (v, k) => this.metadata[k + ':' + v + ':name']);
+      };
 
-    this.search = () => {
-      this.query.page = 1;
-      if (this.query.mgmt) {
-        this.query.api = null;
-        this.query.application = null;
-      }
+      this.onOrgEnvFilterChange = () => {
+        if (this.queryLogType === 'env') {
+          this.query.orgLog = false;
+          this.query.envLog = true;
+        } else if (this.queryLogType === 'org') {
+          this.query.orgLog = true;
+          this.query.envLog = false;
+        } else {
+          this.query.orgLog = false;
+          this.query.envLog = false;
+        }
+      };
 
-      AuditService.list(this.query, this.api).then((response) => {
-        this.handleAuditResponseData(response.data);
-      });
-    };
-  },
+      this.search = () => {
+        this.query.page = 1;
+        if (this.query.mgmt) {
+          this.query.api = null;
+          this.query.application = null;
+        }
+
+        AuditService.list(this.query, this.api).then((response) => {
+          this.handleAuditResponseData(response.data);
+        });
+      };
+    },
+  ],
 };
 
 export default AuditComponent;

--- a/gravitee-apim-console-webui/src/components/autofocus/autofocus.directive.ts
+++ b/gravitee-apim-console-webui/src/components/autofocus/autofocus.directive.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class AutofocusDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'A',

--- a/gravitee-apim-console-webui/src/components/avatar/user-avatar.directive.ts
+++ b/gravitee-apim-console-webui/src/components/avatar/user-avatar.directive.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class UserAvatarDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'A',
@@ -47,8 +46,8 @@ class UserAvatarDirective {
 }
 
 class UserAvatarController {
-  /* @ngInject */
   constructor(private $scope, private $q, private Constants) {}
 }
+UserAvatarController.$inject = ['$scope', '$q', 'Constants'];
 
 export default UserAvatarDirective;

--- a/gravitee-apim-console-webui/src/components/chart/chart.directive.ts
+++ b/gravitee-apim-console-webui/src/components/chart/chart.directive.ts
@@ -20,7 +20,6 @@ import * as _ from 'lodash';
 import 'highcharts/modules/map';
 
 class ChartDirective {
-  /* @ngInject */
   constructor() {
     return {
       restrict: 'E',
@@ -375,8 +374,8 @@ class ChartDirective {
 }
 
 class ChartController {
-  /* @ngInject */
   constructor(private $window: ng.IWindowService) {}
 }
+ChartController.$inject = ['$window'];
 
 export default ChartDirective;

--- a/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
+++ b/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
@@ -23,7 +23,6 @@ class ContextualDocController implements IOnInit, IOnDestroy {
 
   private openContextualDocumentationListener: () => void;
 
-  /* @ngInject */
   constructor(private $transitions, private $http, public $state, private $window, private $rootScope) {
     if (window.pendo && window.pendo.isReady()) {
       // Do nothing, Pendo provide documentation
@@ -85,5 +84,6 @@ class ContextualDocController implements IOnInit, IOnDestroy {
     this.$rootScope.helpDisplayed = this.isOpen;
   }
 }
+ContextualDocController.$inject = ['$transitions', '$http', '$state', '$window', '$rootScope'];
 
 export default ContextualDocController;

--- a/gravitee-apim-console-webui/src/components/dashboard/dashboard-filter.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dashboard/dashboard-filter.controller.ts
@@ -26,7 +26,6 @@ class DashboardFilterController implements IOnInit, IOnDestroy {
   private lastSource: any;
   private readonly filterItemChangeListener: () => void;
 
-  /* @ngInject */
   constructor(
     private readonly $rootScope: IRootScopeService,
     private readonly $state: StateService,
@@ -185,5 +184,6 @@ class DashboardFilterController implements IOnInit, IOnDestroy {
     this.createAndSendQuery(lastFilter.silent);
   }
 }
+DashboardFilterController.$inject = ['$rootScope', '$state', 'AnalyticsService', '$timeout'];
 
 export default DashboardFilterController;

--- a/gravitee-apim-console-webui/src/components/dashboard/dashboard-timeframe.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dashboard/dashboard-timeframe.controller.ts
@@ -46,7 +46,6 @@ class DashboardTimeframeController {
   private displayModes: any[];
   private unRegisterTimeframeZoom: () => void;
 
-  /* @ngInject */
   constructor(
     private $scope,
     private $rootScope,
@@ -368,5 +367,6 @@ class DashboardTimeframeController {
     }
   }
 }
+DashboardTimeframeController.$inject = ['$scope', '$rootScope', '$state', '$timeout', '$interval'];
 
 export default DashboardTimeframeController;

--- a/gravitee-apim-console-webui/src/components/dashboard/dashboard.component.ts
+++ b/gravitee-apim-console-webui/src/components/dashboard/dashboard.component.ts
@@ -25,102 +25,104 @@ const DashboardComponent: ng.IComponentOptions = {
     updateMode: '<',
     customTimeframe: '<',
   },
-  /* @ngInject */
-  controller: function ($scope) {
-    this.initialEventCounter = 2;
-    this.initialTimeFrame = undefined;
-    this.initialQuery = undefined;
+  controller: [
+    '$scope',
+    function ($scope) {
+      this.initialEventCounter = 2;
+      this.initialTimeFrame = undefined;
+      this.initialQuery = undefined;
 
-    this.dashboardOptions = {
-      margins: [10, 10],
-      columns: 6,
-      swapping: false,
-      draggable: {
-        enable: true,
-        handle: 'md-card-title',
-      },
-      resizable: {
-        enabled: true,
-        stop: function () {
-          $scope.$broadcast('onWidgetResize');
+      this.dashboardOptions = {
+        margins: [10, 10],
+        columns: 6,
+        swapping: false,
+        draggable: {
+          enable: true,
+          handle: 'md-card-title',
         },
-      },
-      rowHeight: 330,
-    };
+        resizable: {
+          enabled: true,
+          stop: function () {
+            $scope.$broadcast('onWidgetResize');
+          },
+        },
+        rowHeight: 330,
+      };
 
-    this.timeframeChange = function (timeframe) {
-      if (this.initialEventCounter > 0) {
-        this.initialEventCounter--;
-      }
-      if (this.initialEventCounter === 0) {
-        // TODO: remove event broadcast and call a widget function instead
-        $scope.$broadcast('onTimeframeChange', timeframe);
-        if (this.onTimeframeChange) {
-          this.onTimeframeChange({ timeframe: timeframe });
+      this.timeframeChange = function (timeframe) {
+        if (this.initialEventCounter > 0) {
+          this.initialEventCounter--;
         }
-        if (this.initialQuery) {
-          $scope.$broadcast('onQueryFilterChange', { query: this.initialQuery, source: undefined });
-          if (this.onFilterChange) {
-            this.onFilterChange({ query: this.initialQuery });
-          }
-          delete this.initialQuery;
-        }
-      } else {
-        // waiting for queryFilterChange event ==> store timeframe for further broadcast
-        this.initialTimeFrame = timeframe;
-      }
-    };
-
-    this.queryFilterChange = function (query, widget) {
-      if (this.initialEventCounter > 0) {
-        this.initialEventCounter--;
-      }
-      if (this.initialEventCounter === 0) {
-        // TODO: remove event broadcast and call a widget function instead
-        $scope.$broadcast('onQueryFilterChange', { query: query, source: widget });
-        if (this.onFilterChange) {
-          this.onFilterChange({ query: query });
-        }
-        if (this.initialTimeFrame) {
-          $scope.$broadcast('onTimeframeChange', this.initialTimeFrame);
+        if (this.initialEventCounter === 0) {
+          // TODO: remove event broadcast and call a widget function instead
+          $scope.$broadcast('onTimeframeChange', timeframe);
           if (this.onTimeframeChange) {
-            this.onTimeframeChange({ timeframe: this.initialTimeFrame });
+            this.onTimeframeChange({ timeframe: timeframe });
           }
-          delete this.initialTimeFrame;
+          if (this.initialQuery) {
+            $scope.$broadcast('onQueryFilterChange', { query: this.initialQuery, source: undefined });
+            if (this.onFilterChange) {
+              this.onFilterChange({ query: this.initialQuery });
+            }
+            delete this.initialQuery;
+          }
+        } else {
+          // waiting for queryFilterChange event ==> store timeframe for further broadcast
+          this.initialTimeFrame = timeframe;
         }
-      } else {
-        // waiting for timeFrameChange event ==> store query for further broadcast
-        this.initialQuery = query;
-      }
-    };
+      };
 
-    this.viewLogs = function () {
-      if (this.onViewLogClick) {
-        this.onViewLogClick();
-      }
-    };
+      this.queryFilterChange = function (query, widget) {
+        if (this.initialEventCounter > 0) {
+          this.initialEventCounter--;
+        }
+        if (this.initialEventCounter === 0) {
+          // TODO: remove event broadcast and call a widget function instead
+          $scope.$broadcast('onQueryFilterChange', { query: query, source: widget });
+          if (this.onFilterChange) {
+            this.onFilterChange({ query: query });
+          }
+          if (this.initialTimeFrame) {
+            $scope.$broadcast('onTimeframeChange', this.initialTimeFrame);
+            if (this.onTimeframeChange) {
+              this.onTimeframeChange({ timeframe: this.initialTimeFrame });
+            }
+            delete this.initialTimeFrame;
+          }
+        } else {
+          // waiting for timeFrameChange event ==> store query for further broadcast
+          this.initialQuery = query;
+        }
+      };
 
-    this.$onInit = () => {
-      if (this.model) {
-        _.each(this.model.definition, (widget) => {
-          widget.$uid = this.guid();
-        });
-      }
-    };
+      this.viewLogs = function () {
+        if (this.onViewLogClick) {
+          this.onViewLogClick();
+        }
+      };
 
-    this.guid = function () {
-      function s4() {
-        return Math.floor((1 + Math.random()) * 0x10000)
-          .toString(16)
-          .substring(1);
-      }
-      return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
-    };
+      this.$onInit = () => {
+        if (this.model) {
+          _.each(this.model.definition, (widget) => {
+            widget.$uid = this.guid();
+          });
+        }
+      };
 
-    $scope.$on('onWidgetDelete', (event, widget) => {
-      _.remove(this.model.definition, widget);
-    });
-  },
+      this.guid = function () {
+        function s4() {
+          return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+        }
+        return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4();
+      };
+
+      $scope.$on('onWidgetDelete', (event, widget) => {
+        _.remove(this.model.definition, widget);
+      });
+    },
+  ],
 };
 
 export default DashboardComponent;

--- a/gravitee-apim-console-webui/src/components/dialog/apiKeyMode/api-key-mode-choice-dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dialog/apiKeyMode/api-key-mode-choice-dialog.controller.ts
@@ -18,7 +18,6 @@ import * as angular from 'angular';
 import { ApiKeyMode } from '../../../entities/application/application';
 
 export default class ApiKeyModeChoiceDialogController {
-  /* @ngInject */
   constructor(private $mdDialog: angular.material.IDialogService) {}
 
   get keyModes() {
@@ -33,3 +32,4 @@ export default class ApiKeyModeChoiceDialogController {
     }
   }
 }
+ApiKeyModeChoiceDialogController.$inject = ['$mdDialog'];

--- a/gravitee-apim-console-webui/src/components/dialog/confirmAndValidateDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dialog/confirmAndValidateDialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogConfirmAndValidateController($scope, $mdDialog, locals) {
   $scope.title = locals.title;
   $scope.msg = locals.msg;
@@ -31,5 +30,6 @@ function DialogConfirmAndValidateController($scope, $mdDialog, locals) {
     $mdDialog.hide(true);
   };
 }
+DialogConfirmAndValidateController.$inject = ['$scope', '$mdDialog', 'locals'];
 
 export default DialogConfirmAndValidateController;

--- a/gravitee-apim-console-webui/src/components/dialog/confirmDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dialog/confirmDialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogConfirmController($scope, $mdDialog, locals) {
   $scope.title = locals.title;
   $scope.msg = locals.msg;
@@ -28,5 +27,5 @@ function DialogConfirmController($scope, $mdDialog, locals) {
     $mdDialog.hide(true);
   };
 }
-
+DialogConfirmController.$inject = ['$scope', '$mdDialog', 'locals'];
 export default DialogConfirmController;

--- a/gravitee-apim-console-webui/src/components/dialog/fileChooserDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dialog/fileChooserDialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function FileChooserDialogController($scope, $mdDialog, locals, Constants, NotificationService) {
   $scope.title = locals.title;
   $scope.confirmButton = locals.confirmButton || 'OK';
@@ -33,5 +32,5 @@ function FileChooserDialogController($scope, $mdDialog, locals, Constants, Notif
     }
   };
 }
-
+FileChooserDialogController.$inject = ['$scope', '$mdDialog', 'locals', 'Constants', 'NotificationService'];
 export default FileChooserDialogController;

--- a/gravitee-apim-console-webui/src/components/documentation/dialog/selectfolder.controller.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/dialog/selectfolder.controller.ts
@@ -19,7 +19,6 @@ interface IMoveToFolderScope extends IScope {
   folders: any[];
   title: string;
 }
-/* @ngInject */
 function SelectFolderDialogController($scope: IMoveToFolderScope, $mdDialog: angular.material.IDialogService, locals: any) {
   $scope.folders = locals.folders;
   $scope.title = locals.title;
@@ -32,5 +31,6 @@ function SelectFolderDialogController($scope: IMoveToFolderScope, $mdDialog: ang
     $mdDialog.hide(folderId);
   };
 }
+SelectFolderDialogController.$inject = ['$scope', '$mdDialog', 'locals'];
 
 export default SelectFolderDialogController;

--- a/gravitee-apim-console-webui/src/components/documentation/dialog/selectpage.controller.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/dialog/selectpage.controller.ts
@@ -20,7 +20,6 @@ interface ISelectPageToLinkScope extends IScope {
   title: string;
   selectedPage: any;
 }
-/* @ngInject */
 function SelectPageDialogController($scope: ISelectPageToLinkScope, $mdDialog: angular.material.IDialogService, locals: any) {
   $scope.pages = locals.pages;
   $scope.title = locals.title;
@@ -33,5 +32,6 @@ function SelectPageDialogController($scope: ISelectPageToLinkScope, $mdDialog: a
     $mdDialog.hide($scope.selectedPage);
   };
 }
+SelectPageDialogController.$inject = ['$scope', '$mdDialog', 'locals'];
 
 export default SelectPageDialogController;

--- a/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ajs.ts
@@ -41,7 +41,6 @@ class DocumentationManagementComponentController implements IController {
   newFolderName: string;
   currentTranslation: any;
   fetchAllInProgress: boolean;
-  /* @ngInject */
   constructor(
     private readonly NotificationService: NotificationService,
     private readonly DocumentationService: DocumentationService,
@@ -476,6 +475,7 @@ class DocumentationManagementComponentController implements IController {
     };
   }
 }
+DocumentationManagementComponentController.$inject = ['NotificationService', 'DocumentationService', '$state', '$scope', '$mdDialog'];
 
 export const DocumentationManagementComponentAjs: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ajs.ts
@@ -61,7 +61,6 @@ class EditPageComponentController implements IController {
   canUpdate: boolean;
   newName: any;
 
-  /* @ngInject */
   constructor(
     private readonly NotificationService: NotificationService,
     private readonly DocumentationService: DocumentationService,
@@ -299,6 +298,7 @@ class EditPageComponentController implements IController {
       : 'This page is not published yet and will not be visible to other users';
   }
 }
+EditPageComponentController.$inject = ['NotificationService', 'DocumentationService', 'UserService', '$mdDialog', '$state', '$scope'];
 
 export const DocumentationEditPageComponentAjs: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-link-content.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-link-content.components.ts
@@ -24,7 +24,6 @@ class EditLinkContentComponentController implements IController {
   pageList: any[];
   systemFoldersById: any;
 
-  /* @ngInject */
   constructor(private readonly DocumentationService: DocumentationService) {}
 
   checkIfFolder() {
@@ -76,6 +75,7 @@ class EditLinkContentComponentController implements IController {
     }
   }
 }
+EditLinkContentComponentController.$inject = ['DocumentationService'];
 
 export const EditLinkContentComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-acls.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-acls.components.ts
@@ -28,7 +28,6 @@ class EditPageAclsComponentController implements IController {
   roles: any[];
   isApiPage: boolean;
 
-  /* @ngInject */
   constructor(private readonly RoleService: RoleService, private $scope: IPageScope) {}
 
   $onInit() {
@@ -61,6 +60,7 @@ class EditPageAclsComponentController implements IController {
     );
   }
 }
+EditPageAclsComponentController.$inject = ['RoleService', '$scope'];
 
 export const EditPageAclsComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-attached-resources.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-attached-resources.components.ts
@@ -24,7 +24,6 @@ class EditPageAttachedResourcesComponentController implements IController {
   page: any;
   onSave: () => void;
 
-  /* @ngInject */
   constructor(
     private readonly $mdDialog: angular.material.IDialogService,
     private readonly DocumentationService: DocumentationService,
@@ -86,6 +85,7 @@ class EditPageAttachedResourcesComponentController implements IController {
       });
   };
 }
+EditPageAttachedResourcesComponentController.$inject = ['$mdDialog', 'DocumentationService', 'NotificationService'];
 
 export const EditPageAttachedResourcesComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-configuration.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-configuration.components.ts
@@ -23,7 +23,6 @@ class EditPageConfigurationComponentController implements IController {
   shouldShowOpenApiDocFormat = false;
   settings: any;
 
-  /* @ngInject */
   constructor(private readonly Constants: any) {}
 
   isSwagger(): boolean {
@@ -68,6 +67,7 @@ class EditPageConfigurationComponentController implements IController {
     return this.page.generalConditions;
   }
 }
+EditPageConfigurationComponentController.$inject = ['Constants'];
 
 export const EditPageConfigurationComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-content.components.ts
@@ -32,7 +32,6 @@ class EditPageContentComponentController implements IController {
   // for asciidoc & swagger
   codeMirrorOptions: any;
 
-  /* @ngInject */
   constructor(private $scope: IPageScope) {}
 
   isAsciiDoc(): boolean {
@@ -69,6 +68,7 @@ class EditPageContentComponentController implements IController {
     }
   }
 }
+EditPageContentComponentController.$inject = ['$scope'];
 
 export const EditPageContentComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-fetchers.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-fetchers.component.ts
@@ -31,7 +31,6 @@ class EditPageFetchersComponentController implements IController {
 
   fetcherJsonSchemaForm: string[];
 
-  /* @ngInject */
   constructor(private $scope: IPageScope) {}
 
   $onInit() {
@@ -52,6 +51,7 @@ class EditPageFetchersComponentController implements IController {
     this.$scope.fetcherJsonSchema = angular.fromJson(fetcher.schema);
   }
 }
+EditPageFetchersComponentController.$inject = ['$scope'];
 
 export const EditPageFetchersComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-translations.components.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-tabs/edit-page-translations.components.ts
@@ -25,7 +25,6 @@ class EditPageTranslationsComponentController implements IController {
   pagesToLink: any[];
   page: any;
 
-  /* @ngInject */
   constructor(
     private readonly $mdDialog: angular.material.IDialogService,
     private $scope: IScope,
@@ -124,6 +123,7 @@ class EditPageTranslationsComponentController implements IController {
     }
   }
 }
+EditPageTranslationsComponentController.$inject = ['$mdDialog', '$scope', 'DocumentationService', 'NotificationService'];
 
 export const EditPageTranslationsComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/import-pages.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/import-pages.component.ajs.ts
@@ -33,7 +33,6 @@ class ImportPagesComponentController implements IController {
   page: any;
   fetchers: any[];
   importInProgress: boolean;
-  /* @ngInject */
   constructor(
     private readonly NotificationService: NotificationService,
     private readonly DocumentationService: DocumentationService,
@@ -105,6 +104,7 @@ class ImportPagesComponentController implements IController {
     }
   }
 }
+ImportPagesComponentController.$inject = ['NotificationService', 'DocumentationService', '$state', '$scope'];
 
 export const DocumentationImportPagesComponentAjs: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/link/new-link.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/link/new-link.component.ts
@@ -25,7 +25,6 @@ class DocumentationNewLinkComponentController implements IController {
   pageList: any;
   onSave: () => void;
 
-  /* @ngInject */
   constructor(private readonly DocumentationService: DocumentationService) {}
 
   checkIfFolder() {
@@ -62,6 +61,7 @@ class DocumentationNewLinkComponentController implements IController {
     }
   }
 }
+DocumentationNewLinkComponentController.$inject = ['DocumentationService'];
 
 export const DocumentationNewLinkComponent: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/new-page.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/new-page.component.ajs.ts
@@ -41,7 +41,7 @@ class NewPageComponentController implements IController {
   pageList: any[];
   templates: any[];
   selectedTemplate: any;
-  /* @ngInject */
+
   constructor(
     private readonly NotificationService: NotificationService,
     private readonly DocumentationService: DocumentationService,
@@ -183,6 +183,7 @@ class NewPageComponentController implements IController {
     }
   }
 }
+NewPageComponentController.$inject = ['NotificationService', 'DocumentationService', 'Constants', '$state', '$scope'];
 
 export const DocumentationNewPageComponentAjs: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
@@ -35,7 +35,6 @@ class ComponentCtrl implements ng.IComponentController {
 
   private tuiEditor: Editor;
 
-  /* @ngInject */
   constructor(
     private readonly $http: ng.IHttpService,
     private readonly Constants,
@@ -141,6 +140,7 @@ class ComponentCtrl implements ng.IComponentController {
     });
   }
 }
+ComponentCtrl.$inject = ['$http', 'Constants', '$state', '$mdDialog', 'NotificationService'];
 
 export const PageEditorMarkdownComponent: ng.IComponentOptions = {
   template: require('./page-editormarkdown.html'),

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-markdown.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-markdown.component.ts
@@ -17,7 +17,6 @@
 import { marked } from 'marked';
 
 export class PageMarkdownController implements ng.IComponentController, ng.IOnInit {
-  /* @ngInject */
   constructor(private readonly $sanitize: ng.sanitize.ISanitizeService) {}
 
   page: any;
@@ -27,6 +26,7 @@ export class PageMarkdownController implements ng.IComponentController, ng.IOnIn
     this.htmlContent = this.$sanitize(marked.parse(this.page?.content ?? ''));
   }
 }
+PageMarkdownController.$inject = ['$sanitize'];
 
 export const PageMarkdownComponent: ng.IComponentOptions = {
   template: require('./page-markdown.html'),

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
@@ -34,14 +34,13 @@ const DisableTryItOutPlugin = function () {
     },
   };
 };
-
 class PageSwaggerComponentController implements IController {
   pageConfiguration: any;
   pageContent: string;
   edit: boolean;
 
   cfg: Record<string, unknown>;
-  /* @ngInject */
+
   constructor(
     private readonly Constants,
     private readonly UserService: UserService,
@@ -143,6 +142,7 @@ class PageSwaggerComponentController implements IController {
     );
   }
 }
+PageSwaggerComponentController.$inject = ['Constants', 'UserService', '$state', '$window'];
 
 export const PageSwaggerComponent: ng.IComponentOptions = {
   template: require('./page-swagger.html'),

--- a/gravitee-apim-console-webui/src/components/emptystate/emptystate.directive.ts
+++ b/gravitee-apim-console-webui/src/components/emptystate/emptystate.directive.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class EmptyStateDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'E',

--- a/gravitee-apim-console-webui/src/components/form/form.directive.ts
+++ b/gravitee-apim-console-webui/src/components/form/form.directive.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class FormDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'A',

--- a/gravitee-apim-console-webui/src/components/identityPicture/identityPicture.directive.ts
+++ b/gravitee-apim-console-webui/src/components/identityPicture/identityPicture.directive.ts
@@ -17,7 +17,6 @@
 import * as jdenticon from 'jdenticon';
 
 class IdentityPictureDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'E',
@@ -43,7 +42,6 @@ class IdentityPictureDirective {
 }
 
 class IdentityPictureController {
-  /* @ngInject */
   constructor(private $scope) {
     $scope.imgError = function () {
       document.querySelector('#avatar_' + $scope.imageId).classList.remove('show');
@@ -72,5 +70,6 @@ class IdentityPictureController {
     return this.$scope.imageUrl || this.$scope.imageDefault || '';
   }
 }
+IdentityPictureController.$inject = ['$scope'];
 
 export default IdentityPictureDirective;

--- a/gravitee-apim-console-webui/src/components/identityProviders/identity-providers.component.ts
+++ b/gravitee-apim-console-webui/src/components/identityProviders/identity-providers.component.ts
@@ -35,151 +35,163 @@ const IdentityProvidersComponent: ng.IComponentOptions = {
     settings: '<',
   },
   template: require('./identity-providers.html'),
-  /* @ngInject */
-  controller: function (
-    $mdDialog: angular.material.IDialogService,
-    IdentityProviderService: IdentityProviderService,
-    EnvironmentService: EnvironmentService,
-    OrganizationService: OrganizationService,
-    ConsoleSettingsService: ConsoleSettingsService,
-    PortalSettingsService: PortalSettingsService,
-    NotificationService: NotificationService,
-    UserService: UserService,
-    $state: StateService,
-    Constants,
-    $rootScope: IScope,
-  ) {
-    this.$rootScope = $rootScope;
-    this.activatedIdps = {};
+  controller: [
+    '$mdDialog',
+    'IdentityProviderService',
+    'EnvironmentService',
+    'OrganizationService',
+    'ConsoleSettingsService',
+    'PortalSettingsService',
+    'NotificationService',
+    'UserService',
+    '$state',
+    'Constants',
+    '$rootScope',
+    function (
+      $mdDialog: angular.material.IDialogService,
+      IdentityProviderService: IdentityProviderService,
+      EnvironmentService: EnvironmentService,
+      OrganizationService: OrganizationService,
+      ConsoleSettingsService: ConsoleSettingsService,
+      PortalSettingsService: PortalSettingsService,
+      NotificationService: NotificationService,
+      UserService: UserService,
+      $state: StateService,
+      Constants,
+      $rootScope: IScope,
+    ) {
+      this.$rootScope = $rootScope;
+      this.activatedIdps = {};
 
-    this.providedConfigurationMessage = 'Configuration provided by the system';
+      this.providedConfigurationMessage = 'Configuration provided by the system';
 
-    this.$onInit = () => {
-      this.identities.forEach((ipa: IdentityProviderActivation) => (this.activatedIdps[ipa.identityProvider] = true));
-      this.hasEnabledIdp = this.identityProviders.filter((idp) => idp.enabled).length > 0;
-      this.canUpdatePortalSettings = UserService.isUserHasPermissions([
-        'environment-settings-c',
-        'environment-settings-u',
-        'environment-settings-d',
-      ]);
-      this.canUpdateConsoleSettings = UserService.isUserHasPermissions([
-        'organization-settings-c',
-        'organization-settings-u',
-        'organization-settings-d',
-      ]);
-    };
+      this.$onInit = () => {
+        this.identities.forEach((ipa: IdentityProviderActivation) => (this.activatedIdps[ipa.identityProvider] = true));
+        this.hasEnabledIdp = this.identityProviders.filter((idp) => idp.enabled).length > 0;
+        this.canUpdatePortalSettings = UserService.isUserHasPermissions([
+          'environment-settings-c',
+          'environment-settings-u',
+          'environment-settings-d',
+        ]);
+        this.canUpdateConsoleSettings = UserService.isUserHasPermissions([
+          'organization-settings-c',
+          'organization-settings-u',
+          'organization-settings-d',
+        ]);
+      };
 
-    this.availableProviders = [
-      { name: 'Gravitee.io AM', icon: 'perm_identity', type: 'GRAVITEEIO_AM' },
-      { name: 'Google', icon: 'google-plus', type: 'GOOGLE' },
-      { name: 'GitHub', icon: 'github-circle', type: 'GITHUB' },
-      { name: 'OpenID Connect', icon: 'perm_identity', type: 'OIDC' },
-    ];
+      this.availableProviders = [
+        { name: 'Gravitee.io AM', icon: 'perm_identity', type: 'GRAVITEEIO_AM' },
+        { name: 'Google', icon: 'google-plus', type: 'GOOGLE' },
+        { name: 'GitHub', icon: 'github-circle', type: 'GITHUB' },
+        { name: 'OpenID Connect', icon: 'perm_identity', type: 'OIDC' },
+      ];
 
-    this.create = (type) => {
-      $state.go('organization.identity-new', { type: type });
-    };
+      this.create = (type) => {
+        $state.go('organization.identity-new', { type: type });
+      };
 
-    this.delete = (provider: IdentityProvider) => {
-      $mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: 'Are you sure you want to delete this identity provider?',
-            msg: '',
-            confirmButton: 'Delete',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            IdentityProviderService.delete(provider).then(() => {
-              NotificationService.show("Identity provider '" + provider.name + "' has been deleted");
-              $state.go('organization.identities', {}, { reload: true });
-            });
+      this.delete = (provider: IdentityProvider) => {
+        $mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: 'Are you sure you want to delete this identity provider?',
+              msg: '',
+              confirmButton: 'Delete',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              IdentityProviderService.delete(provider).then(() => {
+                NotificationService.show("Identity provider '" + provider.name + "' has been deleted");
+                $state.go('organization.identities', {}, { reload: true });
+              });
+            }
+          });
+      };
+
+      this.hasActivatedIdp = () => {
+        if (this.target === 'ENVIRONMENT') {
+          // activated IDP must also be enabled
+          const enabledIdpIds = this.identityProviders.filter((idp) => idp.enabled === true).map((idp) => idp.id);
+          for (const idpId of enabledIdpIds) {
+            if (this.activatedIdps[idpId]) {
+              return true;
+            }
           }
-        });
-    };
-
-    this.hasActivatedIdp = () => {
-      if (this.target === 'ENVIRONMENT') {
-        // activated IDP must also be enabled
-        const enabledIdpIds = this.identityProviders.filter((idp) => idp.enabled === true).map((idp) => idp.id);
-        for (const idpId of enabledIdpIds) {
-          if (this.activatedIdps[idpId]) {
-            return true;
-          }
+          return false;
+        } else {
+          return Object.keys(this.activatedIdps).length > 0;
         }
-        return false;
-      } else {
-        return Object.keys(this.activatedIdps).length > 0;
-      }
-    };
+      };
 
-    this.saveForceLogin = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        NotificationService.show('Authentication is now ' + (this.settings.authentication.forceLogin.enabled ? 'mandatory' : 'optional'));
-        this.settings = response.data;
-        $state.reload();
-      });
-    };
-
-    this.saveShowLoginForm = () => {
-      if (this.target === 'ENVIRONMENT') {
+      this.saveForceLogin = () => {
         PortalSettingsService.save(this.settings).then((response) => {
-          NotificationService.show('Login form is now ' + (this.settings.authentication.localLogin.enabled ? 'enabled' : 'disabled'));
+          NotificationService.show('Authentication is now ' + (this.settings.authentication.forceLogin.enabled ? 'mandatory' : 'optional'));
           this.settings = response.data;
           $state.reload();
         });
-      } else {
-        ConsoleSettingsService.save(this.settings).then((response) => {
-          NotificationService.show('Login form is now ' + (this.settings.authentication.localLogin.enabled ? 'enabled' : 'disabled'));
-          this.consoleSettings = response.data;
-          $state.reload();
-        });
-      }
-    };
+      };
 
-    this.toggleActivatedIdp = (identityProviderId: string) => {
-      const updatedIPA: Partial<IdentityProviderActivation>[] = _.filter(
-        Object.keys(this.activatedIdps),
-        (idpId) => this.activatedIdps[idpId] === true,
-      ).map((idpId) => ({ identityProvider: idpId }));
-
-      if (this.target === 'ENVIRONMENT') {
-        EnvironmentService.updateEnvironmentIdentities(this.targetId, updatedIPA).then(this._updateHandler(identityProviderId));
-      } else {
-        OrganizationService.updateOrganizationIdentities(updatedIPA).then(this._updateHandler(identityProviderId));
-      }
-    };
-
-    this._updateHandler = (identityProviderId) => {
-      return () => {
-        NotificationService.show(identityProviderId + ' is now ' + (this.activatedIdps[identityProviderId] ? 'enabled' : 'disabled'));
-        if (!this.activatedIdps[identityProviderId]) {
-          delete this.activatedIdps[identityProviderId];
-          this.updateLocalLoginState();
+      this.saveShowLoginForm = () => {
+        if (this.target === 'ENVIRONMENT') {
+          PortalSettingsService.save(this.settings).then((response) => {
+            NotificationService.show('Login form is now ' + (this.settings.authentication.localLogin.enabled ? 'enabled' : 'disabled'));
+            this.settings = response.data;
+            $state.reload();
+          });
+        } else {
+          ConsoleSettingsService.save(this.settings).then((response) => {
+            NotificationService.show('Login form is now ' + (this.settings.authentication.localLogin.enabled ? 'enabled' : 'disabled'));
+            this.consoleSettings = response.data;
+            $state.reload();
+          });
         }
       };
-    };
 
-    this.updateLocalLoginState = () => {
-      if (!this.hasActivatedIdp() && !this.settings.authentication.localLogin.enabled) {
-        this.settings.authentication.localLogin.enabled = true;
-        this.saveShowLoginForm();
-      }
-    };
+      this.toggleActivatedIdp = (identityProviderId: string) => {
+        const updatedIPA: Partial<IdentityProviderActivation>[] = _.filter(
+          Object.keys(this.activatedIdps),
+          (idpId) => this.activatedIdps[idpId] === true,
+        ).map((idpId) => ({ identityProvider: idpId }));
 
-    this.isReadonlySetting = (property: string): boolean => {
-      if (this.target === 'ENVIRONMENT') {
-        return PortalSettingsService.isReadonly(this.settings, property);
-      } else {
-        return ConsoleSettingsService.isReadonly(this.settings, property);
-      }
-    };
-  },
+        if (this.target === 'ENVIRONMENT') {
+          EnvironmentService.updateEnvironmentIdentities(this.targetId, updatedIPA).then(this._updateHandler(identityProviderId));
+        } else {
+          OrganizationService.updateOrganizationIdentities(updatedIPA).then(this._updateHandler(identityProviderId));
+        }
+      };
+
+      this._updateHandler = (identityProviderId) => {
+        return () => {
+          NotificationService.show(identityProviderId + ' is now ' + (this.activatedIdps[identityProviderId] ? 'enabled' : 'disabled'));
+          if (!this.activatedIdps[identityProviderId]) {
+            delete this.activatedIdps[identityProviderId];
+            this.updateLocalLoginState();
+          }
+        };
+      };
+
+      this.updateLocalLoginState = () => {
+        if (!this.hasActivatedIdp() && !this.settings.authentication.localLogin.enabled) {
+          this.settings.authentication.localLogin.enabled = true;
+          this.saveShowLoginForm();
+        }
+      };
+
+      this.isReadonlySetting = (property: string): boolean => {
+        if (this.target === 'ENVIRONMENT') {
+          return PortalSettingsService.isReadonly(this.settings, property);
+        } else {
+          return ConsoleSettingsService.isReadonly(this.settings, property);
+        }
+      };
+    },
+  ],
 };
 
 export default IdentityProvidersComponent;

--- a/gravitee-apim-console-webui/src/components/image/image.directive.ts
+++ b/gravitee-apim-console-webui/src/components/image/image.directive.ts
@@ -17,7 +17,6 @@
 import NotificationService from '../../services/notification.service';
 
 class ImageDirective {
-  /* @ngInject */
   constructor() {
     const directive = {
       restrict: 'E',
@@ -50,7 +49,6 @@ class ImageDirective {
 }
 
 class ImageController {
-  /* @ngInject */
   constructor(private $rootScope, private $scope, private Upload, private NotificationService: NotificationService) {
     $scope.maxSize = '1MB';
     if ($scope.accept == null) {
@@ -109,5 +107,6 @@ class ImageController {
     }
   }
 }
+ImageController.$inject = ['$rootScope', '$scope', 'Upload', 'NotificationService'];
 
 export default ImageDirective;

--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
@@ -135,7 +135,6 @@ class LogsFiltersController {
     return '(' + params.join(' OR ') + ')';
   }
 
-  /* @ngInject */
   constructor(
     private $scope: ILogsFiltersScope,
     private $state: StateService,
@@ -379,5 +378,6 @@ class LogsFiltersController {
     return applications;
   }
 }
+LogsFiltersController.$inject = ['$scope', '$state', '$timeout', '$log', 'ApiService', 'ApplicationService'];
 
 export default LogsFiltersController;

--- a/gravitee-apim-console-webui/src/components/logs/logs-timeframe.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-timeframe.controller.ts
@@ -34,7 +34,6 @@ class LogsTimeframeController {
   private onTimeframeChange: any;
   private unRegisterTimeframeZoom: () => void;
 
-  /* @ngInject */
   constructor(private $scope, private $rootScope, private $state: StateService, private $timeout: ng.ITimeoutService) {
     this.timeframes = [
       {
@@ -254,5 +253,6 @@ class LogsTimeframeController {
     });
   }
 }
+LogsTimeframeController.$inject = ['$scope', '$rootScope', '$state', '$timeout'];
 
 export default LogsTimeframeController;

--- a/gravitee-apim-console-webui/src/components/metadata/dialog/delete.metadata.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/metadata/dialog/delete.metadata.dialog.controller.ts
@@ -17,7 +17,6 @@ import { ApiService } from '../../../services/api.service';
 import ApplicationService from '../../../services/application.service';
 import MetadataService from '../../../services/metadata.service';
 
-/* @ngInject */
 function DeleteMetadataDialogController(
   MetadataService: MetadataService,
   ApiService: ApiService,
@@ -56,5 +55,6 @@ function DeleteMetadataDialogController(
     }
   };
 }
+DeleteMetadataDialogController.$inject = ['MetadataService', 'ApiService', 'ApplicationService', '$mdDialog', 'metadata', '$stateParams'];
 
 export default DeleteMetadataDialogController;

--- a/gravitee-apim-console-webui/src/components/metadata/dialog/new.metadata.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/metadata/dialog/new.metadata.dialog.controller.ts
@@ -16,7 +16,7 @@
 import { ApiService } from '../../../services/api.service';
 import ApplicationService from '../../../services/application.service';
 import MetadataService from '../../../services/metadata.service';
-/* @ngInject */
+
 function NewMetadataDialogController(
   MetadataService: MetadataService,
   ApiService: ApiService,
@@ -60,5 +60,13 @@ function NewMetadataDialogController(
     }
   };
 }
+NewMetadataDialogController.$inject = [
+  'MetadataService',
+  'ApiService',
+  'ApplicationService',
+  '$mdDialog',
+  'metadataFormats',
+  '$stateParams',
+];
 
 export default NewMetadataDialogController;

--- a/gravitee-apim-console-webui/src/components/metadata/dialog/update.metadata.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/metadata/dialog/update.metadata.dialog.controller.ts
@@ -16,7 +16,7 @@
 import { ApiService } from '../../../services/api.service';
 import ApplicationService from '../../../services/application.service';
 import MetadataService from '../../../services/metadata.service';
-/* @ngInject */
+
 function UpdateMetadataDialogController(
   MetadataService: MetadataService,
   ApiService: ApiService,
@@ -64,5 +64,14 @@ function UpdateMetadataDialogController(
     }
   };
 }
+UpdateMetadataDialogController.$inject = [
+  'MetadataService',
+  'ApiService',
+  'ApplicationService',
+  '$mdDialog',
+  'metadata',
+  'metadataFormats',
+  '$stateParams',
+];
 
 export default UpdateMetadataDialogController;

--- a/gravitee-apim-console-webui/src/components/metadata/metadata.controller.ts
+++ b/gravitee-apim-console-webui/src/components/metadata/metadata.controller.ts
@@ -29,7 +29,6 @@ class MetadataController {
   private canUpdate: boolean;
   private canDelete: boolean;
 
-  /* @ngInject */
   constructor(
     private MetadataService: MetadataService,
     private NotificationService: NotificationService,
@@ -115,5 +114,6 @@ class MetadataController {
     return !this.referenceType || (this.referenceType && metadata.value !== undefined);
   }
 }
+MetadataController.$inject = ['MetadataService', 'NotificationService', '$mdDialog', 'UserService', '$rootScope', '$state'];
 
 export default MetadataController;

--- a/gravitee-apim-console-webui/src/components/notifications/notificationsettings/addnotificationsettings.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/notifications/notificationsettings/addnotificationsettings.dialog.controller.ts
@@ -15,7 +15,6 @@
  */
 import { Notifier } from '../../../entities/notifier';
 
-/* @ngInject */
 function DialogAddNotificationSettingsController($scope, $mdDialog: angular.material.IDialogService, notifiers: Notifier[]) {
   this.notifiers = notifiers;
   this.selectedNotifier = notifiers[0];
@@ -34,5 +33,6 @@ function DialogAddNotificationSettingsController($scope, $mdDialog: angular.mate
     $mdDialog.hide(cfg);
   };
 }
+DialogAddNotificationSettingsController.$inject = ['$scope', '$mdDialog', 'notifiers'];
 
 export default DialogAddNotificationSettingsController;

--- a/gravitee-apim-console-webui/src/components/quick-time-range/quick-time-range.controller.ts
+++ b/gravitee-apim-console-webui/src/components/quick-time-range/quick-time-range.controller.ts
@@ -20,7 +20,6 @@ class QuickTimeRangeController {
   private timeframes: ITimeframe[];
   private onTimeframeChange: any;
 
-  /* @ngInject */
   constructor() {
     this.timeframes = [
       TimeframeRanges.LAST_MINUTE,

--- a/gravitee-apim-console-webui/src/components/theme/theme-element.directive.ts
+++ b/gravitee-apim-console-webui/src/components/theme/theme-element.directive.ts
@@ -15,9 +15,9 @@
  */
 
 class ThemeElementController {
-  /* @ngInject */
   constructor(private Theme) {}
 }
+ThemeElementController.$inject = ['Theme'];
 
 const ThemeElementDirective: ng.IDirective = {
   restrict: 'A',

--- a/gravitee-apim-console-webui/src/components/user-autocomplete/user-autocomplete.controller.ts
+++ b/gravitee-apim-console-webui/src/components/user-autocomplete/user-autocomplete.controller.ts
@@ -30,7 +30,6 @@ class UserAutocompleteController {
   private minLength: number;
   private autofocus: boolean;
 
-  /* @ngInject */
   constructor(private UserService: UserService) {}
 
   $onInit() {
@@ -78,5 +77,6 @@ class UserAutocompleteController {
     }
   }
 }
+UserAutocompleteController.$inject = ['UserService'];
 
 export default UserAutocompleteController;

--- a/gravitee-apim-console-webui/src/components/widget/line/widget-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/line/widget-chart-line.component.ts
@@ -26,113 +26,119 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
   require: {
     parent: '^gvWidget',
   },
-  /* @ngInject */
-  controller: function ($scope, $element, $rootScope, $state, AnalyticsService: AnalyticsService, eventService: EventService) {
-    this.AnalyticsService = AnalyticsService;
-    this.eventService = eventService;
-    this.$scope = $scope;
+  controller: [
+    '$scope',
+    '$element',
+    '$rootScope',
+    '$state',
+    'AnalyticsService',
+    'eventService',
+    function ($scope, $element, $rootScope, $state, AnalyticsService: AnalyticsService, eventService: EventService) {
+      this.AnalyticsService = AnalyticsService;
+      this.eventService = eventService;
+      this.$scope = $scope;
 
-    this.$onInit = () => {
-      this.widget = this.parent.widget;
-    };
+      this.$onInit = () => {
+        this.widget = this.parent.widget;
+      };
 
-    this.$onChanges = (changes) => {
-      if (changes.data) {
-        const data = changes.data.currentValue;
-        this.series = { values: [] };
-        this.gvChartLine = $element.children()[0];
+      this.$onChanges = (changes) => {
+        if (changes.data) {
+          const data = changes.data.currentValue;
+          this.series = { values: [] };
+          this.gvChartLine = $element.children()[0];
 
-        if ((data.values && data.values.length > 0) || (data.events && data.events.content && data.events.content.length > 0)) {
-          this.prepareData(data);
+          if ((data.values && data.values.length > 0) || (data.events && data.events.content && data.events.content.length > 0)) {
+            this.prepareData(data);
 
-          // Send data to gv-chart-line
-          this.gvChartLine.setAttribute('series', JSON.stringify(this.series));
-          this.gvChartLine.setAttribute('options', JSON.stringify(this.options));
+            // Send data to gv-chart-line
+            this.gvChartLine.setAttribute('series', JSON.stringify(this.series));
+            this.gvChartLine.setAttribute('options', JSON.stringify(this.options));
 
-          // Events from gv-chart-line and dashboard resizing
-          this.gvChartLine.addEventListener('gv-chart-line:zoom', this.onZoom.bind(this));
-          this.gvChartLine.addEventListener('gv-chart-line:select', this.onSelect.bind(this));
-          $scope.$on('onWidgetResize', this.onResize.bind(this));
-        } else {
-          this.gvChartLine.setAttribute('options', JSON.stringify([{}]));
-          this.gvChartLine.setAttribute('series', JSON.stringify([{}]));
-        }
-      }
-    };
-
-    this.prepareData = (data) => {
-      const timestamp = data.timestamp;
-      this.events = data.events && data.events.content;
-
-      const orderedBucketNames = [];
-
-      data.values.forEach((value, idx) => {
-        let label = this.parent.widget.chart.labels ? this.parent.widget.chart.labels[idx] : '';
-
-        if (value.buckets.length === 0) {
-          const bucketCount = (data.timestamp.to - data.timestamp.from) / data.timestamp.interval;
-
-          orderedBucketNames.push(label);
-
-          this.series.values.push({
-            name: label,
-            data: Array(bucketCount).fill(0),
-            labelPrefix: label,
-            id: label,
-            visible: true,
-          });
-        } else {
-          let field = this.parent.widget.chart.request.field;
-          if (this.parent.widget.chart.request.aggs && this.parent.widget.chart.request.aggs.includes('field:')) {
-            field = this.parent.widget.chart.request.aggs.replace('field:', '');
+            // Events from gv-chart-line and dashboard resizing
+            this.gvChartLine.addEventListener('gv-chart-line:zoom', this.onZoom.bind(this));
+            this.gvChartLine.addEventListener('gv-chart-line:select', this.onSelect.bind(this));
+            $scope.$on('onWidgetResize', this.onResize.bind(this));
+          } else {
+            this.gvChartLine.setAttribute('options', JSON.stringify([{}]));
+            this.gvChartLine.setAttribute('series', JSON.stringify([{}]));
           }
-          const queryFilters = this.AnalyticsService.getQueryFilters();
-          value.buckets.forEach((bucket) => {
-            if (bucket) {
-              let isFieldRequest = this.parent.widget.chart.request.aggs.split('%3B')[idx].includes('field:');
-              if (
-                bucket.name === '1' ||
-                bucket.name.match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
-              ) {
-                isFieldRequest = false;
-              }
-              if (!label || (value.metadata && value.metadata[bucket.name])) {
-                label = value.metadata[bucket.name].name;
-              }
-
-              const valueName = isFieldRequest ? bucket.name : label;
-              orderedBucketNames.push(valueName);
-
-              this.series.values.push({
-                name: valueName,
-                data: bucket.data,
-                labelPrefix: isFieldRequest ? label : '',
-                id: bucket.name,
-                visible: queryFilters && queryFilters[field] ? queryFilters[field].includes(bucket.name) : true,
-              });
-            }
-          });
-          orderedBucketNames.sort();
         }
-      });
+      };
 
-      this.series.values.forEach((value) => {
-        value.legendIndex = orderedBucketNames.indexOf(value.name);
-      });
+      this.prepareData = (data) => {
+        const timestamp = data.timestamp;
+        this.events = data.events && data.events.content;
 
-      this.options = {
-        labelPrefix: 'HTTP Status',
-        pointStart: timestamp.from,
-        pointInterval: timestamp.interval,
-        stacking: this.parent.widget.chart.stacked ? 'normal' : null,
-        plotLines: (this.events || []).map((event) => {
-          return {
-            color: 'rgba(223, 169, 65, 0.4)',
-            width: 2,
-            value: event.created_at,
-            label: {
-              useHTML: true,
-              text: `
+        const orderedBucketNames = [];
+
+        data.values.forEach((value, idx) => {
+          let label = this.parent.widget.chart.labels ? this.parent.widget.chart.labels[idx] : '';
+
+          if (value.buckets.length === 0) {
+            const bucketCount = (data.timestamp.to - data.timestamp.from) / data.timestamp.interval;
+
+            orderedBucketNames.push(label);
+
+            this.series.values.push({
+              name: label,
+              data: Array(bucketCount).fill(0),
+              labelPrefix: label,
+              id: label,
+              visible: true,
+            });
+          } else {
+            let field = this.parent.widget.chart.request.field;
+            if (this.parent.widget.chart.request.aggs && this.parent.widget.chart.request.aggs.includes('field:')) {
+              field = this.parent.widget.chart.request.aggs.replace('field:', '');
+            }
+            const queryFilters = this.AnalyticsService.getQueryFilters();
+            value.buckets.forEach((bucket) => {
+              if (bucket) {
+                let isFieldRequest = this.parent.widget.chart.request.aggs.split('%3B')[idx].includes('field:');
+                if (
+                  bucket.name === '1' ||
+                  bucket.name.match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+                ) {
+                  isFieldRequest = false;
+                }
+                if (!label || (value.metadata && value.metadata[bucket.name])) {
+                  label = value.metadata[bucket.name].name;
+                }
+
+                const valueName = isFieldRequest ? bucket.name : label;
+                orderedBucketNames.push(valueName);
+
+                this.series.values.push({
+                  name: valueName,
+                  data: bucket.data,
+                  labelPrefix: isFieldRequest ? label : '',
+                  id: bucket.name,
+                  visible: queryFilters && queryFilters[field] ? queryFilters[field].includes(bucket.name) : true,
+                });
+              }
+            });
+            orderedBucketNames.sort();
+          }
+        });
+
+        this.series.values.forEach((value) => {
+          value.legendIndex = orderedBucketNames.indexOf(value.name);
+        });
+
+        this.options = {
+          labelPrefix: 'HTTP Status',
+          pointStart: timestamp.from,
+          pointInterval: timestamp.interval,
+          stacking: this.parent.widget.chart.stacked ? 'normal' : null,
+          plotLines: (this.events || []).map((event) => {
+            return {
+              color: 'rgba(223, 169, 65, 0.4)',
+              width: 2,
+              value: event.created_at,
+              label: {
+                useHTML: true,
+                text: `
                   <div style="
                         background-color: var(--gv-theme-font-color-dark, #262626);
                         color: white;
@@ -144,66 +150,67 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
                     <br>
                     <span>${event.properties.deployment_label || ''}</span>
                   </div>`,
-              rotation: 0,
-              style: {
-                visibility: 'hidden',
+                rotation: 0,
+                style: {
+                  visibility: 'hidden',
+                },
               },
-            },
-          };
-        }),
+            };
+          }),
+        };
       };
-    };
 
-    this.onZoom = (event) => {
-      $rootScope.$broadcast('timeframeZoom', {
-        from: Math.floor(event.detail.from),
-        to: Math.round(event.detail.to),
-      });
-    };
+      this.onZoom = (event) => {
+        $rootScope.$broadcast('timeframeZoom', {
+          from: Math.floor(event.detail.from),
+          to: Math.round(event.detail.to),
+        });
+      };
 
-    this.onSelect = (event) => {
-      const selected = event.detail.chart.series[event.detail.index];
+      this.onSelect = (event) => {
+        const selected = event.detail.chart.series[event.detail.index];
 
-      if (this.parent.widget.chart.selectable) {
-        const query = this.parent.widget.chart.request.query;
-        if (query && query.includes(selected.name)) {
-          this.updateQuery(selected, false);
-        } else {
-          this.updateQuery(selected, true);
-        }
-      } else {
-        this.series.values.forEach((serie) => {
-          if (serie.name === selected.name) {
-            serie.visible = !selected.visible;
+        if (this.parent.widget.chart.selectable) {
+          const query = this.parent.widget.chart.request.query;
+          if (query && query.includes(selected.name)) {
+            this.updateQuery(selected, false);
+          } else {
+            this.updateQuery(selected, true);
           }
-        });
+        } else {
+          this.series.values.forEach((serie) => {
+            if (serie.name === selected.name) {
+              serie.visible = !selected.visible;
+            }
+          });
 
-        this.gvChartLine.setAttribute('series', JSON.stringify(this.series));
-      }
-    };
-
-    this.onResize = () => {
-      this.options = {
-        ...this.options,
-        height: this.gvChartLine.offsetHeight,
-        width: this.gvChartLine.offsetWidth,
+          this.gvChartLine.setAttribute('series', JSON.stringify(this.series));
+        }
       };
 
-      this.gvChartLine.setAttribute('options', JSON.stringify(this.options));
-    };
+      this.onResize = () => {
+        this.options = {
+          ...this.options,
+          height: this.gvChartLine.offsetHeight,
+          width: this.gvChartLine.offsetWidth,
+        };
 
-    this.updateQuery = (item, add) => {
-      if (this.widget && item.userOptions) {
-        this.$scope.$emit('filterItemChange', {
-          widget: this.widget.$uid,
-          field: this.widget.chart.request.aggs.split(':')[1],
-          key: item.userOptions.id,
-          name: item.name,
-          mode: add ? 'add' : 'remove',
-        });
-      }
-    };
-  },
+        this.gvChartLine.setAttribute('options', JSON.stringify(this.options));
+      };
+
+      this.updateQuery = (item, add) => {
+        if (this.widget && item.userOptions) {
+          this.$scope.$emit('filterItemChange', {
+            widget: this.widget.$uid,
+            field: this.widget.chart.request.aggs.split(':')[1],
+            key: item.userOptions.id,
+            name: item.name,
+            mode: add ? 'add' : 'remove',
+          });
+        }
+      };
+    },
+  ],
 };
 
 export default WidgetChartLineComponent;

--- a/gravitee-apim-console-webui/src/components/widget/map/widget-chart-map-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/map/widget-chart-map-configuration.component.ts
@@ -19,7 +19,6 @@ const WidgetChartMapConfigurationComponent: ng.IComponentOptions = {
   bindings: {
     chart: '<',
   },
-  /* @ngInject */
   controller: function () {
     this.$onInit = () => {
       if (!this.chart.request) {

--- a/gravitee-apim-console-webui/src/components/widget/map/widget-chart-map.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/map/widget-chart-map.component.ts
@@ -23,40 +23,43 @@ const WidgetChartMapComponent: ng.IComponentOptions = {
   require: {
     parent: '^gvWidget',
   },
-  /* @ngInject */
-  controller: function widgetChartMapController($scope, $element) {
-    this.options = {
-      name: 'Number of API requests',
-      excludedKeys: ['Unknown'],
-    };
-
-    this.$onInit = () => {
-      $scope.$on('onWidgetResize', this.onResize.bind(this));
-    };
-
-    this.$onChanges = function (changes) {
-      this.gvChartMap = $element.children()[0];
-
-      if (changes.data) {
-        const series = {
-          values: changes.data.currentValue ? changes.data.currentValue.values : [],
-        };
-
-        // Send data to gv-chart-map
-        this.gvChartMap.setAttribute('series', JSON.stringify(series));
-        this.gvChartMap.setAttribute('options', JSON.stringify(this.options));
-      }
-    };
-
-    this.onResize = () => {
+  controller: [
+    '$scope',
+    '$element',
+    function widgetChartMapController($scope, $element) {
       this.options = {
-        ...this.options,
-        height: this.gvChartMap.offsetHeight,
-        width: this.gvChartMap.offsetWidth,
+        name: 'Number of API requests',
+        excludedKeys: ['Unknown'],
       };
-      this.gvChartMap.setAttribute('options', JSON.stringify(this.options));
-    };
-  },
+
+      this.$onInit = () => {
+        $scope.$on('onWidgetResize', this.onResize.bind(this));
+      };
+
+      this.$onChanges = function (changes) {
+        this.gvChartMap = $element.children()[0];
+
+        if (changes.data) {
+          const series = {
+            values: changes.data.currentValue ? changes.data.currentValue.values : [],
+          };
+
+          // Send data to gv-chart-map
+          this.gvChartMap.setAttribute('series', JSON.stringify(series));
+          this.gvChartMap.setAttribute('options', JSON.stringify(this.options));
+        }
+      };
+
+      this.onResize = () => {
+        this.options = {
+          ...this.options,
+          height: this.gvChartMap.offsetHeight,
+          width: this.gvChartMap.offsetWidth,
+        };
+        this.gvChartMap.setAttribute('options', JSON.stringify(this.options));
+      };
+    },
+  ],
 };
 
 export default WidgetChartMapComponent;

--- a/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie-configuration.component.ts
@@ -22,74 +22,76 @@ const WidgetChartPieConfigurationComponent: ng.IComponentOptions = {
   bindings: {
     chart: '<',
   },
-  /* @ngInject */
-  controller: function (DashboardService: DashboardService) {
-    this.fields = DashboardService.getNumericFields();
+  controller: [
+    'DashboardService',
+    function (DashboardService: DashboardService) {
+      this.fields = DashboardService.getNumericFields();
 
-    this.$onInit = () => {
-      this.data = [];
-      if (this.chart.request) {
-        if (this.chart.request.ranges) {
-          const ranges = this.chart.request.ranges.split('%3B');
-          let i = 0;
-          _.forEach(ranges, (range) => {
-            if (range) {
-              this.data.push({
-                min: parseInt(range.split(':')[0], 10),
-                max: parseInt(range.split(':')[1], 10),
-                label: this.chart.labels[i],
-                color: this.chart.colors[i++],
-              });
-            }
+      this.$onInit = () => {
+        this.data = [];
+        if (this.chart.request) {
+          if (this.chart.request.ranges) {
+            const ranges = this.chart.request.ranges.split('%3B');
+            let i = 0;
+            _.forEach(ranges, (range) => {
+              if (range) {
+                this.data.push({
+                  min: parseInt(range.split(':')[0], 10),
+                  max: parseInt(range.split(':')[1], 10),
+                  label: this.chart.labels[i],
+                  color: this.chart.colors[i++],
+                });
+              }
+            });
+          }
+        } else {
+          _.merge(this.chart, {
+            request: {
+              type: 'group_by',
+              field: this.fields[0].value,
+              ranges: '',
+            },
+            labels: [],
+            colors: [],
           });
         }
-      } else {
-        _.merge(this.chart, {
-          request: {
-            type: 'group_by',
-            field: this.fields[0].value,
-            ranges: '',
-          },
-          labels: [],
-          colors: [],
+
+        if (this.chart.request.field.startsWith('custom')) {
+          this.field = this.chart.request.field.substr('custom.'.length);
+          this.isCustomField = true;
+        } else {
+          this.field = this.chart.request.field;
+          this.isCustomField = false;
+        }
+      };
+
+      this.onFieldChanged = () => {
+        this.chart.request.field = 'custom.' + this.field;
+      };
+
+      this.onDataChanged = () => {
+        this.chart.request.ranges = '';
+        this.chart.labels = [];
+        this.chart.colors = [];
+        const last = _.last(this.data);
+        _.forEach(this.data, (data) => {
+          this.chart.request.ranges += data.min + ':' + data.max + (last === data ? '' : '%3B');
+          this.chart.labels.push(data.label);
+          this.chart.colors.push(data.color);
         });
-      }
+      };
 
-      if (this.chart.request.field.startsWith('custom')) {
-        this.field = this.chart.request.field.substr('custom.'.length);
-        this.isCustomField = true;
-      } else {
-        this.field = this.chart.request.field;
-        this.isCustomField = false;
-      }
-    };
+      this.addData = () => {
+        this.data.push({});
+        this.onDataChanged();
+      };
 
-    this.onFieldChanged = () => {
-      this.chart.request.field = 'custom.' + this.field;
-    };
-
-    this.onDataChanged = () => {
-      this.chart.request.ranges = '';
-      this.chart.labels = [];
-      this.chart.colors = [];
-      const last = _.last(this.data);
-      _.forEach(this.data, (data) => {
-        this.chart.request.ranges += data.min + ':' + data.max + (last === data ? '' : '%3B');
-        this.chart.labels.push(data.label);
-        this.chart.colors.push(data.color);
-      });
-    };
-
-    this.addData = () => {
-      this.data.push({});
-      this.onDataChanged();
-    };
-
-    this.removeData = (data) => {
-      _.remove(this.data, data);
-      this.onDataChanged();
-    };
-  },
+      this.removeData = (data) => {
+        _.remove(this.data, data);
+        this.onDataChanged();
+      };
+    },
+  ],
 };
 
 export default WidgetChartPieConfigurationComponent;

--- a/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie.component.ts
@@ -23,55 +23,58 @@ const WidgetChartPieComponent: ng.IComponentOptions = {
   require: {
     parent: '^gvWidget',
   },
-  /* @ngInject */
-  controller: function widgetChartPieController($scope, $element) {
-    this.$onInit = () => {
-      $scope.$on('onWidgetResize', this.onResize.bind(this));
-    };
-
-    this.$onChanges = function (changes) {
-      if (changes.data) {
-        this.gvChartPie = $element.children()[0];
-        this.options = {
-          name: this.parent.widget.title,
-          data: Object.keys(changes.data.currentValue.values || {}).map((label, idx) => {
-            // The next lines are weird and would need a complete refactor, it
-            // will happen with the Angular migration of this component
-            if (this.parent.widget.chart.labels && this.parent.widget.chart.labels.includes(label)) {
-              const index = this.parent.widget.chart.labels.indexOf(label);
-              return {
-                name: this.parent.widget.chart.labels[index],
-                color: this.parent.widget.chart.colors[index],
-              };
-            }
-
-            return {
-              // Set the color and name based on the chart config (coming from the parent)
-              name: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.labels[idx] : label,
-              color: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.colors[idx] : undefined,
-            };
-          }),
-        };
-
-        const series = {
-          values: changes.data.currentValue ? changes.data.currentValue.values : {},
-        };
-
-        // Send data to gv-chart-pie
-        this.gvChartPie.setAttribute('series', JSON.stringify(series));
-        this.gvChartPie.setAttribute('options', JSON.stringify(this.options));
-      }
-    };
-
-    this.onResize = () => {
-      this.options = {
-        ...this.options,
-        height: this.gvChartPie.offsetHeight,
-        width: this.gvChartPie.offsetWidth,
+  controller: [
+    '$scope',
+    '$element',
+    function widgetChartPieController($scope, $element) {
+      this.$onInit = () => {
+        $scope.$on('onWidgetResize', this.onResize.bind(this));
       };
-      this.gvChartPie.setAttribute('options', JSON.stringify(this.options));
-    };
-  },
+
+      this.$onChanges = function (changes) {
+        if (changes.data) {
+          this.gvChartPie = $element.children()[0];
+          this.options = {
+            name: this.parent.widget.title,
+            data: Object.keys(changes.data.currentValue.values || {}).map((label, idx) => {
+              // The next lines are weird and would need a complete refactor, it
+              // will happen with the Angular migration of this component
+              if (this.parent.widget.chart.labels && this.parent.widget.chart.labels.includes(label)) {
+                const index = this.parent.widget.chart.labels.indexOf(label);
+                return {
+                  name: this.parent.widget.chart.labels[index],
+                  color: this.parent.widget.chart.colors[index],
+                };
+              }
+
+              return {
+                // Set the color and name based on the chart config (coming from the parent)
+                name: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.labels[idx] : label,
+                color: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.colors[idx] : undefined,
+              };
+            }),
+          };
+
+          const series = {
+            values: changes.data.currentValue ? changes.data.currentValue.values : {},
+          };
+
+          // Send data to gv-chart-pie
+          this.gvChartPie.setAttribute('series', JSON.stringify(series));
+          this.gvChartPie.setAttribute('options', JSON.stringify(this.options));
+        }
+      };
+
+      this.onResize = () => {
+        this.options = {
+          ...this.options,
+          height: this.gvChartPie.offsetHeight,
+          width: this.gvChartPie.offsetWidth,
+        };
+        this.gvChartPie.setAttribute('options', JSON.stringify(this.options));
+      };
+    },
+  ],
 };
 
 export default WidgetChartPieComponent;

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
@@ -44,7 +44,6 @@ class WidgetDataStatsConfigurationController implements IOnInit {
   selectedStatsKeys: string[] = [];
   availableStats: Stat[];
 
-  /* @ngInject */
   constructor(private readonly DashboardService: DashboardService) {}
 
   $onInit(): void {
@@ -143,6 +142,7 @@ class WidgetDataStatsConfigurationController implements IOnInit {
     }
   }
 }
+WidgetDataStatsConfigurationController.$inject = ['DashboardService'];
 
 const WidgetDataStatsConfigurationComponent: ng.IComponentOptions = {
   template: require('./widget-data-stats-configuration.html'),

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats.component.ts
@@ -24,41 +24,44 @@ const WidgetDataStatsComponent: ng.IComponentOptions = {
   require: {
     parent: '^gvWidget',
   },
-  /* @ngInject */
-  controller: function ($scope, $element) {
-    this.$onInit = () => {
-      this.chartData = _.cloneDeep(this.parent.widget.chart.data);
-      checkFallback();
-    };
-    const checkFallback = () => {
-      const gvStats = $element.children()[0];
+  controller: [
+    '$scope',
+    '$element',
+    function ($scope, $element) {
+      this.$onInit = () => {
+        this.chartData = _.cloneDeep(this.parent.widget.chart.data);
+        checkFallback();
+      };
+      const checkFallback = () => {
+        const gvStats = $element.children()[0];
 
-      const stats = {};
-      if (Object.values(this.data).some((data) => data !== 0)) {
-        this.chartData.forEach((data) => {
-          stats[data.key] = this.data[data.key];
+        const stats = {};
+        if (Object.values(this.data).some((data) => data !== 0)) {
+          this.chartData.forEach((data) => {
+            stats[data.key] = this.data[data.key];
+          });
+        }
+
+        const options = this.chartData.map((data) => {
+          return {
+            key: data.key,
+            unit: data.unit,
+            color: data.color,
+            label: data.label,
+            fallback:
+              data.fallback &&
+              data.fallback.map((fallback) => {
+                return { key: fallback.key, label: fallback.label };
+              }),
+          };
         });
-      }
 
-      const options = this.chartData.map((data) => {
-        return {
-          key: data.key,
-          unit: data.unit,
-          color: data.color,
-          label: data.label,
-          fallback:
-            data.fallback &&
-            data.fallback.map((fallback) => {
-              return { key: fallback.key, label: fallback.label };
-            }),
-        };
-      });
-
-      // Send data to gv-stats
-      gvStats.setAttribute('stats', JSON.stringify(stats));
-      gvStats.setAttribute('options', JSON.stringify(options));
-    };
-  },
+        // Send data to gv-stats
+        gvStats.setAttribute('stats', JSON.stringify(stats));
+        gvStats.setAttribute('options', JSON.stringify(options));
+      };
+    },
+  ],
 };
 
 export default WidgetDataStatsComponent;

--- a/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
@@ -22,85 +22,87 @@ const WidgetDataTableConfigurationComponent: ng.IComponentOptions = {
   bindings: {
     chart: '<',
   },
-  /* @ngInject */
-  controller: function (DashboardService: DashboardService) {
-    this.fields = DashboardService.getIndexedFields();
-    this.projections = _.concat(
-      {
-        label: 'Hits',
-        value: '_count',
-        type: 'count',
-      },
-      DashboardService.getAverageableFields(),
-    );
-    this.projectionOrders = [
-      { label: 'Desc', value: '-' },
-      { label: 'Asc', value: '' },
-    ];
+  controller: [
+    'DashboardService',
+    function (DashboardService: DashboardService) {
+      this.fields = DashboardService.getIndexedFields();
+      this.projections = _.concat(
+        {
+          label: 'Hits',
+          value: '_count',
+          type: 'count',
+        },
+        DashboardService.getAverageableFields(),
+      );
+      this.projectionOrders = [
+        { label: 'Desc', value: '-' },
+        { label: 'Asc', value: '' },
+      ];
 
-    this.$onInit = () => {
-      if (!this.chart.request) {
-        _.merge(this.chart, {
-          request: {
-            type: 'group_by',
-            field: this.fields[0].value,
-          },
-          columns: [],
-          paging: 5,
-        });
-      }
-      if (this.chart.request.field.startsWith('custom')) {
-        this.field = this.chart.request.field.substr('custom.'.length);
-        this.isCustomField = true;
-      } else {
-        this.field = this.chart.request.field;
-        this.isCustomField = false;
-      }
-
-      if (this.chart.request.order) {
-        const splittedOrder = this.chart.request.order.split(':');
-        const aggregate = splittedOrder[0];
-        const projection = splittedOrder[1];
-        if ('-' === aggregate.charAt(0)) {
-          this.order = '-';
-          this.aggregate = aggregate.substring(1);
+      this.$onInit = () => {
+        if (!this.chart.request) {
+          _.merge(this.chart, {
+            request: {
+              type: 'group_by',
+              field: this.fields[0].value,
+            },
+            columns: [],
+            paging: 5,
+          });
+        }
+        if (this.chart.request.field.startsWith('custom')) {
+          this.field = this.chart.request.field.substr('custom.'.length);
+          this.isCustomField = true;
         } else {
-          this.order = '';
-          this.aggregate = aggregate;
+          this.field = this.chart.request.field;
+          this.isCustomField = false;
         }
-        this.projection = projection ? projection : '_count';
-      } else {
-        this.order = '-';
-        this.aggregate = 'avg';
-        this.projection = '_count';
-      }
-      this.onFieldChanged();
-      this.onProjectionChanged();
-    };
 
-    this.onFieldChanged = () => {
-      if (this.isCustomField) {
-        this.chart.request.field = 'custom.' + this.field;
-      } else {
-        this.chart.request.field = this.field;
-      }
-
-      const existingField = _.find(this.fields, (f) => f.value === this.field);
-      this.chart.columns[0] = existingField ? existingField.label : this.field;
-    };
-
-    this.onProjectionChanged = () => {
-      this.chart.columns[1] = _.find(this.projections, (p) => p.value === this.projection).label;
-      if (this.projection) {
-        this.chart.request.order = this.order + this.aggregate + ':' + this.projection;
-        if (this.projection !== '_count') {
-          this.chart.percent = false;
+        if (this.chart.request.order) {
+          const splittedOrder = this.chart.request.order.split(':');
+          const aggregate = splittedOrder[0];
+          const projection = splittedOrder[1];
+          if ('-' === aggregate.charAt(0)) {
+            this.order = '-';
+            this.aggregate = aggregate.substring(1);
+          } else {
+            this.order = '';
+            this.aggregate = aggregate;
+          }
+          this.projection = projection ? projection : '_count';
+        } else {
+          this.order = '-';
+          this.aggregate = 'avg';
+          this.projection = '_count';
         }
-      } else {
-        delete this.chart.request.order;
-      }
-    };
-  },
+        this.onFieldChanged();
+        this.onProjectionChanged();
+      };
+
+      this.onFieldChanged = () => {
+        if (this.isCustomField) {
+          this.chart.request.field = 'custom.' + this.field;
+        } else {
+          this.chart.request.field = this.field;
+        }
+
+        const existingField = _.find(this.fields, (f) => f.value === this.field);
+        this.chart.columns[0] = existingField ? existingField.label : this.field;
+      };
+
+      this.onProjectionChanged = () => {
+        this.chart.columns[1] = _.find(this.projections, (p) => p.value === this.projection).label;
+        if (this.projection) {
+          this.chart.request.order = this.order + this.aggregate + ':' + this.projection;
+          if (this.projection !== '_count') {
+            this.chart.percent = false;
+          }
+        } else {
+          delete this.chart.request.order;
+        }
+      };
+    },
+  ],
 };
 
 export default WidgetDataTableConfigurationComponent;

--- a/gravitee-apim-console-webui/src/components/widget/table/widget-data-table.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/table/widget-data-table.component.ts
@@ -26,99 +26,103 @@ const WidgetDataTableComponent: ng.IComponentOptions = {
   require: {
     parent: '^gvWidget',
   },
-  /* @ngInject */
-  controller: function ($scope, $state: StateService, AnalyticsService: AnalyticsService) {
-    this.AnalyticsService = AnalyticsService;
-    this.$scope = $scope;
-    this.$state = $state;
-    this.selected = [];
+  controller: [
+    '$scope',
+    '$state',
+    'AnalyticsService',
+    function ($scope, $state: StateService, AnalyticsService: AnalyticsService) {
+      this.AnalyticsService = AnalyticsService;
+      this.$scope = $scope;
+      this.$state = $state;
+      this.selected = [];
 
-    this.$onInit = function () {
-      this.widget = this.parent.widget;
-    };
+      this.$onInit = function () {
+        this.widget = this.parent.widget;
+      };
 
-    this.$onChanges = (changes) => {
-      if (changes.data) {
-        const data = changes.data.currentValue;
-        this.paging = 1;
-        this.results = _.map(data.values, (value, key) => {
-          let percent;
-          if (_.includes(value, '/')) {
-            const splittedValue = value.split('/');
-            value = parseInt(splittedValue[0], 10);
-            percent = parseFloat(splittedValue[1]);
-          }
-          const result = {
-            key: key,
-            value: value,
-            percent: percent,
-            metadata: data && data.metadata ? { ...data.metadata[key], order: +data.metadata[key].order } : undefined,
-          };
-          const widget = this.widget || this.parent.widget;
-          if (widget) {
-            const queryFilters = this.AnalyticsService.getQueryFilters();
-            if (queryFilters) {
-              const queryFilter = queryFilters[widget.chart.request.field];
-              if (queryFilter && queryFilter.includes(key)) {
-                setTimeout(() => {
-                  this.selected.push(result);
-                });
+      this.$onChanges = (changes) => {
+        if (changes.data) {
+          const data = changes.data.currentValue;
+          this.paging = 1;
+          this.results = _.map(data.values, (value, key) => {
+            let percent;
+            if (_.includes(value, '/')) {
+              const splittedValue = value.split('/');
+              value = parseInt(splittedValue[0], 10);
+              percent = parseFloat(splittedValue[1]);
+            }
+            const result = {
+              key: key,
+              value: value,
+              percent: percent,
+              metadata: data && data.metadata ? { ...data.metadata[key], order: +data.metadata[key].order } : undefined,
+            };
+            const widget = this.widget || this.parent.widget;
+            if (widget) {
+              const queryFilters = this.AnalyticsService.getQueryFilters();
+              if (queryFilters) {
+                const queryFilter = queryFilters[widget.chart.request.field];
+                if (queryFilter && queryFilter.includes(key)) {
+                  setTimeout(() => {
+                    this.selected.push(result);
+                  });
+                }
               }
             }
-          }
-          return result;
-        });
-      }
-    };
-
-    this.selectItem = (item) => {
-      this.updateQuery(item, true);
-    };
-
-    this.deselectItem = (item) => {
-      this.updateQuery(item, false);
-    };
-
-    this.updateQuery = (item, add) => {
-      this.$scope.$emit('filterItemChange', {
-        widget: this.widget.$uid,
-        field: this.widget.chart.request.field,
-        fieldLabel: this.widget.chart.request.fieldLabel,
-        key: item.key,
-        name: item.metadata.name,
-        mode: add ? 'add' : 'remove',
-      });
-    };
-
-    this.isClickable = function (result) {
-      return (
-        ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') &&
-        !result.metadata.unknown &&
-        (this.widget.chart.request.field === 'api' || this.widget.chart.request.field === 'application')
-      );
-    };
-
-    this.goto = function (key) {
-      // only on platform analytics
-      if ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') {
-        if (this.widget.chart.request.field === 'api') {
-          this.$state.go('management.apis.analytics-overview-v2', {
-            apiId: key,
-            from: this.widget.chart.request.from,
-            to: this.widget.chart.request.to,
-            q: this.widget.chart.request.query,
-          });
-        } else if (this.widget.chart.request.field === 'application') {
-          this.$state.go('management.applications.application.analytics', {
-            applicationId: key,
-            from: this.widget.chart.request.from,
-            to: this.widget.chart.request.to,
-            q: this.widget.chart.request.query,
+            return result;
           });
         }
-      }
-    };
-  },
+      };
+
+      this.selectItem = (item) => {
+        this.updateQuery(item, true);
+      };
+
+      this.deselectItem = (item) => {
+        this.updateQuery(item, false);
+      };
+
+      this.updateQuery = (item, add) => {
+        this.$scope.$emit('filterItemChange', {
+          widget: this.widget.$uid,
+          field: this.widget.chart.request.field,
+          fieldLabel: this.widget.chart.request.fieldLabel,
+          key: item.key,
+          name: item.metadata.name,
+          mode: add ? 'add' : 'remove',
+        });
+      };
+
+      this.isClickable = function (result) {
+        return (
+          ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') &&
+          !result.metadata.unknown &&
+          (this.widget.chart.request.field === 'api' || this.widget.chart.request.field === 'application')
+        );
+      };
+
+      this.goto = function (key) {
+        // only on platform analytics
+        if ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') {
+          if (this.widget.chart.request.field === 'api') {
+            this.$state.go('management.apis.analytics-overview-v2', {
+              apiId: key,
+              from: this.widget.chart.request.from,
+              to: this.widget.chart.request.to,
+              q: this.widget.chart.request.query,
+            });
+          } else if (this.widget.chart.request.field === 'application') {
+            this.$state.go('management.applications.application.analytics', {
+              applicationId: key,
+              from: this.widget.chart.request.from,
+              to: this.widget.chart.request.to,
+              q: this.widget.chart.request.query,
+            });
+          }
+        }
+      };
+    },
+  ],
 };
 
 export default WidgetDataTableComponent;

--- a/gravitee-apim-console-webui/src/components/widget/widget.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/widget.component.ts
@@ -27,164 +27,170 @@ const WidgetComponent: ng.IComponentOptions = {
     globalQuery: '<',
     customTimeframe: '<',
   },
-  /* @ngInject */
-  controller: function ($scope, $state, AnalyticsService: AnalyticsService, eventService: EventService, ApiService: ApiService) {
-    this.$state = $state;
-    this.AnalyticsService = AnalyticsService;
-    this.eventService = eventService;
-    this.ApiService = ApiService;
+  controller: [
+    '$scope',
+    '$state',
+    'AnalyticsService',
+    'eventService',
+    'ApiService',
+    function ($scope, $state, AnalyticsService: AnalyticsService, eventService: EventService, ApiService: ApiService) {
+      this.$state = $state;
+      this.AnalyticsService = AnalyticsService;
+      this.eventService = eventService;
+      this.ApiService = ApiService;
 
-    $scope.$on('gridster-resized', () => {
-      $scope.$broadcast('onWidgetResize');
-    });
+      $scope.$on('gridster-resized', () => {
+        $scope.$broadcast('onWidgetResize');
+      });
 
-    this.$onChanges = (changes) => {
-      if (changes.customTimeframe && changes.customTimeframe.currentValue) {
-        this.customTimeframe = changes.customTimeframe.currentValue;
-        this.changeTimeframe(this.customTimeframe);
-        // We need to send this event to compute the size of the widget when input data changes.
-        setTimeout(() => {
-          $scope.$broadcast('onWidgetResize');
-        }, 100);
-      }
-    };
-
-    $scope.$on('onTimeframeChange', (event, timeframe) => {
-      this.changeTimeframe(timeframe);
-    });
-
-    const unregisterFn = $scope.$on('onQueryFilterChange', () => {
-      if (this.widget.chart && this.widget.chart.request) {
-        this.reload();
-      }
-    });
-
-    $scope.$on('$destroy', unregisterFn);
-
-    this.changeTimeframe = (timeframe) => {
-      if (this.widget.chart && this.widget.chart.request) {
-        let query;
-
-        if (this.widget.chart.request.query) {
-          query = this.widget.chart.request.query;
+      this.$onChanges = (changes) => {
+        if (changes.customTimeframe && changes.customTimeframe.currentValue) {
+          this.customTimeframe = changes.customTimeframe.currentValue;
+          this.changeTimeframe(this.customTimeframe);
+          // We need to send this event to compute the size of the widget when input data changes.
+          setTimeout(() => {
+            $scope.$broadcast('onWidgetResize');
+          }, 100);
         }
+      };
 
-        // Associate the new timeframe to the chart request
-        _.assignIn(this.widget.chart.request, {
-          interval: timeframe.interval,
-          from: timeframe.from,
-          to: timeframe.to,
-          query: query,
-        });
-        this.reload();
-      }
-    };
+      $scope.$on('onTimeframeChange', (event, timeframe) => {
+        this.changeTimeframe(timeframe);
+      });
 
-    this.reload = () => {
-      // Call the analytics service
-      this.fetchData = true;
-
-      // Prepare arguments
-      const chartRequest = _.cloneDeep(this.widget.chart.request);
-      let field = this.widget.chart.request.field;
-      if (this.widget.chart.request.aggs && this.widget.chart.request.aggs.includes('field:')) {
-        field = this.widget.chart.request.aggs.replace('field:', '');
-      }
-      const queryFilters = this.AnalyticsService.getQueryFilters();
-      if (queryFilters) {
-        let filters;
-        if (Object.keys(queryFilters).find((q) => q === field)) {
-          filters = Object.keys(queryFilters).filter((q) => chartRequest.ranges || q !== field);
-        } else {
-          filters = Object.keys(queryFilters);
+      const unregisterFn = $scope.$on('onQueryFilterChange', () => {
+        if (this.widget.chart && this.widget.chart.request) {
+          this.reload();
         }
+      });
 
-        chartRequest.query = [
-          // Specific initial query or empty string
-          chartRequest.query,
-          filters.map((f) => `(${f}:${queryFilters[f].map((qp) => this.AnalyticsService.buildQueryParam(qp, f)).join(' OR ')})`),
-        ]
-          .reduce((acc, val) => acc.concat(val), [])
-          .filter((part) => part)
-          .join(' AND ');
-      }
+      $scope.$on('$destroy', unregisterFn);
 
-      if (this.globalQuery) {
-        if (chartRequest.query) {
-          if (!_.includes(chartRequest.query, this.globalQuery)) {
-            chartRequest.query += ' AND ' + this.globalQuery;
+      this.changeTimeframe = (timeframe) => {
+        if (this.widget.chart && this.widget.chart.request) {
+          let query;
+
+          if (this.widget.chart.request.query) {
+            query = this.widget.chart.request.query;
           }
-        } else {
-          chartRequest.query = this.globalQuery;
+
+          // Associate the new timeframe to the chart request
+          _.assignIn(this.widget.chart.request, {
+            interval: timeframe.interval,
+            from: timeframe.from,
+            to: timeframe.to,
+            query: query,
+          });
+          this.reload();
         }
-      }
+      };
 
-      const args = [this.widget.root, chartRequest];
+      this.reload = () => {
+        // Call the analytics service
+        this.fetchData = true;
 
-      if (!this.widget.root) {
-        args.splice(0, 1);
-      }
+        // Prepare arguments
+        const chartRequest = _.cloneDeep(this.widget.chart.request);
+        let field = this.widget.chart.request.field;
+        if (this.widget.chart.request.aggs && this.widget.chart.request.aggs.includes('field:')) {
+          field = this.widget.chart.request.aggs.replace('field:', '');
+        }
+        const queryFilters = this.AnalyticsService.getQueryFilters();
+        if (queryFilters) {
+          let filters;
+          if (Object.keys(queryFilters).find((q) => q === field)) {
+            filters = Object.keys(queryFilters).filter((q) => chartRequest.ranges || q !== field);
+          } else {
+            filters = Object.keys(queryFilters);
+          }
 
-      this.widget.chart.service.function
-        .apply(this.widget.chart.service.caller, args)
-        .then((response) => {
-          this.results = response.data;
-          if (this.widget.chart.type === 'line') {
-            if (response.data.timestamp) {
-              // call searchEvent only if there are some results to the aggregation call
-              if (this.$state.params.apiId) {
-                return this.ApiService.searchApiEvents(
-                  ['PUBLISH_API'],
-                  this.$state.params.apiId,
-                  response.data.timestamp.from,
-                  response.data.timestamp.to,
-                  0,
-                  10,
-                ).then((response) => {
-                  this.results.events = response.data;
-                });
-              } else {
-                return this.eventService
-                  .search(['PUBLISH_API'], [], response.data.timestamp.from, response.data.timestamp.to, 0, 10)
-                  .then((response) => {
+          chartRequest.query = [
+            // Specific initial query or empty string
+            chartRequest.query,
+            filters.map((f) => `(${f}:${queryFilters[f].map((qp) => this.AnalyticsService.buildQueryParam(qp, f)).join(' OR ')})`),
+          ]
+            .reduce((acc, val) => acc.concat(val), [])
+            .filter((part) => part)
+            .join(' AND ');
+        }
+
+        if (this.globalQuery) {
+          if (chartRequest.query) {
+            if (!_.includes(chartRequest.query, this.globalQuery)) {
+              chartRequest.query += ' AND ' + this.globalQuery;
+            }
+          } else {
+            chartRequest.query = this.globalQuery;
+          }
+        }
+
+        const args = [this.widget.root, chartRequest];
+
+        if (!this.widget.root) {
+          args.splice(0, 1);
+        }
+
+        this.widget.chart.service.function
+          .apply(this.widget.chart.service.caller, args)
+          .then((response) => {
+            this.results = response.data;
+            if (this.widget.chart.type === 'line') {
+              if (response.data.timestamp) {
+                // call searchEvent only if there are some results to the aggregation call
+                if (this.$state.params.apiId) {
+                  return this.ApiService.searchApiEvents(
+                    ['PUBLISH_API'],
+                    this.$state.params.apiId,
+                    response.data.timestamp.from,
+                    response.data.timestamp.to,
+                    0,
+                    10,
+                  ).then((response) => {
                     this.results.events = response.data;
                   });
+                } else {
+                  return this.eventService
+                    .search(['PUBLISH_API'], [], response.data.timestamp.from, response.data.timestamp.to, 0, 10)
+                    .then((response) => {
+                      this.results.events = response.data;
+                    });
+                }
               }
-            }
-          } else if (this.widget.chart.percent) {
-            delete chartRequest.query;
-            chartRequest.type = 'count';
-            return this.widget.chart.service.function.apply(this.widget.chart.service.caller, args).then((responseTotal) => {
-              _.forEach(this.results.values, (value, key) => {
-                this.results.values[key] = value + '/' + _.round((value / responseTotal.data.hits) * 100, 2);
+            } else if (this.widget.chart.percent) {
+              delete chartRequest.query;
+              chartRequest.type = 'count';
+              return this.widget.chart.service.function.apply(this.widget.chart.service.caller, args).then((responseTotal) => {
+                _.forEach(this.results.values, (value, key) => {
+                  this.results.values[key] = value + '/' + _.round((value / responseTotal.data.hits) * 100, 2);
+                });
               });
-            });
-          }
-        })
-        .finally(() => (this.fetchData = false));
-    };
+            }
+          })
+          .finally(() => (this.fetchData = false));
+      };
 
-    this.delete = () => {
-      $scope.$emit('onWidgetDelete', this.widget);
-    };
+      this.delete = () => {
+        $scope.$emit('onWidgetDelete', this.widget);
+      };
 
-    this.getIconFromType = () => {
-      switch (this.widget.chart.type) {
-        case 'line':
-          return 'multiline_chart';
-        case 'map':
-          return 'map';
-        case 'pie':
-          return 'pie_chart';
-        case 'stats':
-          return 'bubble_chart';
-        case 'table':
-          return 'view_list';
-        default:
-          return 'insert_chart';
-      }
-    };
-  },
+      this.getIconFromType = () => {
+        switch (this.widget.chart.type) {
+          case 'line':
+            return 'multiline_chart';
+          case 'map':
+            return 'map';
+          case 'pie':
+            return 'pie_chart';
+          case 'stats':
+            return 'bubble_chart';
+          case 'table':
+            return 'view_list';
+          default:
+            return 'insert_chart';
+        }
+      };
+    },
+  ],
 };
 
 export default WidgetComponent;

--- a/gravitee-apim-console-webui/src/index.route.ts
+++ b/gravitee-apim-console-webui/src/index.route.ts
@@ -18,13 +18,11 @@ import { StateProvider, UrlService } from '@uirouter/angularjs';
 import OrganizationService from './services/organization.service';
 import UserService from './services/user.service';
 
-/* @ngInject */
 function routerConfig($stateProvider: StateProvider, $urlServiceProvider: UrlService) {
   $stateProvider
     .state('root', {
       resolve: {
-        /* @ngInject */
-        graviteeUser: (UserService: UserService) => UserService.current(),
+        graviteeUser: ['UserService', (UserService: UserService) => UserService.current()],
       },
     })
     .state('withoutSidenav', {
@@ -58,8 +56,7 @@ function routerConfig($stateProvider: StateProvider, $urlServiceProvider: UrlSer
       component: 'user',
       parent: 'withSidenav',
       resolve: {
-        /* @ngInject */
-        user: (UserService: UserService) => UserService.refreshCurrent(),
+        user: ['UserService', (UserService: UserService) => UserService.refreshCurrent()],
       },
     })
     .state('login', {
@@ -74,9 +71,10 @@ function routerConfig($stateProvider: StateProvider, $urlServiceProvider: UrlSer
         }
       },
       resolve: {
-        /* @ngInject */
-        identityProviders: (OrganizationService: OrganizationService) =>
-          OrganizationService.listSocialIdentityProviders().then((response) => response.data),
+        identityProviders: [
+          'OrganizationService',
+          (OrganizationService: OrganizationService) => OrganizationService.listSocialIdentityProviders().then((response) => response.data),
+        ],
       },
       params: {
         redirectUri: {
@@ -117,12 +115,11 @@ function routerConfig($stateProvider: StateProvider, $urlServiceProvider: UrlSer
       controller: 'NewsletterSubscriptionController',
       controllerAs: '$ctrl',
       resolve: {
-        /* @ngInject */
-        taglines: (UserService: UserService) => UserService.getNewsletterTaglines().then((response) => response.data),
+        taglines: ['UserService', (UserService: UserService) => UserService.getNewsletterTaglines().then((response) => response.data)],
       },
     });
 
   $urlServiceProvider.rules.otherwise('/login');
 }
-
+routerConfig.$inject = ['$stateProvider', '$urlServiceProvider'];
 export default routerConfig;

--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -141,7 +141,9 @@ function initComponents() {
 }
 
 function bootstrapApplication(constants: Constants) {
-  angular.module('gravitee-management').config(($urlServiceProvider: UrlService) => $urlServiceProvider.deferIntercept());
+  const urlDeferInterceptorConfig = ($urlServiceProvider: UrlService) => $urlServiceProvider.deferIntercept();
+  urlDeferInterceptorConfig.$inject = ['$urlServiceProvider'];
+  angular.module('gravitee-management').config(urlDeferInterceptorConfig);
   const resourceURL = `${constants.v2BaseURL}/license`;
   const featureInfoData = FeatureInfoData;
   const licenseConfiguration: LicenseConfiguration = {

--- a/gravitee-apim-console-webui/src/libraries/angular-schema-form/boostrap-decorator.ts
+++ b/gravitee-apim-console-webui/src/libraries/angular-schema-form/boostrap-decorator.ts
@@ -1,140 +1,140 @@
 import * as angular from 'angular';
 
-angular.module('schemaForm').run(
-  /* @ngInject */
-  ($templateCache: angular.ITemplateCacheService) => {
-    $templateCache.put(
-      'directives/decorators/bootstrap/actions-trcl.html',
-      '<div class="btn-group schema-form-actions {{form.htmlClass}}" ng-transclude=""></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/actions.html',
-      '<div class="btn-group schema-form-actions {{form.htmlClass}}"><input ng-repeat-start="item in form.items" type="submit" class="btn {{ item.style || "btn-default" }} {{form.fieldHtmlClass}}" value="{{item.title}}" ng-if="item.type === "submit""> <button ng-repeat-end="" class="btn {{ item.style || "btn-default" }} {{form.fieldHtmlClass}}" type="button" ng-disabled="form.readonly" ng-if="item.type !== "submit"" ng-click="buttonClick($event,item)"><span ng-if="item.icon" class="{{item.icon}}"></span>{{item.title}}</button></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/array.html',
-      '<div sf-array="form" class="schema-form-array {{form.htmlClass}}" ng-model="$$value$$" ng-model-options="form.ngModelOptions"><label class="control-label" ng-show="showTitle()">{{ form.title }}</label><ol class="list-group" ng-model="modelArray" ui-sortable=""><li class="list-group-item {{form.fieldHtmlClass}}" ng-repeat="item in modelArray track by $index"><button ng-hide="form.readonly || form.remove === null" ng-click="deleteFromArray($index)" style="position: relative; z-index: 20;" type="button" class="close pull-right"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button><sf-decorator ng-init="arrayIndex = $index" form="copyWithIndex($index)"></sf-decorator></li></ol><div class="clearfix" style="padding: 15px;"><button ng-hide="form.readonly || form.add === null" ng-click="appendToArray()" type="button" class="btn {{ form.style.add || "btn-default" }} pull-right"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</button></div><div class="help-block" ng-show="(hasError() && errorMessage(schemaError())) || form.description" ng-bind-html="(hasError() && errorMessage(schemaError())) || form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/checkbox.html',
-      '<div class="checkbox schema-form-checkbox {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="{{form.labelHtmlClass}}"><input type="checkbox" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="{{form.fieldHtmlClass}}" name="{{form.key.slice(-1)[0]}}"> <span ng-bind-html="form.title"></span></label><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/checkboxes.html',
-      '<div sf-array="form" ng-model="$$value$$" class="form-group schema-form-checkboxes {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div class="checkbox" ng-repeat="val in titleMapValues track by $index"><label><input type="checkbox" ng-disabled="form.readonly" sf-changed="form" class="{{form.fieldHtmlClass}}" ng-model="titleMapValues[$index]" name="{{form.key.slice(-1)[0]}}"> <span ng-bind-html="form.titleMap[$index].name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/default.html',
-      '<div class="form-group schema-form-{{form.type}} {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess(), "has-feedback": form.feedback !== false }"><label class="control-label {{form.labelHtmlClass}}" ng-class="{"sr-only": !showTitle()}" for="{{form.key.slice(-1)[0]}}">{{form.title}}</label> <input ng-if="!form.fieldAddonLeft && !form.fieldAddonRight" ng-show="form.key" type="{{form.type}}" step="any" sf-changed="form" placeholder="{{form.placeholder}}" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" ng-model-options="form.ngModelOptions" ng-model="$$value$$" ng-disabled="form.readonly" schema-validate="form" name="{{form.key.slice(-1)[0]}}" aria-describedby="{{form.key.slice(-1)[0] + "Status"}}"><div ng-if="form.fieldAddonLeft || form.fieldAddonRight" ng-class="{"input-group": (form.fieldAddonLeft || form.fieldAddonRight)}"><span ng-if="form.fieldAddonLeft" class="input-group-addon" ng-bind-html="form.fieldAddonLeft"></span> <input ng-show="form.key" type="{{form.type}}" step="any" sf-changed="form" placeholder="{{form.placeholder}}" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" ng-model-options="form.ngModelOptions" ng-model="$$value$$" ng-disabled="form.readonly" schema-validate="form" name="{{form.key.slice(-1)[0]}}" aria-describedby="{{form.key.slice(-1)[0] + "Status"}}"> <span ng-if="form.fieldAddonRight" class="input-group-addon" ng-bind-html="form.fieldAddonRight"></span></div><span ng-if="form.feedback !== false" class="form-control-feedback" ng-class="evalInScope(form.feedback) || {"glyphicon": true, "glyphicon-ok": hasSuccess(), "glyphicon-remove": hasError() }" aria-hidden="true"></span> <span ng-if="hasError() || hasSuccess()" id="{{form.key.slice(-1)[0] + "Status"}}" class="sr-only">{{ hasSuccess() ? "(success)" : "(error)" }}</span><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/fieldset-trcl.html',
-      '<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}"><legend ng-class="{"sr-only": !showTitle() }">{{ form.title }}</legend><div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div><div ng-transclude=""></div></fieldset>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/fieldset.html',
-      '<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}"><legend ng-class="{"sr-only": !showTitle() }">{{ form.title }}</legend><div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div><sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator></fieldset>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/help.html',
-      '<div class="helpvalue schema-form-helpvalue {{form.htmlClass}}" ng-bind-html="form.helpvalue"></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/radio-buttons.html',
-      '<div class="form-group schema-form-radiobuttons {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><div><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label></div><div class="btn-group"><label class="btn {{ (item.value === $$value$$) ? form.style.selected || "btn-default" : form.style.unselected || "btn-default"; }}" ng-class="{ active: item.value === $$value$$ }" ng-repeat="item in form.titleMap"><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" style="display: none;" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/radios-inline.html',
-      '<div class="form-group schema-form-radios-inline {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div><label class="radio-inline" ng-repeat="item in form.titleMap"><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/radios.html',
-      '<div class="form-group schema-form-radios {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div class="radio" ng-repeat="item in form.titleMap"><label><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/section.html',
-      '<div class="schema-form-section {{form.htmlClass}}"><sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/select.html',
-      '<div class="form-group {{form.htmlClass}} schema-form-select" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess(), "has-feedback": form.feedback !== false}"><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><select ng-model="$$value$$" ng-model-options="form.ngModelOptions" ng-disabled="form.readonly" sf-changed="form" class="form-control {{form.fieldHtmlClass}}" schema-validate="form" ng-options="item.value as item.name group by item.group for item in form.titleMap" name="{{form.key.slice(-1)[0]}}"></select><div class="help-block" sf-message="form.description"></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/submit.html',
-      '<div class="form-group schema-form-submit {{form.htmlClass}}"><input type="submit" class="btn {{ form.style || "btn-primary" }} {{form.fieldHtmlClass}}" value="{{form.title}}" ng-disabled="form.readonly" ng-if="form.type === "submit""> <button class="btn {{ form.style || "btn-default" }}" type="button" ng-click="buttonClick($event,form)" ng-disabled="form.readonly" ng-if="form.type !== "submit""><span ng-if="form.icon" class="{{form.icon}}"></span> {{form.title}}</button></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/tabarray.html',
-      '<div sf-array="form" ng-init="selected = { tab: 0 }" class="clearfix schema -form-tabarray schema-form-tabarray-{{form.tabType || "left"}} {{form.htmlClass}}"><div ng-if="!form.tabType || form.tabType !== "right"" ng-class="{"col-xs-3": !form.tabType || form.tabType === "left"}"><ul class="nav nav-tabs" ng-class="{ "tabs-left": !form.tabType || form.tabType === "left"}"><li ng-repeat="item in modelArray track by $index" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{interp(form.title,{"$index":$index, value: item}) || $index}}</a></li><li ng-hide="form.readonly" ng-click="$event.preventDefault() || (selected.tab = appendToArray().length-1)"><a href="#"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</a></li></ul></div><div ng-class="{"col-xs-9": !form.tabType || form.tabType === "left" || form.tabType === "right"}"><div class="tab-content {{form.fieldHtmlClass}}"><div class="tab-pane clearfix" ng-repeat="item in modelArray track by $index" ng-show="selected.tab === $index" ng-class="{active: selected.tab === $index}"><sf-decorator ng-init="arrayIndex = $index" form="copyWithIndex($index)"></sf-decorator><button ng-hide="form.readonly" ng-click="selected.tab = deleteFromArray($index).length-1" type="button" class="btn {{ form.style.remove || "btn-default" }} pull-right"><i class="glyphicon glyphicon-trash"></i> {{ form.remove || "Remove"}}</button></div></div></div><div ng-if="form.tabType === "right"" class="col-xs-3"><ul class="nav nav-tabs tabs-right"><li ng-repeat="item in modelArray track by $index" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{interp(form.title,{"$index":$index, value: item}) || $index}}</a></li><li ng-hide="form.readonly" ng-click="$event.preventDefault() || appendToArray()"><a href="#"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</a></li></ul></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/tabs.html',
-      '<div ng-init="selected = { tab: 0 }" class="schema-form-tabs {{form.htmlClass}}"><ul class="nav nav-tabs"><li ng-repeat="tab in form.tabs" ng-disabled="form.readonly" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{ tab.title }}</a></li></ul><div class="tab-content {{form.fieldHtmlClass}}"><div class="tab-pane" ng-disabled="form.readonly" ng-repeat="tab in form.tabs" ng-show="selected.tab === $index" ng-class="{active: selected.tab === $index}"><bootstrap-decorator ng-repeat="item in tab.items" form="item"></bootstrap-decorator></div></div></div>',
-    );
-    $templateCache.put(
-      'directives/decorators/bootstrap/textarea.html',
-      '<div class="form-group has-feedback {{form.htmlClass}} schema-form-textarea" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="{{form.labelHtmlClass}}" ng-class="{"sr-only": !showTitle()}" for="{{form.key.slice(-1)[0]}}">{{form.title}}</label> <textarea ng-if="!form.fieldAddonLeft && !form.fieldAddonRight" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" sf-changed="form" placeholder="{{form.placeholder}}" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" name="{{form.key.slice(-1)[0]}}"></textarea><div ng-if="form.fieldAddonLeft || form.fieldAddonRight" ng-class="{"input-group": (form.fieldAddonLeft || form.fieldAddonRight)}"><span ng-if="form.fieldAddonLeft" class="input-group-addon" ng-bind-html="form.fieldAddonLeft"></span> <textarea class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" sf-changed="form" placeholder="{{form.placeholder}}" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" name="{{form.key.slice(-1)[0]}}"></textarea> <span ng-if="form.fieldAddonRight" class="input-group-addon" ng-bind-html="form.fieldAddonRight"></span></div><span class="help-block" sf-message="form.description"></span></div>',
-    );
-  },
-);
+const initTemplateCacheRun = ($templateCache: angular.ITemplateCacheService) => {
+  $templateCache.put(
+    'directives/decorators/bootstrap/actions-trcl.html',
+    '<div class="btn-group schema-form-actions {{form.htmlClass}}" ng-transclude=""></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/actions.html',
+    '<div class="btn-group schema-form-actions {{form.htmlClass}}"><input ng-repeat-start="item in form.items" type="submit" class="btn {{ item.style || "btn-default" }} {{form.fieldHtmlClass}}" value="{{item.title}}" ng-if="item.type === "submit""> <button ng-repeat-end="" class="btn {{ item.style || "btn-default" }} {{form.fieldHtmlClass}}" type="button" ng-disabled="form.readonly" ng-if="item.type !== "submit"" ng-click="buttonClick($event,item)"><span ng-if="item.icon" class="{{item.icon}}"></span>{{item.title}}</button></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/array.html',
+    '<div sf-array="form" class="schema-form-array {{form.htmlClass}}" ng-model="$$value$$" ng-model-options="form.ngModelOptions"><label class="control-label" ng-show="showTitle()">{{ form.title }}</label><ol class="list-group" ng-model="modelArray" ui-sortable=""><li class="list-group-item {{form.fieldHtmlClass}}" ng-repeat="item in modelArray track by $index"><button ng-hide="form.readonly || form.remove === null" ng-click="deleteFromArray($index)" style="position: relative; z-index: 20;" type="button" class="close pull-right"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button><sf-decorator ng-init="arrayIndex = $index" form="copyWithIndex($index)"></sf-decorator></li></ol><div class="clearfix" style="padding: 15px;"><button ng-hide="form.readonly || form.add === null" ng-click="appendToArray()" type="button" class="btn {{ form.style.add || "btn-default" }} pull-right"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</button></div><div class="help-block" ng-show="(hasError() && errorMessage(schemaError())) || form.description" ng-bind-html="(hasError() && errorMessage(schemaError())) || form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/checkbox.html',
+    '<div class="checkbox schema-form-checkbox {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="{{form.labelHtmlClass}}"><input type="checkbox" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="{{form.fieldHtmlClass}}" name="{{form.key.slice(-1)[0]}}"> <span ng-bind-html="form.title"></span></label><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/checkboxes.html',
+    '<div sf-array="form" ng-model="$$value$$" class="form-group schema-form-checkboxes {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div class="checkbox" ng-repeat="val in titleMapValues track by $index"><label><input type="checkbox" ng-disabled="form.readonly" sf-changed="form" class="{{form.fieldHtmlClass}}" ng-model="titleMapValues[$index]" name="{{form.key.slice(-1)[0]}}"> <span ng-bind-html="form.titleMap[$index].name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/default.html',
+    '<div class="form-group schema-form-{{form.type}} {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess(), "has-feedback": form.feedback !== false }"><label class="control-label {{form.labelHtmlClass}}" ng-class="{"sr-only": !showTitle()}" for="{{form.key.slice(-1)[0]}}">{{form.title}}</label> <input ng-if="!form.fieldAddonLeft && !form.fieldAddonRight" ng-show="form.key" type="{{form.type}}" step="any" sf-changed="form" placeholder="{{form.placeholder}}" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" ng-model-options="form.ngModelOptions" ng-model="$$value$$" ng-disabled="form.readonly" schema-validate="form" name="{{form.key.slice(-1)[0]}}" aria-describedby="{{form.key.slice(-1)[0] + "Status"}}"><div ng-if="form.fieldAddonLeft || form.fieldAddonRight" ng-class="{"input-group": (form.fieldAddonLeft || form.fieldAddonRight)}"><span ng-if="form.fieldAddonLeft" class="input-group-addon" ng-bind-html="form.fieldAddonLeft"></span> <input ng-show="form.key" type="{{form.type}}" step="any" sf-changed="form" placeholder="{{form.placeholder}}" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" ng-model-options="form.ngModelOptions" ng-model="$$value$$" ng-disabled="form.readonly" schema-validate="form" name="{{form.key.slice(-1)[0]}}" aria-describedby="{{form.key.slice(-1)[0] + "Status"}}"> <span ng-if="form.fieldAddonRight" class="input-group-addon" ng-bind-html="form.fieldAddonRight"></span></div><span ng-if="form.feedback !== false" class="form-control-feedback" ng-class="evalInScope(form.feedback) || {"glyphicon": true, "glyphicon-ok": hasSuccess(), "glyphicon-remove": hasError() }" aria-hidden="true"></span> <span ng-if="hasError() || hasSuccess()" id="{{form.key.slice(-1)[0] + "Status"}}" class="sr-only">{{ hasSuccess() ? "(success)" : "(error)" }}</span><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/fieldset-trcl.html',
+    '<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}"><legend ng-class="{"sr-only": !showTitle() }">{{ form.title }}</legend><div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div><div ng-transclude=""></div></fieldset>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/fieldset.html',
+    '<fieldset ng-disabled="form.readonly" class="schema-form-fieldset {{form.htmlClass}}"><legend ng-class="{"sr-only": !showTitle() }">{{ form.title }}</legend><div class="help-block" ng-show="form.description" ng-bind-html="form.description"></div><sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator></fieldset>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/help.html',
+    '<div class="helpvalue schema-form-helpvalue {{form.htmlClass}}" ng-bind-html="form.helpvalue"></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/radio-buttons.html',
+    '<div class="form-group schema-form-radiobuttons {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><div><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label></div><div class="btn-group"><label class="btn {{ (item.value === $$value$$) ? form.style.selected || "btn-default" : form.style.unselected || "btn-default"; }}" ng-class="{ active: item.value === $$value$$ }" ng-repeat="item in form.titleMap"><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" style="display: none;" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/radios-inline.html',
+    '<div class="form-group schema-form-radios-inline {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div><label class="radio-inline" ng-repeat="item in form.titleMap"><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/radios.html',
+    '<div class="form-group schema-form-radios {{form.htmlClass}}" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><div class="radio" ng-repeat="item in form.titleMap"><label><input type="radio" class="{{form.fieldHtmlClass}}" sf-changed="form" ng-disabled="form.readonly" ng-model="$$value$$" ng-value="item.value" name="{{form.key.join(".")}}"> <span ng-bind-html="item.name"></span></label></div><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/section.html',
+    '<div class="schema-form-section {{form.htmlClass}}"><sf-decorator ng-repeat="item in form.items" form="item"></sf-decorator></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/select.html',
+    '<div class="form-group {{form.htmlClass}} schema-form-select" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess(), "has-feedback": form.feedback !== false}"><label class="control-label {{form.labelHtmlClass}}" ng-show="showTitle()">{{form.title}}</label><select ng-model="$$value$$" ng-model-options="form.ngModelOptions" ng-disabled="form.readonly" sf-changed="form" class="form-control {{form.fieldHtmlClass}}" schema-validate="form" ng-options="item.value as item.name group by item.group for item in form.titleMap" name="{{form.key.slice(-1)[0]}}"></select><div class="help-block" sf-message="form.description"></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/submit.html',
+    '<div class="form-group schema-form-submit {{form.htmlClass}}"><input type="submit" class="btn {{ form.style || "btn-primary" }} {{form.fieldHtmlClass}}" value="{{form.title}}" ng-disabled="form.readonly" ng-if="form.type === "submit""> <button class="btn {{ form.style || "btn-default" }}" type="button" ng-click="buttonClick($event,form)" ng-disabled="form.readonly" ng-if="form.type !== "submit""><span ng-if="form.icon" class="{{form.icon}}"></span> {{form.title}}</button></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/tabarray.html',
+    '<div sf-array="form" ng-init="selected = { tab: 0 }" class="clearfix schema -form-tabarray schema-form-tabarray-{{form.tabType || "left"}} {{form.htmlClass}}"><div ng-if="!form.tabType || form.tabType !== "right"" ng-class="{"col-xs-3": !form.tabType || form.tabType === "left"}"><ul class="nav nav-tabs" ng-class="{ "tabs-left": !form.tabType || form.tabType === "left"}"><li ng-repeat="item in modelArray track by $index" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{interp(form.title,{"$index":$index, value: item}) || $index}}</a></li><li ng-hide="form.readonly" ng-click="$event.preventDefault() || (selected.tab = appendToArray().length-1)"><a href="#"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</a></li></ul></div><div ng-class="{"col-xs-9": !form.tabType || form.tabType === "left" || form.tabType === "right"}"><div class="tab-content {{form.fieldHtmlClass}}"><div class="tab-pane clearfix" ng-repeat="item in modelArray track by $index" ng-show="selected.tab === $index" ng-class="{active: selected.tab === $index}"><sf-decorator ng-init="arrayIndex = $index" form="copyWithIndex($index)"></sf-decorator><button ng-hide="form.readonly" ng-click="selected.tab = deleteFromArray($index).length-1" type="button" class="btn {{ form.style.remove || "btn-default" }} pull-right"><i class="glyphicon glyphicon-trash"></i> {{ form.remove || "Remove"}}</button></div></div></div><div ng-if="form.tabType === "right"" class="col-xs-3"><ul class="nav nav-tabs tabs-right"><li ng-repeat="item in modelArray track by $index" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{interp(form.title,{"$index":$index, value: item}) || $index}}</a></li><li ng-hide="form.readonly" ng-click="$event.preventDefault() || appendToArray()"><a href="#"><i class="glyphicon glyphicon-plus"></i> {{ form.add || "Add"}}</a></li></ul></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/tabs.html',
+    '<div ng-init="selected = { tab: 0 }" class="schema-form-tabs {{form.htmlClass}}"><ul class="nav nav-tabs"><li ng-repeat="tab in form.tabs" ng-disabled="form.readonly" ng-click="$event.preventDefault() || (selected.tab = $index)" ng-class="{active: selected.tab === $index}"><a href="#">{{ tab.title }}</a></li></ul><div class="tab-content {{form.fieldHtmlClass}}"><div class="tab-pane" ng-disabled="form.readonly" ng-repeat="tab in form.tabs" ng-show="selected.tab === $index" ng-class="{active: selected.tab === $index}"><bootstrap-decorator ng-repeat="item in tab.items" form="item"></bootstrap-decorator></div></div></div>',
+  );
+  $templateCache.put(
+    'directives/decorators/bootstrap/textarea.html',
+    '<div class="form-group has-feedback {{form.htmlClass}} schema-form-textarea" ng-class="{"has-error": form.disableErrorState !== true && hasError(), "has-success": form.disableSuccessState !== true && hasSuccess()}"><label class="{{form.labelHtmlClass}}" ng-class="{"sr-only": !showTitle()}" for="{{form.key.slice(-1)[0]}}">{{form.title}}</label> <textarea ng-if="!form.fieldAddonLeft && !form.fieldAddonRight" class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" sf-changed="form" placeholder="{{form.placeholder}}" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" name="{{form.key.slice(-1)[0]}}"></textarea><div ng-if="form.fieldAddonLeft || form.fieldAddonRight" ng-class="{"input-group": (form.fieldAddonLeft || form.fieldAddonRight)}"><span ng-if="form.fieldAddonLeft" class="input-group-addon" ng-bind-html="form.fieldAddonLeft"></span> <textarea class="form-control {{form.fieldHtmlClass}}" id="{{form.key.slice(-1)[0]}}" sf-changed="form" placeholder="{{form.placeholder}}" ng-disabled="form.readonly" ng-model="$$value$$" ng-model-options="form.ngModelOptions" schema-validate="form" name="{{form.key.slice(-1)[0]}}"></textarea> <span ng-if="form.fieldAddonRight" class="input-group-addon" ng-bind-html="form.fieldAddonRight"></span></div><span class="help-block" sf-message="form.description"></span></div>',
+  );
+};
+initTemplateCacheRun.$inject = ['$templateCache'];
+angular.module('schemaForm').run(initTemplateCacheRun);
+
+const bootstrapDecoratorConfig = (schemaFormDecoratorsProvider) => {
+  const base = 'directives/decorators/bootstrap/';
+
+  schemaFormDecoratorsProvider.defineDecorator(
+    'bootstrapDecorator',
+    {
+      textarea: { template: base + 'textarea.html', replace: false },
+      fieldset: { template: base + 'fieldset.html', replace: false },
+      /* fieldset: {template: base + 'fieldset.html', replace: true, builder: function(args) {
+ var children = args.build(args.form.items, args.path + '.items');
+ console.log('fieldset children frag', children.childNodes)
+ args.fieldFrag.childNode.appendChild(children);
+ }},*/
+      array: { template: base + 'array.html', replace: false },
+      tabarray: { template: base + 'tabarray.html', replace: false },
+      tabs: { template: base + 'tabs.html', replace: false },
+      section: { template: base + 'section.html', replace: false },
+      conditional: { template: base + 'section.html', replace: false },
+      actions: { template: base + 'actions.html', replace: false },
+      select: { template: base + 'select.html', replace: false },
+      checkbox: { template: base + 'checkbox.html', replace: false },
+      checkboxes: { template: base + 'checkboxes.html', replace: false },
+      number: { template: base + 'default.html', replace: false },
+      password: { template: base + 'default.html', replace: false },
+      submit: { template: base + 'submit.html', replace: false },
+      button: { template: base + 'submit.html', replace: false },
+      radios: { template: base + 'radios.html', replace: false },
+      'radios-inline': { template: base + 'radios-inline.html', replace: false },
+      radiobuttons: { template: base + 'radio-buttons.html', replace: false },
+      help: { template: base + 'help.html', replace: false },
+      default: { template: base + 'default.html', replace: false },
+    },
+    [],
+  );
+
+  // manual use directives
+  schemaFormDecoratorsProvider.createDirectives({
+    textarea: base + 'textarea.html',
+    select: base + 'select.html',
+    checkbox: base + 'checkbox.html',
+    checkboxes: base + 'checkboxes.html',
+    number: base + 'default.html',
+    submit: base + 'submit.html',
+    button: base + 'submit.html',
+    text: base + 'default.html',
+    date: base + 'default.html',
+    password: base + 'default.html',
+    datepicker: base + 'datepicker.html',
+    input: base + 'default.html',
+    radios: base + 'radios.html',
+    'radios-inline': base + 'radios-inline.html',
+    radiobuttons: base + 'radio-buttons.html',
+  });
+};
+bootstrapDecoratorConfig.$inject = ['schemaFormDecoratorsProvider'];
 angular
   .module('schemaForm')
-  .config(
-    /* @ngInject */ (schemaFormDecoratorsProvider) => {
-      const base = 'directives/decorators/bootstrap/';
-
-      schemaFormDecoratorsProvider.defineDecorator(
-        'bootstrapDecorator',
-        {
-          textarea: { template: base + 'textarea.html', replace: false },
-          fieldset: { template: base + 'fieldset.html', replace: false },
-          /* fieldset: {template: base + 'fieldset.html', replace: true, builder: function(args) {
-     var children = args.build(args.form.items, args.path + '.items');
-     console.log('fieldset children frag', children.childNodes)
-     args.fieldFrag.childNode.appendChild(children);
-     }},*/
-          array: { template: base + 'array.html', replace: false },
-          tabarray: { template: base + 'tabarray.html', replace: false },
-          tabs: { template: base + 'tabs.html', replace: false },
-          section: { template: base + 'section.html', replace: false },
-          conditional: { template: base + 'section.html', replace: false },
-          actions: { template: base + 'actions.html', replace: false },
-          select: { template: base + 'select.html', replace: false },
-          checkbox: { template: base + 'checkbox.html', replace: false },
-          checkboxes: { template: base + 'checkboxes.html', replace: false },
-          number: { template: base + 'default.html', replace: false },
-          password: { template: base + 'default.html', replace: false },
-          submit: { template: base + 'submit.html', replace: false },
-          button: { template: base + 'submit.html', replace: false },
-          radios: { template: base + 'radios.html', replace: false },
-          'radios-inline': { template: base + 'radios-inline.html', replace: false },
-          radiobuttons: { template: base + 'radio-buttons.html', replace: false },
-          help: { template: base + 'help.html', replace: false },
-          default: { template: base + 'default.html', replace: false },
-        },
-        [],
-      );
-
-      // manual use directives
-      schemaFormDecoratorsProvider.createDirectives({
-        textarea: base + 'textarea.html',
-        select: base + 'select.html',
-        checkbox: base + 'checkbox.html',
-        checkboxes: base + 'checkboxes.html',
-        number: base + 'default.html',
-        submit: base + 'submit.html',
-        button: base + 'submit.html',
-        text: base + 'default.html',
-        date: base + 'default.html',
-        password: base + 'default.html',
-        datepicker: base + 'datepicker.html',
-        input: base + 'default.html',
-        radios: base + 'radios.html',
-        'radios-inline': base + 'radios-inline.html',
-        radiobuttons: base + 'radio-buttons.html',
-      });
-    },
-  )
+  .config(bootstrapDecoratorConfig)
   .directive('sfFieldset', () => {
     return {
       transclude: true,

--- a/gravitee-apim-console-webui/src/libraries/angular-schema-form/codemirror-decorator.ts
+++ b/gravitee-apim-console-webui/src/libraries/angular-schema-form/codemirror-decorator.ts
@@ -5,19 +5,16 @@ angular.module('schemaForm').run(($templateCache) => {
   );
 });
 
+const codemirrorConfig = (schemaFormDecoratorsProvider) => {
+  // Add to the bootstrap directive
+  schemaFormDecoratorsProvider.addMapping('bootstrapDecorator', 'codemirror', 'directives/decorators/bootstrap/codemirror/codemirror.html');
+  schemaFormDecoratorsProvider.createDirective('codemirror', 'directives/decorators/bootstrap/codemirror/codemirror.html');
+};
+codemirrorConfig.$inject = ['schemaFormDecoratorsProvider'];
+
 angular
   .module('schemaForm')
-  .config(
-    /* @ngInject */ (schemaFormProvider, schemaFormDecoratorsProvider) => {
-      // Add to the bootstrap directive
-      schemaFormDecoratorsProvider.addMapping(
-        'bootstrapDecorator',
-        'codemirror',
-        'directives/decorators/bootstrap/codemirror/codemirror.html',
-      );
-      schemaFormDecoratorsProvider.createDirective('codemirror', 'directives/decorators/bootstrap/codemirror/codemirror.html');
-    },
-  )
+  .config(codemirrorConfig)
 
   .directive('codemirrorButtons', () => {
     return {

--- a/gravitee-apim-console-webui/src/libraries/angular-ui-codemirror/ui-codemirror.js
+++ b/gravitee-apim-console-webui/src/libraries/angular-ui-codemirror/ui-codemirror.js
@@ -5,9 +5,6 @@
  */
 angular.module('ui.codemirror', []).constant('uiCodemirrorConfig', {}).directive('uiCodemirror', uiCodemirrorDirective);
 
-/**
- * @ngInject
- */
 function uiCodemirrorDirective($timeout, uiCodemirrorConfig) {
   return {
     restrict: 'EA',

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
@@ -28,7 +28,6 @@ class ApiKeysController {
   private listEvent: Observable<void>;
   private backStateParams: StateParams;
 
-  /* @ngInject */
   constructor(
     private $mdDialog: angular.material.IDialogService,
     private NotificationService: NotificationService,
@@ -122,5 +121,6 @@ class ApiKeysController {
     return this.isSharedApiKey() ? 'Shared API Key' : 'API Keys';
   }
 }
+ApiKeysController.$inject = ['$mdDialog', 'NotificationService', 'ApplicationService', '$state'];
 
 export default ApiKeysController;

--- a/gravitee-apim-console-webui/src/management/api/analytics/alerts/api-alerts-dashboard.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/alerts/api-alerts-dashboard.controller.ajs.ts
@@ -23,7 +23,6 @@ class ApiAlertsDashboardControllerAjs {
   private hasAlertingPlugin: boolean;
   apiId: string;
 
-  /* @ngInject */
   constructor(private readonly $state: StateService, private readonly AlertService: AlertService, private readonly $q: ng.IQService) {
     this.apiId = this.$state.params.apiId;
   }
@@ -40,5 +39,6 @@ class ApiAlertsDashboardControllerAjs {
       });
   }
 }
+ApiAlertsDashboardControllerAjs.$inject = ['$state', 'AlertService', '$q'];
 
 export default ApiAlertsDashboardControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-log.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-log.component.ajs.ts
@@ -63,8 +63,6 @@ class ApiAnalyticsLogControllerAjs {
       (obj.headersAsList as Array<[string, string]>).sort(([key1], [key2]) => key1.localeCompare(key2));
     }
   }
-
-  /* @ngInject */
   constructor(
     public readonly Constants: any,
     private readonly $state: StateService,
@@ -238,6 +236,7 @@ class ApiAnalyticsLogControllerAjs {
     this.NotificationService.show('Body has been copied to clipboard');
   }
 }
+ApiAnalyticsLogControllerAjs.$inject = ['Constants', '$state', 'NotificationService', 'AnalyticsService', 'ApiService'];
 
 export const ApiAnalyticsLogComponentAjs: ng.IComponentOptions = {
   controller: ApiAnalyticsLogControllerAjs,

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -32,7 +32,6 @@ class ApiAnalyticsLogsControllerAjs {
   };
   private init: boolean;
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private $scope: IScope,
@@ -146,5 +145,15 @@ class ApiAnalyticsLogsControllerAjs {
     });
   }
 }
+ApiAnalyticsLogsControllerAjs.$inject = [
+  'ApiService',
+  '$scope',
+  'Constants',
+  '$state',
+  '$timeout',
+  'AnalyticsService',
+  'TenantService',
+  '$q',
+];
 
 export default ApiAnalyticsLogsControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/analytics/overview/analytics-overview.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/overview/analytics-overview.controller.ajs.ts
@@ -24,7 +24,6 @@ class ApiAnalyticsOverviewControllerAjs {
   private dashboard: any;
   private dashboards: any[];
 
-  /* @ngInject */
   constructor(
     private ApiService,
     private DashboardService: DashboardService,
@@ -90,5 +89,6 @@ class ApiAnalyticsOverviewControllerAjs {
     this.$state.transitionTo(this.$state.current, _.merge(this.$state.params, { dashboard: dashboardId }), { reload: true });
   }
 }
+ApiAnalyticsOverviewControllerAjs.$inject = ['ApiService', 'DashboardService', '$scope', '$state', '$q'];
 
 export default ApiAnalyticsOverviewControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/audit/general/audit.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/general/audit.controller.ajs.ts
@@ -17,7 +17,6 @@
 import AuditService from '../../../../services/audit.service';
 
 class ApiAuditControllerAjs {
-  /* @ngInject */
   constructor(private AuditService: AuditService, private $scope, private $state) {
     this.$scope.api = this.$state.params.apiId;
     this.$scope.apis = [{ id: this.$state.params.apiId }];
@@ -30,4 +29,6 @@ class ApiAuditControllerAjs {
     });
   }
 }
+ApiAuditControllerAjs.$inject = ['AuditService', '$scope', '$state'];
+
 export default ApiAuditControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
@@ -135,7 +135,6 @@ class ApiHistoryControllerAjs {
   private added: number;
   private removed: number;
 
-  /* @ngInject */
   constructor(
     private $mdDialog: ng.material.IDialogService,
     private $scope: any,
@@ -526,5 +525,18 @@ class ApiHistoryControllerAjs {
       .catch(() => (target.documentation = null));
   }
 }
+ApiHistoryControllerAjs.$inject = [
+  '$mdDialog',
+  '$scope',
+  '$rootScope',
+  '$state',
+  'ApiService',
+  'NotificationService',
+  'AuditService',
+  'PolicyService',
+  'ResourceService',
+  'FlowService',
+  'ngApiV2Service',
+];
 
 export default ApiHistoryControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step1.component.ts
@@ -23,34 +23,36 @@ const ApiCreationStep1Component: ng.IComponentOptions = {
     parent: '^apiCreationV2ComponentAjs',
   },
   template: require('./api-creation-step1.html'),
-  controller: class {
-    private parent: ApiCreationV2ControllerAjs;
-    private advancedMode: boolean;
-    private useGroupAsPrimaryOwner: boolean;
-    public shouldDisplayHint = shouldDisplayHint;
+  controller: [
+    'ApiPrimaryOwnerModeService',
+    class {
+      private parent: ApiCreationV2ControllerAjs;
+      private advancedMode: boolean;
+      private useGroupAsPrimaryOwner: boolean;
+      public shouldDisplayHint = shouldDisplayHint;
 
-    /* @ngInject */
-    constructor(private ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService) {
-      this.advancedMode = false;
-      this.useGroupAsPrimaryOwner = this.ApiPrimaryOwnerModeService.isGroupOnly();
-    }
-
-    toggleAdvancedMode = () => {
-      this.advancedMode = !this.advancedMode;
-      if (!this.advancedMode) {
-        this.parent.api.groups = [];
+      constructor(private ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService) {
+        this.advancedMode = false;
+        this.useGroupAsPrimaryOwner = this.ApiPrimaryOwnerModeService.isGroupOnly();
       }
-    };
 
-    canUseAdvancedMode = () => {
-      return (
-        (this.ApiPrimaryOwnerModeService.isHybrid() &&
-          ((this.parent.attachableGroups && this.parent.attachableGroups.length > 0) ||
-            (this.parent.poGroups && this.parent.poGroups.length > 0))) ||
-        (this.ApiPrimaryOwnerModeService.isGroupOnly() && this.parent.attachableGroups && this.parent.attachableGroups.length > 0)
-      );
-    };
-  },
+      toggleAdvancedMode = () => {
+        this.advancedMode = !this.advancedMode;
+        if (!this.advancedMode) {
+          this.parent.api.groups = [];
+        }
+      };
+
+      canUseAdvancedMode = () => {
+        return (
+          (this.ApiPrimaryOwnerModeService.isHybrid() &&
+            ((this.parent.attachableGroups && this.parent.attachableGroups.length > 0) ||
+              (this.parent.poGroups && this.parent.poGroups.length > 0))) ||
+          (this.ApiPrimaryOwnerModeService.isGroupOnly() && this.parent.attachableGroups && this.parent.attachableGroups.length > 0)
+        );
+      };
+    },
+  ],
 };
 
 export default ApiCreationStep1Component;

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step2.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step2.component.ts
@@ -27,7 +27,6 @@ const ApiCreationStep2Component: ng.IComponentOptions = {
     private parent: ApiCreationV2ControllerAjs;
     private advancedMode: boolean;
 
-    /* @ngInject */
     constructor() {
       this.advancedMode = false;
     }

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step5.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-step5.component.ts
@@ -18,14 +18,16 @@ const ApiCreationStep5Component: ng.IComponentOptions = {
     parent: '^apiCreationV2ComponentAjs',
   },
   template: require('./api-creation-step5.html'),
-  /* @ngInject */
-  controller: function (Constants) {
-    if (Constants.env.settings.documentation && Constants.env.settings.documentation.url) {
-      this.url = Constants.env.settings.documentation.url;
-    } else {
-      this.url = 'https://docs.gravitee.io';
-    }
-  },
+  controller: [
+    'Constants',
+    function (Constants) {
+      if (Constants.env.settings.documentation && Constants.env.settings.documentation.url) {
+        this.url = Constants.env.settings.documentation.url;
+      } else {
+        this.url = 'https://docs.gravitee.io';
+      }
+    },
+  ],
 };
 
 export default ApiCreationStep5Component;

--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.ts
@@ -87,7 +87,6 @@ class ApiCreationV2ControllerAjs {
   private tenants: any[];
   private groups: any[];
 
-  /* @ngInject */
   constructor(
     private $scope,
     private $timeout,
@@ -529,5 +528,20 @@ class ApiCreationV2ControllerAjs {
     this.skippedStep = true;
   }
 }
+ApiCreationV2ControllerAjs.$inject = [
+  '$scope',
+  '$timeout',
+  '$mdDialog',
+  '$stateParams',
+  '$window',
+  'ApiService',
+  'ngApiV2Service',
+  'NotificationService',
+  'UserService',
+  '$state',
+  'Constants',
+  '$rootScope',
+  'ngIfMatchEtagInterceptor',
+];
 
 export default ApiCreationV2ControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/design/policies/addPoliciesPath.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/policies/addPoliciesPath.controller.ts
@@ -21,7 +21,6 @@ class AddPoliciesPathController {
   private rootCtrl: any;
   private canCopyFromRootPath: boolean;
 
-  /* @ngInject */
   constructor(private $mdDialog: ng.material.IDialogService, private locals) {
     this.paths = locals.paths;
     this.rootCtrl = locals.rootCtrl;
@@ -49,5 +48,6 @@ class AddPoliciesPathController {
     this.$mdDialog.hide(this.paths);
   }
 }
+AddPoliciesPathController.$inject = ['$mdDialog', 'locals'];
 
 export default AddPoliciesPathController;

--- a/gravitee-apim-console-webui/src/management/api/design/policies/dialog/policyDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/policies/dialog/policyDialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogEditPolicyController($scope, $mdDialog, locals) {
   $scope.description = locals.description;
 
@@ -25,5 +24,6 @@ function DialogEditPolicyController($scope, $mdDialog, locals) {
     $mdDialog.hide($scope.description);
   };
 }
+DialogEditPolicyController.$inject = ['$scope', '$mdDialog', 'locals'];
 
 export default DialogEditPolicyController;

--- a/gravitee-apim-console-webui/src/management/api/design/policies/policies.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/policies/policies.controller.ajs.ts
@@ -32,7 +32,6 @@ class ApiV1PoliciesControllerAjs {
   private httpMethodsUpdated: boolean;
   private schemaByPolicyId: any;
 
-  /* @ngInject */
   constructor(
     private ApiService,
     private PolicyService,
@@ -486,5 +485,18 @@ class ApiV1PoliciesControllerAjs {
     this.httpMethodsUpdated = false;
   }
 }
+ApiV1PoliciesControllerAjs.$inject = [
+  'ApiService',
+  'PolicyService',
+  '$mdDialog',
+  'NotificationService',
+  '$scope',
+  'dragularService',
+  '$q',
+  '$rootScope',
+  'StringService',
+  'UserService',
+  '$state',
+];
 
 export default ApiV1PoliciesControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check-dashboard/healthcheck-dashboard.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check-dashboard/healthcheck-dashboard.controller.ajs.ts
@@ -31,7 +31,6 @@ class ApiHealthcheckDashboardControllerAjs {
   private transitionLogs: { total: string; logs: any[]; metadata: any };
   private query: LogsQuery;
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private $scope: IScope,
@@ -256,5 +255,6 @@ class ApiHealthcheckDashboardControllerAjs {
     return this.UserService.currentUser.isOrganizationAdmin();
   }
 }
+ApiHealthcheckDashboardControllerAjs.$inject = ['ApiService', '$scope', '$rootScope', '$state', '$q', 'UserService', '$window'];
 
 export default ApiHealthcheckDashboardControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check-dashboard/healthcheck-log.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check-dashboard/healthcheck-log.controller.ajs.ts
@@ -22,7 +22,6 @@ import { ApiService } from '../../../../services/api.service';
 class ApiHealthcheckLogControllerAjs {
   private log: any;
 
-  /* @ngInject */
   constructor(private $scope: IScope, private $state: StateService, private $window, private ApiService: ApiService) {}
 
   $onInit() {
@@ -50,5 +49,6 @@ class ApiHealthcheckLogControllerAjs {
     });
   }
 }
+ApiHealthcheckLogControllerAjs.$inject = ['$scope', '$state', '$window', 'ApiService'];
 
 export default ApiHealthcheckLogControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/add-property.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/add-property.dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogAddPropertyController($scope, $mdDialog) {
   this.hide = function () {
     $mdDialog.hide();
@@ -28,5 +27,6 @@ function DialogAddPropertyController($scope, $mdDialog) {
     $mdDialog.hide(property);
   };
 }
+DialogAddPropertyController.$inject = ['$scope', '$mdDialog'];
 
 export default DialogAddPropertyController;

--- a/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/dynamic-provider-http-dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/dynamic-provider-http-dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogDynamicProviderHttpController($mdDialog: angular.material.IDialogService) {
   this.cancel = $mdDialog.cancel;
 
@@ -54,5 +53,6 @@ function DialogDynamicProviderHttpController($mdDialog: angular.material.IDialog
     2,
   );
 }
+DialogDynamicProviderHttpController.$inject = ['$mdDialog'];
 
 export default DialogDynamicProviderHttpController;

--- a/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/properties.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/properties-v1/properties.controller.ajs.ts
@@ -40,7 +40,6 @@ class ApiV1PropertiesControllerAjs {
   private selectAll: boolean;
   private _initialDynamicPropertyService: any;
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private $mdSidenav: angular.material.ISidenavService,
@@ -297,5 +296,15 @@ class ApiV1PropertiesControllerAjs {
     }
   }
 }
+ApiV1PropertiesControllerAjs.$inject = [
+  'ApiService',
+  '$mdSidenav',
+  '$mdEditDialog',
+  '$mdDialog',
+  'NotificationService',
+  '$scope',
+  '$rootScope',
+  'ngIfMatchEtagInterceptor',
+];
 
 export default ApiV1PropertiesControllerAjs;

--- a/gravitee-apim-console-webui/src/management/api/proxy/resources-v1/resources.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/resources-v1/resources.controller.ajs.ts
@@ -25,7 +25,6 @@ class ApiV1ResourcesControllerAjs {
   private resource: any;
   private resourceJsonSchema: any;
 
-  /* @ngInject */
   constructor(
     private ApiService,
     private $mdSidenav,
@@ -178,5 +177,15 @@ class ApiV1ResourcesControllerAjs {
     return _.find(this.types, { id: resourceTypeId }).name;
   }
 }
+ApiV1ResourcesControllerAjs.$inject = [
+  'ApiService',
+  '$mdSidenav',
+  '$mdDialog',
+  'ResourceService',
+  'NotificationService',
+  '$scope',
+  '$rootScope',
+  '$timeout',
+];
 
 export default ApiV1ResourcesControllerAjs;

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step2.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step2.controller.ts
@@ -21,9 +21,6 @@ class ApplicationCreationStep2Controller {
   private selectedType: ApplicationType;
   private parent: ApplicationCreationController;
 
-  /* @ngInject */
-  constructor(private Constants) {}
-
   $onInit() {
     this.selectedType = this.parent.enabledApplicationTypes[0];
   }

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step4.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step4.component.ts
@@ -18,14 +18,16 @@ const ApplicationCreationStep4Component: ng.IComponentOptions = {
     parent: '^createApplication',
   },
   template: require('./application-creation-step4.html'),
-  /* @ngInject */
-  controller: function (Constants) {
-    if (Constants.env.settings.documentation && Constants.env.settings.documentation.url) {
-      this.url = Constants.env.settings.documentation.url;
-    } else {
-      this.url = 'https://docs.gravitee.io';
-    }
-  },
+  controller: [
+    'Constants',
+    function (Constants) {
+      if (Constants.env.settings.documentation && Constants.env.settings.documentation.url) {
+        this.url = Constants.env.settings.documentation.url;
+      } else {
+        this.url = 'https://docs.gravitee.io';
+      }
+    },
+  ],
 };
 
 export default ApplicationCreationStep4Component;

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
@@ -34,7 +34,6 @@ class ApplicationCreationController {
   private apis: any[] = [];
   private groups: any[];
 
-  /* @ngInject */
   constructor(
     private Constants,
     private $state,
@@ -170,5 +169,14 @@ class ApplicationCreationController {
     return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 }
+ApplicationCreationController.$inject = [
+  'Constants',
+  '$state',
+  '$mdDialog',
+  'ApplicationService',
+  'NotificationService',
+  '$q',
+  'ApiService',
+];
 
 export default ApplicationCreationController;

--- a/gravitee-apim-console-webui/src/management/application/details/analytics/application-analytics.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/analytics/application-analytics.controller.ts
@@ -24,7 +24,6 @@ class ApplicationAnalyticsController {
   private dashboard: any;
   private dashboards: any;
 
-  /* @ngInject */
   constructor(private ApplicationService: ApplicationService, private DashboardService: DashboardService, private $state: StateService) {}
 
   $onInit() {
@@ -70,5 +69,6 @@ class ApplicationAnalyticsController {
     this.$state.transitionTo('management.applications.application.logs.list', this.$state.params);
   }
 }
+ApplicationAnalyticsController.$inject = ['ApplicationService', 'DashboardService', '$state'];
 
 export default ApplicationAnalyticsController;

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.controller.ts
@@ -30,7 +30,6 @@ class ApplicationGeneralController {
 
   private readonly = false;
 
-  /* @ngInject */
   constructor(
     private ApplicationService: ApplicationService,
     private NotificationService: NotificationService,
@@ -143,5 +142,6 @@ class ApplicationGeneralController {
     this.readonly = true;
   }
 }
+ApplicationGeneralController.$inject = ['ApplicationService', 'NotificationService', '$state', '$scope', '$mdDialog'];
 
 export default ApplicationGeneralController;

--- a/gravitee-apim-console-webui/src/management/application/details/header/application-header.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/header/application-header.component.ts
@@ -17,7 +17,6 @@ const ApplicationHeaderComponent: ng.IComponentOptions = {
   bindings: {
     application: '<',
   },
-  /* @ngInject */
   controller: function () {
     this.$onInit = function () {
       this.hideSubscribeLink = this.application.status === 'ARCHIVED';

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-log.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-log.component.ts
@@ -21,33 +21,37 @@ const ApplicationLogComponent: ng.IComponentOptions = {
   bindings: {
     log: '<',
   },
-  /* @ngInject */
-  controller: function ($state: StateService, NotificationService: NotificationService, Constants: any) {
-    this.Constants = Constants;
-    this.NotificationService = NotificationService;
+  controller: [
+    '$state',
+    'NotificationService',
+    'Constants',
+    function ($state: StateService, NotificationService: NotificationService, Constants: any) {
+      this.Constants = Constants;
+      this.NotificationService = NotificationService;
 
-    this.backStateParams = {
-      from: $state.params.from,
-      to: $state.params.to,
-      q: $state.params.q,
-      page: $state.params.page,
-      size: $state.params.size,
-    };
+      this.backStateParams = {
+        from: $state.params.from,
+        to: $state.params.to,
+        q: $state.params.q,
+        page: $state.params.page,
+        size: $state.params.size,
+      };
 
-    this.getMimeType = function (log) {
-      if (log.headers['Content-Type'] !== undefined) {
-        const contentType = log.headers['Content-Type'][0];
-        return contentType.split(';', 1)[0];
-      }
+      this.getMimeType = function (log) {
+        if (log.headers['Content-Type'] !== undefined) {
+          const contentType = log.headers['Content-Type'][0];
+          return contentType.split(';', 1)[0];
+        }
 
-      return null;
-    };
+        return null;
+      };
 
-    this.onCopyBodySuccess = function (evt) {
-      this.NotificationService.show('Body has been copied to clipboard');
-      evt.clearSelection();
-    };
-  },
+      this.onCopyBodySuccess = function (evt) {
+        this.NotificationService.show('Body has been copied to clipboard');
+        evt.clearSelection();
+      };
+    },
+  ],
   template: require('./application-log.html'),
 };
 

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
@@ -29,7 +29,6 @@ class ApplicationLogsController {
   private application: any;
   private init: boolean;
 
-  /* @ngInject */
   constructor(private ApplicationService: ApplicationService, private $state: StateService, private $scope: IScope) {
     this.ApplicationService = ApplicationService;
 
@@ -108,5 +107,6 @@ class ApplicationLogsController {
     });
   }
 }
+ApplicationLogsController.$inject = ['ApplicationService', '$state', '$scope'];
 
 export default ApplicationLogsController;

--- a/gravitee-apim-console-webui/src/management/application/details/members/addMemberDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/members/addMemberDialog.controller.ts
@@ -19,7 +19,6 @@ import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
 import RoleService from '../../../../services/role.service';
 
-/* @ngInject */
 function DialogAddMemberController(
   $scope,
   $mdDialog,
@@ -64,5 +63,14 @@ function DialogAddMemberController(
     $mdDialog.hide($scope.application);
   };
 }
+DialogAddMemberController.$inject = [
+  '$scope',
+  '$mdDialog',
+  'application',
+  'members',
+  'ApplicationService',
+  'NotificationService',
+  'RoleService',
+];
 
 export default DialogAddMemberController;

--- a/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
@@ -38,7 +38,6 @@ class ApplicationMembersController {
   private userFilterFn;
   private defaultUsersList: string[];
 
-  /* @ngInject */
   constructor(
     private ApplicationService: ApplicationService,
     private NotificationService: NotificationService,
@@ -218,5 +217,14 @@ class ApplicationMembersController {
     });
   }
 }
+ApplicationMembersController.$inject = [
+  'ApplicationService',
+  'NotificationService',
+  '$mdDialog',
+  '$state',
+  'RoleService',
+  'GroupService',
+  'UserService',
+];
 
 export default ApplicationMembersController;

--- a/gravitee-apim-console-webui/src/management/application/details/members/transferApplicationDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/members/transferApplicationDialog.controller.ts
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogTransferAppplicationController($scope, $mdDialog, newRole) {
   this.newRole = newRole;
   $scope.cancel = function () {
@@ -27,5 +26,6 @@ function DialogTransferAppplicationController($scope, $mdDialog, newRole) {
     $mdDialog.hide(true);
   };
 }
+DialogTransferAppplicationController.$inject = ['$scope', '$mdDialog', 'newRole'];
 
 export default DialogTransferAppplicationController;

--- a/gravitee-apim-console-webui/src/management/application/details/notifications/applications.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/notifications/applications.notifications.settings.route.ts
@@ -20,7 +20,6 @@ import { Scope as AlertScope } from '../../../../entities/alert';
 
 export default applicationsNotificationsRouterConfig;
 
-/* @ngInject */
 function applicationsNotificationsRouterConfig($stateProvider) {
   $stateProvider
     .state('management.applications.application.notifications', {
@@ -33,16 +32,31 @@ function applicationsNotificationsRouterConfig($stateProvider) {
       },
       resolve: {
         resolvedHookScope: () => Scope.APPLICATION,
-        resolvedHooks: (NotificationSettingsService: NotificationSettingsService) =>
-          NotificationSettingsService.getHooks(Scope.APPLICATION).then((response) => response.data),
-        resolvedNotifiers: (NotificationSettingsService: NotificationSettingsService, $stateParams) =>
-          NotificationSettingsService.getNotifiers(Scope.APPLICATION, $stateParams.applicationId).then((response) => response.data),
-        notificationSettings: (NotificationSettingsService: NotificationSettingsService, $stateParams) =>
-          NotificationSettingsService.getNotificationSettings(Scope.APPLICATION, $stateParams.applicationId).then(
-            (response) => response.data,
-          ),
-        alerts: (AlertService: AlertService, $stateParams) =>
-          AlertService.listAlerts(AlertScope.APPLICATION, true, $stateParams.applicationId).then((response) => response.data),
+        resolvedHooks: [
+          'NotificationSettingsService',
+          (NotificationSettingsService: NotificationSettingsService) =>
+            NotificationSettingsService.getHooks(Scope.APPLICATION).then((response) => response.data),
+        ],
+        resolvedNotifiers: [
+          'NotificationSettingsService',
+          '$stateParams',
+          (NotificationSettingsService: NotificationSettingsService, $stateParams) =>
+            NotificationSettingsService.getNotifiers(Scope.APPLICATION, $stateParams.applicationId).then((response) => response.data),
+        ],
+        notificationSettings: [
+          'NotificationSettingsService',
+          '$stateParams',
+          (NotificationSettingsService: NotificationSettingsService, $stateParams) =>
+            NotificationSettingsService.getNotificationSettings(Scope.APPLICATION, $stateParams.applicationId).then(
+              (response) => response.data,
+            ),
+        ],
+        alerts: [
+          'AlertService',
+          '$stateParams',
+          (AlertService: AlertService, $stateParams) =>
+            AlertService.listAlerts(AlertScope.APPLICATION, true, $stateParams.applicationId).then((response) => response.data),
+        ],
       },
     })
     .state('management.applications.application.notifications.notification', {
@@ -59,3 +73,4 @@ function applicationsNotificationsRouterConfig($stateProvider) {
       },
     });
 }
+applicationsNotificationsRouterConfig.$inject = ['$stateProvider'];

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -36,7 +36,6 @@ class ApplicationSubscribeController {
   private plans = [];
   private subscribedPlans = [];
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private Constants: Constants,
@@ -202,5 +201,14 @@ class ApplicationSubscribeController {
     );
   }
 }
+ApplicationSubscribeController.$inject = [
+  'ApiService',
+  'Constants',
+  'ApplicationService',
+  'NotificationService',
+  '$mdDialog',
+  '$state',
+  '$transitions',
+];
 
 export default ApplicationSubscribeController;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
@@ -27,52 +27,57 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
     subscription: '<',
   },
   template: require('./application-subscription.html'),
-  controller: class {
-    private subscription: any;
-    private keys: any[];
-    private application: any;
-    private $listApiKeysEvent = new Subject<void>();
-    private backStateParams: StateParams;
+  controller: [
+    '$mdDialog',
+    'NotificationService',
+    'ApplicationService',
+    '$state',
+    class {
+      private subscription: any;
+      private keys: any[];
+      private application: any;
+      private $listApiKeysEvent = new Subject<void>();
+      private backStateParams: StateParams;
 
-    /* @ngInject */
-    constructor(
-      private $mdDialog: angular.material.IDialogService,
-      private NotificationService: NotificationService,
-      private ApplicationService: ApplicationService,
-      private $state: StateService,
-    ) {
-      this.backStateParams = $state.params;
-    }
-
-    close() {
-      let msg = 'The application will not be able to consume this API anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY && this.application.api_key_mode !== ApiKeyMode.SHARED) {
-        msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
+      constructor(
+        private $mdDialog: angular.material.IDialogService,
+        private NotificationService: NotificationService,
+        private ApplicationService: ApplicationService,
+        private $state: StateService,
+      ) {
+        this.backStateParams = $state.params;
       }
 
-      this.$mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: 'Are you sure you want to close this subscription?',
-            msg: msg,
-            confirmButton: 'Close',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            this.ApplicationService.closeSubscription(this.application.id, this.subscription.id).then((response) => {
-              this.NotificationService.show('The subscription has been closed');
-              this.subscription = response.data;
-              this.$listApiKeysEvent.next();
-            });
-          }
-        });
-    }
-  },
+      close() {
+        let msg = 'The application will not be able to consume this API anymore.';
+        if (this.subscription.plan.security === PlanSecurityType.API_KEY && this.application.api_key_mode !== ApiKeyMode.SHARED) {
+          msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
+        }
+
+        this.$mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../../../../components/dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: 'Are you sure you want to close this subscription?',
+              msg: msg,
+              confirmButton: 'Close',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              this.ApplicationService.closeSubscription(this.application.id, this.subscription.id).then((response) => {
+                this.NotificationService.show('The subscription has been closed');
+                this.subscription = response.data;
+                this.$listApiKeysEvent.next();
+              });
+            }
+          });
+      }
+    },
+  ],
 };
 
 export default ApplicationSubscriptionComponent;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.controller.ts
@@ -44,7 +44,6 @@ class ApplicationSubscriptionsListController {
 
   private isFirstFilter = true;
 
-  /* @ngInject */
   constructor(private ApplicationService: ApplicationService, private $state: StateService) {
     this.onPaginate = this.onPaginate.bind(this);
   }
@@ -130,5 +129,6 @@ class ApplicationSubscriptionsListController {
     this.$state.transitionTo('management.applications.application.subscriptions.subscription', { subscriptionId, ...this.$state.params });
   }
 }
+ApplicationSubscriptionsListController.$inject = ['ApplicationService', '$state'];
 
 export default ApplicationSubscriptionsListController;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.controller.ts
@@ -44,7 +44,6 @@ class ApplicationSubscriptionsController {
     REJECTED: 'Rejected',
   };
 
-  /* @ngInject */
   constructor(private $state: StateService) {}
 
   $onInit(): void {
@@ -101,5 +100,6 @@ class ApplicationSubscriptionsController {
     this.$filterEvent.next(this.filter);
   }
 }
+ApplicationSubscriptionsController.$inject = ['$state'];
 
 export default ApplicationSubscriptionsController;

--- a/gravitee-apim-console-webui/src/management/configuration/analytics/analytics.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/analytics.component.ts
@@ -29,104 +29,113 @@ const AnalyticsSettingsComponent: ng.IComponentOptions = {
     dashboardsApplication: '<',
   },
   template: require('./analytics.html'),
-  /* @ngInject */
-  controller: function (
-    NotificationService: NotificationService,
-    PortalSettingsService: PortalSettingsService,
-    $state: StateService,
-    Constants: any,
-    $mdDialog: angular.material.IDialogService,
-    DashboardService: DashboardService,
-    $rootScope,
-    UserService: UserService,
-  ) {
-    this.settings = _.cloneDeep(Constants.env.settings);
-    this.$rootScope = $rootScope;
-    this.providedConfigurationMessage = 'Configuration provided by the system';
+  controller: [
+    'NotificationService',
+    'PortalSettingsService',
+    '$state',
+    'Constants',
+    '$mdDialog',
+    'DashboardService',
+    '$rootScope',
+    'UserService',
+    function (
+      NotificationService: NotificationService,
+      PortalSettingsService: PortalSettingsService,
+      $state: StateService,
+      Constants: any,
+      $mdDialog: angular.material.IDialogService,
+      DashboardService: DashboardService,
+      $rootScope,
+      UserService: UserService,
+    ) {
+      this.settings = _.cloneDeep(Constants.env.settings);
+      this.$rootScope = $rootScope;
+      this.providedConfigurationMessage = 'Configuration provided by the system';
 
-    this.$onInit = () => {
-      this.dashboardsByType = {
-        Platform: this.dashboardsPlatform,
-        API: this.dashboardsApi,
-        Application: this.dashboardsApplication,
+      this.$onInit = () => {
+        this.dashboardsByType = {
+          Platform: this.dashboardsPlatform,
+          API: this.dashboardsApi,
+          Application: this.dashboardsApplication,
+        };
+
+        this.canUpdateSettings = UserService.isUserHasPermissions([
+          'environment-settings-c',
+          'environment-settings-u',
+          'environment-settings-d',
+        ]);
       };
 
-      this.canUpdateSettings = UserService.isUserHasPermissions([
-        'environment-settings-c',
-        'environment-settings-u',
-        'environment-settings-d',
-      ]);
-    };
+      this.isDashboardsEmpty = () => {
+        return _.flattenDeep(_.values(this.dashboardsByType)).length === 0;
+      };
 
-    this.isDashboardsEmpty = () => {
-      return _.flattenDeep(_.values(this.dashboardsByType)).length === 0;
-    };
+      this.save = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          _.merge(Constants.env.settings, response.data);
+          NotificationService.show('Configuration saved');
+          this.formSettings.$setPristine();
+        });
+      };
 
-    this.save = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        _.merge(Constants.env.settings, response.data);
-        NotificationService.show('Configuration saved');
+      this.reset = () => {
+        this.settings = _.cloneDeep(Constants.env.settings);
         this.formSettings.$setPristine();
-      });
-    };
+      };
 
-    this.reset = () => {
-      this.settings = _.cloneDeep(Constants.env.settings);
-      this.formSettings.$setPristine();
-    };
+      this.delete = (dashboard: Dashboard) => {
+        $mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../../../components/dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: `Are you sure you want to delete the dashboard '${dashboard.name}'?`,
+              msg: '',
+              confirmButton: 'Delete',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              DashboardService.delete(dashboard).then(() => {
+                NotificationService.show("Dashboard '" + dashboard.name + "' has been deleted");
+                $state.go($state.current, {}, { reload: true });
+              });
+            }
+          });
+      };
 
-    this.delete = (dashboard: Dashboard) => {
-      $mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: `Are you sure you want to delete the dashboard '${dashboard.name}'?`,
-            msg: '',
-            confirmButton: 'Delete',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            DashboardService.delete(dashboard).then(() => {
-              NotificationService.show("Dashboard '" + dashboard.name + "' has been deleted");
-              $state.go($state.current, {}, { reload: true });
-            });
-          }
-        });
-    };
+      this.update = (dashboard: Dashboard) => {
+        DashboardService.update(dashboard)
+          .then(() => {
+            NotificationService.show('Dashboard saved with success');
+          })
+          .finally(() => {
+            $state.go($state.current, {}, { reload: true });
+          });
+      };
 
-    this.update = (dashboard: Dashboard) => {
-      DashboardService.update(dashboard)
-        .then(() => {
-          NotificationService.show('Dashboard saved with success');
-        })
-        .finally(() => {
-          $state.go($state.current, {}, { reload: true });
-        });
-    };
+      this.upward = (dashboard: Dashboard) => {
+        dashboard.order--;
+        this.update(dashboard);
+      };
 
-    this.upward = (dashboard: Dashboard) => {
-      dashboard.order--;
-      this.update(dashboard);
-    };
+      this.downward = (dashboard: Dashboard) => {
+        dashboard.order++;
+        this.update(dashboard);
+      };
 
-    this.downward = (dashboard: Dashboard) => {
-      dashboard.order++;
-      this.update(dashboard);
-    };
+      this.toggleEnable = (dashboard: Dashboard) => {
+        dashboard.enabled = !dashboard.enabled;
+        this.update(dashboard);
+      };
 
-    this.toggleEnable = (dashboard: Dashboard) => {
-      dashboard.enabled = !dashboard.enabled;
-      this.update(dashboard);
-    };
-
-    this.isReadonlySetting = (property: string): boolean => {
-      return PortalSettingsService.isReadonly(this.settings, property);
-    };
-  },
+      this.isReadonlySetting = (property: string): boolean => {
+        return PortalSettingsService.isReadonly(this.settings, property);
+      };
+    },
+  ],
 };
 
 export default AnalyticsSettingsComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.components.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.components.ts
@@ -21,123 +21,131 @@ import DashboardService from '../../../../services/dashboard.service';
 import NotificationService from '../../../../services/notification.service';
 const DashboardComponent: ng.IComponentOptions = {
   template: require('./dashboard.html'),
-  /* @ngInject */
-  controller: function (
-    DashboardService: DashboardService,
-    NotificationService: NotificationService,
-    $state: StateService,
-    $scope,
-    $rootScope,
-    $mdDialog,
-    $timeout,
-  ) {
-    let previousPristine = true;
-    this.fields = DashboardService.getIndexedFields();
-    this.$rootScope = $rootScope;
-    this.updateMode = true;
-    this.$onInit = () => {
-      this.editMode = !!$state.params.dashboardId;
-      if ($state.params.dashboardId) {
-        DashboardService.get($state.params.dashboardId).then((response) => {
-          this.dashboard = response.data;
-          if (this.dashboard.definition) {
-            this.dashboard.definition = JSON.parse(this.dashboard.definition);
-            _.forEach(this.dashboard.definition, (widget) => {
-              _.merge(widget, DashboardService.getChartService());
-            });
-          }
-          $scope.$watch(
-            '$ctrl.dashboard.definition',
-            (newDefinition, oldDefinition) => {
-              if (!_.isEqual(newDefinition, oldDefinition)) {
-                this.formDashboard.$setDirty();
-              }
-            },
-            true,
-          );
-        });
-      } else {
-        this.dashboard = {
-          reference_type: $state.params.type,
-          reference_id: 'DEFAULT',
-          enabled: true,
-          definition: [],
-        };
-      }
-    };
-
-    this.save = () => {
-      let savePromise;
-      const clonedDashboard = _.cloneDeep(this.dashboard);
-      if (clonedDashboard.definition) {
-        _.forEach(clonedDashboard.definition, (widget) => {
-          if (widget.chart) {
-            if (widget.chart.service) {
-              delete widget.chart.service;
+  controller: [
+    'DashboardService',
+    'NotificationService',
+    '$state',
+    '$scope',
+    '$rootScope',
+    '$mdDialog',
+    '$timeout',
+    function (
+      DashboardService: DashboardService,
+      NotificationService: NotificationService,
+      $state: StateService,
+      $scope,
+      $rootScope,
+      $mdDialog,
+      $timeout,
+    ) {
+      let previousPristine = true;
+      this.fields = DashboardService.getIndexedFields();
+      this.$rootScope = $rootScope;
+      this.updateMode = true;
+      this.$onInit = () => {
+        this.editMode = !!$state.params.dashboardId;
+        if ($state.params.dashboardId) {
+          DashboardService.get($state.params.dashboardId).then((response) => {
+            this.dashboard = response.data;
+            if (this.dashboard.definition) {
+              this.dashboard.definition = JSON.parse(this.dashboard.definition);
+              _.forEach(this.dashboard.definition, (widget) => {
+                _.merge(widget, DashboardService.getChartService());
+              });
             }
-            if (widget.chart.request) {
-              delete widget.chart.request.interval;
-              delete widget.chart.request.from;
-              delete widget.chart.request.to;
-            }
-          }
-        });
-        clonedDashboard.definition = angular.toJson(clonedDashboard.definition);
-      }
-      if (this.editMode) {
-        savePromise = DashboardService.update(clonedDashboard);
-      } else {
-        savePromise = DashboardService.create(clonedDashboard);
-      }
-      savePromise.then((response) => {
-        $state.go('management.settings.analytics.dashboard', _.merge($state.params, { dashboardId: response.data.id }), { reload: true });
-        this.formDashboard.$setPristine();
-        NotificationService.show(`Dashboard ${this.editMode ? 'updated' : 'created'} with success`);
-      });
-    };
-
-    this.reset = () => {
-      $state.reload();
-    };
-
-    this.displayPreview = () => {
-      if (this.dashboard && this.dashboard.definition && this.dashboard.definition.length) {
-        return _.every(this.dashboard.definition, (definition) => {
-          return definition.chart.type;
-        });
-      }
-      return false;
-    };
-
-    this.addWidget = () => {
-      this.dashboard.definition.push(DashboardService.getChartService());
-    };
-
-    this.showQueryFilterInformation = () => {
-      $mdDialog.show({
-        controller: 'DialogQueryFilterInformationController',
-        controllerAs: 'ctrl',
-        template: require('./query-filter-information.dialog.html'),
-        parent: angular.element(document.body),
-        clickOutsideToClose: true,
-      });
-    };
-
-    this.tooglePreview = () => {
-      this.updateMode = !this.updateMode;
-      if (this.updateMode) {
-        if (previousPristine) {
-          this.formDashboard.$setPristine();
+            $scope.$watch(
+              '$ctrl.dashboard.definition',
+              (newDefinition, oldDefinition) => {
+                if (!_.isEqual(newDefinition, oldDefinition)) {
+                  this.formDashboard.$setDirty();
+                }
+              },
+              true,
+            );
+          });
         } else {
-          $timeout(() => {
-            this.formDashboard.$setDirty();
-          }, 100);
+          this.dashboard = {
+            reference_type: $state.params.type,
+            reference_id: 'DEFAULT',
+            enabled: true,
+            definition: [],
+          };
         }
-      } else {
-        previousPristine = this.formDashboard.$pristine;
-      }
-    };
-  },
+      };
+
+      this.save = () => {
+        let savePromise;
+        const clonedDashboard = _.cloneDeep(this.dashboard);
+        if (clonedDashboard.definition) {
+          _.forEach(clonedDashboard.definition, (widget) => {
+            if (widget.chart) {
+              if (widget.chart.service) {
+                delete widget.chart.service;
+              }
+              if (widget.chart.request) {
+                delete widget.chart.request.interval;
+                delete widget.chart.request.from;
+                delete widget.chart.request.to;
+              }
+            }
+          });
+          clonedDashboard.definition = angular.toJson(clonedDashboard.definition);
+        }
+        if (this.editMode) {
+          savePromise = DashboardService.update(clonedDashboard);
+        } else {
+          savePromise = DashboardService.create(clonedDashboard);
+        }
+        savePromise.then((response) => {
+          $state.go('management.settings.analytics.dashboard', _.merge($state.params, { dashboardId: response.data.id }), { reload: true });
+          this.formDashboard.$setPristine();
+          NotificationService.show(`Dashboard ${this.editMode ? 'updated' : 'created'} with success`);
+        });
+      };
+
+      this.reset = () => {
+        $state.reload();
+      };
+
+      this.displayPreview = () => {
+        if (this.dashboard && this.dashboard.definition && this.dashboard.definition.length) {
+          return _.every(this.dashboard.definition, (definition) => {
+            return definition.chart.type;
+          });
+        }
+        return false;
+      };
+
+      this.addWidget = () => {
+        this.dashboard.definition.push(DashboardService.getChartService());
+      };
+
+      this.showQueryFilterInformation = () => {
+        $mdDialog.show({
+          controller: 'DialogQueryFilterInformationController',
+          controllerAs: 'ctrl',
+          template: require('./query-filter-information.dialog.html'),
+          parent: angular.element(document.body),
+          clickOutsideToClose: true,
+        });
+      };
+
+      this.tooglePreview = () => {
+        this.updateMode = !this.updateMode;
+        if (this.updateMode) {
+          if (previousPristine) {
+            this.formDashboard.$setPristine();
+          } else {
+            $timeout(() => {
+              this.formDashboard.$setDirty();
+            }, 100);
+          }
+        } else {
+          previousPristine = this.formDashboard.$pristine;
+        }
+      };
+    },
+  ],
 };
 
 export default DashboardComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/query-filter-information.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/query-filter-information.dialog.controller.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogQueryFilterInformationController($mdDialog) {
   this.cancel = $mdDialog.cancel;
 }
+DialogQueryFilterInformationController.$inject = ['$mdDialog'];
 
 export default DialogQueryFilterInformationController;

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.component.ts
@@ -27,122 +27,130 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
     settings: '<',
   },
   template: require('./api-portal-header.html'),
-  /* @ngInject */
-  controller: function (
-    ApiHeaderService: ApiHeaderService,
-    NotificationService: NotificationService,
-    PortalSettingsService: PortalSettingsService,
-    $mdDialog: angular.material.IDialogService,
-    Constants,
-    $rootScope: IScope,
-    UserService: UserService,
-  ) {
-    this.$rootScope = $rootScope;
-    this.$mdDialog = $mdDialog;
+  controller: [
+    'ApiHeaderService',
+    'NotificationService',
+    'PortalSettingsService',
+    '$mdDialog',
+    'Constants',
+    '$rootScope',
+    'UserService',
+    function (
+      ApiHeaderService: ApiHeaderService,
+      NotificationService: NotificationService,
+      PortalSettingsService: PortalSettingsService,
+      $mdDialog: angular.material.IDialogService,
+      Constants,
+      $rootScope: IScope,
+      UserService: UserService,
+    ) {
+      this.$rootScope = $rootScope;
+      this.$mdDialog = $mdDialog;
 
-    this.providedConfigurationMessage = 'Configuration provided by the system';
-    this.canUpdateSettings = UserService.isUserHasPermissions([
-      'environment-settings-c',
-      'environment-settings-u',
-      'environment-settings-d',
-    ]);
+      this.providedConfigurationMessage = 'Configuration provided by the system';
+      this.canUpdateSettings = UserService.isUserHasPermissions([
+        'environment-settings-c',
+        'environment-settings-u',
+        'environment-settings-d',
+      ]);
 
-    this.upward = (header: ApiPortalHeader) => {
-      header.order = header.order - 1;
-      ApiHeaderService.update(header).then(() => {
-        NotificationService.show("Header '" + header.name + "' saved");
-        ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
-      });
-    };
-
-    this.downward = (header: ApiPortalHeader) => {
-      header.order = header.order + 1;
-      ApiHeaderService.update(header).then(() => {
-        NotificationService.show("Header '" + header.name + "' saved");
-        ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
-      });
-    };
-
-    this.createHeader = () => {
-      this.$mdDialog
-        .show({
-          controller: 'NewApiPortalHeaderDialogController',
-          controllerAs: '$ctrl',
-          template: require('./save.api-portal-header.dialog.html'),
-          locals: {},
-        })
-        .then((newHeader) => {
-          NotificationService.show("Header '" + newHeader.name + "' saved");
+      this.upward = (header: ApiPortalHeader) => {
+        header.order = header.order - 1;
+        ApiHeaderService.update(header).then(() => {
+          NotificationService.show("Header '" + header.name + "' saved");
           ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
         });
-    };
+      };
 
-    this.updateHeader = (header: ApiPortalHeader) => {
-      this.$mdDialog
-        .show({
-          controller: 'UpdateApiPortalHeaderDialogController',
-          controllerAs: '$ctrl',
-          template: require('./save.api-portal-header.dialog.html'),
-          locals: {
-            header: Object.assign({}, header),
-          },
-        })
-        .then((updatedHeader) => {
-          NotificationService.show("Header '" + updatedHeader.name + "' saved");
+      this.downward = (header: ApiPortalHeader) => {
+        header.order = header.order + 1;
+        ApiHeaderService.update(header).then(() => {
+          NotificationService.show("Header '" + header.name + "' saved");
           ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
         });
-    };
+      };
 
-    this.deleteHeader = (header: ApiPortalHeader) => {
-      this.$mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: 'Are you sure you want to delete this header?',
-            msg: '',
-            confirmButton: 'Delete',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            ApiHeaderService.delete(header).then(() => {
-              NotificationService.show("Header '" + header.name + "' deleted");
-              ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
-            });
-          }
+      this.createHeader = () => {
+        this.$mdDialog
+          .show({
+            controller: 'NewApiPortalHeaderDialogController',
+            controllerAs: '$ctrl',
+            template: require('./save.api-portal-header.dialog.html'),
+            locals: {},
+          })
+          .then((newHeader) => {
+            NotificationService.show("Header '" + newHeader.name + "' saved");
+            ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
+          });
+      };
+
+      this.updateHeader = (header: ApiPortalHeader) => {
+        this.$mdDialog
+          .show({
+            controller: 'UpdateApiPortalHeaderDialogController',
+            controllerAs: '$ctrl',
+            template: require('./save.api-portal-header.dialog.html'),
+            locals: {
+              header: Object.assign({}, header),
+            },
+          })
+          .then((updatedHeader) => {
+            NotificationService.show("Header '" + updatedHeader.name + "' saved");
+            ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
+          });
+      };
+
+      this.deleteHeader = (header: ApiPortalHeader) => {
+        this.$mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../../../components/dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: 'Are you sure you want to delete this header?',
+              msg: '',
+              confirmButton: 'Delete',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              ApiHeaderService.delete(header).then(() => {
+                NotificationService.show("Header '" + header.name + "' deleted");
+                ApiHeaderService.list().then((response) => (this.apiPortalHeaders = response.data));
+              });
+            }
+          });
+      };
+
+      this.saveShowCategories = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          NotificationService.show(
+            'Categories are now ' + (this.settings.portal.apis.apiHeaderShowCategories.enabled ? 'visible' : 'hidden'),
+          );
+          this.settings = response.data;
         });
-    };
+      };
 
-    this.saveShowCategories = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        NotificationService.show(
-          'Categories are now ' + (this.settings.portal.apis.apiHeaderShowCategories.enabled ? 'visible' : 'hidden'),
-        );
-        this.settings = response.data;
-      });
-    };
+      this.saveShowTags = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          NotificationService.show('Tags are now ' + (this.settings.portal.apis.apiHeaderShowTags.enabled ? 'visible' : 'hidden'));
+          this.settings = response.data;
+        });
+      };
 
-    this.saveShowTags = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        NotificationService.show('Tags are now ' + (this.settings.portal.apis.apiHeaderShowTags.enabled ? 'visible' : 'hidden'));
-        this.settings = response.data;
-      });
-    };
+      this.savePromotedApiMode = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          NotificationService.show('Promoted API is now ' + (this.settings.portal.apis.promotedApiMode.enabled ? 'visible' : 'hidden'));
+          this.settings = response.data;
+        });
+      };
 
-    this.savePromotedApiMode = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        NotificationService.show('Promoted API is now ' + (this.settings.portal.apis.promotedApiMode.enabled ? 'visible' : 'hidden'));
-        this.settings = response.data;
-      });
-    };
-
-    this.isReadonlySetting = (property: string): boolean => {
-      return PortalSettingsService.isReadonly(this.settings, property);
-    };
-  },
+      this.isReadonlySetting = (property: string): boolean => {
+        return PortalSettingsService.isReadonly(this.settings, property);
+      };
+    },
+  ],
 };
 
 export default ApiPortalHeaderComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/new.api-portal-header.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/new.api-portal-header.dialog.controller.ts
@@ -16,7 +16,6 @@
 import { ApiPortalHeader } from '../../../entities/apiPortalHeader';
 import ApiHeaderService from '../../../services/apiHeader.service';
 
-/* @ngInject */
 function NewApiPortalHeaderDialogController(ApiHeaderService: ApiHeaderService, $mdDialog: angular.material.IDialogService) {
   this.header = new ApiPortalHeader();
 
@@ -30,5 +29,6 @@ function NewApiPortalHeaderDialogController(ApiHeaderService: ApiHeaderService, 
     });
   };
 }
+NewApiPortalHeaderDialogController.$inject = ['ApiHeaderService', '$mdDialog'];
 
 export default NewApiPortalHeaderDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/update.api-portal-header.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/update.api-portal-header.dialog.controller.ts
@@ -16,7 +16,6 @@
 import { ApiPortalHeader } from '../../../entities/apiPortalHeader';
 import ApiHeaderService from '../../../services/apiHeader.service';
 
-/* @ngInject */
 function UpdateApiPortalHeaderDialogController(
   ApiHeaderService: ApiHeaderService,
   $mdDialog: angular.material.IDialogService,
@@ -34,5 +33,6 @@ function UpdateApiPortalHeaderDialogController(
     });
   };
 }
+UpdateApiPortalHeaderDialogController.$inject = ['ApiHeaderService', '$mdDialog', 'header'];
 
 export default UpdateApiPortalHeaderDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rule/api-quality-rule.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rule/api-quality-rule.controller.ts
@@ -23,7 +23,6 @@ class ApiQualityRuleController {
   private createMode = false;
   private qualityRule: QualityRule;
 
-  /* @ngInject */
   constructor(
     private QualityRuleService: QualityRuleService,
     private NotificationService: NotificationService,
@@ -52,5 +51,6 @@ class ApiQualityRuleController {
     });
   }
 }
+ApiQualityRuleController.$inject = ['QualityRuleService', 'NotificationService', '$state', '$location'];
 
 export default ApiQualityRuleController;

--- a/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rule/delete-api-quality-rule.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rule/delete-api-quality-rule.dialog.controller.ts
@@ -18,7 +18,6 @@ import { IScope } from 'angular';
 import { QualityRule } from '../../../../entities/qualityRule';
 import QualityRuleService from '../../../../services/qualityRule.service';
 
-/* @ngInject */
 function DeleteApiQualityRuleDialogController(
   $scope: IScope,
   $mdDialog: angular.material.IDialogService,
@@ -37,5 +36,6 @@ function DeleteApiQualityRuleDialogController(
     });
   };
 }
+DeleteApiQualityRuleDialogController.$inject = ['$scope', '$mdDialog', 'qualityRule', 'QualityRuleService'];
 
 export default DeleteApiQualityRuleDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rules.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-quality-rules/api-quality-rules.component.ts
@@ -25,59 +25,66 @@ const ApiQualityRulesComponent: ng.IComponentOptions = {
     qualityRules: '<',
   },
   template: require('./api-quality-rules.html'),
-  /* @ngInject */
-  controller: function (
-    Constants,
-    $rootScope: IScope,
-    PortalSettingsService: PortalSettingsService,
-    NotificationService: NotificationService,
-    $mdDialog: angular.material.IDialogService,
-    UserService: UserService,
-  ) {
-    this.$rootScope = $rootScope;
-    this.settings = _.cloneDeep(Constants.env.settings);
-    this.providedConfigurationMessage = 'Configuration provided by the system';
-    this.canUpdateSettings = UserService.isUserHasPermissions([
-      'environment-settings-c',
-      'environment-settings-u',
-      'environment-settings-d',
-    ]);
-
-    this.save = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        _.merge(Constants.env.settings, response.data);
-        NotificationService.show('API Quality settings saved!');
-        this.formQuality.$setPristine();
-      });
-    };
-
-    this.reset = () => {
+  controller: [
+    'Constants',
+    '$rootScope',
+    'PortalSettingsService',
+    'NotificationService',
+    '$mdDialog',
+    'UserService',
+    function (
+      Constants,
+      $rootScope: IScope,
+      PortalSettingsService: PortalSettingsService,
+      NotificationService: NotificationService,
+      $mdDialog: angular.material.IDialogService,
+      UserService: UserService,
+    ) {
+      this.$rootScope = $rootScope;
       this.settings = _.cloneDeep(Constants.env.settings);
-      this.formQuality.$setPristine();
-    };
+      this.providedConfigurationMessage = 'Configuration provided by the system';
+      this.canUpdateSettings = UserService.isUserHasPermissions([
+        'environment-settings-c',
+        'environment-settings-u',
+        'environment-settings-d',
+      ]);
 
-    this.delete = (qualityRule) => {
-      $mdDialog
-        .show({
-          controller: 'DeleteApiQualityRuleDialogController',
-          controllerAs: '$ctrl',
-          template: require('./api-quality-rule/delete-api-quality-rule.dialog.html'),
-          locals: {
-            qualityRule: qualityRule,
-          },
-        })
-        .then((deletedQualityRule) => {
-          if (deletedQualityRule) {
-            NotificationService.show("Quality rule '" + qualityRule.name + "' deleted with success");
-            _.remove(this.qualityRules, qualityRule);
-          }
+      this.save = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          _.merge(Constants.env.settings, response.data);
+          NotificationService.show('API Quality settings saved!');
+          this.formQuality.$setPristine();
         });
-    };
+      };
 
-    this.isReadonlySetting = (property: string): boolean => {
-      return PortalSettingsService.isReadonly(this.settings, property);
-    };
-  },
+      this.reset = () => {
+        this.settings = _.cloneDeep(Constants.env.settings);
+        this.formQuality.$setPristine();
+      };
+
+      this.delete = (qualityRule) => {
+        $mdDialog
+          .show({
+            controller: 'DeleteApiQualityRuleDialogController',
+            controllerAs: '$ctrl',
+            template: require('./api-quality-rule/delete-api-quality-rule.dialog.html'),
+            locals: {
+              qualityRule: qualityRule,
+            },
+          })
+          .then((deletedQualityRule) => {
+            if (deletedQualityRule) {
+              NotificationService.show("Quality rule '" + qualityRule.name + "' deleted with success");
+              _.remove(this.qualityRules, qualityRule);
+            }
+          });
+      };
+
+      this.isReadonlySetting = (property: string): boolean => {
+        return PortalSettingsService.isReadonly(this.settings, property);
+      };
+    },
+  ],
 };
 
 export default ApiQualityRulesComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/api_logging/api_logging.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api_logging/api_logging.controller.ts
@@ -21,7 +21,6 @@ class ApiLoggingController {
   private formApiLogging: any;
   private settings: any;
 
-  /* @ngInject */
   constructor(private ConsoleSettingsService: ConsoleSettingsService, private NotificationService: NotificationService) {}
 
   save() {
@@ -35,5 +34,6 @@ class ApiLoggingController {
     return this.ConsoleSettingsService.isReadonly(this.settings, property);
   }
 }
+ApiLoggingController.$inject = ['ConsoleSettingsService', 'NotificationService'];
 
 export default ApiLoggingController;

--- a/gravitee-apim-console-webui/src/management/configuration/categories/categories.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/categories/categories.controller.ts
@@ -30,7 +30,6 @@ class CategoriesController {
   private Constants: any;
   private settings: any;
 
-  /* @ngInject */
   constructor(
     private CategoryService: CategoryService,
     private NotificationService: NotificationService,
@@ -127,5 +126,16 @@ class CategoriesController {
     });
   }
 }
+CategoriesController.$inject = [
+  'CategoryService',
+  'NotificationService',
+  '$q',
+  '$mdDialog',
+  '$state',
+  'PortalSettingsService',
+  'Constants',
+  '$rootScope',
+  'UserService',
+];
 
 export default CategoriesController;

--- a/gravitee-apim-console-webui/src/management/configuration/categories/category/category.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/categories/category/category.controller.ts
@@ -34,7 +34,6 @@ class CategoryController {
   private addedAPIs: any[];
   private formChanged = false;
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private CategoryService: CategoryService,
@@ -187,5 +186,16 @@ class CategoryController {
     return this.selectedAPIs;
   }
 }
+CategoryController.$inject = [
+  'ApiService',
+  'CategoryService',
+  'NotificationService',
+  '$q',
+  '$filter',
+  '$state',
+  '$location',
+  '$mdDialog',
+  '$scope',
+];
 
 export default CategoryController;

--- a/gravitee-apim-console-webui/src/management/configuration/categories/category/delete-api-category.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/categories/category/delete-api-category.dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DeleteAPICategoryDialogController($scope, $mdDialog, api) {
   $scope.api = api.name;
 
@@ -25,5 +24,6 @@ function DeleteAPICategoryDialogController($scope, $mdDialog, api) {
     $mdDialog.hide(true);
   };
 }
+DeleteAPICategoryDialogController.$inject = ['$scope', '$mdDialog', 'api'];
 
 export default DeleteAPICategoryDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/categories/delete.category.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/categories/delete.category.dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DeleteCategoryDialogController($scope, $mdDialog, category) {
   $scope.category = category.name;
 
@@ -25,5 +24,6 @@ function DeleteCategoryDialogController($scope, $mdDialog, category) {
     $mdDialog.hide(true);
   };
 }
+DeleteCategoryDialogController.$inject = ['$scope', '$mdDialog', 'category'];
 
 export default DeleteCategoryDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
@@ -38,7 +38,6 @@ import TopApiService from '../../services/top-api.service';
 
 export default configurationRouterConfig;
 
-/* @ngInject */
 function configurationRouterConfig($stateProvider: StateProvider) {
   $stateProvider
     .state('management.settings', {
@@ -55,10 +54,18 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '',
       component: 'analyticsSettings',
       resolve: {
-        dashboardsPlatform: (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
-        dashboardsApi: (DashboardService: DashboardService) => DashboardService.list('API').then((response) => response.data),
-        dashboardsApplication: (DashboardService: DashboardService) =>
-          DashboardService.list('APPLICATION').then((response) => response.data),
+        dashboardsPlatform: [
+          'DashboardService',
+          (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
+        ],
+        dashboardsApi: [
+          'DashboardService',
+          (DashboardService: DashboardService) => DashboardService.list('API').then((response) => response.data),
+        ],
+        dashboardsApplication: [
+          'DashboardService',
+          (DashboardService: DashboardService) => DashboardService.list('APPLICATION').then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -88,8 +95,12 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/dashboard/:type/:dashboardId',
       component: 'dashboard',
       resolve: {
-        dashboard: (DashboardService: DashboardService, $stateParams) =>
-          DashboardService.get($stateParams.dashboardId).then((response) => response.data),
+        dashboard: [
+          'DashboardService',
+          '$stateParams',
+          (DashboardService: DashboardService, $stateParams) =>
+            DashboardService.get($stateParams.dashboardId).then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -105,8 +116,14 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/apiportalheader',
       component: 'configApiPortalHeader',
       resolve: {
-        apiPortalHeaders: (ApiHeaderService: ApiHeaderService) => ApiHeaderService.list().then((response) => response.data),
-        settings: (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        apiPortalHeaders: [
+          'ApiHeaderService',
+          (ApiHeaderService: ApiHeaderService) => ApiHeaderService.list().then((response) => response.data),
+        ],
+        settings: [
+          'PortalSettingsService',
+          (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -127,7 +144,10 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '',
       component: 'configApiQuality',
       resolve: {
-        qualityRules: (QualityRuleService: QualityRuleService) => QualityRuleService.list().then((response) => response.data),
+        qualityRules: [
+          'QualityRuleService',
+          (QualityRuleService: QualityRuleService) => QualityRuleService.list().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -157,8 +177,12 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/:qualityRuleId',
       component: 'qualityRule',
       resolve: {
-        qualityRule: (QualityRuleService: QualityRuleService, $stateParams) =>
-          QualityRuleService.get($stateParams.qualityRuleId).then((response) => response.data),
+        qualityRule: [
+          'QualityRuleService',
+          '$stateParams',
+          (QualityRuleService: QualityRuleService, $stateParams) =>
+            QualityRuleService.get($stateParams.qualityRuleId).then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -179,12 +203,21 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       component: 'identityProviders',
       resolve: {
         target: () => 'ENVIRONMENT',
-        targetId: (Constants) => Constants.org.currentEnv.id,
-        identityProviders: (IdentityProviderService: IdentityProviderService) =>
-          IdentityProviderService.list().then((response) => response),
-        identities: (EnvironmentService: EnvironmentService, Constants) =>
-          EnvironmentService.listEnvironmentIdentities(Constants.org.currentEnv.id).then((response) => response.data),
-        settings: (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        targetId: ['Constants', (Constants) => Constants.org.currentEnv.id],
+        identityProviders: [
+          'IdentityProviderService',
+          (IdentityProviderService: IdentityProviderService) => IdentityProviderService.list().then((response) => response),
+        ],
+        identities: [
+          'EnvironmentService',
+          'Constants',
+          (EnvironmentService: EnvironmentService, Constants) =>
+            EnvironmentService.listEnvironmentIdentities(Constants.org.currentEnv.id).then((response) => response.data),
+        ],
+        settings: [
+          'PortalSettingsService',
+          (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -205,7 +238,10 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '',
       component: 'categories',
       resolve: {
-        categories: (CategoryService: CategoryService) => CategoryService.list(['total-apis']).then((response) => response.data),
+        categories: [
+          'CategoryService',
+          (CategoryService: CategoryService) => CategoryService.list(['total-apis']).then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -222,12 +258,15 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/new',
       component: 'category',
       resolve: {
-        pages: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'MARKDOWN';
-          q.published = true;
-          return DocumentationService.search(q).then((response) => response.data);
-        },
+        pages: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'MARKDOWN';
+            q.published = true;
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
       },
       data: {
         menu: null,
@@ -243,15 +282,26 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/:categoryId',
       component: 'category',
       resolve: {
-        category: (CategoryService: CategoryService, $stateParams) =>
-          CategoryService.get($stateParams.categoryId).then((response) => response.data),
-        categoryApis: (ApiService: ApiService, $stateParams) => ApiService.list($stateParams.categoryId).then((response) => response.data),
-        pages: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'MARKDOWN';
-          q.published = true;
-          return DocumentationService.search(q).then((response) => response.data);
-        },
+        category: [
+          'CategoryService',
+          '$stateParams',
+          (CategoryService: CategoryService, $stateParams) =>
+            CategoryService.get($stateParams.categoryId).then((response) => response.data),
+        ],
+        categoryApis: [
+          'ApiService',
+          '$stateParams',
+          (ApiService: ApiService, $stateParams) => ApiService.list($stateParams.categoryId).then((response) => response.data),
+        ],
+        pages: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'MARKDOWN';
+            q.published = true;
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
       },
       data: {
         menu: null,
@@ -319,25 +369,35 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '?:parent',
       component: 'documentationManagementAjs',
       resolve: {
-        pages: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          const q = new DocumentationQuery();
-          if ($stateParams.parent && '' !== $stateParams.parent) {
-            q.parent = $stateParams.parent;
-          } else {
-            q.root = true;
-          }
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        folders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        systemFolders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'SYSTEM_FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
+        pages: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            const q = new DocumentationQuery();
+            if ($stateParams.parent && '' !== $stateParams.parent) {
+              q.parent = $stateParams.parent;
+            } else {
+              q.root = true;
+            }
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
+        folders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'FOLDER';
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
+        systemFolders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'SYSTEM_FOLDER';
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
       },
       data: {
         menu: null,
@@ -361,48 +421,69 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/new?type&:parent',
       component: 'documentationNewPageAjs',
       resolve: {
-        resolvedFetchers: (FetcherService: FetcherService) => {
-          return FetcherService.list().then((response) => {
-            return response.data;
-          });
-        },
-        pagesToLink: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'MARKDOWN_TEMPLATE') {
+        resolvedFetchers: [
+          'FetcherService',
+          (FetcherService: FetcherService) => {
+            return FetcherService.list().then((response) => {
+              return response.data;
+            });
+          },
+        ],
+        pagesToLink: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'MARKDOWN_TEMPLATE') {
+              const q = new DocumentationQuery();
+              q.homepage = false;
+              q.published = true;
+              return DocumentationService.search(q).then((response) =>
+                response.data.filter(
+                  (page) =>
+                    page.type.toUpperCase() === 'MARKDOWN' ||
+                    page.type.toUpperCase() === 'SWAGGER' ||
+                    page.type.toUpperCase() === 'ASCIIDOC' ||
+                    page.type.toUpperCase() === 'ASYNCAPI',
+                ),
+              );
+            }
+          },
+        ],
+        folders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
             const q = new DocumentationQuery();
-            q.homepage = false;
-            q.published = true;
-            return DocumentationService.search(q).then((response) =>
-              response.data.filter(
-                (page) =>
-                  page.type.toUpperCase() === 'MARKDOWN' ||
-                  page.type.toUpperCase() === 'SWAGGER' ||
-                  page.type.toUpperCase() === 'ASCIIDOC' ||
-                  page.type.toUpperCase() === 'ASYNCAPI',
-              ),
-            );
-          }
-        },
-        folders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        systemFolders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'SYSTEM_FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        pageResources: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'LINK') {
-            const q = new DocumentationQuery();
+            q.type = 'FOLDER';
             return DocumentationService.search(q).then((response) => response.data);
-          }
-        },
-        categoryResources: (CategoryService: CategoryService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'LINK') {
-            return CategoryService.list().then((response) => response.data);
-          }
-        },
+          },
+        ],
+        systemFolders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'SYSTEM_FOLDER';
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
+        pageResources: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'LINK') {
+              const q = new DocumentationQuery();
+              return DocumentationService.search(q).then((response) => response.data);
+            }
+          },
+        ],
+        categoryResources: [
+          'CategoryService',
+          '$stateParams',
+          (CategoryService: CategoryService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'LINK') {
+              return CategoryService.list().then((response) => response.data);
+            }
+          },
+        ],
       },
       data: {
         menu: null,
@@ -430,16 +511,22 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/import',
       component: 'documentationImportPagesAjs',
       resolve: {
-        resolvedFetchers: (FetcherService: FetcherService) => {
-          return FetcherService.list(true).then((response) => {
-            return response.data;
-          });
-        },
-        resolvedRootPage: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'ROOT';
-          return DocumentationService.search(q).then((response) => (response.data && response.data.length > 0 ? response.data[0] : null));
-        },
+        resolvedFetchers: [
+          'FetcherService',
+          (FetcherService: FetcherService) => {
+            return FetcherService.list(true).then((response) => {
+              return response.data;
+            });
+          },
+        ],
+        resolvedRootPage: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'ROOT';
+            return DocumentationService.search(q).then((response) => (response.data && response.data.length > 0 ? response.data[0] : null));
+          },
+        ],
       },
       data: {
         menu: null,
@@ -455,61 +542,93 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/:pageId?:tab&type',
       component: 'documentationEditPageAjs',
       resolve: {
-        resolvedPage: (DocumentationService: DocumentationService, $stateParams: StateParams) =>
-          DocumentationService.get(null, $stateParams.pageId).then((response) => response.data),
-        resolvedGroups: (GroupService: GroupService) => {
-          return GroupService.list().then((response) => {
-            return response.data;
-          });
-        },
-        resolvedFetchers: (FetcherService: FetcherService) => {
-          return FetcherService.list().then((response) => {
-            return response.data;
-          });
-        },
-        pagesToLink: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'MARKDOWN_TEMPLATE') {
+        resolvedPage: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) =>
+            DocumentationService.get(null, $stateParams.pageId).then((response) => response.data),
+        ],
+        resolvedGroups: [
+          'GroupService',
+          (GroupService: GroupService) => {
+            return GroupService.list().then((response) => {
+              return response.data;
+            });
+          },
+        ],
+        resolvedFetchers: [
+          'FetcherService',
+          (FetcherService: FetcherService) => {
+            return FetcherService.list().then((response) => {
+              return response.data;
+            });
+          },
+        ],
+        pagesToLink: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'MARKDOWN_TEMPLATE') {
+              const q = new DocumentationQuery();
+              q.homepage = false;
+              q.published = true;
+              return DocumentationService.search(q).then((response) =>
+                response.data.filter(
+                  (page) =>
+                    (page.type.toUpperCase() === 'MARKDOWN' ||
+                      page.type.toUpperCase() === 'SWAGGER' ||
+                      page.type.toUpperCase() === 'ASCIIDOC' ||
+                      page.type.toUpperCase() === 'ASYNCAPI') &&
+                    page.id !== $stateParams.pageId,
+                ),
+              );
+            }
+          },
+        ],
+        folders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
             const q = new DocumentationQuery();
-            q.homepage = false;
-            q.published = true;
-            return DocumentationService.search(q).then((response) =>
-              response.data.filter(
-                (page) =>
-                  (page.type.toUpperCase() === 'MARKDOWN' ||
-                    page.type.toUpperCase() === 'SWAGGER' ||
-                    page.type.toUpperCase() === 'ASCIIDOC' ||
-                    page.type.toUpperCase() === 'ASYNCAPI') &&
-                  page.id !== $stateParams.pageId,
-              ),
-            );
-          }
-        },
-        folders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        systemFolders: (DocumentationService: DocumentationService) => {
-          const q = new DocumentationQuery();
-          q.type = 'SYSTEM_FOLDER';
-          return DocumentationService.search(q).then((response) => response.data);
-        },
-        pageResources: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'LINK') {
-            const q = new DocumentationQuery();
+            q.type = 'FOLDER';
             return DocumentationService.search(q).then((response) => response.data);
-          }
-        },
-        categoryResources: (CategoryService: CategoryService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'LINK') {
-            return CategoryService.list().then((response) => response.data);
-          }
-        },
-        attachedResources: (DocumentationService: DocumentationService, $stateParams: StateParams) => {
-          if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'ASCIIDOC' || $stateParams.type === 'ASYNCAPI') {
-            return DocumentationService.getMedia($stateParams.pageId, null).then((response) => response.data);
-          }
-        },
+          },
+        ],
+        systemFolders: [
+          'DocumentationService',
+          (DocumentationService: DocumentationService) => {
+            const q = new DocumentationQuery();
+            q.type = 'SYSTEM_FOLDER';
+            return DocumentationService.search(q).then((response) => response.data);
+          },
+        ],
+        pageResources: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'LINK') {
+              const q = new DocumentationQuery();
+              return DocumentationService.search(q).then((response) => response.data);
+            }
+          },
+        ],
+        categoryResources: [
+          'CategoryService',
+          '$stateParams',
+          (CategoryService: CategoryService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'LINK') {
+              return CategoryService.list().then((response) => response.data);
+            }
+          },
+        ],
+        attachedResources: [
+          'DocumentationService',
+          '$stateParams',
+          (DocumentationService: DocumentationService, $stateParams: StateParams) => {
+            if ($stateParams.type === 'MARKDOWN' || $stateParams.type === 'ASCIIDOC' || $stateParams.type === 'ASYNCAPI') {
+              return DocumentationService.getMedia($stateParams.pageId, null).then((response) => response.data);
+            }
+          },
+        ],
       },
       data: {
         menu: null,
@@ -532,8 +651,8 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/metadata',
       component: 'metadata',
       resolve: {
-        metadata: (MetadataService: MetadataService) => MetadataService.list().then((response) => response.data),
-        metadataFormats: (MetadataService: MetadataService) => MetadataService.listFormats(),
+        metadata: ['MetadataService', (MetadataService: MetadataService) => MetadataService.list().then((response) => response.data)],
+        metadataFormats: ['MetadataService', (MetadataService: MetadataService) => MetadataService.listFormats()],
       },
       data: {
         menu: null,
@@ -550,8 +669,11 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/portal',
       component: 'portalSettings',
       resolve: {
-        tags: (TagService: TagService) => TagService.list().then((response) => response.data),
-        settings: (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        tags: ['TagService', (TagService: TagService) => TagService.list().then((response) => response.data)],
+        settings: [
+          'PortalSettingsService',
+          (PortalSettingsService: PortalSettingsService) => PortalSettingsService.get().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -583,7 +705,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/top-apis',
       component: 'topApis',
       resolve: {
-        topApis: (TopApiService: TopApiService) => TopApiService.list().then((response) => response.data),
+        topApis: ['TopApiService', (TopApiService: TopApiService) => TopApiService.list().then((response) => response.data)],
       },
       data: {
         menu: null,
@@ -601,7 +723,10 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/api_logging',
       component: 'apiLogging',
       resolve: {
-        settings: (ConsoleSettingsService: ConsoleSettingsService) => ConsoleSettingsService.get().then((response) => response.data),
+        settings: [
+          'ConsoleSettingsService',
+          (ConsoleSettingsService: ConsoleSettingsService) => ConsoleSettingsService.get().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -622,7 +747,10 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/',
       component: 'dictionaries',
       resolve: {
-        dictionaries: (DictionaryService: DictionaryService) => DictionaryService.list().then((response) => response.data),
+        dictionaries: [
+          'DictionaryService',
+          (DictionaryService: DictionaryService) => DictionaryService.list().then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -652,8 +780,11 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/:dictionaryId',
       component: 'dictionary',
       resolve: {
-        dictionary: (DictionaryService: DictionaryService, $stateParams) =>
-          DictionaryService.get($stateParams.dictionaryId).then((response) => response.data),
+        dictionary: [
+          'DictionaryService',
+          (DictionaryService: DictionaryService, $stateParams) =>
+            DictionaryService.get($stateParams.dictionaryId).then((response) => response.data),
+        ],
       },
       data: {
         menu: null,
@@ -670,9 +801,18 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/custom-user-fields',
       component: 'customUserFields',
       resolve: {
-        fields: (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.list().then((response) => response.data),
-        fieldFormats: (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.listFormats(),
-        predefinedKeys: (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.listPredefinedKeys(),
+        fields: [
+          'CustomUserFieldsService',
+          (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.list().then((response) => response.data),
+        ],
+        fieldFormats: [
+          'CustomUserFieldsService',
+          (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.listFormats(),
+        ],
+        predefinedKeys: [
+          'CustomUserFieldsService',
+          (CustomUserFieldsService: CustomUserFieldsService) => CustomUserFieldsService.listPredefinedKeys(),
+        ],
       },
       data: {
         menu: null,
@@ -693,7 +833,10 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/',
       component: 'groups',
       resolve: {
-        groups: (GroupService: GroupService) => GroupService.list().then((response) => _.filter(response.data, 'manageable')),
+        groups: [
+          'GroupService',
+          (GroupService: GroupService) => GroupService.list().then((response) => _.filter(response.data, 'manageable')),
+        ],
       },
       data: {
         menu: null,
@@ -710,7 +853,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/new',
       component: 'group',
       resolve: {
-        tags: (TagService: TagService) => TagService.list().then((response) => response.data),
+        tags: ['TagService', (TagService: TagService) => TagService.list().then((response) => response.data)],
       },
       data: {
         menu: null,
@@ -726,14 +869,26 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/:groupId',
       component: 'group',
       resolve: {
-        group: (GroupService: GroupService, $stateParams) => GroupService.get($stateParams.groupId).then((response) => response.data),
-        apiRoles: (RoleService: RoleService) =>
-          RoleService.list('API').then((roles) => [{ scope: 'API', name: '', system: false }].concat(roles)),
-        applicationRoles: (RoleService: RoleService) =>
-          RoleService.list('APPLICATION').then((roles) => [{ scope: 'APPLICATION', name: '', system: false }].concat(roles)),
-        invitations: (GroupService: GroupService, $stateParams) =>
-          GroupService.getInvitations($stateParams.groupId).then((response) => response.data),
-        tags: (TagService: TagService) => TagService.list().then((response) => response.data),
+        group: [
+          'GroupService',
+          '$stateParams',
+          (GroupService: GroupService, $stateParams) => GroupService.get($stateParams.groupId).then((response) => response.data),
+        ],
+        apiRoles: [
+          'RoleService',
+          (RoleService: RoleService) => RoleService.list('API').then((roles) => [{ scope: 'API', name: '', system: false }].concat(roles)),
+        ],
+        applicationRoles: [
+          'RoleService',
+          (RoleService: RoleService) =>
+            RoleService.list('APPLICATION').then((roles) => [{ scope: 'APPLICATION', name: '', system: false }].concat(roles)),
+        ],
+        invitations: [
+          'GroupService',
+          '$stateParams',
+          (GroupService: GroupService, $stateParams) => GroupService.getInvitations($stateParams.groupId).then((response) => response.data),
+        ],
+        tags: ['TagService', (TagService: TagService) => TagService.list().then((response) => response.data)],
       },
       data: {
         menu: null,
@@ -746,3 +901,4 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       },
     });
 }
+configurationRouterConfig.$inject = ['$stateProvider'];

--- a/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/custom-user-fields.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/custom-user-fields.controller.ts
@@ -29,7 +29,6 @@ class CustomUserFieldsController {
 
   private fields: any;
 
-  /* @ngInject */
   constructor(
     private $mdDialog: angular.material.IDialogService,
     private NotificationService: NotificationService,
@@ -109,5 +108,6 @@ class CustomUserFieldsController {
     return this.canDelete;
   }
 }
+CustomUserFieldsController.$inject = ['$mdDialog', 'NotificationService', 'UserService', '$state'];
 
 export default CustomUserFieldsController;

--- a/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/delete.custom-user-field.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/delete.custom-user-field.dialog.controller.ts
@@ -15,7 +15,6 @@
  */
 import CustomUserFieldsService from '../../../../services/custom-user-fields.service';
 
-/* @ngInject */
 function DeleteFieldDialogController(CustomUserFieldsService: CustomUserFieldsService, $mdDialog: angular.material.IDialogService, field) {
   this.field = field;
 
@@ -29,5 +28,6 @@ function DeleteFieldDialogController(CustomUserFieldsService: CustomUserFieldsSe
     });
   };
 }
+DeleteFieldDialogController.$inject = ['CustomUserFieldsService', '$mdDialog', 'field'];
 
 export default DeleteFieldDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/new.custom-user-field.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/new.custom-user-field.dialog.controller.ts
@@ -16,7 +16,6 @@
 
 import CustomUserFieldsService from '../../../../services/custom-user-fields.service';
 
-/* @ngInject */
 function NewFieldDialogController(
   CustomUserFieldsService: CustomUserFieldsService,
   $mdDialog: angular.material.IDialogService,
@@ -36,5 +35,6 @@ function NewFieldDialogController(
     });
   };
 }
+NewFieldDialogController.$inject = ['CustomUserFieldsService', '$mdDialog', 'predefinedKeys'];
 
 export default NewFieldDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/update.custom-user-field.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/custom-user-fields/dialog/update.custom-user-field.dialog.controller.ts
@@ -16,7 +16,6 @@
 
 import CustomUserFieldsService from '../../../../services/custom-user-fields.service';
 
-/* @ngInject */
 function UpdateFieldDialogController(
   CustomUserFieldsService: CustomUserFieldsService,
   $mdDialog: angular.material.IDialogService,
@@ -38,5 +37,6 @@ function UpdateFieldDialogController(
     });
   };
 }
+UpdateFieldDialogController.$inject = ['CustomUserFieldsService', '$mdDialog', 'field', 'predefinedKeys'];
 
 export default UpdateFieldDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/dictionaries/add-property.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/dictionaries/add-property.dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DialogDictionaryAddPropertyController($scope, $mdDialog) {
   this.hide = function () {
     $mdDialog.hide();
@@ -28,5 +27,6 @@ function DialogDictionaryAddPropertyController($scope, $mdDialog) {
     $mdDialog.hide(property);
   };
 }
+DialogDictionaryAddPropertyController.$inject = ['$scope', '$mdDialog'];
 
 export default DialogDictionaryAddPropertyController;

--- a/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionaries.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionaries.controller.ts
@@ -17,10 +17,9 @@ import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 
 class DictionariesController {
-  /* @ngInject */
   constructor(private $state: StateService, private $rootScope: IScope) {
     this.$rootScope = $rootScope;
   }
 }
-
+DictionariesController.$inject = ['$state', '$rootScope'];
 export default DictionariesController;

--- a/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionary.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionary.controller.ts
@@ -44,7 +44,6 @@ class DictionaryController {
   private selectAll: boolean;
   private formDictionary: any;
 
-  /* @ngInject */
   constructor(
     private $scope: IDictionaryScope,
     private $state: StateService,
@@ -312,5 +311,6 @@ class DictionaryController {
     return ['GET', 'DELETE', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'TRACE', 'HEAD'];
   }
 }
+DictionaryController.$inject = ['$scope', '$state', '$mdEditDialog', '$mdDialog', 'NotificationService', 'DictionaryService'];
 
 export default DictionaryController;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/addMemberDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/addMemberDialog.controller.ts
@@ -23,7 +23,6 @@ export class Role {
   system: boolean;
 }
 
-/* @ngInject */
 function DialogAddGroupMemberController(
   $mdDialog: angular.material.IDialogService,
   group: any,
@@ -80,5 +79,16 @@ function DialogAddGroupMemberController(
     return this.defaultApiRole === RoleName.PRIMARY_OWNER && this.usersSelected.length > 0;
   };
 }
+DialogAddGroupMemberController.$inject = [
+  '$mdDialog',
+  'group',
+  'defaultApiRole',
+  'defaultApplicationRole',
+  'apiRoles',
+  'applicationRoles',
+  'canChangeDefaultApiRole',
+  'canChangeDefaultApplicationRole',
+  'isApiRoleDisabled',
+];
 
 export default DialogAddGroupMemberController;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -48,148 +48,407 @@ const GroupComponent: ng.IComponentOptions = {
     tags: '<',
   },
   template: require('./group.html'),
-  /* @ngInject */
-  controller: function (
-    GroupService: GroupService,
-    NotificationService: NotificationService,
-    ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService,
-    $mdDialog: angular.material.IDialogService,
-    $state: StateService,
-    $scope: IGroupDetailComponentScope,
-    UserService: UserService,
-    $rootScope,
-  ) {
-    this.$rootScope = $rootScope;
+  controller: [
+    'GroupService',
+    'NotificationService',
+    'ApiPrimaryOwnerModeService',
+    '$mdDialog',
+    '$state',
+    '$scope',
+    'UserService',
+    '$rootScope',
+    function (
+      GroupService: GroupService,
+      NotificationService: NotificationService,
+      ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService,
+      $mdDialog: angular.material.IDialogService,
+      $state: StateService,
+      $scope: IGroupDetailComponentScope,
+      UserService: UserService,
+      $rootScope,
+    ) {
+      this.$rootScope = $rootScope;
 
-    this.$onInit = () => {
-      this.updateMode = this.group !== undefined && this.group.id !== undefined;
-      this.membersLoaded = false;
-      this.defaultPageSize = 10;
+      this.$onInit = () => {
+        this.updateMode = this.group !== undefined && this.group.id !== undefined;
+        this.membersLoaded = false;
+        this.defaultPageSize = 10;
 
-      this.membersPageQuery = {
-        page: $state.params.page ? parseInt($state.params.page, 10) : 1,
-        size: this.defaultPageSize,
-      };
+        this.membersPageQuery = {
+          page: $state.params.page ? parseInt($state.params.page, 10) : 1,
+          size: this.defaultPageSize,
+        };
 
-      if (!this.updateMode) {
-        this.group = {};
-        this.group.lock_api_role = false;
-        this.group.lock_application_role = false;
-        this.group.disable_membership_notifications = false;
-      } else {
-        GroupService.getMembers(this.group?.id).then((response) => {
-          this.membershipState = new MembershipState(response.data);
-          this.getMembersPage(true);
-        });
-      }
+        if (!this.updateMode) {
+          this.group = {};
+          this.group.lock_api_role = false;
+          this.group.lock_application_role = false;
+          this.group.disable_membership_notifications = false;
+        } else {
+          GroupService.getMembers(this.group?.id).then((response) => {
+            this.membershipState = new MembershipState(response.data);
+            this.getMembersPage(true);
+          });
+        }
 
-      $scope.groupApis = [];
-      $scope.groupApplications = [];
-      $scope.currentTab = 'users';
+        $scope.groupApis = [];
+        $scope.groupApplications = [];
+        $scope.currentTab = 'users';
 
-      if (this.group.roles) {
-        this.selectedApiRole = this.group.roles.API;
-        this.selectedApplicationRole = this.group.roles.APPLICATION;
-      }
+        if (this.group.roles) {
+          this.selectedApiRole = this.group.roles.API;
+          this.selectedApplicationRole = this.group.roles.APPLICATION;
+        }
 
-      this.apiByDefault = this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'API_CREATE') !== -1;
-      this.applicationByDefault =
-        this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'APPLICATION_CREATE') !== -1;
+        this.apiByDefault = this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'API_CREATE') !== -1;
+        this.applicationByDefault =
+          this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'APPLICATION_CREATE') !== -1;
 
-      this.currentUserId = UserService.currentUser.id;
-      this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
-      this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
-      this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;
+        this.currentUserId = UserService.currentUser.id;
+        this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
+        this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
+        this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;
 
-      /*
+        /*
         It is written in the members list: "Enable email invitation and/or user search to allow the group administrator to add users."
         It means that to add members, the group must be manageable (i.e. the current user is a group admin) and the group must have email invitation or system invitation enabled.
        */
-      this.canAddMembers = this.isSuperAdmin || (this.group.manageable && (this.group.system_invitation || this.group.email_invitation));
+        this.canAddMembers = this.isSuperAdmin || (this.group.manageable && (this.group.system_invitation || this.group.email_invitation));
 
-      this.loadGroupApis();
-    };
+        this.loadGroupApis();
+      };
 
-    this.updateRole = (member: any) => {
-      if (this.membershipState.isPrimaryOwnerDemotion(member)) {
-        this.demotePrimaryOwner(this.membershipState.stateOf(member));
-      } else if (this.membershipState.isPrimaryOwnerPromotion(member)) {
-        this.promoteNewPrimaryOwner(this.membershipState.stateOf(member));
-      } else {
-        GroupService.addOrUpdateMember(this.group.id, [member]).then(() => {
-          NotificationService.show('Member successfully updated');
+      this.updateRole = (member: any) => {
+        if (this.membershipState.isPrimaryOwnerDemotion(member)) {
+          this.demotePrimaryOwner(this.membershipState.stateOf(member));
+        } else if (this.membershipState.isPrimaryOwnerPromotion(member)) {
+          this.promoteNewPrimaryOwner(this.membershipState.stateOf(member));
+        } else {
+          GroupService.addOrUpdateMember(this.group.id, [member]).then(() => {
+            NotificationService.show('Member successfully updated');
+            $state.reload();
+          });
+        }
+      };
+
+      this.associateToApis = () => {
+        GroupService.associate(this.group.id, 'api').then(() => {
+          $state.reload();
+          NotificationService.show("Group '" + this.group.name + "' has been associated to all APIs");
+        });
+      };
+
+      this.associateToApplications = () => {
+        GroupService.associate(this.group.id, 'application').then(() => {
+          $state.reload();
+          NotificationService.show("Group '" + this.group.name + "' has been associated to all applications");
+        });
+      };
+
+      this.update = () => {
+        GroupService.updateEventRules(this.group, this.apiByDefault, this.applicationByDefault);
+
+        if (!this.updateMode) {
+          GroupService.create(this.group).then((response) => {
+            $state.go('management.settings.groups.group', { groupId: response.data.id }, { reload: true });
+            NotificationService.show("Group '" + this.group.name + "' has been created");
+          });
+        } else {
+          const roles: any = {};
+
+          if (this.selectedApiRole) {
+            roles.API = this.selectedApiRole;
+          } else {
+            delete roles.API;
+          }
+
+          if (this.selectedApplicationRole) {
+            roles.APPLICATION = this.selectedApplicationRole;
+          } else {
+            delete roles.APPLICATION;
+          }
+
+          this.group.roles = roles;
+
+          GroupService.update(this.group).then((response) => {
+            this.group = response.data;
+            this.$onInit();
+            $scope.formGroup.$setPristine();
+            NotificationService.show("Group '" + this.group.name + "' has been updated");
+          });
+        }
+      };
+
+      this.onPaginate = (page: number) => {
+        this.getMembersPage(true, { page, size: this.defaultPageSize });
+      };
+
+      this.removeUser = (ev, member: any) => {
+        ev.stopPropagation();
+
+        const memberState = this.membershipState.stateOf(member);
+        if (memberState.wasPrimaryOwner()) {
+          this.showTransferOwnershipModal(member, ApiOwnershipTransferType.DELETE_PRIMARY_OWNER).then(
+            ({ newPrimaryOwnerRef, primaryOwner }) => {
+              this.deleteMember(primaryOwner).then(() => {
+                const newPrimaryOwner = this.membershipState.findByRef(newPrimaryOwnerRef);
+                newPrimaryOwner.roles['API'] = 'PRIMARY_OWNER';
+                this.updateRole(newPrimaryOwner);
+              });
+            },
+          );
+        } else {
+          $mdDialog
+            .show({
+              controller: 'DialogConfirmController',
+              controllerAs: 'ctrl',
+              template: require('../../../../components/dialog/confirmWarning.dialog.html'),
+              clickOutsideToClose: true,
+              locals: {
+                msg: '',
+                title: 'Are you sure you want to remove the user "' + member.displayName + '"?',
+                confirmButton: 'Remove',
+              },
+            })
+            .then((response) => {
+              if (response) {
+                this.deleteMember(member);
+              }
+            });
+        }
+      };
+
+      this.showAddMemberModal = () => {
+        $mdDialog
+          .show({
+            controller: 'DialogAddGroupMemberController',
+            controllerAs: '$ctrl',
+            template: require('./addMember.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              defaultApiRole: this.selectedApiRole,
+              defaultApplicationRole: this.selectedApplicationRole,
+              group: this.group,
+              apiRoles: this.apiRoles,
+              applicationRoles: this.applicationRoles,
+              canChangeDefaultApiRole: this.canChangeDefaultApiRole,
+              canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
+              isApiRoleDisabled: this.isApiRoleDisabled,
+            },
+          })
+          .then(
+            (members = []) => {
+              if (members.length > 0) {
+                if (this.membershipState.isPrimaryOwnerPromotion(members[0])) {
+                  this.promoteNewPrimaryOwner(this.membershipState.stateOf(members[0]));
+                } else {
+                  GroupService.addOrUpdateMember(this.group.id, members)
+                    .then(() => {
+                      NotificationService.show('Member(s) successfully added');
+                      members
+                        .filter((member) => this.membershipState.isPrimaryOwnerDemotion(member))
+                        .forEach((member) => this.demotePrimaryOwner(this.membershipState.stateOf(member)));
+                    })
+                    .finally(() => this.getMembersPage());
+                }
+              }
+            },
+            () => {
+              // you cancelled the dialog
+            },
+          );
+      };
+
+      this.showTransferOwnershipModal = (primaryOwner, transferType): IPromise<OwnershipTransferResult> => {
+        const members = this.membershipState.findAll();
+
+        return $mdDialog.show({
+          controller: 'DialogTransferOwnershipController',
+          controllerAs: '$ctrl',
+          template: require('./transferOwnershipDialog.html'),
+          clickOutsideToClose: true,
+          locals: {
+            transferType,
+            members,
+            primaryOwner,
+            group: this.group,
+          },
+        });
+      };
+
+      this.demotePrimaryOwner = (memberState: MemberState): void => {
+        this.showTransferOwnershipModal(memberState.getLastState(), ApiOwnershipTransferType.DEMOTE_PRIMARY_OWNER).then(
+          ({ newPrimaryOwnerRef }) => {
+            const newPrimaryOwner = this.membershipState.findByRef(newPrimaryOwnerRef);
+            const previousPrimaryOwner = memberState.getCurrentState();
+
+            newPrimaryOwner.roles['API'] = 'PRIMARY_OWNER';
+
+            GroupService.addOrUpdateMember(this.group.id, [previousPrimaryOwner, newPrimaryOwner])
+              .then(() => {
+                NotificationService.show('Member successfully updated');
+              })
+              .finally(() => this.getMembersPage());
+          },
+          () => this.getMembersPage(),
+        );
+      };
+
+      this.promoteNewPrimaryOwner = (memberState: MemberState): void => {
+        this.showTransferOwnershipModal(this.membershipState.getPrimaryOwner(), ApiOwnershipTransferType.PROMOTE_NEW_PRIMARY_OWNER).then(
+          () => {
+            const previousPrimaryOwner = this.membershipState.getPrimaryOwner();
+            const newPrimaryOwner = memberState.getCurrentState();
+
+            previousPrimaryOwner.roles[RoleScope.API] = RoleName.OWNER;
+            newPrimaryOwner.roles[RoleScope.API] = RoleName.PRIMARY_OWNER;
+
+            GroupService.addOrUpdateMember(this.group.id, [previousPrimaryOwner, newPrimaryOwner])
+              .then(() => {
+                NotificationService.show('Member successfully updated');
+              })
+              .finally(() => this.getMembersPage());
+          },
+          () => this.getMembersPage(),
+        );
+      };
+
+      this.deleteMember = (member: Member): IPromise<void> => {
+        return GroupService.deleteMember(this.group.id, member.id).then(() => {
+          NotificationService.show('Member ' + member.displayName + ' has been successfully removed');
+          if (this.members.length === 1 && this.membersPageQuery.page > 0) {
+            --this.membersPageQuery.page;
+          }
+          return this.getMembersPage().then(() => {
+            if (this.group.apiPrimaryOwner === member.id) {
+              delete this.group.apiPrimaryOwner;
+            }
+          });
+        });
+      };
+
+      this.getMembersPage = (useLoader = false, membersPageQuery: Partial<MemberPageQuery> = {}): IPromise<void> => {
+        this.membersLoaded = !useLoader;
+
+        return GroupService.getMembers(this.group.id, Object.assign(this.membersPageQuery, membersPageQuery))
+          .then((response) => {
+            this.membersPage = response.data;
+            this.membersPageQuery.page = this.membersPage.page.current;
+            this.members = this.membersPage.data;
+            this.membershipState.sync(this.members);
+          })
+          .finally(() => {
+            this.membersLoaded = true;
+          });
+      };
+
+      this.loadGroupApis = () => {
+        GroupService.getMemberships(this.group.id, 'api').then((response) => {
+          $scope.groupApis = _.sortBy(response.data, 'name');
+        });
+      };
+
+      this.loadGroupApplications = () => {
+        GroupService.getMemberships(this.group.id, 'application').then((response) => {
+          $scope.groupApplications = _.sortBy(response.data, 'name');
+        });
+      };
+
+      this.reset = () => {
+        $state.reload();
+      };
+
+      this.isMaxInvitationReached = () => {
+        if (!this.group.max_invitation) {
+          return false;
+        }
+        const numberOfMembers = this.membersPage ? this.membersPage.page.total_elements : 0;
+        const numberOfInvitations = this.invitations ? this.invitations.length : 0;
+        const numberOfSlots = numberOfMembers + numberOfInvitations;
+        return numberOfSlots >= this.group.max_invitation;
+      };
+
+      this.canSave = () => {
+        return !this.updateMode || this.group.manageable;
+      };
+
+      this.updateInvitation = (invitation: any) => {
+        GroupService.updateInvitation(this.group.id, invitation).then(() => {
+          NotificationService.show('Invitation successfully updated');
           $state.reload();
         });
-      }
-    };
+      };
 
-    this.associateToApis = () => {
-      GroupService.associate(this.group.id, 'api').then(() => {
-        $state.reload();
-        NotificationService.show("Group '" + this.group.name + "' has been associated to all APIs");
-      });
-    };
+      this.showInviteMemberModal = () => {
+        $mdDialog
+          .show({
+            controller: [
+              '$mdDialog',
+              'group',
+              'apiRoles',
+              'applicationRoles',
+              'defaultApiRole',
+              'defaultApplicationRole',
+              'canChangeDefaultApiRole',
+              'canChangeDefaultApplicationRole',
+              'isApiRoleDisabled',
+              function (
+                $mdDialog,
+                group,
+                apiRoles,
+                applicationRoles,
+                defaultApiRole,
+                defaultApplicationRole,
+                canChangeDefaultApiRole,
+                canChangeDefaultApplicationRole,
+                isApiRoleDisabled,
+              ) {
+                this.group = group;
+                this.group.api_role = group.api_role || defaultApiRole;
+                this.group.application_role = group.application_role || defaultApplicationRole;
+                this.apiRoles = apiRoles;
+                this.applicationRoles = applicationRoles;
+                this.canChangeDefaultApiRole = canChangeDefaultApiRole;
+                this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
+                this.isApiRoleDisabled = isApiRoleDisabled;
+                this.hide = function () {
+                  $mdDialog.hide();
+                };
+                this.save = function () {
+                  $mdDialog.hide(this.email);
+                };
+              },
+            ],
+            controllerAs: '$ctrl',
+            template: require('./inviteMember.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              defaultApiRole: this.selectedApiRole,
+              defaultApplicationRole: this.selectedApplicationRole,
+              group: this.group,
+              apiRoles: this.apiRoles,
+              applicationRoles: this.applicationRoles,
+              canChangeDefaultApiRole: this.canChangeDefaultApiRole,
+              canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
+              isApiRoleDisabled: this.isApiRoleDisabled,
+            },
+          })
+          .then((email) => {
+            if (email) {
+              GroupService.inviteMember(this.group, email).then((response) => {
+                if (response.data.id) {
+                  NotificationService.show('Invitation successfully sent');
+                } else {
+                  NotificationService.show('Member successfully added');
+                }
+                $state.reload();
+              });
+            }
+          });
+      };
 
-    this.associateToApplications = () => {
-      GroupService.associate(this.group.id, 'application').then(() => {
-        $state.reload();
-        NotificationService.show("Group '" + this.group.name + "' has been associated to all applications");
-      });
-    };
-
-    this.update = () => {
-      GroupService.updateEventRules(this.group, this.apiByDefault, this.applicationByDefault);
-
-      if (!this.updateMode) {
-        GroupService.create(this.group).then((response) => {
-          $state.go('management.settings.groups.group', { groupId: response.data.id }, { reload: true });
-          NotificationService.show("Group '" + this.group.name + "' has been created");
-        });
-      } else {
-        const roles: any = {};
-
-        if (this.selectedApiRole) {
-          roles.API = this.selectedApiRole;
-        } else {
-          delete roles.API;
-        }
-
-        if (this.selectedApplicationRole) {
-          roles.APPLICATION = this.selectedApplicationRole;
-        } else {
-          delete roles.APPLICATION;
-        }
-
-        this.group.roles = roles;
-
-        GroupService.update(this.group).then((response) => {
-          this.group = response.data;
-          this.$onInit();
-          $scope.formGroup.$setPristine();
-          NotificationService.show("Group '" + this.group.name + "' has been updated");
-        });
-      }
-    };
-
-    this.onPaginate = (page: number) => {
-      this.getMembersPage(true, { page, size: this.defaultPageSize });
-    };
-
-    this.removeUser = (ev, member: any) => {
-      ev.stopPropagation();
-
-      const memberState = this.membershipState.stateOf(member);
-      if (memberState.wasPrimaryOwner()) {
-        this.showTransferOwnershipModal(member, ApiOwnershipTransferType.DELETE_PRIMARY_OWNER).then(
-          ({ newPrimaryOwnerRef, primaryOwner }) => {
-            this.deleteMember(primaryOwner).then(() => {
-              const newPrimaryOwner = this.membershipState.findByRef(newPrimaryOwnerRef);
-              newPrimaryOwner.roles['API'] = 'PRIMARY_OWNER';
-              this.updateRole(newPrimaryOwner);
-            });
-          },
-        );
-      } else {
+      this.removeInvitation = (ev, invitation: any) => {
+        ev.stopPropagation();
         $mdDialog
           .show({
             controller: 'DialogConfirmController',
@@ -198,278 +457,38 @@ const GroupComponent: ng.IComponentOptions = {
             clickOutsideToClose: true,
             locals: {
               msg: '',
-              title: 'Are you sure you want to remove the user "' + member.displayName + '"?',
+              title: 'Are you sure you want to remove the invitation for "' + invitation.email + '"?',
               confirmButton: 'Remove',
             },
           })
           .then((response) => {
             if (response) {
-              this.deleteMember(member);
+              GroupService.deleteInvitation(this.group.id, invitation.id).then(() => {
+                NotificationService.show('Invitation for ' + invitation.email + ' has been successfully removed');
+                $state.reload();
+              });
             }
           });
-      }
-    };
+      };
 
-    this.showAddMemberModal = () => {
-      $mdDialog
-        .show({
-          controller: 'DialogAddGroupMemberController',
-          controllerAs: '$ctrl',
-          template: require('./addMember.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            defaultApiRole: this.selectedApiRole,
-            defaultApplicationRole: this.selectedApplicationRole,
-            group: this.group,
-            apiRoles: this.apiRoles,
-            applicationRoles: this.applicationRoles,
-            canChangeDefaultApiRole: this.canChangeDefaultApiRole,
-            canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
-            isApiRoleDisabled: this.isApiRoleDisabled,
-          },
-        })
-        .then(
-          (members = []) => {
-            if (members.length > 0) {
-              if (this.membershipState.isPrimaryOwnerPromotion(members[0])) {
-                this.promoteNewPrimaryOwner(this.membershipState.stateOf(members[0]));
-              } else {
-                GroupService.addOrUpdateMember(this.group.id, members)
-                  .then(() => {
-                    NotificationService.show('Member(s) successfully added');
-                    members
-                      .filter((member) => this.membershipState.isPrimaryOwnerDemotion(member))
-                      .forEach((member) => this.demotePrimaryOwner(this.membershipState.stateOf(member)));
-                  })
-                  .finally(() => this.getMembersPage());
-              }
-            }
-          },
-          () => {
-            // you cancelled the dialog
-          },
-        );
-    };
+      this.hasGroupAdmin = () => {
+        let hasGroupAdmin = false;
+        _.forEach(this.members, (member) => {
+          if (member.roles.GROUP && member.roles.GROUP === 'ADMIN') {
+            hasGroupAdmin = true;
+          }
+        });
+        return hasGroupAdmin;
+      };
 
-    this.showTransferOwnershipModal = (primaryOwner, transferType): IPromise<OwnershipTransferResult> => {
-      const members = this.membershipState.findAll();
-
-      return $mdDialog.show({
-        controller: 'DialogTransferOwnershipController',
-        controllerAs: '$ctrl',
-        template: require('./transferOwnershipDialog.html'),
-        clickOutsideToClose: true,
-        locals: {
-          transferType,
-          members,
-          primaryOwner,
-          group: this.group,
-        },
-      });
-    };
-
-    this.demotePrimaryOwner = (memberState: MemberState): void => {
-      this.showTransferOwnershipModal(memberState.getLastState(), ApiOwnershipTransferType.DEMOTE_PRIMARY_OWNER).then(
-        ({ newPrimaryOwnerRef }) => {
-          const newPrimaryOwner = this.membershipState.findByRef(newPrimaryOwnerRef);
-          const previousPrimaryOwner = memberState.getCurrentState();
-
-          newPrimaryOwner.roles['API'] = 'PRIMARY_OWNER';
-
-          GroupService.addOrUpdateMember(this.group.id, [previousPrimaryOwner, newPrimaryOwner])
-            .then(() => {
-              NotificationService.show('Member successfully updated');
-            })
-            .finally(() => this.getMembersPage());
-        },
-        () => this.getMembersPage(),
-      );
-    };
-
-    this.promoteNewPrimaryOwner = (memberState: MemberState): void => {
-      this.showTransferOwnershipModal(this.membershipState.getPrimaryOwner(), ApiOwnershipTransferType.PROMOTE_NEW_PRIMARY_OWNER).then(
-        () => {
-          const previousPrimaryOwner = this.membershipState.getPrimaryOwner();
-          const newPrimaryOwner = memberState.getCurrentState();
-
-          previousPrimaryOwner.roles[RoleScope.API] = RoleName.OWNER;
-          newPrimaryOwner.roles[RoleScope.API] = RoleName.PRIMARY_OWNER;
-
-          GroupService.addOrUpdateMember(this.group.id, [previousPrimaryOwner, newPrimaryOwner])
-            .then(() => {
-              NotificationService.show('Member successfully updated');
-            })
-            .finally(() => this.getMembersPage());
-        },
-        () => this.getMembersPage(),
-      );
-    };
-
-    this.deleteMember = (member: Member): IPromise<void> => {
-      return GroupService.deleteMember(this.group.id, member.id).then(() => {
-        NotificationService.show('Member ' + member.displayName + ' has been successfully removed');
-        if (this.members.length === 1 && this.membersPageQuery.page > 0) {
-          --this.membersPageQuery.page;
+      this.isApiRoleDisabled = (role) => {
+        if (ApiPrimaryOwnerModeService.isUserOnly()) {
+          return role.name === 'PRIMARY_OWNER';
         }
-        return this.getMembersPage().then(() => {
-          if (this.group.apiPrimaryOwner === member.id) {
-            delete this.group.apiPrimaryOwner;
-          }
-        });
-      });
-    };
-
-    this.getMembersPage = (useLoader = false, membersPageQuery: Partial<MemberPageQuery> = {}): IPromise<void> => {
-      this.membersLoaded = !useLoader;
-
-      return GroupService.getMembers(this.group.id, Object.assign(this.membersPageQuery, membersPageQuery))
-        .then((response) => {
-          this.membersPage = response.data;
-          this.membersPageQuery.page = this.membersPage.page.current;
-          this.members = this.membersPage.data;
-          this.membershipState.sync(this.members);
-        })
-        .finally(() => {
-          this.membersLoaded = true;
-        });
-    };
-
-    this.loadGroupApis = () => {
-      GroupService.getMemberships(this.group.id, 'api').then((response) => {
-        $scope.groupApis = _.sortBy(response.data, 'name');
-      });
-    };
-
-    this.loadGroupApplications = () => {
-      GroupService.getMemberships(this.group.id, 'application').then((response) => {
-        $scope.groupApplications = _.sortBy(response.data, 'name');
-      });
-    };
-
-    this.reset = () => {
-      $state.reload();
-    };
-
-    this.isMaxInvitationReached = () => {
-      if (!this.group.max_invitation) {
-        return false;
-      }
-      const numberOfMembers = this.membersPage ? this.membersPage.page.total_elements : 0;
-      const numberOfInvitations = this.invitations ? this.invitations.length : 0;
-      const numberOfSlots = numberOfMembers + numberOfInvitations;
-      return numberOfSlots >= this.group.max_invitation;
-    };
-
-    this.canSave = () => {
-      return !this.updateMode || this.group.manageable;
-    };
-
-    this.updateInvitation = (invitation: any) => {
-      GroupService.updateInvitation(this.group.id, invitation).then(() => {
-        NotificationService.show('Invitation successfully updated');
-        $state.reload();
-      });
-    };
-
-    this.showInviteMemberModal = () => {
-      $mdDialog
-        .show({
-          /* @ngInject */
-          controller: function (
-            $mdDialog,
-            group,
-            apiRoles,
-            applicationRoles,
-            defaultApiRole,
-            defaultApplicationRole,
-            canChangeDefaultApiRole,
-            canChangeDefaultApplicationRole,
-            isApiRoleDisabled,
-          ) {
-            this.group = group;
-            this.group.api_role = group.api_role || defaultApiRole;
-            this.group.application_role = group.application_role || defaultApplicationRole;
-            this.apiRoles = apiRoles;
-            this.applicationRoles = applicationRoles;
-            this.canChangeDefaultApiRole = canChangeDefaultApiRole;
-            this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
-            this.isApiRoleDisabled = isApiRoleDisabled;
-            this.hide = function () {
-              $mdDialog.hide();
-            };
-            this.save = function () {
-              $mdDialog.hide(this.email);
-            };
-          },
-          controllerAs: '$ctrl',
-          template: require('./inviteMember.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            defaultApiRole: this.selectedApiRole,
-            defaultApplicationRole: this.selectedApplicationRole,
-            group: this.group,
-            apiRoles: this.apiRoles,
-            applicationRoles: this.applicationRoles,
-            canChangeDefaultApiRole: this.canChangeDefaultApiRole,
-            canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
-            isApiRoleDisabled: this.isApiRoleDisabled,
-          },
-        })
-        .then((email) => {
-          if (email) {
-            GroupService.inviteMember(this.group, email).then((response) => {
-              if (response.data.id) {
-                NotificationService.show('Invitation successfully sent');
-              } else {
-                NotificationService.show('Member successfully added');
-              }
-              $state.reload();
-            });
-          }
-        });
-    };
-
-    this.removeInvitation = (ev, invitation: any) => {
-      ev.stopPropagation();
-      $mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            msg: '',
-            title: 'Are you sure you want to remove the invitation for "' + invitation.email + '"?',
-            confirmButton: 'Remove',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            GroupService.deleteInvitation(this.group.id, invitation.id).then(() => {
-              NotificationService.show('Invitation for ' + invitation.email + ' has been successfully removed');
-              $state.reload();
-            });
-          }
-        });
-    };
-
-    this.hasGroupAdmin = () => {
-      let hasGroupAdmin = false;
-      _.forEach(this.members, (member) => {
-        if (member.roles.GROUP && member.roles.GROUP === 'ADMIN') {
-          hasGroupAdmin = true;
-        }
-      });
-      return hasGroupAdmin;
-    };
-
-    this.isApiRoleDisabled = (role) => {
-      if (ApiPrimaryOwnerModeService.isUserOnly()) {
-        return role.name === 'PRIMARY_OWNER';
-      }
-      return role.system && role.name !== 'PRIMARY_OWNER';
-    };
-  },
+        return role.system && role.name !== 'PRIMARY_OWNER';
+      };
+    },
+  ],
 };
 
 export default GroupComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/transferOwnershipDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/transferOwnershipDialog.controller.ts
@@ -30,7 +30,6 @@ export interface OwnershipTransferResult {
 class DialogTransferOwnershipController {
   private readonly usersSelected: Partial<Member>[];
 
-  /* @ngInject */
   constructor(
     private $mdDialog: angular.material.IDialogService,
     private primaryOwner: Member,
@@ -67,5 +66,6 @@ class DialogTransferOwnershipController {
     return this.transferType === ApiOwnershipTransferType.PROMOTE_NEW_PRIMARY_OWNER;
   }
 }
+DialogTransferOwnershipController.$inject = ['$mdDialog', 'primaryOwner', 'members', 'group', 'transferType'];
 
 export default DialogTransferOwnershipController;

--- a/gravitee-apim-console-webui/src/management/configuration/groups/groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/groups.component.ts
@@ -26,71 +26,78 @@ const GroupsComponent: ng.IComponentOptions = {
     groups: '<',
   },
   template: require('./groups.html'),
-  /* @ngInject */
-  controller: function (
-    GroupService: GroupService,
-    UserService: UserService,
-    NotificationService: NotificationService,
-    $mdDialog: angular.material.IDialogService,
-    $state: StateService,
-    $rootScope: IScope,
-  ) {
-    this.$rootScope = $rootScope;
+  controller: [
+    'GroupService',
+    'UserService',
+    'NotificationService',
+    '$mdDialog',
+    '$state',
+    '$rootScope',
+    function (
+      GroupService: GroupService,
+      UserService: UserService,
+      NotificationService: NotificationService,
+      $mdDialog: angular.material.IDialogService,
+      $state: StateService,
+      $rootScope: IScope,
+    ) {
+      this.$rootScope = $rootScope;
 
-    this.$onInit = () => {
-      this.canRemoveGroup = UserService.isUserHasPermissions(['environment-group-d']);
-    };
+      this.$onInit = () => {
+        this.canRemoveGroup = UserService.isUserHasPermissions(['environment-group-d']);
+      };
 
-    this.create = () => {
-      $state.go('management.settings.groups.create');
-    };
+      this.create = () => {
+        $state.go('management.settings.groups.create');
+      };
 
-    this.removeGroup = (ev, groupId, groupName) => {
-      ev.stopPropagation();
-      $mdDialog
-        .show({
-          controller: 'DialogConfirmController',
-          controllerAs: 'ctrl',
-          template: require('../../../components/dialog/confirmWarning.dialog.html'),
-          clickOutsideToClose: true,
-          locals: {
-            title: 'Would you like to remove the group "' + groupName + '"?',
-            confirmButton: 'Remove',
-          },
-        })
-        .then((response) => {
-          if (response) {
-            GroupService.remove(groupId).then(() => {
-              NotificationService.show('Group ' + groupName + ' has been deleted.');
-              GroupService.list().then((response) => {
-                this.groups = _.filter(response.data, 'manageable');
-                this.initEventRules();
+      this.removeGroup = (ev, groupId, groupName) => {
+        ev.stopPropagation();
+        $mdDialog
+          .show({
+            controller: 'DialogConfirmController',
+            controllerAs: 'ctrl',
+            template: require('../../../components/dialog/confirmWarning.dialog.html'),
+            clickOutsideToClose: true,
+            locals: {
+              title: 'Would you like to remove the group "' + groupName + '"?',
+              confirmButton: 'Remove',
+            },
+          })
+          .then((response) => {
+            if (response) {
+              GroupService.remove(groupId).then(() => {
+                NotificationService.show('Group ' + groupName + ' has been deleted.');
+                GroupService.list().then((response) => {
+                  this.groups = _.filter(response.data, 'manageable');
+                  this.initEventRules();
+                });
               });
-            });
-          }
-        });
-    };
+            }
+          });
+      };
 
-    this.saveEventRules = (group: any) => {
-      if (group.manageable) {
-        GroupService.updateEventRules(group, this.apiByDefault[group.id], this.applicationByDefault[group.id]);
-        GroupService.update(group).then(() => {
-          NotificationService.show('Group ' + group.name + ' has been updated.');
-        });
-      }
-    };
+      this.saveEventRules = (group: any) => {
+        if (group.manageable) {
+          GroupService.updateEventRules(group, this.apiByDefault[group.id], this.applicationByDefault[group.id]);
+          GroupService.update(group).then(() => {
+            NotificationService.show('Group ' + group.name + ' has been updated.');
+          });
+        }
+      };
 
-    this.selectGroupUrl = (group: any) => {
-      if (group.manageable) {
-        return $state.go('management.settings.groups.group', { groupId: group.id });
-      }
-      return null;
-    };
+      this.selectGroupUrl = (group: any) => {
+        if (group.manageable) {
+          return $state.go('management.settings.groups.group', { groupId: group.id });
+        }
+        return null;
+      };
 
-    this.hasEvent = (group: any, event: string) => {
-      return group.event_rules && group.event_rules.findIndex((rule) => rule.event === event) !== -1;
-    };
-  },
+      this.hasEvent = (group: any, event: string) => {
+        return group.event_rules && group.event_rules.findIndex((rule) => rule.event === event) !== -1;
+      };
+    },
+  ],
 };
 
 export default GroupsComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
@@ -22,7 +22,6 @@ import { ApimFeature } from '../../../shared/components/gio-license/gio-license-
 
 export default applicationsNotificationsRouterConfig;
 
-/* @ngInject */
 function applicationsNotificationsRouterConfig($stateProvider) {
   $stateProvider
     .state('management.settings.notifications', {
@@ -36,12 +35,21 @@ function applicationsNotificationsRouterConfig($stateProvider) {
       },
       resolve: {
         resolvedHookScope: () => Scope.PORTAL,
-        resolvedHooks: (NotificationSettingsService: NotificationSettingsService) =>
-          NotificationSettingsService.getHooks(Scope.PORTAL).then((response) => response.data),
-        resolvedNotifiers: (NotificationSettingsService: NotificationSettingsService) =>
-          NotificationSettingsService.getNotifiers(Scope.PORTAL, null).then((response) => response.data),
-        notificationSettings: (NotificationSettingsService: NotificationSettingsService) =>
-          NotificationSettingsService.getNotificationSettings(Scope.PORTAL, null).then((response) => response.data),
+        resolvedHooks: [
+          'NotificationSettingsService',
+          (NotificationSettingsService: NotificationSettingsService) =>
+            NotificationSettingsService.getHooks(Scope.PORTAL).then((response) => response.data),
+        ],
+        resolvedNotifiers: [
+          'NotificationSettingsService',
+          (NotificationSettingsService: NotificationSettingsService) =>
+            NotificationSettingsService.getNotifiers(Scope.PORTAL, null).then((response) => response.data),
+        ],
+        notificationSettings: [
+          'NotificationSettingsService',
+          (NotificationSettingsService: NotificationSettingsService) =>
+            NotificationSettingsService.getNotificationSettings(Scope.PORTAL, null).then((response) => response.data),
+        ],
       },
     })
     .state('management.settings.notifications.notification', {
@@ -69,9 +77,14 @@ function applicationsNotificationsRouterConfig($stateProvider) {
       controller: 'AlertsActivityController',
       controllerAs: '$ctrl',
       resolve: {
-        configuredAlerts: (AlertService: AlertService) =>
-          AlertService.listAlerts(AlertScope.ENVIRONMENT, false).then((response) => response.data),
-        alertingStatus: (AlertService: AlertService) => AlertService.getStatus(AlertScope.ENVIRONMENT).then((response) => response.data),
+        configuredAlerts: [
+          'AlertService',
+          (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT, false).then((response) => response.data),
+        ],
+        alertingStatus: [
+          'AlertService',
+          (AlertService: AlertService) => AlertService.getStatus(AlertScope.ENVIRONMENT).then((response) => response.data),
+        ],
       },
       data: {
         docs: {
@@ -95,10 +108,17 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        alerts: (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
-        status: (AlertService: AlertService, $stateParams) =>
-          AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
-        notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        alerts: [
+          'AlertService',
+          (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
+        ],
+        status: [
+          'AlertService',
+          '$stateParams',
+          (AlertService: AlertService, $stateParams) =>
+            AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
+        ],
+        notifiers: ['NotifierService', (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data)],
         mode: () => 'detail',
       },
     })
@@ -115,10 +135,17 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        alerts: (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
-        status: (AlertService: AlertService, $stateParams) =>
-          AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
-        notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        alerts: [
+          'AlertService',
+          (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
+        ],
+        status: [
+          'AlertService',
+          '$stateParams',
+          (AlertService: AlertService, $stateParams) =>
+            AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
+        ],
+        notifiers: ['NotifierService', (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data)],
         mode: () => 'create',
       },
     })
@@ -135,10 +162,18 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        alerts: (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
-        status: (AlertService: AlertService, $stateParams) =>
-          AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
-        notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        alerts: [
+          'AlertService',
+          (AlertService: AlertService) => AlertService.listAlerts(AlertScope.ENVIRONMENT).then((response) => response.data),
+        ],
+        status: [
+          'AlertService',
+          '$stateParams',
+          (AlertService: AlertService, $stateParams) =>
+            AlertService.getStatus(AlertScope.ENVIRONMENT, $stateParams.apiId).then((response) => response.data),
+        ],
+        notifiers: ['NotifierService', (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data)],
       },
     });
 }
+applicationsNotificationsRouterConfig.$inject = ['$stateProvider'];

--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
@@ -28,95 +28,103 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     settings: '<',
   },
   template: require('./portal.html'),
-  /* @ngInject */
-  controller: function (
-    NotificationService: NotificationService,
-    PortalSettingsService: PortalSettingsService,
-    CorsService: CorsService,
-    ApiService: ApiService,
-    UserService: UserService,
-    $state: StateService,
-    Constants: any,
-  ) {
-    this.methods = CorsService.getHttpMethods();
-    this.headers = ApiService.defaultHttpHeaders();
-    this.searchHeaders = null;
-    this.providedConfigurationMessage = 'Configuration provided by the system';
+  controller: [
+    'NotificationService',
+    'PortalSettingsService',
+    'CorsService',
+    'ApiService',
+    'UserService',
+    '$state',
+    'Constants',
+    function (
+      NotificationService: NotificationService,
+      PortalSettingsService: PortalSettingsService,
+      CorsService: CorsService,
+      ApiService: ApiService,
+      UserService: UserService,
+      $state: StateService,
+      Constants: any,
+    ) {
+      this.methods = CorsService.getHttpMethods();
+      this.headers = ApiService.defaultHttpHeaders();
+      this.searchHeaders = null;
+      this.providedConfigurationMessage = 'Configuration provided by the system';
 
-    this.$onInit = () => {
-      this.isReadonlyPage = !UserService.isUserHasPermissions(['environment-settings-u']);
-      this.settings.api.labelsDictionary = this.settings.api.labelsDictionary || [];
-      this.settings.cors.allowOrigin = this.settings.cors.allowOrigin || [];
-      this.settings.cors.allowHeaders = this.settings.cors.allowHeaders || [];
-      this.settings.cors.allowMethods = this.settings.cors.allowMethods || [];
-      this.settings.cors.exposedHeaders = this.settings.cors.exposedHeaders || [];
-      this.settings.authentication.localLogin.enabled = this.settings.authentication.localLogin.enabled || !this.hasIdpDefined();
-      this.overrideHomepageTitle = this.settings.portal.homepageTitle !== null && this.settings.portal.homepageTitle !== undefined;
-      this.initialSettings = _.cloneDeep(this.settings);
-    };
+      this.$onInit = () => {
+        this.isReadonlyPage = !UserService.isUserHasPermissions(['environment-settings-u']);
+        this.settings.api.labelsDictionary = this.settings.api.labelsDictionary || [];
+        this.settings.cors.allowOrigin = this.settings.cors.allowOrigin || [];
+        this.settings.cors.allowHeaders = this.settings.cors.allowHeaders || [];
+        this.settings.cors.allowMethods = this.settings.cors.allowMethods || [];
+        this.settings.cors.exposedHeaders = this.settings.cors.exposedHeaders || [];
+        this.settings.authentication.localLogin.enabled = this.settings.authentication.localLogin.enabled || !this.hasIdpDefined();
+        this.overrideHomepageTitle = this.settings.portal.homepageTitle !== null && this.settings.portal.homepageTitle !== undefined;
+        this.initialSettings = _.cloneDeep(this.settings);
+      };
 
-    this.save = () => {
-      PortalSettingsService.save(this.settings).then((response) => {
-        _.merge(Constants.env.settings, response.data);
-        NotificationService.show('Configuration saved');
-        $state.reload();
-      });
-    };
+      this.save = () => {
+        PortalSettingsService.save(this.settings).then((response) => {
+          _.merge(Constants.env.settings, response.data);
+          NotificationService.show('Configuration saved');
+          $state.reload();
+        });
+      };
 
-    this.reset = () => {
-      this.settings = _.cloneDeep(this.initialSettings);
-      this.overrideHomepageTitle = this.settings.portal.homepageTitle !== null && this.settings.portal.homepageTitle !== undefined;
-      this.formSettings.$setPristine();
-    };
+      this.reset = () => {
+        this.settings = _.cloneDeep(this.initialSettings);
+        this.overrideHomepageTitle = this.settings.portal.homepageTitle !== null && this.settings.portal.homepageTitle !== undefined;
+        this.formSettings.$setPristine();
+      };
 
-    this.hasIdpDefined = () => {
-      return (
-        this.settings.authentication.google.clientId ||
-        this.settings.authentication.github.clientId ||
-        this.settings.authentication.oauth2.clientId
-      );
-    };
+      this.hasIdpDefined = () => {
+        return (
+          this.settings.authentication.google.clientId ||
+          this.settings.authentication.github.clientId ||
+          this.settings.authentication.oauth2.clientId
+        );
+      };
 
-    this.toggleDocType = () => {
-      if (!this.settings.openAPIDocViewer.openAPIDocType.swagger.enabled) {
-        this.settings.openAPIDocViewer.openAPIDocType.defaultType = 'Redoc';
-      }
-      if (!this.settings.openAPIDocViewer.openAPIDocType.redoc.enabled) {
-        this.settings.openAPIDocViewer.openAPIDocType.defaultType = 'Swagger';
-      }
-    };
+      this.toggleDocType = () => {
+        if (!this.settings.openAPIDocViewer.openAPIDocType.swagger.enabled) {
+          this.settings.openAPIDocViewer.openAPIDocType.defaultType = 'Redoc';
+        }
+        if (!this.settings.openAPIDocViewer.openAPIDocType.redoc.enabled) {
+          this.settings.openAPIDocViewer.openAPIDocType.defaultType = 'Swagger';
+        }
+      };
 
-    this.toggleApiKeyPlan = () => {
-      if (!this.settings.plan.security.apikey.enabled) {
-        this.settings.plan.security.customApiKey.enabled = false;
-        this.settings.plan.security.sharedApiKey.enabled = false;
-      }
-    };
+      this.toggleApiKeyPlan = () => {
+        if (!this.settings.plan.security.apikey.enabled) {
+          this.settings.plan.security.customApiKey.enabled = false;
+          this.settings.plan.security.sharedApiKey.enabled = false;
+        }
+      };
 
-    this.isReadonlySetting = (property: string): boolean => {
-      return PortalSettingsService.isReadonly(this.settings, property);
-    };
+      this.isReadonlySetting = (property: string): boolean => {
+        return PortalSettingsService.isReadonly(this.settings, property);
+      };
 
-    this.controlAllowOrigin = (chip, index) => {
-      CorsService.controlAllowOrigin(chip, index, this.settings.cors.allowOrigin);
-    };
+      this.controlAllowOrigin = (chip, index) => {
+        CorsService.controlAllowOrigin(chip, index, this.settings.cors.allowOrigin);
+      };
 
-    this.isRegexValid = () => {
-      return CorsService.isRegexValid(this.settings.cors.allowOrigin);
-    };
+      this.isRegexValid = () => {
+        return CorsService.isRegexValid(this.settings.cors.allowOrigin);
+      };
 
-    this.querySearchHeaders = (query) => {
-      return CorsService.querySearchHeaders(query, this.headers);
-    };
+      this.querySearchHeaders = (query) => {
+        return CorsService.querySearchHeaders(query, this.headers);
+      };
 
-    this.toggleOverrideHomepageTitle = () => {
-      if (this.overrideHomepageTitle) {
-        this.settings.portal.homepageTitle = '';
-      } else {
-        this.settings.portal.homepageTitle = null;
-      }
-    };
-  },
+      this.toggleOverrideHomepageTitle = () => {
+        if (this.overrideHomepageTitle) {
+          this.settings.portal.homepageTitle = '';
+        } else {
+          this.settings.portal.homepageTitle = null;
+        }
+      };
+    },
+  ],
 };
 
 export default PortalSettingsComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/settings.component.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 import { StateService } from '@uirouter/core';
-import { IScope } from 'angular';
 
 const SettingsComponent: ng.IComponentOptions = {
   template: require('./settings.html'),
-  /* @ngInject */
-  controller: function ($rootScope: IScope, $state: StateService) {
-    this.$state = $state;
-  },
+  controller: [
+    '$state',
+    function ($state: StateService) {
+      this.$state = $state;
+    },
+  ],
 };
 
 export default SettingsComponent;

--- a/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
@@ -31,7 +31,6 @@ class ThemeController {
   private themeOptionalLogoURL: string;
   private themeBackgroundURL: string;
 
-  /* @ngInject */
   constructor(
     private $http,
     private $scope,
@@ -492,5 +491,6 @@ class ThemeController {
     }
   }
 }
+ThemeController.$inject = ['$http', '$scope', '$mdDialog', 'Constants', 'ThemeService', 'NotificationService', '$sce'];
 
 export default ThemeController;

--- a/gravitee-apim-console-webui/src/management/configuration/top-apis/dialog/add.top-api.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/top-apis/dialog/add.top-api.dialog.controller.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
-/* @ngInject */
 function AddTopApiDialogController($mdDialog: angular.material.IDialogService, ApiService, TopApiService, NotificationService, topApis) {
   ApiService.list().then((response) => {
     this.apis = _.filter(response.data, (api: any) => {
@@ -33,5 +32,6 @@ function AddTopApiDialogController($mdDialog: angular.material.IDialogService, A
     $mdDialog.cancel();
   };
 }
+AddTopApiDialogController.$inject = ['$mdDialog', 'ApiService', 'TopApiService', 'NotificationService', 'topApis'];
 
 export default AddTopApiDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/top-apis/dialog/delete.top-api.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/top-apis/dialog/delete.top-api.dialog.controller.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function DeleteTopApiDialogController($scope, $mdDialog, topApi, TopApiService, NotificationService) {
   $scope.topApi = topApi;
 
@@ -28,5 +27,6 @@ function DeleteTopApiDialogController($scope, $mdDialog, topApi, TopApiService, 
     });
   };
 }
+DeleteTopApiDialogController.$inject = ['$scope', '$mdDialog', 'topApi', 'TopApiService', 'NotificationService'];
 
 export default DeleteTopApiDialogController;

--- a/gravitee-apim-console-webui/src/management/configuration/top-apis/top-apis.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/top-apis/top-apis.controller.ts
@@ -22,7 +22,6 @@ import TopApiService from '../../../services/top-api.service';
 class TopApisController {
   private topApis: any[];
 
-  /* @ngInject */
   constructor(
     private TopApiService: TopApiService,
     private $mdDialog: angular.material.IDialogService,
@@ -97,5 +96,6 @@ class TopApisController {
       });
   }
 }
+TopApisController.$inject = ['TopApiService', '$mdDialog', 'NotificationService', '$rootScope'];
 
 export default TopApisController;

--- a/gravitee-apim-console-webui/src/management/dashboard-ajs/analytics-dashboard/analytics-dashboard.controller.ts
+++ b/gravitee-apim-console-webui/src/management/dashboard-ajs/analytics-dashboard/analytics-dashboard.controller.ts
@@ -29,7 +29,6 @@ class AnalyticsDashboardController {
   private query: any;
   private dashboard: any;
 
-  /* @ngInject */
   constructor(
     private eventService: EventService,
     private AnalyticsService,
@@ -147,5 +146,15 @@ class AnalyticsDashboardController {
     this.$state.transitionTo('management.logs', this.$state.params);
   }
 }
+AnalyticsDashboardController.$inject = [
+  'eventService',
+  'AnalyticsService',
+  'ApiService',
+  'ApplicationService',
+  '$scope',
+  'Constants',
+  '$state',
+  'dashboards',
+];
 
 export default AnalyticsDashboardController;

--- a/gravitee-apim-console-webui/src/management/management.config.ts
+++ b/gravitee-apim-console-webui/src/management/management.config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { UrlService } from '@uirouter/angularjs';
-/* @ngInject */
+
 function config($logProvider, $urlServiceProvider: UrlService, $permissionProvider, $qProvider) {
   // Enable log
   $logProvider.debugEnabled(false);
@@ -26,5 +26,6 @@ function config($logProvider, $urlServiceProvider: UrlService, $permissionProvid
 
   $qProvider.errorOnUnhandledRejections(false);
 }
+config.$inject = ['$logProvider', '$urlServiceProvider', '$permissionProvider', '$qProvider'];
 
 export default config;

--- a/gravitee-apim-console-webui/src/management/management.delegator.ts
+++ b/gravitee-apim-console-webui/src/management/management.delegator.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
 function delegatorConfig($sceDelegateProvider, Constants) {
   $sceDelegateProvider.resourceUrlWhitelist(['self', Constants.org.baseURL + '/**']);
 }
+delegatorConfig.$inject = ['$sceDelegateProvider', 'Constants'];
 
 export default delegatorConfig;

--- a/gravitee-apim-console-webui/src/management/management.interceptor.ts
+++ b/gravitee-apim-console-webui/src/management/management.interceptor.ts
@@ -38,7 +38,6 @@ export class Future {
   }
 }
 
-/* @ngInject */
 function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
   $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -119,6 +118,7 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
       return $q.reject(error);
     },
   });
+  interceptorUnauthorized.$inject = ['$q', '$injector', '$location', '$state'];
 
   const interceptorTimeout = function ($q: angular.IQService, $injector: angular.auto.IInjectorService): angular.IHttpInterceptor {
     return {
@@ -142,6 +142,7 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
       },
     };
   };
+  interceptorTimeout.$inject = ['$q', '$injector'];
 
   const csrfInterceptor = function ($q: angular.IQService): angular.IHttpInterceptor {
     return {
@@ -165,6 +166,7 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
       },
     };
   };
+  csrfInterceptor.$inject = ['$q'];
 
   const reCaptchaInterceptor = function ($q: angular.IQService, $injector: angular.auto.IInjectorService): angular.IHttpInterceptor {
     return {
@@ -181,6 +183,7 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
       },
     };
   };
+  reCaptchaInterceptor.$inject = ['$q', '$injector'];
 
   // This interceptor aims to resolve the problem with Satellizer which, after exchanging oauth provider's token with apim's one, adds the apim token on all requests (through Authorization bearer header).
   // It caused logout problems between Portal and Management console because session Cookie is successfully removed but token is still sent by Satellizer using Authorization header.
@@ -207,6 +210,7 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
       },
     };
   };
+  replaceEnvInterceptor.$inject = ['$q', '$injector'];
 
   if ($httpProvider.interceptors) {
     // Add custom noSatellizerAuthorizationInterceptor at the beginning of the list to make sure they are activated before others interceptors such as Satellizer's interceptors.
@@ -218,5 +222,6 @@ function interceptorConfig($httpProvider: angular.IHttpProvider, Constants) {
     $httpProvider.interceptors.push(replaceEnvInterceptor);
   }
 }
+interceptorConfig.$inject = ['$httpProvider', 'Constants'];
 
 export default interceptorConfig;

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -496,17 +496,18 @@ angular.module('gravitee-management', [
 
 const graviteeManagementModule = angular.module('gravitee-management');
 
-graviteeManagementModule.config(
-  /* @ngInject */ (cfpLoadingBarProvider) => {
-    cfpLoadingBarProvider.includeSpinner = false;
-  },
-);
+const includeSpinnerConfig = (cfpLoadingBarProvider) => {
+  cfpLoadingBarProvider.includeSpinner = false;
+};
+includeSpinnerConfig.$inject = ['cfpLoadingBarProvider'];
+graviteeManagementModule.config(includeSpinnerConfig);
 
-graviteeManagementModule.config(
-  /* @ngInject */ (localStorageServiceProvider: angular.local.storage.ILocalStorageServiceProvider) => {
-    localStorageServiceProvider.setPrefix('gravitee');
-  },
-);
+const localStorageConfig = (localStorageServiceProvider) => {
+  localStorageServiceProvider.setPrefix('gravitee');
+};
+localStorageConfig.$inject = ['localStorageServiceProvider'];
+graviteeManagementModule.config(localStorageConfig);
+
 graviteeManagementModule.config(config);
 graviteeManagementModule.config(routerConfig);
 graviteeManagementModule.config(authenticationConfig);
@@ -517,7 +518,8 @@ graviteeManagementModule.config(configurationRouterConfig);
 graviteeManagementModule.config(globalNotificationsRouterConfig);
 graviteeManagementModule.config(interceptorConfig);
 graviteeManagementModule.config(delegatorConfig);
-graviteeManagementModule.config(($mdThemingProvider: angular.material.IThemingProvider) => {
+
+const themeConfig = ($mdThemingProvider: angular.material.IThemingProvider) => {
   $mdThemingProvider.definePalette('gravitee', {
     '0': '1b1d3c',
     '50': '1b1d3c',
@@ -560,7 +562,9 @@ graviteeManagementModule.config(($mdThemingProvider: angular.material.IThemingPr
 
   $mdThemingProvider.theme('toast-success');
   $mdThemingProvider.theme('toast-error');
-});
+};
+themeConfig.$inject = ['$mdThemingProvider'];
+graviteeManagementModule.config(themeConfig);
 graviteeManagementModule.run(runBlock);
 
 // New Navigation components

--- a/gravitee-apim-console-webui/src/management/management.route.ts
+++ b/gravitee-apim-console-webui/src/management/management.route.ts
@@ -25,16 +25,19 @@ import InstancesService from '../services/instances.service';
 import TicketService from '../services/ticket.service';
 import { ApimFeature } from '../shared/components/gio-license/gio-license-data';
 
-/* @ngInject */
 function managementRouterConfig($stateProvider) {
   $stateProvider
     .state('management', {
       redirectTo: 'home',
       template: '<div ui-view layout="column" flex></div>',
       parent: 'withSidenav',
-      controller: function ($rootScope, Constants) {
-        $rootScope.consoleTitle = Constants.org.settings.management.title;
-      },
+      controller: [
+        '$rootScope',
+        'Constants',
+        function ($rootScope, Constants) {
+          $rootScope.consoleTitle = Constants.org.settings.management.title;
+        },
+      ],
       controllerAs: '$ctrl',
     })
     .state('management.instances', {
@@ -46,7 +49,10 @@ function managementRouterConfig($stateProvider) {
       url: '/',
       component: 'instances',
       resolve: {
-        instances: (InstancesService: InstancesService) => InstancesService.search().then((response) => response.data),
+        instances: [
+          'InstancesService',
+          (InstancesService: InstancesService) => InstancesService.search().then((response) => response.data),
+        ],
       },
       data: {
         perms: {
@@ -95,16 +101,20 @@ function managementRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        apis: ($stateParams: StateParams, ApiService: ApiService) => ApiService.list(null, false, 1, null, null, null, 10),
-        applications: ($stateParams: StateParams, ApplicationService: ApplicationService) => ApplicationService.list(['owner', 'picture']),
+        apis: ['ApiService', (ApiService: ApiService) => ApiService.list(null, false, 1, null, null, null, 10)],
+        applications: ['ApplicationService', (ApplicationService: ApplicationService) => ApplicationService.list(['owner', 'picture'])],
       },
     })
     .state('management.log', {
       url: '/logs/:logId?timestamp&from&to&q&page&size',
       component: 'platformLog',
       resolve: {
-        log: ($stateParams, AnalyticsService: AnalyticsService) =>
-          AnalyticsService.getLog($stateParams.logId, $stateParams.timestamp).then((response) => response.data),
+        log: [
+          '$stateParams',
+          'AnalyticsService',
+          ($stateParams, AnalyticsService: AnalyticsService) =>
+            AnalyticsService.getLog($stateParams.logId, $stateParams.timestamp).then((response) => response.data),
+        ],
       },
       data: {
         devMode: true,
@@ -185,8 +195,12 @@ function managementRouterConfig($stateProvider) {
       url: '/support/tickets/:ticketId?page&size&order',
       component: 'ticketDetail',
       resolve: {
-        ticket: ($stateParams: StateParams, TicketService: TicketService) =>
-          TicketService.getTicket($stateParams.ticketId).then((response) => response.data),
+        ticket: [
+          '$stateParams',
+          'TicketService',
+          ($stateParams: StateParams, TicketService: TicketService) =>
+            TicketService.getTicket($stateParams.ticketId).then((response) => response.data),
+        ],
       },
     })
     .state('management.analytics', {
@@ -195,7 +209,10 @@ function managementRouterConfig($stateProvider) {
       controller: 'AnalyticsDashboardController',
       controllerAs: '$ctrl',
       resolve: {
-        dashboards: (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
+        dashboards: [
+          'DashboardService',
+          (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
+        ],
       },
       data: {
         perms: {
@@ -225,5 +242,6 @@ function managementRouterConfig($stateProvider) {
       },
     });
 }
+managementRouterConfig.$inject = ['$stateProvider'];
 
 export default managementRouterConfig;

--- a/gravitee-apim-console-webui/src/management/management.run.ts
+++ b/gravitee-apim-console-webui/src/management/management.run.ts
@@ -25,7 +25,6 @@ import UserService from '../services/user.service';
 import ConsoleSettingsService from '../services/consoleSettings.service';
 import NotificationService from '../services/notification.service';
 
-/* @ngInject */
 function runBlock(
   $rootScope,
   $window,
@@ -264,5 +263,24 @@ function runBlock(
     return true;
   });
 }
+runBlock.$inject = [
+  '$rootScope',
+  '$window',
+  '$http',
+  '$mdSidenav',
+  '$transitions',
+  '$state',
+  '$timeout',
+  'UserService',
+  'Constants',
+  'PermissionStrategies',
+  'ReCaptchaService',
+  'ApiService',
+  'EnvironmentService',
+  'PortalConfigService',
+  'ConsoleSettingsService',
+  'NotificationService',
+  'ngGioPendoService',
+];
 
 export default runBlock;

--- a/gravitee-apim-console-webui/src/management/platform/logs/platform-log.component.ts
+++ b/gravitee-apim-console-webui/src/management/platform/logs/platform-log.component.ts
@@ -21,57 +21,61 @@ const PlatformLogComponent: ng.IComponentOptions = {
   bindings: {
     log: '<',
   },
-  /* @ngInject */
-  controller: function ($state: StateService, NotificationService: NotificationService, Constants: any) {
-    this.Constants = Constants;
-    this.NotificationService = NotificationService;
+  controller: [
+    '$state',
+    'NotificationService',
+    'Constants',
+    function ($state: StateService, NotificationService: NotificationService, Constants: any) {
+      this.Constants = Constants;
+      this.NotificationService = NotificationService;
 
-    this.$onInit = () => {
-      this.headersAsList(this.log.clientRequest);
-      this.headersAsList(this.log.proxyRequest);
-      this.headersAsList(this.log.clientResponse);
-      this.headersAsList(this.log.proxyResponse);
-    };
+      this.$onInit = () => {
+        this.headersAsList(this.log.clientRequest);
+        this.headersAsList(this.log.proxyRequest);
+        this.headersAsList(this.log.clientResponse);
+        this.headersAsList(this.log.proxyResponse);
+      };
 
-    this.headersAsList = (obj) => {
-      if (obj) {
-        obj.headersAsList = [];
-        for (const k in obj.headers) {
-          // eslint-disable-next-line no-prototype-builtins
-          if (obj.headers.hasOwnProperty(k)) {
-            for (const v in obj.headers[k]) {
-              // eslint-disable-next-line no-prototype-builtins
-              if (obj.headers[k].hasOwnProperty(v)) {
-                obj.headersAsList.push([k, obj.headers[k][v]]);
+      this.headersAsList = (obj) => {
+        if (obj) {
+          obj.headersAsList = [];
+          for (const k in obj.headers) {
+            // eslint-disable-next-line no-prototype-builtins
+            if (obj.headers.hasOwnProperty(k)) {
+              for (const v in obj.headers[k]) {
+                // eslint-disable-next-line no-prototype-builtins
+                if (obj.headers[k].hasOwnProperty(v)) {
+                  obj.headersAsList.push([k, obj.headers[k][v]]);
+                }
               }
             }
           }
         }
-      }
-    };
+      };
 
-    this.backStateParams = {
-      from: $state.params.from,
-      to: $state.params.to,
-      q: $state.params.q,
-      page: $state.params.page,
-      size: $state.params.size,
-    };
+      this.backStateParams = {
+        from: $state.params.from,
+        to: $state.params.to,
+        q: $state.params.q,
+        page: $state.params.page,
+        size: $state.params.size,
+      };
 
-    this.getMimeType = function (log) {
-      if (log.headers['Content-Type'] !== undefined) {
-        const contentType = log.headers['Content-Type'][0];
-        return contentType.split(';', 1)[0];
-      }
+      this.getMimeType = function (log) {
+        if (log.headers['Content-Type'] !== undefined) {
+          const contentType = log.headers['Content-Type'][0];
+          return contentType.split(';', 1)[0];
+        }
 
-      return null;
-    };
+        return null;
+      };
 
-    this.onCopyBodySuccess = function (evt) {
-      this.NotificationService.show('Body has been copied to clipboard');
-      evt.clearSelection();
-    };
-  },
+      this.onCopyBodySuccess = function (evt) {
+        this.NotificationService.show('Body has been copied to clipboard');
+        evt.clearSelection();
+      };
+    },
+  ],
   template: require('./platform-log.html'),
 };
 

--- a/gravitee-apim-console-webui/src/management/platform/logs/platform-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/platform/logs/platform-logs.controller.ts
@@ -31,7 +31,6 @@ class PlatformLogsController {
   private applications;
   private init: boolean;
 
-  /* @ngInject */
   constructor(
     private ApiService: ApiService,
     private AnalyticsService: AnalyticsService,
@@ -115,5 +114,6 @@ class PlatformLogsController {
     });
   }
 }
+PlatformLogsController.$inject = ['ApiService', 'AnalyticsService', 'Constants', '$state', '$scope'];
 
 export default PlatformLogsController;

--- a/gravitee-apim-console-webui/src/management/support/ticket-detail.component.ts
+++ b/gravitee-apim-console-webui/src/management/support/ticket-detail.component.ts
@@ -20,14 +20,16 @@ const TicketDetailComponent: ng.IComponentOptions = {
   bindings: {
     ticket: '<',
   },
-  /* @ngInject */
-  controller: function ($state: StateService) {
-    this.backStateParams = {
-      page: $state.params.page,
-      size: $state.params.size,
-      order: $state.params.order,
-    };
-  },
+  controller: [
+    '$state',
+    function ($state: StateService) {
+      this.backStateParams = {
+        page: $state.params.page,
+        size: $state.params.size,
+        order: $state.params.order,
+      };
+    },
+  ],
 };
 
 export default TicketDetailComponent;

--- a/gravitee-apim-console-webui/src/management/support/ticket.controller.ts
+++ b/gravitee-apim-console-webui/src/management/support/ticket.controller.ts
@@ -30,7 +30,6 @@ class SupportTicketController {
   private stateParams: any;
   private formTicket: any;
 
-  /* @ngInject */
   constructor(
     private TicketService: TicketService,
     private NotificationService: NotificationService,
@@ -68,5 +67,13 @@ class SupportTicketController {
     });
   }
 }
+SupportTicketController.$inject = [
+  'TicketService',
+  'NotificationService',
+  'UserService',
+  'ApiService',
+  'ApplicationService',
+  '$stateParams',
+];
 
 export default SupportTicketController;

--- a/gravitee-apim-console-webui/src/management/support/tickets-list.controller.ts
+++ b/gravitee-apim-console-webui/src/management/support/tickets-list.controller.ts
@@ -22,7 +22,6 @@ class TicketsListController {
   private query: TicketsQuery;
   private tickets: { totalElements: number; content: any[] };
 
-  /* @ngInject */
   constructor(private TicketService: TicketService, private $scope: IScope, private $state: StateService) {}
 
   $onInit() {
@@ -61,5 +60,6 @@ class TicketsListController {
     });
   }
 }
+TicketsListController.$inject = ['TicketService', '$scope', '$state'];
 
 export default TicketsListController;

--- a/gravitee-apim-console-webui/src/services/alert.service.ts
+++ b/gravitee-apim-console-webui/src/services/alert.service.ts
@@ -31,7 +31,6 @@ export interface IAlertTriggerAnalytics {
 }
 
 class AlertService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   listMetrics(): IHttpPromise<any> {
@@ -136,5 +135,6 @@ class AlertService {
     }
   }
 }
+AlertService.$inject = ['$http', 'Constants'];
 
 export default AlertService;

--- a/gravitee-apim-console-webui/src/services/analytics.service.ts
+++ b/gravitee-apim-console-webui/src/services/analytics.service.ts
@@ -32,7 +32,6 @@ class AnalyticsService {
   private analyticsURL: string;
   private logs: [any];
 
-  /* @ngInject */
   constructor(private $http, private Constants, public $stateParams) {}
 
   /*
@@ -152,5 +151,6 @@ class AnalyticsService {
     return param.replace('%20', ' ').replace(/[()]/g, '').replace(/[\\"]/g, '');
   }
 }
+AnalyticsService.$inject = ['$http', 'Constants', '$stateParams'];
 
 export default AnalyticsService;

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -39,7 +39,6 @@ interface IMembership {
 }
 
 export class ApiService {
-  /* @ngInject */
   constructor(
     private readonly $http: IHttpService,
     private readonly $rootScope: IRootScopeService,
@@ -837,6 +836,7 @@ export class ApiService {
     return api && api.gravitee === '2.0.0';
   }
 }
+ApiService.$inject = ['$http', '$rootScope', 'Constants', 'ngIfMatchEtagInterceptor'];
 
 const blobToBase64 = (blob: Blob): Promise<string> => {
   return new Promise<string>((resolve, reject) => {

--- a/gravitee-apim-console-webui/src/services/apiHeader.service.ts
+++ b/gravitee-apim-console-webui/src/services/apiHeader.service.ts
@@ -19,7 +19,6 @@ import { IHttpPromise } from 'angular';
 import { ApiPortalHeader } from '../entities/apiPortalHeader';
 
 class ApiHeaderService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(): IHttpPromise<ApiPortalHeader[]> {
@@ -42,5 +41,6 @@ class ApiHeaderService {
     return this.$http.delete(`${this.Constants.env.baseURL}/configuration/apiheaders/` + apiHeader.id);
   }
 }
+ApiHeaderService.$inject = ['$http', 'Constants'];
 
 export default ApiHeaderService;

--- a/gravitee-apim-console-webui/src/services/apiPrimaryOwnerMode.service.ts
+++ b/gravitee-apim-console-webui/src/services/apiPrimaryOwnerMode.service.ts
@@ -26,7 +26,6 @@ export enum ApiPrimaryOwnerType {
 }
 
 class ApiPrimaryOwnerModeService {
-  /* @ngInject */
   constructor(private Constants) {}
 
   isGroupOnly = () => {
@@ -41,5 +40,6 @@ class ApiPrimaryOwnerModeService {
     return this.Constants.env.settings.api.primaryOwnerMode.toUpperCase() === ApiPrimaryOwnerMode.HYBRID;
   };
 }
+ApiPrimaryOwnerModeService.$inject = ['Constants'];
 
 export default ApiPrimaryOwnerModeService;

--- a/gravitee-apim-console-webui/src/services/application.service.ts
+++ b/gravitee-apim-console-webui/src/services/application.service.ts
@@ -38,7 +38,6 @@ interface IMembership {
 export type ApplicationExcludeFilter = 'owner' | 'picture';
 
 class ApplicationService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   getAnalyticsHttpTimeout() {
@@ -339,5 +338,6 @@ class ApplicationService {
     return clonedQuery;
   }
 }
+ApplicationService.$inject = ['$http', 'Constants'];
 
 export default ApplicationService;

--- a/gravitee-apim-console-webui/src/services/applicationTypes.service.ts
+++ b/gravitee-apim-console-webui/src/services/applicationTypes.service.ts
@@ -17,12 +17,12 @@
 import { ApplicationType } from '../entities/application';
 
 class ApplicationTypesService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   getEnabledApplicationTypes(): ng.IHttpPromise<Array<ApplicationType>> {
     return this.$http.get(`${this.Constants.env.baseURL}/configuration/applications/types`);
   }
 }
+ApplicationTypesService.$inject = ['$http', 'Constants'];
 
 export default ApplicationTypesService;

--- a/gravitee-apim-console-webui/src/services/audit.service.ts
+++ b/gravitee-apim-console-webui/src/services/audit.service.ts
@@ -26,7 +26,6 @@ export class AuditQuery {
 }
 
 class AuditService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(query?: AuditQuery, api?: string) {
@@ -57,5 +56,6 @@ class AuditService {
     return this.$http.get(url);
   }
 }
+AuditService.$inject = ['$http', 'Constants'];
 
 export default AuditService;

--- a/gravitee-apim-console-webui/src/services/authentication.service.ts
+++ b/gravitee-apim-console-webui/src/services/authentication.service.ts
@@ -25,7 +25,6 @@ import UserService from './user.service';
 import { IdentityProvider } from '../entities/identity-provider/identityProvider';
 
 class AuthenticationService {
-  /* @ngInject */
   constructor(
     private $rootScope: IScope,
     private Constants,
@@ -102,5 +101,15 @@ class AuthenticationService {
     return text;
   }
 }
+AuthenticationService.$inject = [
+  '$rootScope',
+  'Constants',
+  '$window',
+  '$state',
+  '$auth',
+  'UserService',
+  'RouterService',
+  'SatellizerConfig',
+];
 
 export default AuthenticationService;

--- a/gravitee-apim-console-webui/src/services/category.service.ts
+++ b/gravitee-apim-console-webui/src/services/category.service.ts
@@ -15,7 +15,6 @@
  */
 
 class CategoryService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(include?: string[]) {
@@ -45,5 +44,6 @@ class CategoryService {
     return this.$http.delete(`${this.Constants.env.baseURL}/configuration/categories/` + category.id);
   }
 }
+CategoryService.$inject = ['$http', 'Constants'];
 
 export default CategoryService;

--- a/gravitee-apim-console-webui/src/services/connector.service.ts
+++ b/gravitee-apim-console-webui/src/services/connector.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class ConnectorService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(expandSchema = false, expandIcon = false) {
@@ -40,5 +39,6 @@ class ConnectorService {
     return this.$http.get(`${this.Constants.env.baseURL}/connectors/${connectorId}/documentation`);
   }
 }
+ConnectorService.$inject = ['$http', 'Constants'];
 
 export default ConnectorService;

--- a/gravitee-apim-console-webui/src/services/consoleSettings.service.ts
+++ b/gravitee-apim-console-webui/src/services/consoleSettings.service.ts
@@ -15,7 +15,6 @@
  */
 
 class ConsoleSettingsService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   save(config) {
@@ -37,5 +36,6 @@ class ConsoleSettingsService {
     return false;
   }
 }
+ConsoleSettingsService.$inject = ['$http', 'Constants'];
 
 export default ConsoleSettingsService;

--- a/gravitee-apim-console-webui/src/services/cors.service.ts
+++ b/gravitee-apim-console-webui/src/services/cors.service.ts
@@ -17,7 +17,6 @@ class CorsService {
   private allowOriginPattern =
     '^(?:(?:[htps\\(\\)?\\|]+):\\/\\/)*(?:[\\w\\(\\)\\[\\]\\{\\}?\\|.*-](?:(?:[?+*]|\\{\\d+(?:,\\d*)?\\}))?)+(?:[a-zA-Z0-9]{2,6})?(?::\\d{1,5})?$';
 
-  /* @ngInject */
   constructor(private $mdDialog) {}
 
   getHttpMethods() {
@@ -101,5 +100,6 @@ class CorsService {
     };
   };
 }
+CorsService.$inject = ['$mdDialog'];
 
 export default CorsService;

--- a/gravitee-apim-console-webui/src/services/custom-user-fields.service.ts
+++ b/gravitee-apim-console-webui/src/services/custom-user-fields.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class CustomUserFieldsService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   valuesAsList = function (field: any) {
@@ -72,5 +71,6 @@ class CustomUserFieldsService {
     return this.$http.delete(`${this.Constants.org.baseURL}/configuration/custom-user-fields` + '/' + field.key);
   }
 }
+CustomUserFieldsService.$inject = ['$http', 'Constants'];
 
 export default CustomUserFieldsService;

--- a/gravitee-apim-console-webui/src/services/dashboard.service.ts
+++ b/gravitee-apim-console-webui/src/services/dashboard.service.ts
@@ -28,7 +28,6 @@ export interface AverageableField {
 class DashboardService {
   private AnalyticsService: AnalyticsService;
 
-  /* @ngInject */
   constructor(private $http, private Constants, AnalyticsService: AnalyticsService) {
     this.AnalyticsService = AnalyticsService;
   }
@@ -210,5 +209,6 @@ class DashboardService {
     );
   }
 }
+DashboardService.$inject = ['$http', 'Constants', 'AnalyticsService'];
 
 export default DashboardService;

--- a/gravitee-apim-console-webui/src/services/debugApi.service.ts
+++ b/gravitee-apim-console-webui/src/services/debugApi.service.ts
@@ -20,7 +20,6 @@ import { Event } from '../entities/event/event';
 import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
 
 export class DebugApiService {
-  /* @ngInject */
   constructor(
     private readonly $http: IHttpService,
     private readonly Constants: Constants,
@@ -82,3 +81,4 @@ export class DebugApiService {
       .then((value) => value.data);
   }
 }
+DebugApiService.$inject = ['$http', 'Constants', 'ngIfMatchEtagInterceptor'];

--- a/gravitee-apim-console-webui/src/services/dictionary.service.ts
+++ b/gravitee-apim-console-webui/src/services/dictionary.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class DictionaryService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   list(): ng.IPromise<any> {
@@ -60,5 +59,6 @@ class DictionaryService {
     return this.$http.post([`${this.Constants.env.baseURL}/configuration/dictionaries`, dictionary.id].join('/') + '?action=STOP', {});
   }
 }
+DictionaryService.$inject = ['$http', 'Constants'];
 
 export default DictionaryService;

--- a/gravitee-apim-console-webui/src/services/documentation.service.ts
+++ b/gravitee-apim-console-webui/src/services/documentation.service.ts
@@ -74,7 +74,6 @@ export enum FolderSituation {
 }
 
 export class DocumentationService {
-  /* @ngInject */
   constructor(private readonly $http: ng.IHttpService, private readonly $q: ng.IQService, private readonly Constants: Constants) {}
 
   buildPageList(pagesToFilter: any[], withRootFolder?: boolean, folderSituation?: FolderSituation) {
@@ -278,3 +277,4 @@ export class DocumentationService {
     return this.$http.get(this.url(apiId, pageId) + '/media');
   }
 }
+DocumentationService.$inject = ['$http', '$q', 'Constants'];

--- a/gravitee-apim-console-webui/src/services/entrypoint.service.ts
+++ b/gravitee-apim-console-webui/src/services/entrypoint.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class EntrypointService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   findById(entrypoint) {
@@ -43,5 +42,6 @@ class EntrypointService {
     }
   }
 }
+EntrypointService.$inject = ['$http', 'Constants'];
 
 export default EntrypointService;

--- a/gravitee-apim-console-webui/src/services/environment.service.ts
+++ b/gravitee-apim-console-webui/src/services/environment.service.ts
@@ -20,8 +20,7 @@ import * as _ from 'lodash';
 import { IdentityProviderActivation } from '../entities/identity-provider';
 
 class EnvironmentService {
-  /* @ngInject */
-  constructor(private $http, private Constants, private $q) {}
+  constructor(private $http, private Constants) {}
 
   /*
    * Analytics
@@ -75,5 +74,6 @@ class EnvironmentService {
     return environments?.find((environment) => environment.id === id || (environment.hrids && environment.hrids.includes(id)));
   }
 }
+EnvironmentService.$inject = ['$http', 'Constants'];
 
 export default EnvironmentService;

--- a/gravitee-apim-console-webui/src/services/event.service.ts
+++ b/gravitee-apim-console-webui/src/services/event.service.ts
@@ -19,7 +19,6 @@ import { Constants } from '../entities/Constants';
 import { Event } from '../entities/event/event';
 
 export class EventService {
-  /* @ngInject */
   constructor(private readonly $http: IHttpService, private readonly Constants: Constants) {}
 
   public search(type: string, apis: string, from: string, to: string, page: number | string, size: number | string): IHttpPromise<any> {
@@ -32,3 +31,4 @@ export class EventService {
     return this.$http.get<Event>(`${this.Constants.env.baseURL}/apis/${apiId}/events/${eventId}`).then((response) => response.data);
   }
 }
+EventService.$inject = ['$http', 'Constants'];

--- a/gravitee-apim-console-webui/src/services/fetcher.service.ts
+++ b/gravitee-apim-console-webui/src/services/fetcher.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class FetcherService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(onlyImportFromDirectory?: boolean) {
@@ -22,5 +21,6 @@ class FetcherService {
     return this.$http.get(url);
   }
 }
+FetcherService.$inject = ['$http', 'Constants'];
 
 export default FetcherService;

--- a/gravitee-apim-console-webui/src/services/flow.service.ts
+++ b/gravitee-apim-console-webui/src/services/flow.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class FlowService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   getConfigurationSchema() {
@@ -29,5 +28,6 @@ class FlowService {
     return this.$http.get(`${this.Constants.org.baseURL}/configuration/flows/`);
   }
 }
+FlowService.$inject = ['$http', 'Constants'];
 
 export default FlowService;

--- a/gravitee-apim-console-webui/src/services/group.service.ts
+++ b/gravitee-apim-console-webui/src/services/group.service.ts
@@ -30,7 +30,6 @@ class GroupService {
     };
   }
 
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   get(groupId: string): ng.IPromise<any> {
@@ -159,5 +158,6 @@ class GroupService {
       .filter(({ roles }) => !!roles.length); // at least one role is mandatory
   }
 }
+GroupService.$inject = ['$http', 'Constants'];
 
 export default GroupService;

--- a/gravitee-apim-console-webui/src/services/identityProvider.service.ts
+++ b/gravitee-apim-console-webui/src/services/identityProvider.service.ts
@@ -19,7 +19,6 @@ import { IHttpPromise, IPromise } from 'angular';
 import { IdentityProvider } from '../entities/identity-provider/identityProvider';
 
 class IdentityProviderService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(): IPromise<IdentityProvider[]> {
@@ -85,5 +84,6 @@ class IdentityProviderService {
     return this.$http.delete(`${this.Constants.org.baseURL}/configuration/identities/` + identityProvider.id);
   }
 }
+IdentityProviderService.$inject = ['$http', 'Constants'];
 
 export default IdentityProviderService;

--- a/gravitee-apim-console-webui/src/services/installation.service.ts
+++ b/gravitee-apim-console-webui/src/services/installation.service.ts
@@ -15,12 +15,12 @@
  */
 
 class InstallationService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   getInstallationInformation() {
     return this.$http.get(`${this.Constants.org.baseURL}/installation/`);
   }
 }
+InstallationService.$inject = ['$http', 'Constants'];
 
 export default InstallationService;

--- a/gravitee-apim-console-webui/src/services/instances.service.ts
+++ b/gravitee-apim-console-webui/src/services/instances.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class InstancesService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   search(includeStopped?: boolean, from?: number, to?: number, page?: number, size?: number) {
@@ -51,5 +50,6 @@ class InstancesService {
     return this.$http.get(`${this.Constants.env.baseURL}/instances/` + id + '/monitoring/' + gatewayId);
   }
 }
+InstancesService.$inject = ['$http', 'Constants'];
 
 export default InstancesService;

--- a/gravitee-apim-console-webui/src/services/message.service.ts
+++ b/gravitee-apim-console-webui/src/services/message.service.ts
@@ -15,7 +15,6 @@
  */
 
 class MessageService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   sendFromPortal(
@@ -90,5 +89,6 @@ class MessageService {
     }
   }
 }
+MessageService.$inject = ['$http', 'Constants'];
 
 export default MessageService;

--- a/gravitee-apim-console-webui/src/services/metadata.service.ts
+++ b/gravitee-apim-console-webui/src/services/metadata.service.ts
@@ -16,7 +16,6 @@
 class MetadataService {
   private metadataURL: string;
 
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   listFormats() {
@@ -39,5 +38,6 @@ class MetadataService {
     return this.$http.delete(`${this.Constants.env.baseURL}/configuration/metadata/` + metadata.key);
   }
 }
+MetadataService.$inject = ['$http', 'Constants'];
 
 export default MetadataService;

--- a/gravitee-apim-console-webui/src/services/notification.service.ts
+++ b/gravitee-apim-console-webui/src/services/notification.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class NotificationService {
-  /* @ngInject */
   constructor(private $mdToast: ng.material.IToastService, private $state) {}
 
   show(message: any, errorStatus?: number) {
@@ -49,5 +48,6 @@ class NotificationService {
     );
   }
 }
+NotificationService.$inject = ['$mdToast', '$state'];
 
 export default NotificationService;

--- a/gravitee-apim-console-webui/src/services/notificationSettings.service.ts
+++ b/gravitee-apim-console-webui/src/services/notificationSettings.service.ts
@@ -20,7 +20,6 @@ import { NotificationConfig } from '../entities/notificationConfig';
 import { Scope } from '../entities/scope';
 
 class NotificationSettingsService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   getHooks(scope: Scope): IHttpPromise<any> {
@@ -102,5 +101,6 @@ class NotificationSettingsService {
     }
   }
 }
+NotificationSettingsService.$inject = ['$http', 'Constants'];
 
 export default NotificationSettingsService;

--- a/gravitee-apim-console-webui/src/services/notificationTemplates.service.ts
+++ b/gravitee-apim-console-webui/src/services/notificationTemplates.service.ts
@@ -17,7 +17,6 @@
 import { IHttpPromise } from 'angular';
 
 class NotificationTemplatesService {
-  /* @ngInject */
   constructor(private $http: ng.IHttpService, private Constants) {}
 
   getNotificationTemplates(hook?: string, scope?: string): IHttpPromise<any> {
@@ -39,5 +38,6 @@ class NotificationTemplatesService {
     );
   }
 }
+NotificationTemplatesService.$inject = ['$http', 'Constants'];
 
 export default NotificationTemplatesService;

--- a/gravitee-apim-console-webui/src/services/notifier.service.ts
+++ b/gravitee-apim-console-webui/src/services/notifier.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class NotifierService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -25,5 +24,6 @@ class NotifierService {
     return this.$http.get(`${this.Constants.env.baseURL}/notifiers/` + notifier + '/schema');
   }
 }
+NotifierService.$inject = ['$http', 'Constants'];
 
 export default NotifierService;

--- a/gravitee-apim-console-webui/src/services/organization.service.ts
+++ b/gravitee-apim-console-webui/src/services/organization.service.ts
@@ -26,7 +26,6 @@ export class Organization {
 }
 
 class OrganizationService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   listSocialIdentityProviders() {
@@ -49,5 +48,6 @@ class OrganizationService {
     return this.$http.get(`${this.Constants.org.baseURL}`);
   }
 }
+OrganizationService.$inject = ['$http', 'Constants'];
 
 export default OrganizationService;

--- a/gravitee-apim-console-webui/src/services/policy.service.ts
+++ b/gravitee-apim-console-webui/src/services/policy.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class PolicyService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(expandSchema = false, expandIcon = false, withoutResource = false) {
@@ -47,5 +46,6 @@ class PolicyService {
     return this.$http.get(`${this.Constants.env.baseURL}/policies/${policyId}/documentation`);
   }
 }
+PolicyService.$inject = ['$http', 'Constants'];
 
 export default PolicyService;

--- a/gravitee-apim-console-webui/src/services/portal.service.ts
+++ b/gravitee-apim-console-webui/src/services/portal.service.ts
@@ -15,7 +15,6 @@
  */
 
 class PortalService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   searchApis(query?: string, opts?: any) {
@@ -23,5 +22,6 @@ class PortalService {
     return this.$http.post(url, {}, opts);
   }
 }
+PortalService.$inject = ['$http', 'Constants'];
 
 export default PortalService;

--- a/gravitee-apim-console-webui/src/services/portalConfig.service.ts
+++ b/gravitee-apim-console-webui/src/services/portalConfig.service.ts
@@ -15,12 +15,12 @@
  */
 
 class PortalConfigService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   get() {
     return this.$http.get(`${this.Constants.env.baseURL}/portal/`);
   }
 }
+PortalConfigService.$inject = ['$http', 'Constants'];
 
 export default PortalConfigService;

--- a/gravitee-apim-console-webui/src/services/portalSettings.service.ts
+++ b/gravitee-apim-console-webui/src/services/portalSettings.service.ts
@@ -15,7 +15,6 @@
  */
 
 class PortalSettingsService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   save(config) {
@@ -33,5 +32,6 @@ class PortalSettingsService {
     return false;
   }
 }
+PortalSettingsService.$inject = ['$http', 'Constants'];
 
 export default PortalSettingsService;

--- a/gravitee-apim-console-webui/src/services/promotion.service.ts
+++ b/gravitee-apim-console-webui/src/services/promotion.service.ts
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IHttpService, IPromise, IQService } from 'angular';
+import { IHttpService, IPromise } from 'angular';
 
 import { Constants } from '../entities/Constants';
 import { Promotion, PromotionRequest, PromotionTarget } from '../entities/promotion';
 import { PromotionSearchParams } from '../entities/promotion/promotionSearchParams';
 
 export class PromotionService {
-  /* @ngInject */
-  constructor(private $http: IHttpService, private Constants: Constants, private $q: IQService) {}
+  constructor(private $http: IHttpService, private Constants: Constants) {}
 
   listPromotionTargets(): IPromise<PromotionTarget[]> {
     return this.$http.get<PromotionTarget[]>(`${this.Constants.env.baseURL}/promotion-targets`).then((response) => response.data);
@@ -51,3 +50,4 @@ export class PromotionService {
       .then((response) => response.data);
   }
 }
+PromotionService.$inject = ['$http', 'Constants'];

--- a/gravitee-apim-console-webui/src/services/qualityRule.service.ts
+++ b/gravitee-apim-console-webui/src/services/qualityRule.service.ts
@@ -20,7 +20,6 @@ import { ApiQualityRule } from '../entities/apiQualityRule';
 import { QualityRule } from '../entities/qualityRule';
 
 class QualityRuleService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(): IHttpPromise<QualityRule[]> {
@@ -65,5 +64,6 @@ class QualityRuleService {
     });
   }
 }
+QualityRuleService.$inject = ['$http', 'Constants'];
 
 export default QualityRuleService;

--- a/gravitee-apim-console-webui/src/services/reCaptcha.service.ts
+++ b/gravitee-apim-console-webui/src/services/reCaptcha.service.ts
@@ -24,7 +24,6 @@ class ReCaptchaService {
   private reCaptchaToken: string;
   private display = false;
 
-  /* @ngInject */
   constructor(private $http, Constants) {
     this.enabled = Constants.org.settings.reCaptcha && !!Constants.org.settings.reCaptcha.enabled;
     if (this.enabled) {
@@ -106,5 +105,6 @@ class ReCaptchaService {
     }
   }
 }
+ReCaptchaService.$inject = ['$http', 'Constants'];
 
 export default ReCaptchaService;

--- a/gravitee-apim-console-webui/src/services/resource.service.ts
+++ b/gravitee-apim-console-webui/src/services/resource.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class ResourceService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(expandSchema = false, expandIcon = false) {
@@ -40,5 +39,6 @@ class ResourceService {
     return this.$http.get(`${this.Constants.env.baseURL}/resources/${resourceId}/documentation`);
   }
 }
+ResourceService.$inject = ['$http', 'Constants'];
 
 export default ResourceService;

--- a/gravitee-apim-console-webui/src/services/role.service.ts
+++ b/gravitee-apim-console-webui/src/services/role.service.ts
@@ -18,7 +18,6 @@ import * as _ from 'lodash';
 class RoleService {
   private permissionsByScope: any;
 
-  /* @ngInject */
   constructor(private $http, private Constants, private $q) {}
 
   listRights() {
@@ -107,5 +106,6 @@ class RoleService {
     }
   }
 }
+RoleService.$inject = ['$http', 'Constants', '$q'];
 
 export default RoleService;

--- a/gravitee-apim-console-webui/src/services/serviceDiscovery.service.ts
+++ b/gravitee-apim-console-webui/src/services/serviceDiscovery.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class ServiceDiscoveryService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -26,5 +25,6 @@ class ServiceDiscoveryService {
     return this.$http.get(`${this.Constants.env.baseURL}/services-discovery/${pluginId}/schema`);
   }
 }
+ServiceDiscoveryService.$inject = ['$http', 'Constants'];
 
 export default ServiceDiscoveryService;

--- a/gravitee-apim-console-webui/src/services/spel.service.ts
+++ b/gravitee-apim-console-webui/src/services/spel.service.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 class SpelService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   getGrammar() {
     return this.$http.get(`${this.Constants.env.baseURL}/configuration/spel/grammar`);
   }
 }
+SpelService.$inject = ['$http', 'Constants'];
 
 export default SpelService;

--- a/gravitee-apim-console-webui/src/services/subscription.service.ts
+++ b/gravitee-apim-console-webui/src/services/subscription.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class SubscriptionService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list(plan, application) {
@@ -28,5 +27,6 @@ class SubscriptionService {
     return this.$http.get(url);
   }
 }
+SubscriptionService.$inject = ['$http', 'Constants'];
 
 export default SubscriptionService;

--- a/gravitee-apim-console-webui/src/services/tag.service.ts
+++ b/gravitee-apim-console-webui/src/services/tag.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class TagService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -43,5 +42,6 @@ class TagService {
     }
   }
 }
+TagService.$inject = ['$http', 'Constants'];
 
 export default TagService;

--- a/gravitee-apim-console-webui/src/services/tenant.service.ts
+++ b/gravitee-apim-console-webui/src/services/tenant.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class TenantService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -39,5 +38,6 @@ class TenantService {
     }
   }
 }
+TenantService.$inject = ['$http', 'Constants'];
 
 export default TenantService;

--- a/gravitee-apim-console-webui/src/services/theme.service.ts
+++ b/gravitee-apim-console-webui/src/services/theme.service.ts
@@ -17,7 +17,6 @@
 import { Theme } from '../entities/theme';
 
 class ThemeService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   getCurrent() {
@@ -81,5 +80,6 @@ class ThemeService {
     return imageUrl;
   }
 }
+ThemeService.$inject = ['$http', 'Constants'];
 
 export default ThemeService;

--- a/gravitee-apim-console-webui/src/services/ticket.service.ts
+++ b/gravitee-apim-console-webui/src/services/ticket.service.ts
@@ -22,7 +22,6 @@ export class TicketsQuery {
 }
 
 class TicketService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   create(ticket) {
@@ -50,5 +49,6 @@ class TicketService {
     return url;
   }
 }
+TicketService.$inject = ['$http', 'Constants'];
 
 export default TicketService;

--- a/gravitee-apim-console-webui/src/services/token.service.ts
+++ b/gravitee-apim-console-webui/src/services/token.service.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 class TokenService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -33,5 +32,6 @@ class TokenService {
     }
   }
 }
+TokenService.$inject = ['$http', 'Constants'];
 
 export default TokenService;

--- a/gravitee-apim-console-webui/src/services/top-api.service.ts
+++ b/gravitee-apim-console-webui/src/services/top-api.service.ts
@@ -16,7 +16,6 @@
 import * as _ from 'lodash';
 
 class TopApiService {
-  /* @ngInject */
   constructor(private $http, private Constants) {}
 
   list() {
@@ -46,5 +45,6 @@ class TopApiService {
     }
   }
 }
+TopApiService.$inject = ['$http', 'Constants'];
 
 export default TopApiService;

--- a/gravitee-apim-console-webui/src/services/user.service.ts
+++ b/gravitee-apim-console-webui/src/services/user.service.ts
@@ -35,7 +35,6 @@ class UserService {
   public currentUser: User;
   private isLogout = false;
 
-  /* @ngInject */
   constructor(
     private $http: ng.IHttpService,
     private $q: ng.IQService,
@@ -364,5 +363,21 @@ class UserService {
     );
   }
 }
+UserService.$inject = [
+  '$http',
+  '$q',
+  'Constants',
+  'RoleService',
+  'PermPermissionStore',
+  'ApplicationService',
+  'ApiService',
+  'EnvironmentService',
+  '$location',
+  '$cookies',
+  '$window',
+  'StringService',
+  'Base64Service',
+  '$rootScope',
+];
 
 export default UserService;

--- a/gravitee-apim-console-webui/src/user/login/login.controller.ts
+++ b/gravitee-apim-console-webui/src/user/login/login.controller.ts
@@ -30,7 +30,6 @@ class LoginController {
   userCreationEnabled: boolean;
   localLoginDisabled: boolean;
 
-  /* @ngInject */
   constructor(
     private AuthenticationService: AuthenticationService,
     private UserService: UserService,
@@ -167,5 +166,19 @@ class LoginController {
     return redirectUri;
   }
 }
+LoginController.$inject = [
+  'AuthenticationService',
+  'UserService',
+  '$state',
+  'Constants',
+  '$rootScope',
+  'RouterService',
+  'identityProviders',
+  '$window',
+  '$stateParams',
+  '$scope',
+  'ReCaptchaService',
+  'ngGioPendoService',
+];
 
 export default LoginController;

--- a/gravitee-apim-console-webui/src/user/logout/logout.component.ts
+++ b/gravitee-apim-console-webui/src/user/logout/logout.component.ts
@@ -20,7 +20,6 @@ import { Constants } from '../../entities/Constants';
 import UserService from '../../services/user.service';
 
 class LogoutComponentController implements IOnInit {
-  /* @ngInject */
   constructor(
     private readonly UserService: UserService,
     private readonly $state: StateService,
@@ -72,6 +71,7 @@ class LogoutComponentController implements IOnInit {
     }
   }
 }
+LogoutComponentController.$inject = ['UserService', '$state', '$rootScope', '$window', 'Constants'];
 
 export const LogoutComponent: IComponentOptions = {
   controller: LogoutComponentController,

--- a/gravitee-apim-console-webui/src/user/newsletter/newsletter-subscription.controller.ts
+++ b/gravitee-apim-console-webui/src/user/newsletter/newsletter-subscription.controller.ts
@@ -19,7 +19,6 @@ import '@gravitee/ui-components/wc/gv-newsletter-subscription';
 class NewsletterSubscriptionController {
   newsletterPage;
 
-  /* @ngInject */
   constructor(
     private $state,
     private $scope,
@@ -60,5 +59,15 @@ class NewsletterSubscriptionController {
     this.$state.go('management');
   }
 }
+NewsletterSubscriptionController.$inject = [
+  '$state',
+  '$scope',
+  'UserService',
+  'NotificationService',
+  'Constants',
+  '$window',
+  '$rootScope',
+  'taglines',
+];
 
 export default NewsletterSubscriptionController;

--- a/gravitee-apim-console-webui/src/user/registration/confirm/confirm.controller.ts
+++ b/gravitee-apim-console-webui/src/user/registration/confirm/confirm.controller.ts
@@ -16,7 +16,6 @@
 import ReCaptchaService from '../../../services/reCaptcha.service';
 
 class ConfirmController {
-  /* @ngInject */
   constructor(jwtHelper, $state, $scope, UserService, NotificationService, ReCaptchaService: ReCaptchaService) {
     ReCaptchaService.displayBadge();
 
@@ -56,5 +55,6 @@ class ConfirmController {
     };
   }
 }
+ConfirmController.$inject = ['jwtHelper', '$state', '$scope', 'UserService', 'NotificationService', 'ReCaptchaService'];
 
 export default ConfirmController;

--- a/gravitee-apim-console-webui/src/user/registration/registration.controller.ts
+++ b/gravitee-apim-console-webui/src/user/registration/registration.controller.ts
@@ -20,7 +20,6 @@ class RegistrationController {
   user: { firstname?: string; lastname?: string; email?: string; customFields?: any } = {};
   fields: any[] = [];
 
-  /* @ngInject */
   constructor(
     private UserService: UserService,
     private $scope,
@@ -55,5 +54,6 @@ class RegistrationController {
       );
   }
 }
+RegistrationController.$inject = ['UserService', '$scope', 'NotificationService', 'ReCaptchaService'];
 
 export default RegistrationController;

--- a/gravitee-apim-console-webui/src/user/resetPassword/resetPassword.controller.ts
+++ b/gravitee-apim-console-webui/src/user/resetPassword/resetPassword.controller.ts
@@ -16,7 +16,6 @@
 import ReCaptchaService from '../../services/reCaptcha.service';
 
 class ResetPasswordController {
-  /* @ngInject */
   constructor(jwtHelper, $state, $scope, UserService, NotificationService, ReCaptchaService: ReCaptchaService) {
     ReCaptchaService.displayBadge();
 
@@ -53,5 +52,6 @@ class ResetPasswordController {
     };
   }
 }
+ResetPasswordController.$inject = ['jwtHelper', '$state', '$scope', 'UserService', 'NotificationService', 'ReCaptchaService'];
 
 export default ResetPasswordController;

--- a/gravitee-apim-console-webui/src/user/token/generateTokenDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/user/token/generateTokenDialog.controller.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* @ngInject */
+
 function DialogGenerateTokenController($scope, $mdDialog, locals, TokenService, NotificationService, Constants, $location) {
   this.title = locals.title;
   this.msg = locals.msg;
@@ -45,5 +45,6 @@ function DialogGenerateTokenController($scope, $mdDialog, locals, TokenService, 
     return `curl -H "Authorization: Bearer ${token}" "${envBaseURL}"`;
   };
 }
+DialogGenerateTokenController.$inject = ['$scope', '$mdDialog', 'locals', 'TokenService', 'NotificationService', 'Constants', '$location'];
 
 export default DialogGenerateTokenController;

--- a/gravitee-apim-console-webui/src/user/user.controller.ts
+++ b/gravitee-apim-console-webui/src/user/user.controller.ts
@@ -33,7 +33,6 @@ class UserController {
   private fields: any[] = [];
   private groups = '';
 
-  /* @ngInject */
   constructor(
     private UserService: UserService,
     private NotificationService: NotificationService,
@@ -170,5 +169,6 @@ class UserController {
       });
   }
 }
+UserController.$inject = ['UserService', 'NotificationService', '$state', '$scope', '$rootScope', 'TokenService', '$mdDialog', 'Constants'];
 
 export default UserController;


### PR DESCRIPTION
## Issue

Preparing the migration of the application to angular. To avoid too many big bang changes that day, I'm eliminating a few points upstream. even if it won't happen for a long time yet 

## Description

Remove use of angularJs annotation (@ngInject) and use native way to config DI.
Annotation requires special webpack or babel configuration. In the future, when we want to switch to angular cli, deleting this approach will avoid the need for special webpack configuration. (and especially no longer supported in the latest webpack version used by angular cli)


## Additional context

Possible error: 
This PR can generate DI errors. 1ngular reports in the console that it cannot resolve an injection. It's easy to correct, but not easy to "find" without opening the page. 

To avoid this, here's what I did: 


- [x] Browse all the angularJs pages
- [x] run e2e



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5572/console](https://pr.team-apim.gravitee.dev/5572/console)
      Portal: [https://pr.team-apim.gravitee.dev/5572/portal](https://pr.team-apim.gravitee.dev/5572/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5572/api/management](https://pr.team-apim.gravitee.dev/5572/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5572](https://pr.team-apim.gravitee.dev/5572)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5572](https://pr.gateway-v3.team-apim.gravitee.dev/5572)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iuejeavhjg.chromatic.com)
<!-- Storybook placeholder end -->
