### PR TITLE
feat: implement confirmation on exit page creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.html
@@ -30,7 +30,7 @@
         </div>
       </div>
     </div>
-    <div><button mat-stroked-button uiSref="management.apis.documentationV4">Exit without saving</button></div>
+    <div><button mat-stroked-button (click)="exitWithoutSaving()">Exit without saving</button></div>
   </div>
   <div class="stepper">
     <mat-stepper linear color="accent" disableRipple>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2792

## Description

Implement confirmation dialog on exit without saving

![Screenshot 2023-10-18 at 10 59 17](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/ded2b1ac-72a4-4f97-a5c8-d30bc3b942d3)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-daimbpyjsu.chromatic.com)
<!-- Storybook placeholder end -->
