### PR TITLE
chore: bump jaeger tracer to a compatible version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <gravitee-reporter-elasticsearch.version>4.2.2</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.0.0</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.0.0</gravitee-reporter-tcp.version>
-        <gravitee-tracer-jaeger.version>2.0.0</gravitee-tracer-jaeger.version>
+        <gravitee-tracer-jaeger.version>3.0.0</gravitee-tracer-jaeger.version>
 
         <!-- Versions of the plugins for the full distribution on dev environment-->
         <!-- Management API & Gateway -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3027

## Description

Use version 3 of jaeger tracer, which is compatible with APIM 4+ (Vert.X 4.4, JDK 17, etc...)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kahatwxfuz.chromatic.com)
<!-- Storybook placeholder end -->
