### PR TITLE
feat: add reset filters button in connection logs list 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -430,6 +430,19 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await componentHarness.getApplicationsChipText()).toStrictEqual(expectedApplicationChip);
         expectApiWithLogs(10, { page: 1, perPage: 10, applicationIds: '1,2' });
       });
+
+      it("should reset all filters when clicking on 'reset filters'", async () => {
+        expect(await componentHarness.getApplicationsChip()).toBeTruthy();
+        expect(await componentHarness.getPlanChip()).toBeTruthy();
+        expectApplicationFindById(application);
+        expectApplicationFindById(anotherApplication);
+
+        await componentHarness.quickFiltersHarness().then((harness) => harness.clickResetFilters());
+        expect(await componentHarness.getApplicationsTags()).toHaveLength(0);
+        expect(await componentHarness.getSelectedPlans()).toEqual('');
+        expectApiWithLogs(10, { page: 1, perPage: 10, planIds: '1,2' });
+        expectApiWithLogs(10, { page: 1, perPage: 10 });
+      });
     });
 
     describe('should load page 2 by default', () => {

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.html
@@ -63,6 +63,10 @@
           </mat-chip>
         </ng-container>
       </mat-chip-list>
+      <button mat-icon-button class="quick-filters__reset" data-testId="reset-filters-button" (click)="resetAllFilters()">
+        <mat-icon svgIcon="gio:x-circle"></mat-icon>
+        <span class="quick-filters__reset__label">Reset filters</span>
+      </button>
     </ng-container>
     <ng-container *ngIf="!isFiltering"><span>No filter applied</span></ng-container>
   </div>

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.scss
@@ -58,5 +58,14 @@ $typography: map.get(gio.$mat-theme, typography);
   &__applied {
     display: flex;
     flex-direction: row;
+    align-items: center;
+  }
+
+  &__reset {
+    margin-left: 12px;
+
+    &__label {
+      margin-left: 8px;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
@@ -38,6 +38,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
   @Input() initialValues: LogFiltersInitialValues;
   @Input() plans: Plan[];
   @Output() refresh = new EventEmitter<void>();
+  @Output() resetFilters = new EventEmitter<void>();
 
   readonly periods = PERIODS;
   isFiltering = false;
@@ -73,6 +74,10 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
     this.quickFiltersForm.get(removedFilter.key).patchValue(defaultValue);
     this.currentFilter[removedFilter.key] = defaultValue;
     this.isFiltering = !isEqual(this.currentFilter, DEFAULT_FILTERS);
+  }
+
+  resetAllFilters() {
+    this.quickFiltersForm.reset(DEFAULT_FILTERS);
   }
 
   @Input()

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.harness.ts
@@ -32,6 +32,7 @@ export class ApiRuntimeLogsQuickFiltersHarness extends ComponentHarness {
   public getPlansSelect = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="plans"]' }));
   public getPlansChip = this.locatorFor(MatChipHarness.with({ text: /^plans:/ }));
   public getRefreshButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testId=refresh-button]' }));
+  public getResetFiltersButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testId=reset-filters-button]' }));
 
   public getApplicationAutocomplete() {
     return this.getApplicationFormField()
@@ -41,5 +42,9 @@ export class ApiRuntimeLogsQuickFiltersHarness extends ComponentHarness {
 
   public clickRefresh() {
     return this.getRefreshButton().then((button) => button.click());
+  }
+
+  public clickResetFilters() {
+    return this.getResetFiltersButton().then((button) => button.click());
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2847

## Description

Add refresh button to refresh connection logs list

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4171593/190834f9-e34d-46e1-b2a4-50ea794a3137)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zgoguhdfxc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5660/console](https://pr.team-apim.gravitee.dev/5660/console)
      Portal: [https://pr.team-apim.gravitee.dev/5660/portal](https://pr.team-apim.gravitee.dev/5660/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5660/api/management](https://pr.team-apim.gravitee.dev/5660/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5660](https://pr.team-apim.gravitee.dev/5660)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5660](https://pr.gateway-v3.team-apim.gravitee.dev/5660)

<!-- Environment placeholder end -->
