### PR TITLE
Improve performances when querying AlertEvent related metrics

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertEventRepository.java
@@ -39,6 +39,14 @@ public interface AlertEventRepository extends CrudRepository<AlertEvent, String>
     Page<AlertEvent> search(AlertEventCriteria criteria, Pageable pageable);
 
     /**
+     * Counts the number of {@link AlertEvent}s that match the given criteria.
+     *
+     * @param criteria The criteria to match the {@link AlertEvent}s against.
+     * @return The number of {@link AlertEvent}s that match the given criteria.
+     */
+    long count(AlertEventCriteria criteria);
+
+    /**
      * delete all events of the provided alert
      * @param alertId
      */

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
@@ -128,6 +128,11 @@ public class MongoAlertEventRepository implements AlertEventRepository {
     }
 
     @Override
+    public long count(AlertEventCriteria criteria) {
+        return internalAlertEventRepo.count(criteria);
+    }
+
+    @Override
     public Set<AlertEvent> findAll() throws TechnicalException {
         return internalAlertEventRepo
             .findAll()

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryCustom.java
@@ -28,4 +28,6 @@ public interface AlertEventMongoRepositoryCustom {
     Page<AlertEventMongo> search(AlertEventCriteria criteria, Pageable pageable);
 
     void deleteAll(String alertId);
+
+    long count(AlertEventCriteria criteria);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
@@ -40,21 +40,10 @@ public class AlertEventMongoRepositoryImpl implements AlertEventMongoRepositoryC
 
     @Override
     public Page<AlertEventMongo> search(AlertEventCriteria criteria, Pageable pageable) {
-        Query query = new Query();
-
-        if (criteria.getAlert() != null) {
-            query.addCriteria(Criteria.where("alert").is(criteria.getAlert()));
-        }
-
-        // set range query
-        if (criteria.getFrom() != 0 && criteria.getTo() != 0) {
-            query.addCriteria(Criteria.where("createdAt").gte(new Date(criteria.getFrom())).lt(new Date(criteria.getTo())));
-        }
-
-        // set sort by updated at
-        query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
-
+        Query query = buildQueryFromCriteria(criteria);
         long total = mongoTemplate.count(query, AlertEventMongo.class);
+
+        query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
 
         // set pageable
         if (pageable != null) {
@@ -70,5 +59,24 @@ public class AlertEventMongoRepositoryImpl implements AlertEventMongoRepositoryC
     public void deleteAll(String alertId) {
         Query query = new Query().addCriteria(Criteria.where("alert").is(alertId));
         mongoTemplate.remove(query, AlertEventMongo.class);
+    }
+
+    @Override
+    public long count(AlertEventCriteria criteria) {
+        Query query = buildQueryFromCriteria(criteria);
+        return mongoTemplate.count(query, AlertEventMongo.class);
+    }
+
+    private static Query buildQueryFromCriteria(AlertEventCriteria criteria) {
+        Query query = new Query();
+
+        if (criteria.getAlert() != null) {
+            query.addCriteria(Criteria.where("alert").is(criteria.getAlert()));
+        }
+
+        if (criteria.getFrom() != 0 && criteria.getTo() != 0) {
+            query.addCriteria(Criteria.where("createdAt").gte(new Date(criteria.getFrom())).lt(new Date(criteria.getTo())));
+        }
+        return query;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -122,6 +122,7 @@ db.getCollection(`${prefix}alert_triggers`).reIndex();
 db.getCollection(`${prefix}alert_events`).dropIndexes();
 db.getCollection(`${prefix}alert_events`).createIndex( { "alert": 1 }, { "name": "a1" } );
 db.getCollection(`${prefix}alert_events`).createIndex( { "createdAt": 1 }, { "name": "c1" } );
+db.getCollection(`${prefix}alert_events`).createIndex( { "alert": 1, "createdAt": 1 }, { "name": "a1c1" } );
 db.getCollection(`${prefix}alert_events`).reIndex();
 
 // "customUserFields" collection

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AlertEventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AlertEventRepositoryTest.java
@@ -141,4 +141,22 @@ public class AlertEventRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("2 before", 2, before);
         assertEquals("0 after", 0, after);
     }
+
+    @Test
+    public void shouldCountWithCriteria() {
+        long count = alertEventRepository.count(
+            new AlertEventCriteria.Builder().alert("alert-parent-id").from(1439022010900L).to(1439022010999L).build()
+        );
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void shouldSearchWithCriteria() {
+        Page<AlertEvent> result = alertEventRepository.search(
+            new AlertEventCriteria.Builder().alert("alert-parent-id").from(1439022010900L).to(1439022010999L).build(),
+            null
+        );
+        assertEquals(1, result.getTotalElements());
+        assertEquals("an-alert-to-update", result.getContent().get(0).getId());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/alertevent-tests/alertEvents.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/alertevent-tests/alertEvents.json
@@ -9,8 +9,8 @@
       "id": "an-alert-to-update",
       "alert": "alert-parent-id",
       "message": "Message of the alert to update",
-      "createdAt": 1439022010883,
-      "updatedAt": 1439022010883
+      "createdAt": 1439022010920,
+      "updatedAt": 1439022010920
    },
    {
       "id": "latest-alert",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -334,23 +334,27 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
 
                     final Date from = new Date(System.currentTimeMillis());
 
-                    Map<String, Integer> counters = new HashMap<>();
-                    counters.put(
-                        "5m",
-                        countEvents(entity.getId(), from.toInstant().minus(Duration.ofMinutes(5)).toEpochMilli(), from.getTime())
-                    );
-                    counters.put(
-                        "1h",
-                        countEvents(entity.getId(), from.toInstant().minus(Duration.ofHours(1)).toEpochMilli(), from.getTime())
-                    );
-                    counters.put(
-                        "1d",
-                        countEvents(entity.getId(), from.toInstant().minus(Duration.ofDays(1)).toEpochMilli(), from.getTime())
-                    );
-                    counters.put(
-                        "1M",
-                        countEvents(entity.getId(), from.toInstant().minus(Duration.ofDays(30)).toEpochMilli(), from.getTime())
-                    );
+                    Map<String, Integer> counters = Map
+                        .of(
+                            "5m",
+                            from.toInstant().minus(Duration.ofMinutes(5)),
+                            "1h",
+                            from.toInstant().minus(Duration.ofHours(1)),
+                            "1d",
+                            from.toInstant().minus(Duration.ofDays(1)),
+                            "1M",
+                            from.toInstant().minus(Duration.ofDays(30))
+                        )
+                        .entrySet()
+                        // Get the count of events for each time period in parallel to speed up the process
+                        .parallelStream()
+                        .map(entry ->
+                            new AbstractMap.SimpleEntry<>(
+                                entry.getKey(),
+                                countEvents(entity.getId(), entry.getValue().toEpochMilli(), from.getTime())
+                            )
+                        )
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
                     entity.setCounters(counters);
                     return entity;
@@ -796,12 +800,8 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
     }
 
     private int countEvents(final String triggerId, final long from, final long to) {
-        return (int) alertEventRepository
-            .search(
-                new AlertEventCriteria.Builder().alert(triggerId).from(from).to(to).build(),
-                new PageableBuilder().pageNumber(0).pageSize(1).build()
-            )
-            .getTotalElements();
+        AlertEventCriteria criteria = new AlertEventCriteria.Builder().alert(triggerId).from(from).to(to).build();
+        return Math.toIntExact(alertEventRepository.count(criteria));
     }
 
     private Optional<AlertEvent> getLastEvent(final String triggerId) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3190
https://github.com/gravitee-io/issues/issues/9362

## Description

- Create a `count` method in AlertEvent repository to use the count of DBs
- Use this new method in AlertService
- Parallelize fetching of Alert metrics instead of doing it sequentially
- Add a missing index
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lanwenodsg.chromatic.com)
<!-- Storybook placeholder end -->
