### PR TITLE
fix(helm): protect namespace with quote

### DIFF
--- a/helm/templates/common/rolebinding.yaml
+++ b/helm/templates/common/rolebinding.yaml
@@ -27,5 +27,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "apim.serviceAccount" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 {{- end -}}

--- a/helm/tests/common/rolebinding_test.yaml
+++ b/helm/tests/common/rolebinding_test.yaml
@@ -93,3 +93,35 @@ tests:
     asserts:
       - hasDocuments:
           count: 1
+
+
+  - it: should protect namespace with quote
+    template: common/rolebinding.yaml
+    set:
+      apim:
+        managedServiceAccount: true
+    release:
+      name: my-apim
+      namespace: 1234
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+      - isAPIVersion:
+          of: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: my-apim-apim-role-binding
+      - equal:
+          path: roleRef
+          value:
+            kind: Role
+            name: my-apim-apim-role
+            apiGroup: rbac.authorization.k8s.io
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: my-apim-apim
+              namespace: "1234"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3075

## Description

In case of release name as a number, we should use quote to let it used
as namespace name.

