### PR TITLE
Test/set up cypress cloud run e2e

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -96,6 +96,7 @@ const secrets = {
   azureRegistryUsername: 'keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login',
   azureTenant: 'keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant',
   chromaticProjectToken: 'keeper://Hp1bFl5s0doxnQgqkMdCdg/field/password',
+  cypressCloudKey: 'keeper://FVzylPCgY-LJsgjkW4q1eQ/field/password',
   circleCiToken: 'keeper://G4hBnFUDBYb9Sw3TxhvjHg/custom_field/token',
   dockerhubBotUserName: 'keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login',
   dockerhubBotUserToken: 'keeper://cooU9UoXIk8Kj0hsP2rkBw/field/password',

--- a/.circleci/ci/src/jobs/e2e/job-e2e-cypress.ts
+++ b/.circleci/ci/src/jobs/e2e/job-e2e-cypress.ts
@@ -19,6 +19,8 @@ import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/C
 import { computeImagesTag } from '../../utils';
 import { CircleCIEnvironment } from '../../pipelines';
 import { UbuntuExecutor } from '../../executors';
+import { keeper } from '../../orbs/keeper';
+import { config } from '../../config';
 
 export class E2ECypressJob {
   private static jobName = `job-e2e-cypress`;
@@ -36,6 +38,10 @@ export class E2ECypressJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new reusable.ReusedCommand(dockerAzureLoginCmd),
+      new reusable.ReusedCommand(keeper.commands['env-export'], {
+        'secret-url': config.secrets.cypressCloudKey,
+        'var-name': 'CYPRESS_CLOUD_KEY',
+      }),
       new commands.Run({
         name: `Running UI tests`,
         command: `cd gravitee-apim-e2e

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -831,6 +831,9 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-docker-azure-login
+      - keeper/env-export:
+          secret-url: keeper://FVzylPCgY-LJsgjkW4q1eQ/field/password
+          var-name: CYPRESS_CLOUD_KEY
       - run:
           name: Running UI tests
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -831,6 +831,9 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-docker-azure-login
+      - keeper/env-export:
+          secret-url: keeper://FVzylPCgY-LJsgjkW4q1eQ/field/password
+          var-name: CYPRESS_CLOUD_KEY
       - run:
           name: Running UI tests
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -791,6 +791,9 @@ jobs:
       - attach_workspace:
           at: .
       - cmd-docker-azure-login
+      - keeper/env-export:
+          secret-url: keeper://FVzylPCgY-LJsgjkW4q1eQ/field/password
+          var-name: CYPRESS_CLOUD_KEY
       - run:
           name: Running UI tests
           command: |-

--- a/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
+++ b/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "cypress";
 import { unlinkSync } from "fs";
 
 export default defineConfig({
+    projectId: "88vnc3",
     env: {
         failOnStatusCode: false,
         api_publisher_user_login: "api1",
@@ -20,7 +21,6 @@ export default defineConfig({
         wiremockUrl: 'http://wiremock:8080',
     },
     e2e: {
-        projectId: "ui-test",
         specPattern: "./ui-test/integration/**/*.spec.ts",
         viewportWidth: 1920,
         viewportHeight: 1080,

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -20,7 +20,7 @@ services:
   cypress:
     image: cypress/included:12.17.3
     working_dir: /test
-    command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts'"
+    command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts' --record"
     volumes:
       - ./:/test
       - ./docker/ui-tests/conf/cypress-ui-config.ts:/test/cypress-ui-config.ts
@@ -29,6 +29,7 @@ services:
     environment:
       # Disable colors in Cypress output to avoid ANSI escape sequences in logs
       - NO_COLOR=1
+      - CYPRESS_RECORD_KEY=${CYPRESS_CLOUD_KEY}
     depends_on:
       nginx:
         condition: service_healthy

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/cypress-ui-config.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/cypress-ui-config.ts
@@ -17,6 +17,7 @@ import { defineConfig } from 'cypress';
 import cypressConfig from '../cypress-apim-config';
 
 export default defineConfig({
+  projectId: '88vnc3',
   env: {
     ...cypressConfig.env,
   },


### PR DESCRIPTION
The changes made in this PR enables us to use the Cypress Cloud. CircleCI will send UI test results recording to the Cypress Cloud which is currently running on paid Cloud plan, allowing us to record and analyse up to 120.000 test results per month.

This config requires a CYPRESS_CLOUD_KEY environment parameter to be set as a secret an provided during runtime.



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wjpumpsjwi.chromatic.com)
<!-- Storybook placeholder end -->
