### PR TITLE
fix: properly update flow resolver based on latest organization deployed

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolverFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolverFactory.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.handlers.api.definition.Api;
-import io.gravitee.gateway.platform.Organization;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
 import io.gravitee.gateway.reactive.core.condition.ConditionFilter;
 import io.gravitee.gateway.reactive.flow.BestMatchFlowResolver;
@@ -63,14 +62,7 @@ public class FlowResolverFactory {
     }
 
     public FlowResolver forPlatform(ReactableApi<?> api, OrganizationManager organizationManager) {
-        final PlatformFlowResolver flowResolver = new PlatformFlowResolver(api, organizationManager, flowFilter);
-        final Organization organization = organizationManager.getCurrentOrganization();
-
-        if (organization != null && isBestMatchFlowMode(organization.getFlowMode())) {
-            return new BestMatchFlowResolver(flowResolver, bestMatchFlowSelector);
-        }
-
-        return flowResolver;
+        return new PlatformFlowResolver(api.getOrganizationId(), organizationManager, flowFilter, bestMatchFlowSelector);
     }
 
     private static boolean isBestMatchFlowMode(FlowMode flowMode) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolverFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolverFactoryTest.java
@@ -112,7 +112,6 @@ class FlowResolverFactoryTest {
         final Api api = mock(Api.class);
 
         when(organizationManager.getCurrentOrganization()).thenReturn(organization);
-        when(organization.getFlowMode()).thenReturn(FlowMode.DEFAULT);
         when(organization.getId()).thenReturn(ORGANIZATION_ID);
         when(api.getOrganizationId()).thenReturn(ORGANIZATION_ID);
 
@@ -133,21 +132,5 @@ class FlowResolverFactoryTest {
 
         assertNotNull(flowResolver);
         assertTrue(flowResolver instanceof PlatformFlowResolver);
-    }
-
-    @Test
-    void shouldCreateBestMatchPlatformFlowResolver() {
-        final OrganizationManager organizationManager = mock(OrganizationManager.class);
-        final Organization organization = mock(Organization.class);
-        final Api api = mock(Api.class);
-
-        when(organizationManager.getCurrentOrganization()).thenReturn(organization);
-        when(organization.getFlowMode()).thenReturn(FlowMode.BEST_MATCH);
-        when(organization.getId()).thenReturn(ORGANIZATION_ID);
-
-        final FlowResolver flowResolver = cut.forPlatform(mock(Api.class), organizationManager);
-
-        assertNotNull(flowResolver);
-        assertTrue(flowResolver instanceof BestMatchFlowResolver);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -294,9 +294,6 @@ public class GatewayRunner {
         try {
             organizationManager.register(organization);
             deployedOrganization = organization;
-            // When deploying an organization at method level, it's important to set the organization id on every already deployed apis (at class level)
-            final ApiManager apiManager = gatewayContainer.applicationContext().getBean(ApiManager.class);
-            apiManager.apis().forEach(api -> api.setOrganizationId(deployedOrganization.getId()));
         } catch (Exception e) {
             LOGGER.error("An error occurred deploying the organization {}: {}", organization.getId(), e.getMessage());
             throw e;


### PR DESCRIPTION
## Description

When an api is deployed, a PlatformFlowResolver is created and attached to the created reactor, that allows to dynamically resolved the flows accordingly. However if the flowmode changed, the resolver is not updated and so can lead to wrong execution.

This PR fixes the issue by encapsulating the BestMatchResolver.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-njvlqyzsue.chromatic.com)
<!-- Storybook placeholder end -->
