### PR TITLE
feat: implement a doOnReport feature

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
@@ -37,6 +37,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.shutdown.ShutdownProc
 import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
+import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.node.api.Node;
@@ -78,6 +79,7 @@ public class ApiProcessorChainFactory {
         final List<Processor> processors = new ArrayList<>();
 
         if (LoggingUtils.getLoggingContext(api.getDefinition()) != null) {
+            processors.add(LogInitProcessor.instance());
             processors.add(LogRequestProcessor.instance());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -49,7 +49,8 @@ public class LoggingHook implements InvokerHook {
             final LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext != null && loggingContext.endpointRequest()) {
-                log.setEndpointRequest(new LogEndpointRequest(loggingContext, ctx));
+                ((LogEndpointRequest) log.getEndpointRequest()).capture();
+
                 ((MutableExecutionContext) ctx).response().setHeaders(new LogHeadersCaptor(ctx.response().headers()));
             }
         });
@@ -67,8 +68,7 @@ public class LoggingHook implements InvokerHook {
             }
 
             if (log != null && loggingContext != null && loggingContext.endpointResponse()) {
-                final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, ctx.response());
-                log.setEndpointResponse(logResponse);
+                ((LogEndpointResponse) log.getEndpointResponse()).capture();
 
                 final MutableResponse response = ((MutableExecutionContext) ctx).response();
                 response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
@@ -32,14 +32,16 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 abstract class LogRequest extends io.gravitee.reporter.api.common.Request {
 
     protected final LoggingContext loggingContext;
-    protected final GenericRequest request;
+    protected final HttpRequest request;
 
     protected LogRequest(LoggingContext loggingContext, HttpRequest request) {
         this.loggingContext = loggingContext;
         this.request = request;
 
         this.setMethod(request.method());
+    }
 
+    public void capture() {
         if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE))) {
             final Buffer buffer = Buffer.buffer();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
@@ -35,7 +35,9 @@ abstract class LogResponse extends io.gravitee.reporter.api.common.Response {
     protected LogResponse(LoggingContext loggingContext, HttpResponse response) {
         this.loggingContext = loggingContext;
         this.response = response;
+    }
 
+    public void capture() {
         if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE))) {
             final Buffer buffer = Buffer.buffer();
             response.chunks(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -38,6 +38,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.subscription.Subscrip
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
+import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.pathparameters.PathParametersExtractor;
@@ -90,6 +91,7 @@ public class ApiProcessorChainFactory {
         io.gravitee.definition.model.v4.Api apiDefinition = api.getDefinition();
         Analytics analytics = apiDefinition.getAnalytics();
         if (AnalyticsUtils.isLoggingEnabled(analytics)) {
+            processors.add(LogInitProcessor.instance());
             processors.add(LogRequestProcessor.instance());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
+
+import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_API;
+
+import io.gravitee.gateway.reactive.api.context.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.HttpResponse;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFilter;
+import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
+import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.request.LogEndpointRequest;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.request.LogEntrypointRequest;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEndpointResponse;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEntrypointResponse;
+import io.gravitee.reporter.api.v4.log.Log;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Processor in charge of initializing the {@link Log} entity during the request phase if logging condition is evaluated to true.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LogInitProcessor implements Processor {
+
+    public static final String ID = "processor-init-logging";
+    private static final ExpressionLanguageConditionFilter<LoggingContext> CONDITION_FILTER = new ExpressionLanguageConditionFilter<>();
+
+    public static LogInitProcessor instance() {
+        return Holder.INSTANCE;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Completable execute(final MutableExecutionContext ctx) {
+        return Completable.defer(() -> {
+            final AnalyticsContext analyticsContext = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT);
+
+            if (!analyticsContext.isLoggingEnabled()) {
+                return Completable.complete();
+            }
+
+            return CONDITION_FILTER
+                .filter(ctx, analyticsContext.getLoggingContext())
+                .doOnSuccess(activeLoggingContext -> initLogEntity(ctx, activeLoggingContext))
+                .ignoreElement();
+        });
+    }
+
+    private void initLogEntity(final MutableExecutionContext ctx, final LoggingContext loggingContext) {
+        HttpRequest request = ctx.request();
+        HttpResponse response = ctx.response();
+
+        Log log = Log
+            .builder()
+            .timestamp(request.timestamp())
+            .requestId(request.id())
+            .clientIdentifier(request.clientIdentifier())
+            .apiId(ctx.getAttribute(ATTR_API))
+            .build();
+        ctx.metrics().setLog(log);
+
+        if (loggingContext.entrypointRequest()) {
+            final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+            log.setEntrypointRequest(logRequest);
+        }
+        if (loggingContext.entrypointResponse()) {
+            final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+            log.setEntrypointResponse(logResponse);
+        }
+        if (loggingContext.endpointRequest()) {
+            final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+            log.setEndpointRequest(logRequest);
+        }
+        if (loggingContext.endpointResponse()) {
+            final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+            log.setEndpointResponse(logResponse);
+        }
+    }
+
+    private static class Holder {
+
+        private static final LogInitProcessor INSTANCE = new LogInitProcessor();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
@@ -44,15 +44,14 @@ public class LogResponseProcessor implements Processor {
     }
 
     @Override
-    public Completable execute(MutableExecutionContext ctx) {
+    public Completable execute(final MutableExecutionContext ctx) {
         return Completable.fromRunnable(() -> {
             final Log log = ctx.metrics().getLog();
             final AnalyticsContext analyticsContext = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT);
             LoggingContext loggingContext = analyticsContext.getLoggingContext();
 
             if (log != null && loggingContext.entrypointResponse()) {
-                final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, ctx.response());
-                log.setEntrypointResponse(logResponse);
+                ((LogEntrypointResponse) log.getEntrypointResponse()).capture();
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
@@ -38,6 +38,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.pathparameters.PathPa
 import io.gravitee.gateway.reactive.handlers.api.processor.shutdown.ShutdownProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
+import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.node.api.Node;
@@ -116,7 +117,12 @@ class ApiProcessorChainFactoryTest {
         ProcessorChain processorChain = apiProcessorChainFactory.beforeHandle(api);
         assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-handle");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof LogRequestProcessor);
+        processors
+            .test()
+            .assertComplete()
+            .assertValueCount(2)
+            .assertValueAt(0, processor -> processor instanceof LogInitProcessor)
+            .assertValueAt(1, processor -> processor instanceof LogRequestProcessor);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHookTest.java
@@ -28,6 +28,8 @@ import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.request.LogEndpointRequest;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEndpointResponse;
 import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.v4.log.Log;
 import io.gravitee.reporter.api.v4.metric.Metrics;
@@ -106,6 +108,8 @@ class LoggingHookTest {
         when(loggingContext.endpointRequest()).thenReturn(true);
         when(request.chunks()).thenReturn(Flowable.empty());
 
+        log.setEndpointRequest(new LogEndpointRequest(loggingContext, ctx));
+
         final TestObserver<Void> obs = cut.pre("test", ctx, ExecutionPhase.REQUEST).test();
         obs.assertComplete();
 
@@ -166,6 +170,7 @@ class LoggingHookTest {
     @Test
     void shouldSetEndpointResponseWhenEndpointResponse() {
         Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, response));
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.endpointResponse()).thenReturn(true);
@@ -180,6 +185,7 @@ class LoggingHookTest {
     @Test
     void shouldSetEndpointResponseWhenEndpointResponseAndInterrupt() {
         Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, response));
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.endpointResponse()).thenReturn(true);
@@ -194,6 +200,7 @@ class LoggingHookTest {
     @Test
     void shouldSetEndpointResponseWhenProxyModeAndInterruptWith() {
         Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, response));
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.endpointResponse()).thenReturn(true);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
@@ -79,6 +79,7 @@ class LogEndpointRequestTest {
         when(request.chunks()).thenReturn(Flowable.empty()).thenAnswer(i -> chunksCaptor.getValue());
 
         final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+        logRequest.capture();
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -106,6 +107,7 @@ class LogEndpointRequestTest {
         when(request.chunks()).thenReturn(Flowable.empty()).thenAnswer(i -> chunksCaptor.getValue());
 
         final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+        logRequest.capture();
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -130,6 +132,7 @@ class LogEndpointRequestTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+        logRequest.capture();
         verify(request, times(2)).chunks(any(Flowable.class));
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -154,6 +157,7 @@ class LogEndpointRequestTest {
         when(loggingContext.isContentTypeLoggable("application/octet-stream")).thenReturn(false);
 
         final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+        logRequest.capture();
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -178,6 +182,7 @@ class LogEndpointRequestTest {
         when(loggingContext.getMaxSizeLogMessage()).thenReturn(maxPayloadSize);
 
         final LogEndpointRequest logRequest = new LogEndpointRequest(loggingContext, ctx);
+        logRequest.capture();
         verify(request, times(2)).chunks(any(Flowable.class));
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getAllValues().get(chunksCaptor.getAllValues().size() - 1).test();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -65,7 +65,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.entrypointRequestPayload()).thenReturn(false);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
-
+        logRequest.capture();
         assertThat(logRequest.getMethod()).isEqualTo(HttpMethod.POST);
         assertThat(logRequest.getUri()).isEqualTo(URI);
         assertNull(logRequest.getHeaders());
@@ -85,6 +85,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.entrypointRequestPayload()).thenReturn(false);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture();
 
         assertNotSame(headers, logRequest.getHeaders());
         assertThat(logRequest.getHeaders().deeplyEquals(headers)).isTrue();
@@ -104,6 +105,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture();
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -123,6 +125,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.isContentTypeLoggable("application/octet-stream")).thenReturn(false);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture();
         verify(request, times(0)).chunks(any(Flowable.class));
 
         assertNull(logRequest.getHeaders());
@@ -143,6 +146,7 @@ class LogEntrypointRequestTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointRequest logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture();
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -63,6 +63,7 @@ class LogEndpointResponseTest {
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
 
         assertThat(logResponse.getStatus()).isEqualTo(HttpStatusCode.OK_200);
         assertNull(logResponse.getHeaders());
@@ -83,6 +84,7 @@ class LogEndpointResponseTest {
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
 
         assertNotSame(headers, logResponse.getHeaders());
         assertThat(logResponse.getHeaders().deeplyEquals(headers)).isTrue();
@@ -104,6 +106,7 @@ class LogEndpointResponseTest {
         when(loggingContext.endpointResponsePayload()).thenReturn(false);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
 
         assertNotSame(headers, logResponse.getHeaders());
         assertThat(logResponse.getHeaders().deeplyEquals(HttpHeaders.create())).isTrue();
@@ -123,6 +126,7 @@ class LogEndpointResponseTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
         verify(response).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -143,6 +147,7 @@ class LogEndpointResponseTest {
         when(loggingContext.isContentTypeLoggable("application/octet-stream")).thenReturn(false);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
         verify(response, times(0)).chunks(any(Flowable.class));
 
         assertNull(logResponse.getHeaders());
@@ -163,6 +168,7 @@ class LogEndpointResponseTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEndpointResponse logResponse = new LogEndpointResponse(loggingContext, response);
+        logResponse.capture();
         verify(response).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -62,6 +62,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.entrypointResponsePayload()).thenReturn(false);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture();
 
         assertThat(logResponse.getStatus()).isEqualTo(HttpStatusCode.OK_200);
         assertNull(logResponse.getHeaders());
@@ -81,6 +82,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.entrypointResponsePayload()).thenReturn(false);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture();
 
         assertNotSame(headers, logResponse.getHeaders());
         assertThat(logResponse.getHeaders().deeplyEquals(headers)).isTrue();
@@ -100,6 +102,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture();
         verify(response).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();
@@ -120,7 +123,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.isContentTypeLoggable("application/octet-stream")).thenReturn(false);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
-
+        logResponse.capture();
         verify(response, times(0)).chunks(any(Flowable.class));
 
         assertNull(logResponse.getHeaders());
@@ -141,6 +144,7 @@ class LogEntrypointResponseTest {
         when(loggingContext.isContentTypeLoggable(any())).thenReturn(true);
 
         final LogEntrypointResponse logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture();
         verify(response).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -26,7 +26,6 @@ import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
-import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.gateway.reactive.core.processor.Processor;
@@ -41,6 +40,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.shutdown.ShutdownProc
 import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
+import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.gateway.report.ReporterService;
@@ -123,7 +123,12 @@ class ApiProcessorChainFactoryTest {
         ProcessorChain processorChain = apiProcessorChainFactory.beforeHandle(api);
         assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-handle");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof LogRequestProcessor);
+        processors
+            .test()
+            .assertComplete()
+            .assertValueCount(2)
+            .assertValueAt(0, processor -> processor instanceof LogInitProcessor)
+            .assertValueAt(1, processor -> processor instanceof LogRequestProcessor);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
+
+import static io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor.ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
+import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
+import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.processor.AbstractV4ProcessorTest;
+import io.gravitee.reporter.api.v4.log.Log;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class LogInitProcessorTest extends AbstractV4ProcessorTest {
+
+    protected static final String REQUEST_ID = "requestId";
+    private final LogInitProcessor cut = LogInitProcessor.instance();
+
+    @Mock
+    private AnalyticsContext analyticsContext;
+
+    @Mock
+    private LoggingContext loggingContext;
+
+    @BeforeEach
+    public void beforeEach() {
+        lenient().when(analyticsContext.isEnabled()).thenReturn(true);
+        lenient().when(analyticsContext.getLoggingContext()).thenReturn(loggingContext);
+        lenient().when(analyticsContext.isLoggingEnabled()).thenReturn(true);
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT, analyticsContext);
+    }
+
+    @Test
+    void shouldNotLogWhenLoggingDisabled() {
+        when(analyticsContext.isLoggingEnabled()).thenReturn(false);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        verifyNoInteractions(mockMetrics);
+        verifyNoInteractions(mockRequest);
+    }
+
+    @Test
+    void shouldNotLogWhenLoggingConditionIsEvaluatedToFalse() {
+        when(loggingContext.getCondition()).thenReturn("false");
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+        verifyNoInteractions(mockMetrics);
+        verifyNoInteractions(mockRequest);
+    }
+
+    @Test
+    void shouldCreateLogWhenLoggingConditionIsEvaluatedToTrue() {
+        final long timestamp = System.currentTimeMillis();
+
+        when(loggingContext.getCondition()).thenReturn("true");
+        when(loggingContext.entrypointRequest()).thenReturn(false);
+        when(mockRequest.timestamp()).thenReturn(timestamp);
+        when(mockRequest.id()).thenReturn(REQUEST_ID);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        ArgumentCaptor<Log> logCaptor = ArgumentCaptor.forClass(Log.class);
+        verify(mockMetrics).setLog(logCaptor.capture());
+
+        final Log log = logCaptor.getValue();
+        assertNotNull(log);
+        assertEquals(timestamp, log.getTimestamp());
+        assertEquals(REQUEST_ID, log.getRequestId());
+        assertNull(log.getEntrypointRequest());
+    }
+
+    @Test
+    void shouldCreateLogWhenLoggingConditionIsNull() {
+        when(loggingContext.getCondition()).thenReturn(null);
+        when(loggingContext.entrypointRequest()).thenReturn(false);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        verify(mockMetrics).setLog(any(Log.class));
+    }
+
+    @Test
+    void shouldCreateLogWhenLoggingConditionIsEmpty() {
+        when(loggingContext.getCondition()).thenReturn("");
+        when(loggingContext.entrypointRequest()).thenReturn(false);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        verify(mockMetrics).setLog(any(Log.class));
+    }
+
+    @Test
+    void shouldInitEntrypointRequestWhenEntrypointRequestLogEnabled() {
+        when(loggingContext.entrypointRequest()).thenReturn(true);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        ArgumentCaptor<Log> logCaptor = ArgumentCaptor.forClass(Log.class);
+        verify(mockMetrics).setLog(logCaptor.capture());
+        assertNotNull(logCaptor.getValue().getEntrypointRequest());
+    }
+
+    @Test
+    void shouldInitEntrypointResponseWhenEntrypointResponseLogEnabled() {
+        when(loggingContext.entrypointResponse()).thenReturn(true);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        ArgumentCaptor<Log> logCaptor = ArgumentCaptor.forClass(Log.class);
+        verify(mockMetrics).setLog(logCaptor.capture());
+        assertNotNull(logCaptor.getValue().getEntrypointResponse());
+    }
+
+    @Test
+    void shouldInitEndpointRequestWhenEndpointRequestLogEnabled() {
+        when(loggingContext.endpointRequest()).thenReturn(true);
+        when(mockRequest.chunks()).thenReturn(Flowable.empty());
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        ArgumentCaptor<Log> logCaptor = ArgumentCaptor.forClass(Log.class);
+        verify(mockMetrics).setLog(logCaptor.capture());
+        assertNotNull(logCaptor.getValue().getEndpointRequest());
+    }
+
+    @Test
+    void shouldInitEndpointResponseWhenEndpointResponseLogEnabled() {
+        when(loggingContext.endpointResponse()).thenReturn(true);
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertComplete();
+
+        ArgumentCaptor<Log> logCaptor = ArgumentCaptor.forClass(Log.class);
+        verify(mockMetrics).setLog(logCaptor.capture());
+        assertNotNull(logCaptor.getValue().getEndpointResponse());
+    }
+
+    @Test
+    void shouldReturnId() {
+        assertEquals(ID, cut.getId());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessorTest.java
@@ -17,20 +17,19 @@ package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
 
 import static io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor.ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
-import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEntrypointResponse;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.AbstractV4ProcessorTest;
-import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
 import io.gravitee.reporter.api.v4.log.Log;
 import io.reactivex.rxjava3.observers.TestObserver;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -83,6 +82,8 @@ class LogResponseProcessorTest extends AbstractV4ProcessorTest {
     @Test
     void shouldSetClientResponseWhenEntrypointResponseLogEnabled() {
         Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEntrypointResponse(new LogEntrypointResponse(loggingContext, mockResponse));
+
         when(mockMetrics.getLog()).thenReturn(log);
         when(loggingContext.entrypointResponse()).thenReturn(true);
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/ActionReportPolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/ActionReportPolicy.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.fake;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+import io.gravitee.reporter.api.log.Log;
+import io.reactivex.rxjava3.core.Completable;
+import io.vertx.core.Vertx;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Allow to add some actions that will be executed just before reporting metrics.
+ * @author GraviteeSource Team
+ */
+public class ActionReportPolicy implements Policy {
+
+    @Override
+    public String id() {
+        return "action-report-policy";
+    }
+
+    @Override
+    public Completable onRequest(HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() -> {
+            ctx.metrics().getLog().getEntrypointRequest().doOnReport(this::prefixHeader);
+            ctx.metrics().getLog().getEntrypointRequest().doOnReport(this::prefixBody);
+            ctx.metrics().getLog().getEndpointRequest().doOnReport(this::prefixHeader);
+            ctx.metrics().getLog().getEndpointRequest().doOnReport(this::prefixBody);
+        });
+    }
+
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() -> {
+            ctx.metrics().getLog().getEntrypointResponse().doOnReport(this::prefixHeader);
+            ctx.metrics().getLog().getEntrypointResponse().doOnReport(this::prefixBody);
+            ctx.metrics().getLog().getEndpointResponse().doOnReport(this::prefixHeader);
+            ctx.metrics().getLog().getEndpointResponse().doOnReport(this::prefixBody);
+        });
+    }
+
+    private void prefixHeader(io.gravitee.reporter.api.common.Request clientRequest) {
+        clientRequest.getHeaders().toSingleValueMap().forEach((key, value) -> clientRequest.getHeaders().set(key, "prefix-" + value));
+    }
+
+    private void prefixBody(io.gravitee.reporter.api.common.Request clientRequest) {
+        clientRequest.setBody("prefix-" + clientRequest.getBody());
+    }
+
+    private void prefixHeader(io.gravitee.reporter.api.common.Response clientResponse) {
+        clientResponse.getHeaders().toSingleValueMap().forEach((key, value) -> clientResponse.getHeaders().set(key, "prefix-" + value));
+    }
+
+    private void prefixBody(io.gravitee.reporter.api.common.Response clientResponse) {
+        clientResponse.setBody("prefix-" + clientResponse.getBody());
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/DoOnReportV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/DoOnReportV4EmulationIntegrationTest.java
@@ -1,0 +1,131 @@
+package io.gravitee.apim.integration.tests.reporting;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.apim.integration.tests.fake.ActionReportPolicy;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.definition.model.Logging;
+import io.gravitee.definition.model.LoggingContent;
+import io.gravitee.definition.model.LoggingMode;
+import io.gravitee.definition.model.LoggingScope;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.reporter.api.log.Log;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
+@DeployApi({ "/apis/http/api-report.json" })
+class DoOnReportV4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    BehaviorSubject<Log> subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = BehaviorSubject.create();
+
+        FakeReporter fakeReporter = getBean(FakeReporter.class);
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Log) {
+                subject.onNext((Log) reportable);
+            }
+        });
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Logging logging = new Logging();
+        logging.setMode(LoggingMode.CLIENT_PROXY);
+        logging.setContent(LoggingContent.HEADERS_PAYLOADS);
+        logging.setScope(LoggingScope.REQUEST_RESPONSE);
+        logging.setCondition("{#response.status == 200}");
+
+        if (api.getDefinition() instanceof Api) {
+            ((Api) api.getDefinition()).getProxy().setLogging(logging);
+        }
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("action-report-policy", PolicyBuilder.build("action-report-policy", ActionReportPolicy.class));
+    }
+
+    @Test
+    @DisplayName("Should prefix all headers and bodies")
+    void shouldPrefixAllHeadersAndBodies(HttpClient httpClient, VertxTestContext context) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok("response from backend").withHeader("X-ResponseHeader", "ResponseHeaderValue")));
+
+        subject
+            .doOnNext(log -> {
+                assertThat(log.getClientRequest().getBody()).isEqualTo("prefix-body request");
+                assertThat(log.getClientRequest().getHeaders().get("X-RequestHeader")).isEqualTo("prefix-RequestHeaderValue");
+                assertThat(log.getProxyRequest().getBody()).isEqualTo("prefix-body request");
+                assertThat(log.getProxyRequest().getHeaders().get("X-RequestHeader")).isEqualTo("prefix-RequestHeaderValue");
+
+                assertThat(log.getClientResponse().getBody()).isEqualTo("prefix-response from backend");
+                assertThat(log.getClientResponse().getHeaders().get("X-ResponseHeader")).isEqualTo("prefix-ResponseHeaderValue");
+                assertThat(log.getProxyResponse().getBody()).isEqualTo("prefix-response from backend");
+                assertThat(log.getProxyResponse().getHeaders().get("X-ResponseHeader")).isEqualTo("prefix-ResponseHeaderValue");
+            })
+            .doOnNext(m -> context.completeNow())
+            .doOnError(context::failNow)
+            .subscribe();
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(request -> request.putHeader("X-RequestHeader", "RequestHeaderValue").rxSend("body request"))
+            .flatMapPublisher(response -> {
+                assertThat(response.getHeader("X-ResponseHeader")).isEqualTo("ResponseHeaderValue");
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/DoOnReportV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/reporting/DoOnReportV4IntegrationTest.java
@@ -1,0 +1,144 @@
+package io.gravitee.apim.integration.tests.reporting;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.apim.integration.tests.fake.ActionReportPolicy;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingContent;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingPhase;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.reporter.api.v4.log.Log;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi({ "/apis/v4/http/api-report.json" })
+class DoOnReportV4IntegrationTest extends AbstractGatewayTest {
+
+    BehaviorSubject<Log> subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = BehaviorSubject.create();
+
+        FakeReporter fakeReporter = getBean(FakeReporter.class);
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Log) {
+                subject.onNext((Log) reportable);
+            }
+        });
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Logging logging = new Logging();
+        logging.setMode(LoggingMode.builder().entrypoint(true).endpoint(true).build());
+        logging.setContent(LoggingContent.builder().headers(true).payload(true).build());
+        logging.setPhase(LoggingPhase.builder().request(true).response(true).build());
+        logging.setCondition("{#response.status == 200}");
+
+        var analytics = new Analytics();
+        analytics.setEnabled(true);
+        analytics.setLogging(logging);
+
+        if (api.getDefinition() instanceof Api) {
+            ((Api) api.getDefinition()).setAnalytics(analytics);
+        }
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("action-report-policy", PolicyBuilder.build("action-report-policy", ActionReportPolicy.class));
+    }
+
+    @Test
+    @DisplayName("Should prefix all headers and bodies")
+    void shouldPrefixAllHeadersAndBodies(HttpClient httpClient, VertxTestContext context) throws InterruptedException {
+        wiremock.stubFor(post("/endpoint").willReturn(ok("response from backend").withHeader("X-ResponseHeader", "ResponseHeaderValue")));
+
+        subject
+            .doOnNext(log -> {
+                assertThat(log.getEntrypointRequest().getBody()).isEqualTo("prefix-body request");
+                assertThat(log.getEntrypointRequest().getHeaders().get("X-RequestHeader")).isEqualTo("prefix-RequestHeaderValue");
+                assertThat(log.getEndpointRequest().getBody()).isEqualTo("prefix-body request");
+                assertThat(log.getEndpointRequest().getHeaders().get("X-RequestHeader")).isEqualTo("prefix-RequestHeaderValue");
+
+                assertThat(log.getEntrypointResponse().getBody()).isEqualTo("prefix-response from backend");
+                assertThat(log.getEntrypointResponse().getHeaders().get("X-ResponseHeader")).isEqualTo("prefix-ResponseHeaderValue");
+                assertThat(log.getEndpointResponse().getBody()).isEqualTo("prefix-response from backend");
+                assertThat(log.getEndpointResponse().getHeaders().get("X-ResponseHeader")).isEqualTo("prefix-ResponseHeaderValue");
+            })
+            .doOnNext(m -> context.completeNow())
+            .doOnError(context::failNow)
+            .subscribe();
+
+        httpClient
+            .rxRequest(HttpMethod.POST, "/test")
+            .flatMap(request -> request.putHeader("X-RequestHeader", "RequestHeaderValue").rxSend("body request"))
+            .flatMapPublisher(response -> {
+                assertThat(response.getHeader("X-ResponseHeader")).isEqualTo("ResponseHeaderValue");
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/api-report.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/api-report.json
@@ -1,0 +1,50 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "POST"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "action-report-policy",
+          "description": "",
+          "enabled": true,
+          "policy": "action-report-policy",
+          "configuration": {}
+        }
+      ],
+      "post": [
+        {
+          "name": "action-report-policy",
+          "description": "",
+          "enabled": true,
+          "policy": "action-report-policy",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-report.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-report.json
@@ -1,0 +1,81 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "POST"
+          ]
+        }
+      ],
+      "request": [
+        {
+          "name": "action-report-policy",
+          "description": "",
+          "enabled": true,
+          "policy": "action-report-policy",
+          "configuration": {}
+        }
+      ],
+      "response": [
+        {
+          "name": "action-report-policy",
+          "description": "",
+          "enabled": true,
+          "policy": "action-report-policy",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": true
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-plugin.version>2.0.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.27.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.28.0</gravitee-reporter-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2626

## Description

Allow to execute some actions just before the metrics are reported.

To allow policies adding report actions, we must ensure that all the logs objects are created. 

That's the purpose of the LogInitProcessor which init logRequests and logResponses.
Then the logRequestProcessor captures the entrypoint request.
The logging hook takes care of capturing the endpoint request and endpoint response.
And finally the logResponseProcessor captures the entrypoint response.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pvydheshhc.chromatic.com)
<!-- Storybook placeholder end -->
