### PR TITLE
Test/fix flaky api plan test run e2e

### DIFF
--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -39,7 +39,7 @@
         "@types/node": "16.10.9",
         "@types/node-fetch": "2.6.1",
         "ansi-regex": "6.0.1",
-        "cypress": "13.3.0",
+        "cypress": "13.3.3",
         "dotenv": "16.0.0",
         "har-validator": "5.1.5",
         "jest": "27.5.1",

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -22,7 +22,7 @@ import { ApiImport } from '@model/api-imports';
 
 import apiDetails from 'ui-test/support/PageObjects/Apis/ApiDetails';
 
-describe('API Plans Feature', () => {
+describe('API Plans Feature', { retries: 2 }, () => {
   beforeEach(() => {
     cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
     cy.visit('/#!/environments/default/apis/');
@@ -172,7 +172,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_list_edit_button').first().click();
     ApiDetails.plansMenuItem().click();
     cy.get('[type="button"]').contains('STAGING').click();
-    cy.getByDataTestId('api_plans_close_plan_button').first().click();
+    cy.getByDataTestId('api_plans_close_plan_button').click();
     cy.get(`[placeholder="${planName}-Keyless"]`).type(`${planName}-Keyless`);
     cy.getByDataTestId('confirm-dialog').click();
     cy.contains(`The plan ${planName}-Keyless has been closed with success.`).should('be.visible');


### PR DESCRIPTION
## Description
The API plan spec file is very flaky. However, until today it's not fully clear why. The test doesn't show the same behaviour when executed locally thus difficult to investigate. 
It seems sometimes a reload happens just before Cypress tries to click on a button which leads to an error. The main strategy here is to simply introduce test retries which will prevent the test from failing and we can have a closer look at what happens, now that we have Cypress Cloud with built-in Test Replay.

