### PR TITLE
fix: remove confirmation dialog when user clicks on Exit without saving

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -28,12 +28,12 @@
   <div class="actions">
     <ng-container *ngIf="page?.published; else notPublished">
       <button mat-flat-button color="primary" [disabled]="content?.length === 0" (click)="save()">Publish changes</button>
-      <button mat-stroked-button (click)="exitWithoutSaving()">Cancel</button>
+      <button mat-stroked-button (click)="exit()">Cancel</button>
     </ng-container>
     <ng-template #notPublished>
       <button mat-flat-button color="primary" [disabled]="content?.length === 0" (click)="saveAndPublish()">Save and publish</button>
       <button mat-stroked-button [disabled]="content?.length === 0" (click)="save()">Save</button>
-      <button mat-stroked-button (click)="exitWithoutSaving()">Cancel</button>
+      <button mat-stroked-button (click)="exit()">Cancel</button>
     </ng-template>
   </div>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
@@ -201,14 +201,14 @@ describe('ApiDocumentationV4EditPageComponent', () => {
       expect(await snackBar.getMessage()).toEqual('Cannot publish page');
     });
 
-    it('should request confirmation before exit without saving', async () => {
+    it('should request confirmation before exit', async () => {
       const editor = await harnessLoader.getHarness(ApiDocumentationV4ContentEditorHarness).then((harness) => harness.getContentEditor());
       expect(editor).toBeDefined();
       expect(await editor.getValue()).toEqual('Initial content');
 
       await editor.setValue('## New content');
 
-      const exitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Exit without saving' }));
+      const exitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
       await exitBtn.click();
 
       const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -104,11 +104,10 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
       }),
     );
   }
-
-  exitWithoutSaving() {
+  exit() {
     // When no changes, exit without confirmation
     if (this.content === this.page.content) {
-      this.ajsState.go('management.apis.documentationV4', { ...this.ajsStateParams, parentId: this.page.parentId });
+      this.exitWithoutSaving();
     } else {
       this.matDialog
         .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
@@ -125,12 +124,12 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
         .afterClosed()
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe((shouldExit) => {
-          if (shouldExit)
-            this.ajsState.go('management.apis.documentationV4', {
-              ...this.ajsStateParams,
-              parentId: this.page.parentId,
-            });
+          if (shouldExit) this.exitWithoutSaving();
         });
     }
+  }
+
+  exitWithoutSaving() {
+    this.ajsState.go('management.apis.documentationV4', { ...this.ajsStateParams, parentId: this.page.parentId });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.spec.ts
@@ -21,7 +21,7 @@ import { MatStepperHarness } from '@angular/material/stepper/testing';
 import { UIRouterModule } from '@uirouter/angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { FormsModule } from '@angular/forms';
-import { GioConfirmDialogHarness, GioMonacoEditorHarness } from '@gravitee/ui-particles-angular';
+import { GioMonacoEditorHarness } from '@gravitee/ui-particles-angular';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
@@ -94,21 +94,9 @@ describe('ApiDocumentationV4NewPageComponent', () => {
       expect(await steps[2].getLabel()).toEqual('Add content');
     });
 
-    it('should request confirmation before exit without saving', async () => {
+    it('should exit without saving', async () => {
       const exitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Exit without saving' }));
       await exitBtn.click();
-
-      const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
-      expect(confirmDialog).toBeDefined();
-
-      // should stay on page if cancel
-      await confirmDialog.cancel();
-
-      await exitBtn.click();
-      const newConfirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
-      expect(newConfirmDialog).toBeDefined();
-      // should leave page on confirm
-      await newConfirmDialog.confirm();
       expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.documentationV4', {
         apiId: API_ID,
         parentId: 'ROOT',

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-new-page/api-documentation-v4-new-page.component.ts
@@ -17,8 +17,6 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { StateParams } from '@uirouter/core';
 import { StateService } from '@uirouter/angularjs';
-import { MatDialog } from '@angular/material/dialog';
-import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { catchError, switchMap, takeUntil } from 'rxjs/operators';
 import { EMPTY, Observable, Subject } from 'rxjs';
 
@@ -43,7 +41,6 @@ export class ApiDocumentationV4NewPageComponent implements OnInit, OnDestroy {
 
   constructor(
     private readonly formBuilder: FormBuilder,
-    private readonly matDialog: MatDialog,
     @Inject(UIRouterState) private readonly ajsState: StateService,
     @Inject(UIRouterStateParams) private readonly ajsStateParams: StateParams,
     private readonly apiDocumentationService: ApiDocumentationV2Service,
@@ -106,22 +103,6 @@ export class ApiDocumentationV4NewPageComponent implements OnInit, OnDestroy {
   }
 
   exitWithoutSaving() {
-    this.matDialog
-      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
-        width: GIO_DIALOG_WIDTH.SMALL,
-        data: {
-          title: 'Are you sure?',
-          content: 'If you leave this page, you will lose any info you added.',
-          confirmButton: 'Discard changes',
-          cancelButton: 'Keep creating',
-        },
-        role: 'alertdialog',
-        id: 'exitWithoutSaving',
-      })
-      .afterClosed()
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((shouldExit) => {
-        if (shouldExit) this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
-      });
+    this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3129

## Description

Remove confirmation dialog when user clicks on "Exit without saving" as button label is already explicit enough
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vqkilmtnlx.chromatic.com)
<!-- Storybook placeholder end -->
