### PR TITLE
fix(service): control parentId when creating page

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/usecase/ApiGetDocumentationPagesUsecase.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomain
 import io.gravitee.apim.core.documentation.model.Breadcrumb;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.exception.DomainException;
+import io.gravitee.apim.core.exception.InvalidPageParentException;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -50,7 +51,7 @@ public class ApiGetDocumentationPagesUsecase {
             // Check if parentId exists + is a folder
             var parent = pageCrudService.get(input.parentId);
             if (!parent.isFolder()) {
-                throw new DomainException("parentId must be a FOLDER: " + parent.getId());
+                throw new InvalidPageParentException(parent.getId());
             }
 
             // Calculate breadcrumb list

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/InvalidPageParentException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/InvalidPageParentException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.exception;
+
+public class InvalidPageParentException extends DomainException {
+
+    public InvalidPageParentException(String parentId) {
+        super("parentId must be a FOLDER: " + parentId);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3049

## Description

- Transform empty parentId to null for page creation
- Check if parent is folder for page creation

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

