### PR TITLE
fix(console): add application in the cache on findById in logs page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
@@ -83,6 +83,12 @@ export class ApiRuntimeLogsHarness extends ComponentHarness {
     return this.quickFiltersHarness().then((quickFilters) => quickFilters.getApplicationsChip());
   }
 
+  async getApplicationsChipText() {
+    return this.quickFiltersHarness()
+      .then((quickFilters) => quickFilters.getApplicationsChip())
+      .then((chip) => chip.getText());
+  }
+
   async removeApplicationsChip() {
     return this.getApplicationsChip()
       .then((chip) => chip.getRemoveButton())

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/applications-filter/applications-filter.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/components/applications-filter/applications-filter.component.ts
@@ -65,7 +65,14 @@ export class ApplicationsFilterComponent implements ControlValueAccessor {
 
   public displayValueWith: DisplayValueWithFn = (value: string) => {
     return this.applicationService.getById(value).pipe(
-      map((application) => `${application.name} ( ${application.owner?.displayName} )`),
+      map((application) => {
+        const label = `${application.name} ( ${application.owner?.displayName} )`;
+        if (!this._applicationsCache.find((cache) => cache.value === application.id)) {
+          this._applicationsCache.push({ value: application.id, label });
+          this.applicationCache.emit(this._applicationsCache);
+        }
+        return label;
+      }),
       catchError(() => {
         return of(value);
       }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2477

## Description

Add application in the cache when the are found by id per the tags input component

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/9c44f12e-6467-4d0e-ba83-2e56d2229c3e

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kynzbjqjhu.chromatic.com)
<!-- Storybook placeholder end -->
