### PR TITLE
fix(rest-api): keep dynamic property specification & body into string

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapper.java
@@ -73,14 +73,10 @@ public interface ServiceMapper {
     @Mapping(target = "configuration", qualifiedByName = "deserializeConfiguration")
     EndpointDiscoveryService map(io.gravitee.definition.model.services.discovery.EndpointDiscoveryService endpointDiscoveryService);
 
-    @Mapping(target = "specification", qualifiedByName = "serializeConfiguration")
-    @Mapping(target = "body", qualifiedByName = "serializeConfiguration")
     io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration map(
         HttpDynamicPropertyProviderConfiguration httpDynamicPropertyProviderConfiguration
     );
 
-    @Mapping(target = "specification", qualifiedByName = "deserializeConfiguration")
-    @Mapping(target = "body", qualifiedByName = "deserializeConfiguration")
     HttpDynamicPropertyProviderConfiguration map(
         io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration httpDynamicPropertyProviderConfiguration
     );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -4742,7 +4742,7 @@ components:
                     description: The url of the dynamic property provider
                     example: http://my-provider.com
                 specification:
-                    type: object
+                    type: string
                     description: The specification of the dynamic property provider
                     example: my-specification
                 useSystemProxy:
@@ -4756,7 +4756,7 @@ components:
                     items:
                         $ref: "#/components/schemas/HttpHeader"
                 body:
-                    type: object
+                    type: string
                     description: The body of the request
                     example: my body
         HttpHeader:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ServiceFixture.java
@@ -39,7 +39,7 @@ public class ServiceFixture {
                     .builder()
                     .url("http://localhost")
                     .method(HttpMethod.GET)
-                    .specification(new LinkedHashMap<>(Map.of("nice", "configuration")))
+                    .specification(String.valueOf(new LinkedHashMap<>(Map.of("nice", "configuration"))))
                     .body("body")
                     .build()
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ServiceMapperTest.java
@@ -50,14 +50,7 @@ public class ServiceMapperTest {
             );
         assertThat(config.getSpecification())
             .isEqualTo(
-                new GraviteeMapper()
-                    .writeValueAsString(
-                        apiServicesV2
-                            .getDynamicProperty()
-                            .getConfiguration()
-                            .getHttpDynamicPropertyProviderConfiguration()
-                            .getSpecification()
-                    )
+                apiServicesV2.getDynamicProperty().getConfiguration().getHttpDynamicPropertyProviderConfiguration().getSpecification()
             );
         assertThat(config.getBody())
             .isEqualTo(apiServicesV2.getDynamicProperty().getConfiguration().getHttpDynamicPropertyProviderConfiguration().getBody());


### PR DESCRIPTION
## Issue

n/a

## Description

corrects dynamic properties that are no longer displayed correctly after save.

bug : 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/06ee4a92-c3c8-4819-8c56-5271541f0060)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5718/console](https://pr.team-apim.gravitee.dev/5718/console)
      Portal: [https://pr.team-apim.gravitee.dev/5718/portal](https://pr.team-apim.gravitee.dev/5718/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5718/api/management](https://pr.team-apim.gravitee.dev/5718/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5718](https://pr.team-apim.gravitee.dev/5718)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5718](https://pr.gateway-v3.team-apim.gravitee.dev/5718)

<!-- Environment placeholder end -->
