### PR TITLE
test(ui):fix: flaky info dangerzone fix 

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
@@ -185,6 +185,7 @@ describe('API Info Page functionality', () => {
     cy.getByDataTestId('confirm-dialog').click();
     cy.contains('can not be started without at least one published plan');
     cy.visit(`/#!/environments/DEFAULT/apis/${v4dangerzoneApi.id}/general`);
+    cy.contains(`${v4dangerzoneApi.name}`).should('be.visible');
     cy.getByDataTestId('api_info_dangerzone_start_api').click();
     cy.getByDataTestId('confirm-dialog').click();
     cy.contains('The API has been started with success.');
@@ -193,7 +194,7 @@ describe('API Info Page functionality', () => {
     cy.contains('The API has been stopped with success.');
   });
 
-  it('Danger Zone - Publish and Unpublish the API)', () => {
+  it('Danger Zone - Publish and Unpublish the API', () => {
     cy.visit(`/#!/environments/DEFAULT/apis/${v4dangerzoneApi.id}/general`);
     cy.getByDataTestId('api_info_dangerzone_publish_api').click();
     cy.getByDataTestId('confirm-dialog').click();
@@ -203,7 +204,7 @@ describe('API Info Page functionality', () => {
     cy.contains('The API has been unpublish with success.');
   });
 
-  it('Danger Zone - Make Public and Make Private the API)', () => {
+  it('Danger Zone - Make Public and Make Private the API', () => {
     cy.visit(`/#!/environments/DEFAULT/apis/${v4dangerzoneApi.id}/general`);
     cy.getByDataTestId('api_info_dangerzone_make_public', { timeout: 60000 }).click();
     cy.getByDataTestId('confirm-dialog').click();
@@ -213,7 +214,7 @@ describe('API Info Page functionality', () => {
     cy.contains('The API has been Make Private with success.');
   });
 
-  it('Danger Zone - Deprecate the API)', () => {
+  it('Danger Zone - Deprecate the API', () => {
     cy.visit(`/#!/environments/DEFAULT/apis/${v4dangerzoneApi.id}/general`);
     cy.getByDataTestId('api_info_dangerzone_deprecate_api').click();
     cy.getByDataTestId('confirm-dialog').click();
@@ -226,7 +227,7 @@ describe('API Info Page functionality', () => {
     cy.getByDataTestId('api_info_dangerzone_deprecate_api').should('not.exist');
   });
 
-  it('Danger Zone - Delete the API)', () => {
+  it('Danger Zone - Delete the API', () => {
     cy.visit(`/#!/environments/DEFAULT/apis/${v4dangerzoneApi.id}/general`);
     cy.getByDataTestId('api_dangerzone_delete_api').click();
     cy.getByDataTestId('confirm-input-dialog').type(`${v4dangerzoneApi.name}`);


### PR DESCRIPTION
Adding check for api with plan name before starting api

## Issue

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/27289/workflows/05d37ef5-956d-4098-8f0b-4b59c758bb4b/jobs/491078

## Description

I was unable to reproduce this error locally, but looking at Circle CI, it appeared to fail because cypress clicked the dangerzone "Start API" button for the previous API (that checks it can't start without a plan), before the screen had fully loaded the correct API containing a plan. 

Just added a single line to wait for the api with plan's name to be visible on screen before clicking "Start API" again. Also just tidied up some of the text for the test names. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gdilgcxsgb.chromatic.com)
<!-- Storybook placeholder end -->
