### PR TITLE
fix: use ConcurrentHashMap for CORS to avoid ConcurrentModificationException

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/GraviteeUrlBasedCorsConfigurationSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/GraviteeUrlBasedCorsConfigurationSource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.cors.CorsConfiguration;
@@ -34,7 +35,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class GraviteeUrlBasedCorsConfigurationSource extends UrlBasedCorsConfigurationSource {
 
-    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new HashMap<>();
+    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new ConcurrentHashMap<>();
 
     private final ParameterService parameterService;
     private final AccessPointQueryService accessPointQueryService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/GraviteeUrlBasedCorsConfigurationSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/GraviteeUrlBasedCorsConfigurationSource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.cors.CorsConfiguration;
@@ -37,7 +38,7 @@ public class GraviteeUrlBasedCorsConfigurationSource extends UrlBasedCorsConfigu
     private final ParameterService parameterService;
     private final AccessPointQueryService accessPointQueryService;
     private final EventManager eventManager;
-    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new HashMap<>();
+    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new ConcurrentHashMap<>();
 
     @Override
     public CorsConfiguration getCorsConfiguration(final @NonNull HttpServletRequest request) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/GraviteeUrlBasedCorsConfigurationSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/GraviteeUrlBasedCorsConfigurationSource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.cors.CorsConfiguration;
@@ -37,7 +38,7 @@ public class GraviteeUrlBasedCorsConfigurationSource extends UrlBasedCorsConfigu
     private final ParameterService parameterService;
     private final AccessPointQueryService accessPointQueryService;
     private final EventManager eventManager;
-    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByEnvironment = new HashMap<>();
+    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByEnvironment = new ConcurrentHashMap<>();
 
     @Override
     public CorsConfiguration getCorsConfiguration(final @NonNull HttpServletRequest request) {


### PR DESCRIPTION
## Description

When concurrent request are made on the MAPI, issue with cors configuration could throw a ConcurrentModificationException, this code attend to fix this.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

