### PR TITLE
fix: ignore metadata without value in notification templates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
@@ -122,6 +122,7 @@ public class TemplateDataFetcher {
                         .findApiMetadata(apiId)
                         .entrySet()
                         .stream()
+                        .filter(entry -> entry.getValue().getValue() != null)
                         .map(entry -> Map.entry(entry.getKey(), entry.getValue().getValue()))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
@@ -186,7 +186,7 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                 PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build(),
                 List.of(
                     ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    //                    ApiMetadata.builder().key("email-support").value("${api.name}").format(MetadataFormat.STRING).build()
+                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
                     ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
                 )
             );
@@ -602,7 +602,7 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                 PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build(),
                 List.of(
                     ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    //                    ApiMetadata.builder().key("email-support").value("${api.name}").format(MetadataFormat.STRING).build()
+                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
                     ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
                 )
             );


### PR DESCRIPTION
## Description

We ignore null value metadata to prevent an error while building the Metadata map when we fetch data for a Notification template.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

