### PR TITLE
fix(mapi-v2): require non null + not empty name for page create + update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResource.java
@@ -73,9 +73,9 @@ public class ApiPagesResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = { RolePermissionAction.CREATE }) })
     public Response createDocumentationPage(@PathParam("apiId") String apiId, @Valid @NotNull CreateDocumentation createDocumentation) {
-        Page pageToCreate = createDocumentation.getActualInstance() instanceof CreateDocumentationMarkdown
-            ? Mappers.getMapper(PageMapper.class).map(createDocumentation.getCreateDocumentationMarkdown())
-            : Mappers.getMapper(PageMapper.class).map(createDocumentation.getCreateDocumentationFolder());
+        Page pageToCreate = createDocumentation instanceof CreateDocumentationMarkdown
+            ? Mappers.getMapper(PageMapper.class).map((CreateDocumentationMarkdown) createDocumentation)
+            : Mappers.getMapper(PageMapper.class).map((CreateDocumentationFolder) createDocumentation);
 
         pageToCreate.setReferenceId(apiId);
         pageToCreate.setReferenceType(Page.ReferenceType.API);
@@ -108,9 +108,9 @@ public class ApiPagesResource extends AbstractResource {
     ) {
         var mapper = Mappers.getMapper(PageMapper.class);
         var auditInfo = getAuditInfo();
-        var input = updateDocumentation.getActualInstance() instanceof UpdateDocumentationMarkdown
-            ? mapper.map(updateDocumentation.getUpdateDocumentationMarkdown(), apiId, pageId, auditInfo)
-            : mapper.map(updateDocumentation.getUpdateDocumentationFolder(), apiId, pageId, auditInfo);
+        var input = updateDocumentation instanceof UpdateDocumentationMarkdown
+            ? mapper.map((UpdateDocumentationMarkdown) updateDocumentation, apiId, pageId, auditInfo)
+            : mapper.map((UpdateDocumentationFolder) updateDocumentation, apiId, pageId, auditInfo);
 
         var page = updateDocumentationPageUsecase.execute(input).page();
         return Response.ok(mapper.mapPage(page)).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -2749,6 +2749,7 @@ components:
             enum:
                 - PUBLIC
                 - PRIVATE
+
         ApiWorkflowState:
             type: string
             description: The status of the API regarding the review feature.
@@ -5615,39 +5616,24 @@ components:
 
         CreateDocumentation:
             type: object
-            oneOf:
-                - $ref: "#/components/schemas/CreateDocumentationFolder"
-                - $ref: "#/components/schemas/CreateDocumentationMarkdown"
-            required:
-                - name
-                - type
-            discriminator:
-                propertyName: type
-                mapping:
-                    FOLDER: CreateDocumentationFolder
-                    MARKDOWN: CreateDocumentationMarkdown
-
-        CreateDocumentationType:
-            type: string
-            description: The type of the page. Only MARKDOWN and FOLDER types can be created.
-            example: MARKDOWN
-            enum:
-                - MARKDOWN
-                - FOLDER
-
-        BaseCreateDocumentation:
-            type: object
             properties:
                 name:
                     type: string
                     description: Page's name.
                     example: My Page
+                    minLength: 1
                 type:
-                    $ref: "#/components/schemas/CreateDocumentationType"
+                    type: string
+                    description: The type of the page. Only MARKDOWN and FOLDER types can be created.
+                    example: MARKDOWN
+                    enum:
+                        - MARKDOWN
+                        - FOLDER
                 order:
                     type: integer
                     description: Page's order.
                     example: 1
+                    default: 0
                 visibility:
                     $ref: "#/components/schemas/Visibility"
                 parentId:
@@ -5668,7 +5654,7 @@ components:
             description: Create documentation folder.
             type: object
             allOf:
-                - $ref: "#/components/schemas/BaseCreateDocumentation"
+                - $ref: "#/components/schemas/CreateDocumentation"
             required:
                 - name
                 - type
@@ -5678,7 +5664,7 @@ components:
             description: Create documentation markdown page.
             type: object
             allOf:
-                - $ref: "#/components/schemas/BaseCreateDocumentation"
+                - $ref: "#/components/schemas/CreateDocumentation"
                 - properties:
                     content:
                         type: string
@@ -5694,19 +5680,6 @@ components:
 
         UpdateDocumentation:
             type: object
-            oneOf:
-                - $ref: "#/components/schemas/UpdateDocumentationFolder"
-                - $ref: "#/components/schemas/UpdateDocumentationMarkdown"
-            required:
-                - type
-            discriminator:
-                propertyName: type
-                mapping:
-                    FOLDER: UpdateDocumentationFolder
-                    MARKDOWN: UpdateDocumentationMarkdown
-
-        BaseUpdateDocumentation:
-            type: object
             properties:
                 type:
                     type: string
@@ -5718,14 +5691,17 @@ components:
                     type: string
                     description: Page's name.
                     example: My Page
+                    minLength: 1
                 order:
                     type: integer
                     description: Page's order.
                     example: 1
+                    default: 0
                 visibility:
                     $ref: "#/components/schemas/Visibility"
             required:
                 - type
+                - name
             discriminator:
                 propertyName: type
                 mapping:
@@ -5737,14 +5713,14 @@ components:
             description: Update documentation folder.
             type: object
             allOf:
-                - $ref: "#/components/schemas/BaseUpdateDocumentation"
+                - $ref: "#/components/schemas/UpdateDocumentation"
 
         UpdateDocumentationMarkdown:
             title: "UpdateDocumentationMarkdown"
             description: Update documentation markdown page.
             type: object
             allOf:
-                - $ref: "#/components/schemas/BaseUpdateDocumentation"
+                - $ref: "#/components/schemas/UpdateDocumentation"
                 - properties:
                       content:
                           type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.documentation;
 
-import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
-import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -410,7 +409,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .name("created page")
                 .homepage(true)
                 .content("nice content")
-                .type(CreateDocumentationType.MARKDOWN)
+                .type(CreateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .parentId(null)
                 .visibility(Visibility.PUBLIC)
@@ -438,7 +437,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             var folderToCreate = CreateDocumentationFolder
                 .builder()
                 .name("created page")
-                .type(CreateDocumentationType.FOLDER)
+                .type(CreateDocumentation.TypeEnum.FOLDER)
                 .order(1)
                 .parentId(null)
                 .visibility(Visibility.PUBLIC)
@@ -457,6 +456,50 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
             assertThat(createdPage.getId()).isNotNull();
             assertThat(createdPage.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        public void should_not_allow_null_name() {
+            var request = CreateDocumentationMarkdown
+                .builder()
+                .type(CreateDocumentation.TypeEnum.MARKDOWN)
+                .parentId("parent")
+                .order(1)
+                .visibility(Visibility.PRIVATE)
+                .name(null)
+                .build();
+
+            final Response response = rootTarget().request().post(Entity.json(request));
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Validation error");
+        }
+
+        @Test
+        public void should_not_allow_empty_name() {
+            var request = CreateDocumentationMarkdown
+                .builder()
+                .type(CreateDocumentation.TypeEnum.MARKDOWN)
+                .parentId("parent")
+                .order(1)
+                .visibility(Visibility.PRIVATE)
+                .name("")
+                .build();
+
+            final Response response = rootTarget().request().post(Entity.json(request));
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Validation error");
         }
     }
 
@@ -588,7 +631,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .name("created page")
                 .homepage(true)
                 .content("nice content")
-                .type(BaseUpdateDocumentation.TypeEnum.MARKDOWN)
+                .type(UpdateDocumentation.TypeEnum.MARKDOWN)
                 .order(1)
                 .visibility(Visibility.PUBLIC)
                 .build();
@@ -630,7 +673,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             var folderToCreate = UpdateDocumentationFolder
                 .builder()
                 .name("new name")
-                .type(BaseUpdateDocumentation.TypeEnum.FOLDER)
+                .type(UpdateDocumentation.TypeEnum.FOLDER)
                 .order(24)
                 .visibility(Visibility.PUBLIC)
                 .build();
@@ -662,6 +705,48 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
             assertThat(updatedPage.getId()).isNotNull();
             assertThat(updatedPage.getUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        public void should_not_allow_null_name() {
+            var request = UpdateDocumentationMarkdown
+                .builder()
+                .type(UpdateDocumentation.TypeEnum.MARKDOWN)
+                .order(1)
+                .visibility(Visibility.PRIVATE)
+                .name(null)
+                .build();
+
+            final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Validation error");
+        }
+
+        @Test
+        public void should_not_allow_empty_name() {
+            var request = UpdateDocumentationMarkdown
+                .builder()
+                .type(UpdateDocumentation.TypeEnum.MARKDOWN)
+                .order(1)
+                .visibility(Visibility.PRIVATE)
+                .name("")
+                .build();
+
+            final Response response = rootTarget().path(PAGE_ID).request().put(Entity.json(request));
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Validation error");
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3050

## Description

Fix DTO to effectively check if name is null or empty for page creation + update.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qoxlxgwhct.chromatic.com)
<!-- Storybook placeholder end -->
