### PR TITLE
feat(helm): backport HTTP 2 configuration from gravitee.yml to helm values

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -28,3 +28,4 @@ annotations:
     - Allow wildcard in ingress host
     - Add unknownExpireAfter in management-api configuration
     - Allow users to define extra manifests
+    - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -39,7 +39,7 @@ data:
       maxChunkSize: {{ .Values.gateway.http.maxChunkSize }}
       maxInitialLineLength: {{ .Values.gateway.http.maxInitialLineLength }}
       maxFormAttributeSize: {{ .Values.gateway.http.maxFormAttributeSize }}
-      alpn: true
+      alpn: {{ .Values.gateway.http.alpn | default "true" }}
       {{- if .Values.gateway.ssl.enabled }}
       secured: true
       ssl:
@@ -352,7 +352,6 @@ data:
             {{- end }}
           {{- if .Values.gateway.services.bridge.ssl }}
           secured: {{ .Values.gateway.services.bridge.ssl.enabled | default false }}
-          alpn: true
           ssl:
             {{- if .Values.gateway.services.bridge.ssl.keystore}}
             keystore:

--- a/helm/tests/gateway/configmap_http_test.yaml
+++ b/helm/tests/gateway/configmap_http_test.yaml
@@ -1,0 +1,47 @@
+suite: Test Gateway configmap section alpn
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Default ALPN value (true)
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: true
+
+  - it: Enable ALPN
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          alpn: "true"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: true
+
+  - it: Disable ALPN
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          alpn: "false"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            alpn: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -747,6 +747,7 @@ gateway:
     maxChunkSize: 8192
     maxInitialLineLength: 4096
     maxFormAttributeSize: 2048
+    alpn: "true"
   logging:
     debug: false
     stdout:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/DEVOPS-282

## Description

Previously the `http.alpn` option was hardcoded as `true` in `gravitee.yml`.
Now we add the option `gateway.http.alpn` to configure it in helm `values.yml`
which is set to `true` by default for backward compatibility.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcwygfzguy.chromatic.com)
<!-- Storybook placeholder end -->
