### PR TITLE
fix: bump http-get and websocket entrypoint versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,11 +259,11 @@
         <gravitee-secretprovider-kubernetes.version>1.0.0-alpha.4</gravitee-secretprovider-kubernetes.version>
 
         <!-- Enterprise plugins -->
-        <gravitee-entrypoint-http-get.version>1.0.2</gravitee-entrypoint-http-get.version>
+        <gravitee-entrypoint-http-get.version>1.0.3</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.0.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>4.0.2</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>2.0.2</gravitee-entrypoint-webhook.version>
-        <gravitee-entrypoint-websocket.version>1.0.2</gravitee-entrypoint-websocket.version>
+        <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.2.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.1.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>1.2.0</gravitee-endpoint-rabbitmq.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3065
https://gravitee.atlassian.net/browse/APIM-3131

## Description

Update websocket en http-get entrypoints to fix backpressure issues.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qpgcrkrmkz.chromatic.com)
<!-- Storybook placeholder end -->
