### PR TITLE
Remove max length on user email extensions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EmailValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EmailValidator.java
@@ -34,7 +34,7 @@ public class EmailValidator {
 
     @SuppressWarnings("squid:S5998") // A max email size validation is done before the regexp to avoid applying it
     private static final Pattern PATTERN = Pattern.compile(
-        "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$"
+        "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,}$"
     );
 
     public static boolean isValid(String email) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EmailValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EmailValidatorTest.java
@@ -36,6 +36,7 @@ public class EmailValidatorTest {
         "_______@gravitee.io",
         "firstname-lastname@gravitee.io",
         "firstname-lastname@gravitee.io",
+        "firstname-lastname@gravitee.technology",
     };
 
     private static final String[] INVALID_EMAILS = {


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/9293
https://gravitee.atlassian.net/browse/APIM-2971

## Description

Remove the upper bound on the length of user email's extension (e.g., .technology, .international, etc.), following this guideline https://owasp.org/www-community/OWASP_Validation_Regex_Repository. 

## Additional context

All credits go to @bill-pond as the original author of the PR https://github.com/gravitee-io/gravitee-api-management/pull/5579!

This PR is a backport to apply the fix on all supported versions of APIM


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ycdbmxqbce.chromatic.com)
<!-- Storybook placeholder end -->
