### PR TITLE
feat(mapi-v2): add parentId query param

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
@@ -19,11 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
-import io.gravitee.rest.api.management.v2.rest.model.Media;
-import io.gravitee.rest.api.management.v2.rest.model.Page;
-import io.gravitee.rest.api.management.v2.rest.model.PageMedia;
-import io.gravitee.rest.api.management.v2.rest.model.PageSource;
-import io.gravitee.rest.api.management.v2.rest.model.Revision;
+import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.model.MediaEntity;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageMediaEntity;
@@ -87,6 +83,9 @@ public interface PageMapper {
     io.gravitee.apim.core.documentation.model.Page map(
         io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationFolder createDocumentationFolder
     );
+
+    Breadcrumb map(io.gravitee.apim.core.documentation.model.Breadcrumb breadcrumb);
+    List<Breadcrumb> map(List<io.gravitee.apim.core.documentation.model.Breadcrumb> breadcrumbList);
 
     @Named("deserializeJsonConfiguration")
     default JsonNode deserializeJsonConfiguration(Object configuration) throws JsonProcessingException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -1629,11 +1629,17 @@ paths:
             - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         get:
+            parameters:
+                - $ref: "#/components/parameters/parentId"
             tags:
                 - API Documentation
             summary: Get API documentation pages
             description: |-
-                Get API documentation pages. The result contains a list of pages and folders of the API.
+                Get API documentation pages.
+                When no parentId is specified, returns all the pages of the API.
+                
+                When parentId is specified (either ID of a folder, or 'ROOT'), only the pages with the given parent are returned, 
+                and the breadcrumb of the specified folder is added to the response. 
                 
                 User must have the API_DOCUMENTATION[READ] permission.
             operationId: getApiPages
@@ -1667,7 +1673,6 @@ paths:
                                 $ref: "#/components/schemas/Page"
                 default:
                     $ref: "#/components/responses/Error"
-
 
     # Plugins - Endpoints
     /plugins/endpoints:
@@ -5658,6 +5663,22 @@ components:
                     description: Revision number.
                     example: 1
 
+        Breadcrumb:
+            type: object
+            properties:
+                position:
+                    type: integer
+                    description: Distance of folder from the root
+                    example: 1
+                id:
+                    type: string
+                    description: Id of the folder
+                    example: folder-id
+                name:
+                    type: string
+                    description: Name of the folder
+                    example: A lovely folder name
+
         # Metadata Page
         Metadata:
             type: object
@@ -5758,6 +5779,13 @@ components:
             in: path
             required: true
             description: Id of an API member.
+            schema:
+                type: string
+        pageIdParam:
+            name: pageId
+            in: path
+            required: true
+            description: Id of a documentation page.
             schema:
                 type: string
         planIdParam:
@@ -5876,6 +5904,20 @@ components:
                 type: array
                 items:
                     type: string
+        parentId:
+            name: parentId
+            in: query
+            required: false
+            description: Id of the parent folder or 'ROOT' for the top folder.
+            examples:
+                root:
+                    value: ROOT
+                    summary: Hard-coded value for top level folder
+                parentId:
+                    value: 919a8df8-6e53-11ee-b962-0242ac120002
+                    summary: ID of the parent folder
+            schema:
+                type: string
         planIds:
             name: planIds
             description: List of plan ids to filter on.
@@ -6100,6 +6142,11 @@ components:
                                 type: array
                                 items:
                                     $ref: "#/components/schemas/Page"
+                            breadcrumb:
+                                type: array
+                                description: Breadcrumb to the root folder. Only returned when parentId is specified.
+                                items:
+                                    $ref: "#/components/schemas/Breadcrumb"
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
@@ -29,6 +29,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public ApiCrudServiceInMemory apiCrudServiceInMemory() {
+        return new ApiCrudServiceInMemory();
+    }
+
+    @Bean
     public ApplicationCrudServiceInMemory applicationRepository() {
         return new ApplicationCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
@@ -54,6 +54,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public ApiCrudServiceInMemory apiCrudServiceInMemory() {
+        return new ApiCrudServiceInMemory();
+    }
+
+    @Bean
     public AuditCrudServiceInMemory auditCrudServiceInMemory() {
         return new AuditCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
@@ -54,6 +54,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public ApiCrudServiceInMemory apiCrudServiceInMemory() {
+        return new ApiCrudServiceInMemory();
+    }
+
+    @Bean
     AuditCrudServiceInMemory auditCrudServiceInMemory() {
         return new AuditCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.crud_service;
+
+import io.gravitee.apim.core.api.model.Api;
+
+public interface ApiCrudService {
+    Api get(String id);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/crud_service/PageCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/crud_service/PageCrudService.java
@@ -16,9 +16,11 @@
 package io.gravitee.apim.core.documentation.crud_service;
 
 import io.gravitee.apim.core.documentation.model.Page;
+import java.util.Optional;
 
 public interface PageCrudService {
     Page createDocumentationPage(Page page);
     Page updateDocumentationPage(Page pageToUpdate);
     Page get(String id);
+    Optional<Page> findById(String id);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.documentation.domain_service;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import java.util.List;
+import java.util.Objects;
 
 public class ApiDocumentationDomainService {
 
@@ -27,7 +28,12 @@ public class ApiDocumentationDomainService {
         this.pageQueryService = pageQueryService;
     }
 
-    public List<Page> getApiPages(String apiId) {
-        return pageQueryService.searchByApiId(apiId);
+    public List<Page> getApiPages(String apiId, String parentId) {
+        if (Objects.nonNull(parentId) && !parentId.isEmpty()) {
+            var parentIdParam = "ROOT".equals(parentId) ? null : parentId;
+            return pageQueryService.searchByApiIdAndParentId(apiId, parentIdParam);
+        } else {
+            return pageQueryService.searchByApiId(apiId);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/Breadcrumb.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/Breadcrumb.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.documentation.query_service;
+package io.gravitee.apim.core.documentation.model;
 
-import io.gravitee.apim.core.documentation.model.Page;
-import java.util.List;
-import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public interface PageQueryService {
-    List<Page> searchByApiId(String apiId);
-    Optional<Page> findHomepageByApiId(String apiId);
-    List<Page> searchByApiIdAndParentId(String apiId, String parentId);
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Breadcrumb {
+
+    private String id;
+    private String name;
+    private int position;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecase.java
@@ -15,23 +15,72 @@
  */
 package io.gravitee.apim.core.documentation.usecase;
 
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.model.Breadcrumb;
 import io.gravitee.apim.core.documentation.model.Page;
-import java.util.List;
+import io.gravitee.apim.core.exception.DomainException;
+import java.util.*;
+import java.util.stream.Stream;
 
 public class ApiGetDocumentationPagesUsecase {
 
     private final ApiDocumentationDomainService apiDocumentationDomainService;
+    private final PageCrudService pageCrudService;
+    private final ApiCrudService apiCrudService;
 
-    public ApiGetDocumentationPagesUsecase(ApiDocumentationDomainService apiDocumentationDomainService) {
+    public ApiGetDocumentationPagesUsecase(
+        ApiDocumentationDomainService apiDocumentationDomainService,
+        PageCrudService pageCrudService,
+        ApiCrudService apiCrudService
+    ) {
         this.apiDocumentationDomainService = apiDocumentationDomainService;
+        this.pageCrudService = pageCrudService;
+        this.apiCrudService = apiCrudService;
     }
 
     public Output execute(Input input) {
-        return new Output(apiDocumentationDomainService.getApiPages(input.apiId));
+        // Check that api exists
+        apiCrudService.get(input.apiId);
+
+        List<Breadcrumb> breadcrumbList = new ArrayList<>();
+
+        if (!"ROOT".equals(input.parentId) && this.isNotEmpty(input.parentId)) {
+            // Check if parentId exists + is a folder
+            var parent = pageCrudService.get(input.parentId);
+            if (!parent.isFolder()) {
+                throw new DomainException("parentId must be a FOLDER: " + parent.getId());
+            }
+
+            // Calculate breadcrumb list
+            var pageBreadcrumbList = this.constructBreadcrumbs(parent).toList();
+            for (int i = 0; i < pageBreadcrumbList.size(); i++) {
+                var page = pageBreadcrumbList.get(i);
+                breadcrumbList.add(Breadcrumb.builder().id(page.getId()).name(page.getName()).position(i + 1).build());
+            }
+        }
+
+        var pages = apiDocumentationDomainService.getApiPages(input.apiId, input.parentId);
+
+        return new Output(pages, breadcrumbList);
     }
 
-    public record Input(String apiId) {}
+    public record Input(String apiId, String parentId) {}
 
-    public record Output(List<Page> pages) {}
+    public record Output(List<Page> pages, List<Breadcrumb> breadcrumbList) {}
+
+    private Stream<Page> constructBreadcrumbs(Page page) {
+        if (this.isNotEmpty(page.getParentId())) {
+            var parent = pageCrudService.findById(page.getParentId());
+            if (parent.isPresent()) {
+                return Stream.concat(this.constructBreadcrumbs(parent.get()), Stream.of(page));
+            }
+        }
+        return Stream.of(page);
+    }
+
+    private boolean isNotEmpty(String str) {
+        return !Objects.isNull(str) && !str.isEmpty();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.api;
+
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_key.crud_service.ApiKeyCrudService;
+import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
+import io.gravitee.apim.infra.adapter.ApiKeyAdapter;
+import io.gravitee.apim.infra.adapter.PageAdapter;
+import io.gravitee.apim.infra.crud_service.documentation.PageCrudServiceImpl;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiCrudServiceImpl implements ApiCrudService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiCrudServiceImpl.class);
+    private final ApiRepository apiRepository;
+
+    public ApiCrudServiceImpl(@Lazy ApiRepository apiRepository) {
+        this.apiRepository = apiRepository;
+    }
+
+    @Override
+    public Api get(String id) {
+        try {
+            var foundApi = apiRepository.findById(id);
+            if (foundApi.isPresent()) {
+                return ApiAdapter.INSTANCE.toEntity(foundApi.get());
+            }
+        } catch (TechnicalException e) {
+            logger.error("An error occurred while finding Api by id {}", id, e);
+        }
+        throw new ApiNotFoundException(id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/documentation/PageCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/documentation/PageCrudServiceImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.infra.adapter.PageAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,15 +59,17 @@ public class PageCrudServiceImpl implements PageCrudService {
 
     @Override
     public Page get(String id) {
+        return this.findById(id).orElseThrow(() -> new PageNotFoundException(id));
+    }
+
+    @Override
+    public Optional<Page> findById(String id) {
         try {
-            var foundPage = pageRepository.findById(id);
-            if (foundPage.isPresent()) {
-                return PageAdapter.INSTANCE.toEntity(foundPage.get());
-            }
+            return pageRepository.findById(id).map(PageAdapter.INSTANCE::toEntity);
         } catch (TechnicalException e) {
             logger.error("An error occurred while finding Page by id {}", id, e);
         }
-        throw new PageNotFoundException(id);
+        return Optional.empty();
     }
 
     private io.gravitee.repository.management.model.Page createDocumentation(io.gravitee.repository.management.model.Page page) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.spring;
 
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.usecase.VerifyApiPathsUsecase;
@@ -87,8 +88,12 @@ public class UsecaseSpringConfiguration {
     }
 
     @Bean
-    public ApiGetDocumentationPagesUsecase apiGetDocumentationPagesUsecase(ApiDocumentationDomainService apiDocumentationService) {
-        return new ApiGetDocumentationPagesUsecase(apiDocumentationService);
+    public ApiGetDocumentationPagesUsecase apiGetDocumentationPagesUsecase(
+        ApiDocumentationDomainService apiDocumentationService,
+        PageCrudService pageCrudService,
+        ApiCrudService apiCrudService
+    ) {
+        return new ApiGetDocumentationPagesUsecase(apiDocumentationService, pageCrudService, apiCrudService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternative<Api> {
+
+    final ArrayList<Api> apis = new ArrayList<>();
+
+    @Override
+    public Api get(String id) {
+        var foundApi = apis.stream().filter(api -> id.equals(api.getId())).findFirst();
+        return foundApi.orElseThrow(() -> new ApiNotFoundException(id));
+    }
+
+    @Override
+    public void initWith(List<Api> items) {
+        apis.clear();
+        apis.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        apis.clear();
+    }
+
+    @Override
+    public List<Api> storage() {
+        return Collections.unmodifiableList(apis);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageCrudServiceInMemory.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.infra.adapter.PageAdapter;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class PageCrudServiceInMemory implements InMemoryAlternative<Page>, PageCrudService {
@@ -45,11 +46,12 @@ public class PageCrudServiceInMemory implements InMemoryAlternative<Page>, PageC
 
     @Override
     public Page get(String id) {
-        var page = pages.stream().filter(p -> p.getId().equals(id)).findFirst();
-        if (page.isPresent()) {
-            return page.get();
-        }
-        throw new PageNotFoundException(id);
+        return this.findById(id).orElseThrow(() -> new PageNotFoundException(id));
+    }
+
+    @Override
+    public Optional<Page> findById(String id) {
+        return pages.stream().filter(p -> p.getId().equals(id)).findFirst();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public class PageQueryServiceInMemory implements InMemoryAlternative<Page>, PageQueryService {
@@ -42,6 +43,28 @@ public class PageQueryServiceInMemory implements InMemoryAlternative<Page>, Page
                 apiId.equals(page.getReferenceId()) && Page.ReferenceType.API.equals(page.getReferenceType()) && page.isHomepage()
             )
             .findFirst();
+    }
+
+    @Override
+    public List<Page> searchByApiIdAndParentId(String apiId, String parentId) {
+        if (Objects.isNull(parentId) || parentId.isEmpty()) {
+            return pages
+                .stream()
+                .filter(page ->
+                    apiId.equals(page.getReferenceId()) &&
+                    Page.ReferenceType.API.equals(page.getReferenceType()) &&
+                    (Objects.isNull(page.getParentId()) || page.getParentId().isEmpty())
+                )
+                .toList();
+        }
+        return pages
+            .stream()
+            .filter(page ->
+                apiId.equals(page.getReferenceId()) &&
+                Page.ReferenceType.API.equals(page.getReferenceType()) &&
+                parentId.equals(page.getParentId())
+            )
+            .toList();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecaseTest.java
@@ -16,37 +16,169 @@
 package io.gravitee.apim.core.documentation.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.model.Breadcrumb;
 import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.core.exception.DomainException;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ApiGetDocumentationPagesUsecaseTest {
 
     private final PageQueryServiceInMemory pageQueryService = new PageQueryServiceInMemory();
+    private final PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiGetDocumentationPagesUsecase useCase = new ApiGetDocumentationPagesUsecase(
-        new ApiDocumentationDomainService(pageQueryService)
+        new ApiDocumentationDomainService(pageQueryService),
+        pageCrudService,
+        apiCrudService
     );
+
+    private static final String API_ID = "api-id";
 
     @AfterEach
     void tearDown() {
         pageQueryService.reset();
+        pageCrudService.reset();
+        apiCrudService.reset();
     }
 
-    @Test
-    void should_return_pages_for_api() {
-        pageQueryService.initWith(
-            List.of(
-                Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
-                Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId("api-id").build()
-            )
-        );
-        var res = useCase.execute(new ApiGetDocumentationPagesUsecase.Input("api-id")).pages();
-        assertThat(res).hasSize(2);
-        assertThat(res.get(0).getId()).isEqualTo("page#1");
-        assertThat(res.get(1).getId()).isEqualTo("page#2");
+    @Nested
+    class GetAll {
+
+        @Test
+        void should_return_all_pages_for_api() {
+            initApiServices(List.of(Api.builder().id(API_ID).build()));
+            initPageServices(
+                List.of(
+                    Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId(API_ID).build(),
+                    Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId(API_ID).build()
+                )
+            );
+            var res = useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, null)).pages();
+            assertThat(res).hasSize(2);
+            assertThat(res.get(0).getId()).isEqualTo("page#1");
+            assertThat(res.get(1).getId()).isEqualTo("page#2");
+        }
+
+        @Test
+        void should_throw_error_if_api_not_found() {
+            initApiServices(List.of(Api.builder().id("not-my-api").build()));
+            assertThatThrownBy(() -> useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, null)))
+                .isInstanceOf(ApiNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class GetRootPage {
+
+        @Test
+        void should_return_all_root_pages_for_api_and_no_breadcrumb() {
+            initApiServices(List.of(Api.builder().id(API_ID).build()));
+            initPageServices(
+                List.of(
+                    Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId(API_ID).build(),
+                    basicPageWithParent("page#2", "not-root"),
+                    basicPageWithParent("page#2", "")
+                )
+            );
+            var res = useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, "ROOT"));
+            var pages = res.pages();
+            assertThat(pages).hasSize(2);
+            assertThat(pages.get(0).getId()).isEqualTo("page#1");
+            assertThat(pages.get(1).getId()).isEqualTo("page#2");
+
+            assertThat(res.breadcrumbList()).isNotNull().hasSize(0);
+        }
+    }
+
+    @Nested
+    class GetPageByParentId {
+
+        @BeforeEach
+        void setUp() {
+            initApiServices(List.of(Api.builder().id(API_ID).build()));
+        }
+
+        @Test
+        void should_return_pages_and_breadcrumb_for_a_parent_id() {
+            var parentIdPos1 = "parent-id-pos-1";
+            var parentIdPos2 = "parent-id-pos-2";
+            var parentIdPos3 = "parent-id-pos-3";
+
+            var resultList = List.of(basicPageWithParent("result-1", parentIdPos3), basicPageWithParent("result-2", parentIdPos3));
+
+            var databasePages = new ArrayList<>(resultList);
+            databasePages.add(basicPageWithParent(parentIdPos3, parentIdPos2));
+            databasePages.add(basicPageWithParent(parentIdPos2, parentIdPos1));
+            databasePages.add(basicPageWithParent(parentIdPos1, ""));
+
+            initPageServices(databasePages);
+
+            var res = useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, parentIdPos3));
+            var pages = res.pages();
+            assertThat(pages).hasSize(2);
+            assertThat(pages.get(0).getId()).isEqualTo("result-1");
+            assertThat(pages.get(1).getId()).isEqualTo("result-2");
+
+            assertThat(res.breadcrumbList()).isNotNull().hasSize(3);
+            assertThat(res.breadcrumbList().get(0))
+                .isNotNull()
+                .isEqualTo(Breadcrumb.builder().position(1).id(parentIdPos1).name(parentIdPos1 + "-name").build());
+
+            assertThat(res.breadcrumbList().get(1))
+                .isNotNull()
+                .isEqualTo(Breadcrumb.builder().position(2).id(parentIdPos2).name(parentIdPos2 + "-name").build());
+
+            assertThat(res.breadcrumbList().get(2))
+                .isNotNull()
+                .isEqualTo(Breadcrumb.builder().position(3).id(parentIdPos3).name(parentIdPos3 + "-name").build());
+        }
+
+        @Test
+        void should_throw_error_if_parent_not_found() {
+            assertThatThrownBy(() -> useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, "parent-id")))
+                .isInstanceOf(PageNotFoundException.class);
+        }
+
+        @Test
+        void should_throw_error_if_parent_is_not_a_folder() {
+            initPageServices(List.of(Page.builder().id("parent-id").type(Page.Type.MARKDOWN).build()));
+            assertThatThrownBy(() -> useCase.execute(new ApiGetDocumentationPagesUsecase.Input(API_ID, "parent-id")))
+                .isInstanceOf(DomainException.class);
+        }
+    }
+
+    private void initPageServices(List<Page> pages) {
+        pageQueryService.initWith(pages);
+        pageCrudService.initWith(pages);
+    }
+
+    private void initApiServices(List<Api> apis) {
+        apiCrudService.initWith(apis);
+    }
+
+    private Page basicPageWithParent(String id, String parentId) {
+        return Page
+            .builder()
+            .id(id)
+            .name(id + "-name")
+            .referenceType(Page.ReferenceType.API)
+            .referenceId(API_ID)
+            .parentId(parentId)
+            .type(Page.Type.FOLDER)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.api;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.*;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ApiCrudServiceImplTest {
+
+    ApiRepository apiRepository;
+
+    ApiCrudServiceImpl service;
+
+    private static final String API_ID = "api-id";
+
+    @BeforeEach
+    void setUp() {
+        apiRepository = mock(ApiRepository.class);
+
+        service = new ApiCrudServiceImpl(apiRepository);
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_get_a_page() throws TechnicalException {
+            var existingApi = Api
+                .builder()
+                .id(API_ID)
+                .apiLifecycleState(ApiLifecycleState.PUBLISHED)
+                .lifecycleState(LifecycleState.STARTED)
+                .mode("fully_managed")
+                .origin("management")
+                .build();
+            when(apiRepository.findById(API_ID)).thenReturn(Optional.of(existingApi));
+
+            var expectedApi = io.gravitee.apim.core.api.model.Api
+                .builder()
+                .id(API_ID)
+                .apiLifecycleState(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.PUBLISHED)
+                .lifecycleState(io.gravitee.apim.core.api.model.Api.LifecycleState.STARTED)
+                .mode("fully_managed")
+                .origin("management")
+                .build();
+
+            var foundPage = service.get(API_ID);
+            Assertions.assertThat(foundPage).usingRecursiveComparison().isEqualTo(expectedApi);
+        }
+
+        @Test
+        void should_throw_exception_if_page_not_found() throws TechnicalException {
+            when(apiRepository.findById(API_ID)).thenReturn(Optional.empty());
+
+            Assertions.assertThatThrownBy(() -> service.get(API_ID)).isInstanceOf(ApiNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3043

## Description

Add query param to /pages endpoint for user to search by parentId to return a list of pages with the given parentId.
Add breadcrumb to response.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vtksdfnpuy.chromatic.com)
<!-- Storybook placeholder end -->
