### PR TITLE
fix(rest-api): make MAPIV2 work with endpoint inherit configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,17 +17,6 @@
 -->
 <mat-card *ngIf="healthCheckForm" [formGroup]="healthCheckForm">
   <mat-card-content class="health-check-card">
-    <!-- Enable health-check -->
-    <gio-form-slide-toggle class="health-check-card__enable-toggle">
-      <gio-form-label>Enable health-check</gio-form-label>
-      <mat-slide-toggle
-        gioFormSlideToggle
-        formControlName="enabled"
-        aria-label="Health-check enable toggle"
-        name="enableHealthCheck"
-      ></mat-slide-toggle>
-    </gio-form-slide-toggle>
-
     <!-- Inherit configuration -->
     <gio-form-slide-toggle *ngIf="inheritHealthCheck" class="health-check-card__inherit-toggle">
       <gio-form-label>Inherit configuration</gio-form-label>
@@ -39,18 +28,58 @@
       ></mat-slide-toggle>
     </gio-form-slide-toggle>
 
+    <!-- Enable health-check -->
+    <gio-form-slide-toggle class="health-check-card__enable-toggle">
+      <gio-form-label>Enable health-check</gio-form-label>
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="enabled"
+        aria-label="Health-check enable toggle"
+        name="enableHealthCheck"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+
     <mat-divider></mat-divider>
 
-    <gio-banner-info *ngIf="inheritHealthCheck && healthCheckForm.get('inherit').value" class="health-check-card__banner">
-      {{
-        inheritHealthCheck.enabled
-          ? 'Inherited configuration preview from global health-check settings.'
-          : 'No global health-check settings defined. When defined, they will be inherited.'
-      }}
-    </gio-banner-info>
+    <ng-container *ngIf="inheritHealthCheck">
+      <gio-banner-info
+        *ngIf="inheritHealthCheck.enabled && healthCheckForm.get('enabled').value && healthCheckForm.get('inherit').value"
+        class="health-check-card__banner"
+      >
+        Inherited configuration preview from global health-check settings.
+      </gio-banner-info>
+
+      <gio-banner-info
+        *ngIf="healthCheckForm.get('inherit').value && !healthCheckForm.get('enabled').value"
+        class="health-check-card__banner"
+      >
+        No global health-check settings defined. When defined, they will be inherited.
+      </gio-banner-info>
+
+      <gio-banner-info
+        *ngIf="!healthCheckForm.get('inherit').value && !healthCheckForm.get('enabled').value"
+        class="health-check-card__banner"
+      >
+        Health-check configuration is disabled.
+      </gio-banner-info>
+
+      <gio-banner-info
+        *ngIf="healthCheckForm.get('enabled').value && !healthCheckForm.get('inherit').value"
+        class="health-check-card__banner"
+      >
+        Configure a specific health-check for this endpoint.
+      </gio-banner-info>
+    </ng-container>
 
     <div
-      *ngIf="!inheritHealthCheck || !(inheritHealthCheck && !inheritHealthCheck.enabled && healthCheckForm.get('inherit').value)"
+      *ngIf="
+        !inheritHealthCheck ||
+        (inheritHealthCheck &&
+          inheritHealthCheck.enabled &&
+          healthCheckForm.get('inherit').value &&
+          healthCheckForm.get('enabled').value) ||
+        (inheritHealthCheck && !healthCheckForm.get('inherit').value && healthCheckForm.get('enabled').value)
+      "
       [class.disabled]="isDisabled$ | async"
       class="health-check-card--forms"
     >

--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
@@ -203,18 +203,18 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     fixture.detectChanges();
 
     // Enable health check
-    const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
-    expect(await enabledSlideToggle.isChecked()).toEqual(false);
-    await enabledSlideToggle.check();
-
     const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
-    expect(await inheritSlideToggle.isChecked()).toEqual(true);
+    expect(await inheritSlideToggle.isChecked()).toEqual(false);
     await inheritSlideToggle.check();
+
+    const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
+    expect(await enabledSlideToggle.isChecked()).toEqual(true);
+    expect(await enabledSlideToggle.isDisabled()).toEqual(true);
 
     // Expect inherit preview :
 
     // Trigger
-    component.healthCheckForm.get('schedule').setValue('1 * * * *');
+    expect(component.healthCheckForm.get('schedule').value).toEqual('1 * * * *');
 
     // Request
     const allowMethodsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="method"]' }));
@@ -243,7 +243,170 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     expect(await assertion_0.getValue()).toEqual('inherit');
 
     expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, true)).toEqual({
+      inherit: true,
+    });
+  });
+
+  it('should display with an unconfigured global health check', async () => {
+    initHealthCheckFormComponent({
+      inherit: true,
+    });
+
+    const inheritHealthCheck: HealthCheck = {
+      enabled: false,
+    };
+    component.inheritHealthCheck = inheritHealthCheck;
+    component.ngOnChanges({ inheritHealthCheck: {} } as any);
+    fixture.detectChanges();
+
+    // Enable health check
+    const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
+    const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
+
+    expect(await inheritSlideToggle.isChecked()).toEqual(true);
+    expect(await enabledSlideToggle.isChecked()).toEqual(false);
+    expect(await enabledSlideToggle.isDisabled()).toEqual(true);
+
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, true)).toEqual({
+      inherit: true,
+    });
+  });
+
+  it('should override inherited health check', async () => {
+    initHealthCheckFormComponent({
       enabled: true,
+      inherit: true,
+    });
+
+    const inheritHealthCheck: HealthCheck = {
+      enabled: true,
+      schedule: '1 * * * *',
+      steps: [
+        {
+          request: {
+            method: 'PUT',
+            path: '/inherit',
+            body: 'The inherit body',
+            headers: [{ name: 'X-Test', value: 'inherit' }],
+            fromRoot: true,
+          },
+          response: {
+            assertions: ['inherit'],
+          },
+        },
+      ],
+    };
+    component.inheritHealthCheck = inheritHealthCheck;
+    component.ngOnChanges({ inheritHealthCheck: {} } as any);
+    fixture.detectChanges();
+
+    // Enable health check
+    const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
+    const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
+
+    expect(await inheritSlideToggle.isChecked()).toEqual(true);
+    expect(await enabledSlideToggle.isChecked()).toEqual(true);
+    ``;
+    await inheritSlideToggle.toggle();
+    expect(await inheritSlideToggle.isChecked()).toEqual(false);
+
+    // Trigger
+    component.healthCheckForm.get('schedule').setValue('* */5 * * * *');
+
+    // Request
+    const allowMethodsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="method"]' }));
+    expect(await allowMethodsInput.isDisabled()).toEqual(false);
+    await allowMethodsInput.clickOptions({ text: 'GET' });
+
+    const pathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="path"]' }));
+    expect(await pathInput.isDisabled()).toEqual(false);
+    await pathInput.setValue('/override');
+
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, true)).toEqual({
+      enabled: true,
+      inherit: false,
+      schedule: '* */5 * * * *',
+      steps: [
+        {
+          request: {
+            body: undefined,
+            fromRoot: undefined,
+            headers: [],
+            method: 'GET',
+            path: '/override',
+          },
+          response: {
+            assertions: ['#response.status == 200'],
+          },
+        },
+      ],
+    });
+  });
+
+  it('should preview the inherited health check', async () => {
+    initHealthCheckFormComponent({
+      enabled: true,
+      inherit: true,
+    });
+
+    const inheritHealthCheck: HealthCheck = {
+      enabled: true,
+      schedule: '1 * * * *',
+      steps: [
+        {
+          request: {
+            method: 'PUT',
+            path: '/inherit',
+            body: 'The inherit body',
+            headers: [{ name: 'X-Test', value: 'inherit' }],
+            fromRoot: true,
+          },
+          response: {
+            assertions: ['inherit'],
+          },
+        },
+      ],
+    };
+    component.inheritHealthCheck = inheritHealthCheck;
+    component.ngOnChanges({ inheritHealthCheck: {} } as any);
+    fixture.detectChanges();
+
+    // Enable health check
+    const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
+    expect(await enabledSlideToggle.isChecked()).toEqual(true);
+
+    const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
+    expect(await inheritSlideToggle.isChecked()).toEqual(true);
+
+    // Expect inherit preview :
+
+    // Request
+    const allowMethodsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="method"]' }));
+    expect(await allowMethodsInput.isDisabled()).toEqual(true);
+    expect(await allowMethodsInput.getValueText()).toEqual('PUT');
+
+    const pathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="path"]' }));
+    expect(await pathInput.isDisabled()).toEqual(true);
+    expect(await pathInput.getValue()).toEqual('/inherit');
+
+    const fromRootSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="fromRoot"]' }));
+    expect(await fromRootSlideToggle.isDisabled()).toEqual(true);
+    expect(await fromRootSlideToggle.isChecked()).toEqual(true);
+
+    const bodyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="body"]' }));
+    expect(await bodyInput.isDisabled()).toEqual(true);
+    expect(await bodyInput.getValue()).toEqual('The inherit body');
+
+    const headersInput = await loader.getHarness(GioFormHeadersHarness.with({ selector: '[formControlName="headers"]' }));
+    expect(await headersInput.isDisabled()).toEqual(true);
+    expect(await (await headersInput.getHeaderRows())[0].valueInput.getValue()).toEqual('inherit');
+
+    // Assertion
+    const assertion_0 = await loader.getHarness(MatInputHarness.with({ selector: '[ng-reflect-name="0"]' }));
+    expect(await assertion_0.isDisabled()).toEqual(true);
+    expect(await assertion_0.getValue()).toEqual('inherit');
+
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, true)).toEqual({
       inherit: true,
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -187,7 +187,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   inherit: true,
                   tenants: [tenants[0].id],
                   healthcheck: {
-                    enabled: false,
+                    inherit: true,
                   },
                 },
                 {
@@ -257,7 +257,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   proxy: { enabled: false },
                   ssl: {},
                   healthcheck: {
-                    enabled: false,
+                    inherit: true,
                   },
                 },
                 {
@@ -363,7 +363,6 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                 type: 'http',
                 inherit: true,
                 healthcheck: {
-                  enabled: true,
                   inherit: true,
                 },
               },
@@ -443,7 +442,6 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                 type: 'http',
                 inherit: true,
                 healthcheck: {
-                  enabled: true,
                   inherit: true,
                 },
               },
@@ -528,7 +526,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                 type: 'http',
                 inherit: true,
                 healthcheck: {
-                  enabled: false,
+                  inherit: true,
                 },
               },
             ],

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -199,11 +199,8 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
       ],
     });
 
-    // If the endpoint group has a health check enabled, by default, the endpoint will inherit it during creation
-    const defaultHealthCheck =
-      this.api?.services?.['health-check']?.enabled && this.mode === 'new' ? { enabled: true, inherit: true } : { enabled: false };
     this.healthCheckForm = ApiProxyHealthCheckFormComponent.NewHealthCheckFormGroup(
-      this.endpoint?.healthcheck ?? defaultHealthCheck,
+      this.endpoint?.healthcheck ?? { inherit: true },
       this.isReadOnly,
     );
     this.inheritHealthCheck = this.api?.services?.['health-check'] ?? { enabled: false };

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.html
@@ -98,8 +98,15 @@
         <td mat-cell *matCellDef="let element">
           <div class="endpoint-list__table__hc">
             <span *ngIf="element.isBackup" matTooltip="Secondary endpoint" class="gio-badge-neutral">Secondary</span>
-            <mat-icon *ngIf="element.healthcheck" matTooltip="Health check is enabled">favorite</mat-icon>
-            <mat-icon *ngIf="element.inherit" matTooltip="HTTP configuration inherited">subdirectory_arrow_right</mat-icon>
+            <span *ngIf="element.healthcheck === 'inherit-enable'" matTooltip="Health-check is enabled (inherit)" class="gio-badge-neutral"
+              ><mat-icon svgIcon="gio:heart"></mat-icon
+            ></span>
+            <span *ngIf="element.healthcheck === 'enable'" matTooltip="Health-check is enabled locally" class="gio-badge-primary"
+              ><mat-icon svgIcon="gio:heart"></mat-icon
+            ></span>
+            <span *ngIf="element.inherit" matTooltip="HTTP configuration inherited" class="gio-badge-neutral"
+              ><mat-icon svgIcon="gio:network-alt"></mat-icon
+            ></span>
           </div>
         </td>
       </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
@@ -187,13 +187,11 @@ describe('ApiProxyEndpointListComponent', () => {
       );
 
       expect(await endpointsGroupHarness.getTableRows(0)).toEqual([
-        ['default', 'favorite', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
-        ['secondary endpoint', 'favorite', 'https://api.gravitee.io/echo', 'HTTP', '1', ''],
+        ['default', 'heart', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
+        ['secondary endpoint', 'heart', 'https://api.gravitee.io/echo', 'HTTP', '1', ''],
       ]);
 
-      expect(await endpointsGroupHarness.getTableRows(1)).toEqual([
-        ['default', 'favorite', 'https://api.gravitee.io/echo', 'HTTP', '1', ''],
-      ]);
+      expect(await endpointsGroupHarness.getTableRows(1)).toEqual([['default', 'heart', 'https://api.gravitee.io/echo', 'HTTP', '1', '']]);
     });
 
     it("should display health check icon when it's configured at endpoint level", async () => {
@@ -231,7 +229,7 @@ describe('ApiProxyEndpointListComponent', () => {
         }),
       );
 
-      expect(await loader.getHarness(MatIconHarness.with({ selector: '[mattooltip="Health check is enabled"]' }))).toBeTruthy();
+      expect(await loader.getChildLoader('[mattooltip="Health-check is enabled locally"]')).toBeTruthy();
     });
 
     it("should display health check icon when it's configured at API level", async () => {
@@ -246,7 +244,7 @@ describe('ApiProxyEndpointListComponent', () => {
         }),
       );
 
-      expect(await loader.getHarness(MatIconHarness.with({ selector: '[mattooltip="Health check is enabled"]' }))).toBeTruthy();
+      expect(await loader.getChildLoader('[mattooltip="Health-check is enabled (inherit)"]')).toBeTruthy();
     });
 
     it('should not display health check icon', async () => {
@@ -281,7 +279,7 @@ describe('ApiProxyEndpointListComponent', () => {
       await initComponent(api);
 
       expect(await endpointsGroupHarness.getTableRows(0)).toEqual([
-        ['default', 'favoritesubdirectory_arrow_right', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
+        ['default', 'heart network-alt', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
       ]);
 
       await endpointsGroupHarness.deleteEndpointGroup(rootLoader);
@@ -324,8 +322,8 @@ describe('ApiProxyEndpointListComponent', () => {
       await initComponent(api);
 
       expect(await endpointsGroupHarness.getTableRows(0)).toEqual([
-        ['default', 'favorite', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
-        ['secondary endpoint', 'favorite', 'https://api.gravitee.io/echo', 'HTTP', '1', ''],
+        ['default', 'heart', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
+        ['secondary endpoint', 'heart', 'https://api.gravitee.io/echo', 'HTTP', '1', ''],
       ]);
 
       await endpointsGroupHarness.deleteEndpoint(1, rootLoader);
@@ -353,7 +351,7 @@ describe('ApiProxyEndpointListComponent', () => {
       });
 
       expect(await endpointsGroupHarness.getTableRows(0)).toEqual([
-        ['default', 'favorite', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
+        ['default', 'heart', 'https://api.le-systeme-solaire.net/rest/', 'HTTP', '1', ''],
       ]);
     });
   });
@@ -383,7 +381,7 @@ describe('ApiProxyEndpointListComponent', () => {
         }),
       );
 
-      expect(await loader.getHarness(MatIconHarness.with({ selector: '[mattooltip="HTTP configuration inherited"]' }))).toBeTruthy();
+      expect(await loader.getChildLoader('[mattooltip="HTTP configuration inherited"]')).toBeTruthy();
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.html
@@ -26,13 +26,7 @@
 </div>
 
 <gio-banner-info class="api-proxy-health-check__banner-info">
-  <span
-    >Enabling health check on the API will activate health check for all non-backup endpoints, except if the health check is disabled at
-    endpoint level.
-    <br />
-    Disabling health check on the API will deactivate health check for all endpoints configured to inherit health check settings from the
-    API.
-  </span>
+  <span> Updating health check at the API level will impact all inherited health check configurations at endpoints level. </span>
 </gio-banner-info>
 
 <form *ngIf="healthCheckForm" autocomplete="off" gioFormFocusInvalid [formGroup]="healthCheckForm">

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.scss
@@ -19,6 +19,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
   &__header {
     display: flex;
+    align-items: center;
 
     &__description {
       flex: 1;

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
@@ -143,7 +143,7 @@ describe('ApiProxyHealthCheckComponent', () => {
           {
             name: 'default',
             endpoints: [
-              { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { enabled: false } },
+              { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { enabled: false, inherit: false } },
               { name: 'endpoint1-with-healthcheck-activated', healthcheck: { enabled: true, inherit: true } },
               { name: 'endpoint1-without-healthcheck' },
             ],
@@ -151,7 +151,7 @@ describe('ApiProxyHealthCheckComponent', () => {
           {
             name: 'group-2',
             endpoints: [
-              { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { enabled: false } },
+              { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { enabled: false, inherit: false } },
               { name: 'endpoint2-with-healthcheck-activated', healthcheck: { enabled: true, inherit: true } },
               { name: 'endpoint2-without-healthcheck' },
             ],
@@ -192,17 +192,17 @@ describe('ApiProxyHealthCheckComponent', () => {
       {
         name: 'default',
         endpoints: [
-          { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { enabled: false } },
-          { name: 'endpoint1-with-healthcheck-activated', healthcheck: { enabled: true, inherit: true } },
-          { name: 'endpoint1-without-healthcheck', healthcheck: { enabled: true, inherit: true } },
+          { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { enabled: false, inherit: false } },
+          { name: 'endpoint1-with-healthcheck-activated', healthcheck: { inherit: true } },
+          { name: 'endpoint1-without-healthcheck', healthcheck: { inherit: true } },
         ],
       },
       {
         name: 'group-2',
         endpoints: [
-          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { enabled: false } },
-          { name: 'endpoint2-with-healthcheck-activated', healthcheck: { enabled: true, inherit: true } },
-          { name: 'endpoint2-without-healthcheck', healthcheck: { enabled: true, inherit: true } },
+          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { enabled: false, inherit: false } },
+          { name: 'endpoint2-with-healthcheck-activated', healthcheck: { inherit: true } },
+          { name: 'endpoint2-without-healthcheck', healthcheck: { inherit: true } },
         ],
       },
     ]);
@@ -280,19 +280,19 @@ describe('ApiProxyHealthCheckComponent', () => {
       {
         name: 'default',
         endpoints: [
-          { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { enabled: false } },
-          { name: 'endpoint1-with-healthcheck-activated-inherited', healthcheck: { enabled: false, inherit: true } },
+          { name: 'endpoint1-with-healthcheck-deactivated', healthcheck: { inherit: false, enabled: false } },
+          { name: 'endpoint1-with-healthcheck-activated-inherited', healthcheck: { inherit: true } },
           { name: 'endpoint1-with-healthcheck-activated', healthcheck: { enabled: true, inherit: false } },
-          { name: 'endpoint1-without-healthcheck' },
+          { name: 'endpoint1-without-healthcheck', healthcheck: { inherit: true } },
         ],
       },
       {
         name: 'group-2',
         endpoints: [
-          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { enabled: false } },
-          { name: 'endpoint2-with-healthcheck-activated-inherited', healthcheck: { enabled: false, inherit: true } },
+          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { inherit: true } },
+          { name: 'endpoint2-with-healthcheck-activated-inherited', healthcheck: { inherit: true } },
           { name: 'endpoint2-with-healthcheck-activated', healthcheck: { enabled: true, inherit: false } },
-          { name: 'endpoint2-without-healthcheck' },
+          { name: 'endpoint2-without-healthcheck', healthcheck: { inherit: true } },
         ],
       },
     ]);

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
@@ -289,7 +289,7 @@ describe('ApiProxyHealthCheckComponent', () => {
       {
         name: 'group-2',
         endpoints: [
-          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { inherit: true } },
+          { name: 'endpoint2-with-healthcheck-deactivated', healthcheck: { inherit: false, enabled: false } },
           { name: 'endpoint2-with-healthcheck-activated-inherited', healthcheck: { inherit: true } },
           { name: 'endpoint2-with-healthcheck-activated', healthcheck: { enabled: true, inherit: false } },
           { name: 'endpoint2-without-healthcheck', healthcheck: { inherit: true } },

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
@@ -72,7 +72,7 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
       .pipe(
         switchMap((api) => {
           const apiHealthCheck = ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm, false);
-          this.updateEndpointsHealthCheckConfig(api.proxy?.groups, apiHealthCheck.enabled);
+          this.updateEndpointsHealthCheckConfig(api.proxy?.groups);
 
           return this.apiService.update({
             ...api,
@@ -97,28 +97,26 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
     this.ajsState.go('management.apis.detail.proxy.healthCheckDashboard.visualize');
   }
 
-  updateEndpointsHealthCheckConfig(groups: Api['proxy']['groups'], apiHealthCheckEnabled: boolean) {
-    if (apiHealthCheckEnabled === true) {
-      // If the API healthcheck is enabled, we enable the health-check for all endpoints without `healthcheck` config
-      groups.forEach((group) => {
-        group.endpoints.forEach((endpoint) => {
-          if (!endpoint.healthcheck) {
-            endpoint.healthcheck = {
-              enabled: true,
-              inherit: true,
-            };
-          }
-        });
+  updateEndpointsHealthCheckConfig(groups: Api['proxy']['groups']) {
+    groups.forEach((group) => {
+      group.endpoints.forEach((endpoint) => {
+        // If healthcheck is disabled, set inherit to false
+        if (
+          (endpoint.healthcheck?.inherit === undefined || endpoint.healthcheck?.inherit === true) &&
+          endpoint.healthcheck?.enabled === false
+        ) {
+          endpoint.healthcheck = {
+            inherit: false,
+            enabled: false,
+          };
+        }
+        // Enable healthcheck if inherit is true or not defined
+        else if (endpoint.healthcheck?.inherit === undefined || endpoint.healthcheck?.inherit === true) {
+          endpoint.healthcheck = {
+            inherit: true,
+          };
+        }
       });
-    } else {
-      // If the API healthcheck is disabled, we disable the health-check for all endpoints inheriting the health-check config
-      groups.forEach((group) => {
-        group.endpoints.forEach((endpoint) => {
-          if (endpoint.healthcheck?.enabled === true && endpoint.healthcheck?.inherit === true) {
-            endpoint.healthcheck.enabled = false;
-          }
-        });
-      });
-    }
+    });
   }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -26,12 +26,13 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
+@SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Endpoint implements Serializable {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/endpoint/HttpEndpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/endpoint/HttpEndpoint.java
@@ -24,12 +24,14 @@ import io.gravitee.definition.model.HttpClientSslOptions;
 import io.gravitee.definition.model.HttpProxy;
 import io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService;
 import java.util.List;
+import lombok.experimental.SuperBuilder;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Deprecated(since = "3.13", forRemoval = true)
+@SuperBuilder
 public class HttpEndpoint extends Endpoint {
 
     @JsonProperty("proxy")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
@@ -49,6 +49,9 @@ public interface ServiceMapper {
     @Mapping(target = "discoveryService", source = "discovery")
     Services map(EndpointGroupServicesV2 endpointGroupServicesV2);
 
+    @Mapping(target = "discovery", source = "discoveryService")
+    EndpointGroupServicesV2 mapToEndpointGroupServices(Services endpointGroupServicesV2);
+
     @Mapping(target = "configuration", qualifiedByName = "toDynamicPropertyServiceConfiguration")
     @Mapping(target = "name", constant = io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService.SERVICE_KEY)
     io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService map(DynamicPropertyService dynamicPropertyService);
@@ -64,6 +67,7 @@ public interface ServiceMapper {
 
     HealthCheckService map(io.gravitee.definition.model.services.healthcheck.HealthCheckService healthCheckService);
 
+    @Mapping(target = "configuration", qualifiedByName = "deserializeConfiguration")
     EndpointDiscoveryService map(io.gravitee.definition.model.services.discovery.EndpointDiscoveryService endpointDiscoveryService);
 
     @Mapping(target = "specification", qualifiedByName = "serializeConfiguration")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -4283,7 +4283,6 @@ components:
                       inherit:
                           type: boolean
                           description: Inherit the configuration of the parent endpoint.
-                          default: true
         EndpointStatus:
             type: string
             description: The status of the endpoint.
@@ -4422,7 +4421,6 @@ components:
                   enabled:
                       type: boolean
                       description: Is the service enabled or not.
-                      default: true
         HealthCheckStep:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EndpointFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/EndpointFixtures.java
@@ -46,7 +46,7 @@ public class EndpointFixtures {
         .backup(false)
         .status(EndpointStatus.UP)
         .tenants(List.of("tenant1", "tenant2"))
-        .type("HTTP")
+        .type("http")
         .inherit(true)
         .healthCheck(EndpointHealthCheckService.builder().build())
         .headers(Collections.emptyList())
@@ -93,12 +93,17 @@ public class EndpointFixtures {
         .endpoints(List.of(BASE_ENDPOINT_V4.build()))
         .services(BASE_ENDPOINTGROUP_SERVICES_V4.build());
 
-    public static HttpEndpointV2 anHtpEndpointV2() {
+    private static final EndpointHealthCheckService.EndpointHealthCheckServiceBuilder BASE_HEALTH_CHECK_SERVICE = EndpointHealthCheckService
+        .builder()
+        .enabled(true)
+        .schedule("0 */5 * * * *");
+
+    public static HttpEndpointV2 anHttpEndpointV2() {
         return BASE_HTTP_ENDPOINT_V2.build();
     }
 
     public static EndpointV2 anEndpointV2() {
-        return new EndpointV2(anHtpEndpointV2());
+        return new EndpointV2(anHttpEndpointV2());
     }
 
     public static EndpointGroupV2 anEndpointGroupV2() {
@@ -127,5 +132,9 @@ public class EndpointFixtures {
 
     public static EndpointGroup aModelEndpointGroupV4() {
         return EndpointModelFixtures.aModelEndpointGroupV4();
+    }
+
+    public static EndpointHealthCheckService anEndpointHealthCheckService() {
+        return BASE_HEALTH_CHECK_SERVICE.build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
@@ -72,4 +72,8 @@ public class ServiceFixture {
     public static ServiceV4 aServiceV4() {
         return BASE_API_V4_SERVICE.build();
     }
+
+    public static HealthCheckService aHealthCheckService() {
+        return BASE_HEALTH_CHECK_SERVICE.build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -434,9 +434,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             // check endpoints configuration
             checkEndpointsConfiguration(api);
 
-            // check HC inheritance
-            checkHealthcheckInheritance(api);
-
             // check CORS Allow-origin format
             corsValidationService.validateAndSanitize(api.getProxy().getCors());
 
@@ -658,36 +655,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                         throw new InvalidDataException(e);
                     }
                 }
-            }
-        }
-    }
-
-    private void checkHealthcheckInheritance(UpdateApiEntity api) {
-        boolean inherit = false;
-
-        if (api.getProxy() != null && api.getProxy().getGroups() != null) {
-            for (EndpointGroup group : api.getProxy().getGroups()) {
-                if (group.getEndpoints() != null) {
-                    for (Endpoint endpoint : group.getEndpoints()) {
-                        if (isHttpEndpoint(endpoint) && endpoint.getHealthCheck() != null && endpoint.getHealthCheck().isInherit()) {
-                            inherit = true;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        if (inherit) {
-            //if endpoints are set to inherit HC configuration, this configuration must exists.
-            boolean hcServiceExists = false;
-            if (api.getServices() != null) {
-                HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-                hcServiceExists = healthCheckService != null;
-            }
-
-            if (!hcServiceExists) {
-                throw new HealthcheckInheritanceException();
             }
         }
     }
@@ -986,9 +953,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // check endpoints configuration
             checkEndpointsConfiguration(updateApiEntity);
-
-            // check HC inheritance
-            checkHealthcheckInheritance(updateApiEntity);
 
             // validate HC cron schedule
             validateHealtcheckSchedule(updateApiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EndpointModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/EndpointModelFixtures.java
@@ -15,6 +15,7 @@
  */
 package fixtures;
 
+import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import java.util.Collections;
@@ -34,10 +35,26 @@ public class EndpointModelFixtures {
             .backup(false)
             .status(io.gravitee.definition.model.Endpoint.Status.UP)
             .tenants(List.of("tenant1", "tenant2"))
-            .type("HTTP")
+            .type("http")
             .inherit(true)
             .healthCheck(io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.builder().build())
             .configuration(null);
+
+    private static final HttpEndpoint.HttpEndpointBuilder BASE_MODEL_HTTP_ENDPOINT_V2 = HttpEndpoint
+        .builder()
+        .name("Endpoint name")
+        .target("http://gravitee.io")
+        .weight(1)
+        .backup(false)
+        .status(HttpEndpoint.Status.UP)
+        .tenants(List.of("tenant1", "tenant2"))
+        .type("http")
+        .inherit(false)
+        .healthCheck(io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.builder().build())
+        .headers(Collections.emptyList())
+        .httpProxy(null)
+        .httpClientOptions(null)
+        .httpClientSslOptions(null);
 
     private static final io.gravitee.definition.model.EndpointGroup.EndpointGroupBuilder BASE_MODEL_ENDPOINTGROUP_V2 =
         io.gravitee.definition.model.EndpointGroup
@@ -79,8 +96,15 @@ public class EndpointModelFixtures {
         .endpoints(List.of(BASE_MODEL_ENDPOINT_V4.build()))
         .services(io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices.builder().healthCheck(null).build());
 
+    private static final io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.EndpointHealthCheckServiceBuilder BASE_HEALTH_CHECK_SERVICE =
+        io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService.builder().enabled(true).schedule("0 */5 * * * *");
+
     public static io.gravitee.definition.model.Endpoint aModelEndpointV2() {
         return BASE_MODEL_ENDPOINT_V2.build();
+    }
+
+    public static HttpEndpoint aModelHttpEndpointV2() {
+        return BASE_MODEL_HTTP_ENDPOINT_V2.build();
     }
 
     public static io.gravitee.definition.model.EndpointGroup aModelEndpointGroupV2() {
@@ -93,5 +117,9 @@ public class EndpointModelFixtures {
 
     public static EndpointGroup aModelEndpointGroupV4() {
         return BASE_MODEL_ENDPOINTGROUP_V4.build();
+    }
+
+    public static io.gravitee.definition.model.services.healthcheck.EndpointHealthCheckService aModelHealthCheckService() {
+        return BASE_HEALTH_CHECK_SERVICE.build();
     }
 }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-3002

## Description

Make MAPIV2 work with endpoint inherit configuration


And improve UX with HealthCheck and real HC enable / disable / inherit 


Here is a table to show the possible combinations  :

| JSON | UI | Banner |
|--------|--------|--------|
| `hasGlobalHCEnable: false;  inherit: true; enable: true` | InheritToggle: ✅  ; enableToggle : ❌  | No global health-check settings defined. When defined, they will be inherited. |
| `hasGlobalHCEnable: false;  inherit: true; enable: false` | InheritToggle: ❌  ; enableToggle : ❌  | Health-check configuration is disabled. |
| `hasGlobalHCEnable: false;  inherit: false; enable: true + config` | InheritToggle: ❌ ; enableToggle : ✅ |  Configure a specific health-check for this endpoint. |
| `hasGlobalHCEnable: false;  inherit: false; enable: false` | InheritToggle: ❌  ; enableToggle : ❌  | Health-check configuration is disabled. |
| `hasGlobalHCEnable: true;  inherit: true; enable: true` | InheritToggle: ✅ ; enableToggle : ✅ | Inherited configuration preview from global health-check settings. |
| `hasGlobalHCEnable: true;  inherit: true; enable: false` | InheritToggle: ❌  ; enableToggle : ❌  | Health-check configuration is disabled. |
| `hasGlobalHCEnable: true;  inherit: false; enable: true + config` | InheritToggle: ❌ ; enableToggle : ✅  | Configure a specific health-check for this endpoint. |
| `hasGlobalHCEnable: true;  inherit: false; enable: false` | InheritToggle: ❌  ; enableToggle : ❌  | Health-check configuration is disabled. |
| `hasGlobalHCEnable: true;  inherit: true ` | InheritToggle: ✅ ; enableToggle : ✅ | Inherited configuration preview from global health-check settings. |
| `hasGlobalHCEnable: false;  inherit: true` | InheritToggle: ✅  ; enableToggle : ❌  | No global health-check settings defined. When defined, they will be inherited. |
| `hasGlobalHCEnable: true;  enable: false` | InheritToggle: ❌  ; enableToggle : ❌  | Health-check configuration is disabled. |
| `hasGlobalHCEnable: false;  enable: true` | InheritToggle: ✅  ; enableToggle : ❌  | No global health-check settings defined. When defined, they will be inherited. |
| `hasGlobalHCEnable: true; enable: true` | InheritToggle: ✅  ; enableToggle : ✅  | Inherited configuration preview from global health-check settings. |
| `hasGlobalHCEnable: true; ` | InheritToggle: ✅  ; enableToggle : ✅  | Inherited configuration preview from global health-check settings. |
| `hasGlobalHCEnable: false ` | InheritToggle: ✅  ; enableToggle : ❌  | No global health-check settings defined. When defined, they will be inherited. |




## Additional context

<img width="1055" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4974420/ea60bf13-d326-4b64-bedb-cd043d897ee2">



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ozxwrsdwge.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5585/console](https://pr.team-apim.gravitee.dev/5585/console)
      Portal: [https://pr.team-apim.gravitee.dev/5585/portal](https://pr.team-apim.gravitee.dev/5585/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5585/api/management](https://pr.team-apim.gravitee.dev/5585/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5585](https://pr.team-apim.gravitee.dev/5585)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5585](https://pr.gateway-v3.team-apim.gravitee.dev/5585)

<!-- Environment placeholder end -->
