### PR TITLE
feat(console): some touchups for pages list + new page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.html
@@ -86,7 +86,6 @@
               <div class="stepper__content__fill__header__title">
                 <h4>Page content</h4>
                 <span class="gio-badge-neutral">Unpublished</span>
-                <span class="gio-badge-error">Draft</span>
               </div>
               <button mat-stroked-button (click)="preview = !preview">Toggle preview</button>
             </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.spec.ts
@@ -174,12 +174,12 @@ describe('ApiDocumentationV4NewPageComponent', () => {
 
     it('should show markdown preview', async () => {
       const preview = getMarkdownPreview();
-      expect(preview).toBeFalsy();
+      expect(preview).toBeTruthy();
 
       const togglePreviewButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Toggle preview' }));
       await togglePreviewButton.click();
 
-      expect(getMarkdownPreview()).toBeDefined();
+      expect(getMarkdownPreview()).toBeFalsy();
     });
 
     it('should save content', async () => {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.ts
@@ -36,7 +36,7 @@ export class ApiDocumentationV4NewPageComponent implements OnInit, OnDestroy {
   pageTitle = 'Add new page';
   source: 'FILL' | 'IMPORT' | 'EXTERNAL' = 'FILL';
   content = '';
-  preview = false;
+  preview = true;
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -27,7 +27,7 @@
       <td mat-cell *matCellDef="let page">
         <div class="documentation-pages-list__table__name">
           <mat-icon *ngIf="page.type === 'FOLDER'" svgIcon="gio:folder"></mat-icon>
-          <mat-icon *ngIf="page.type != 'FOLDER'" svgIcon="gio:file"></mat-icon>
+          <mat-icon *ngIf="page.type != 'FOLDER'" svgIcon="gio:page"></mat-icon>
           <p>{{ page.name }}</p>
         </div>
       </td>
@@ -51,6 +51,12 @@
       <th mat-header-cell *matHeaderCellDef>Last Updated</th>
       <td mat-cell *matCellDef="let page">
         {{ page.updatedAt | date : 'medium' }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="order">
+      <th mat-header-cell *matHeaderCellDef>Order</th>
+      <td mat-cell *matCellDef="let page">
+        {{ page.order }}
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
@@ -37,7 +37,7 @@ export class ApiDocumentationV4PagesListComponent implements OnChanges {
   @Output()
   onDeletePage = new EventEmitter<Page>();
 
-  public displayedColumns = ['name', 'status', 'visibility', 'lastUpdated', 'actions'];
+  public displayedColumns = ['name', 'status', 'visibility', 'lastUpdated', 'order', 'actions'];
   public dataSource: MatTableDataSource<Page>;
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2791
https://gravitee.atlassian.net/browse/APIM-2792


## Description

- set markdown preview as default for new page creation
- remove Draft badge from new page creation (Draft will potentially not be implemented in M1)
- fix file icon in pages list
- add order column to pages to explain ordering of pages

TODO: Make the table prettier with the Order column 

![Screenshot 2023-10-18 at 18 11 13](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/cb5f92b2-7584-4c5c-93f9-fd814a61138b)

![Screenshot 2023-10-18 at 18 11 53](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/7b0fba52-3d44-4d7b-9a5c-2b83b80cb477)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xfwegauqnd.chromatic.com)
<!-- Storybook placeholder end -->
