### PR TITLE
Look only for the latest event when deploying an API 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
@@ -79,30 +79,5 @@ public interface EventService {
         final List<String> environments
     );
 
-    <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        final List<String> environmentsIds
-    );
-
-    <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        Predicate<T> filter,
-        final List<String> environmentsIds
-    );
-
     Collection<EventEntity> search(ExecutionContext executionContext, EventQuery query);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
@@ -274,43 +274,6 @@ public class EventServiceImpl extends TransactionalService implements EventServi
     }
 
     @Override
-    public <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        final List<String> environmentsIds
-    ) {
-        return search(executionContext, eventTypes, properties, from, to, page, size, mapper, (T t) -> true, environmentsIds);
-    }
-
-    @Override
-    public <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        Predicate<T> filter,
-        final List<String> environmentsIds
-    ) {
-        Page<EventEntity> result = search(executionContext, eventTypes, properties, from, to, page, size, environmentsIds);
-        return new Page<>(
-            result.getContent().stream().map(mapper).filter(filter).collect(Collectors.toList()),
-            page,
-            size,
-            result.getTotalElements()
-        );
-    }
-
-    @Override
     public Collection<EventEntity> search(ExecutionContext executionContext, final EventQuery query) {
         LOGGER.debug("Search APIs by {}", query);
         return convert(executionContext, eventRepository.search(queryToCriteria(executionContext, query).build()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
@@ -385,69 +385,6 @@ public class EventServiceTest {
     }
 
     @Test
-    public void shouldFilterEvent() throws TechnicalException {
-        when(eventRepository.search(any(), any()))
-            .thenReturn(
-                new Page<>(
-                    Arrays.asList(
-                        generateInstanceEvent("evt1", false),
-                        generateInstanceEvent("evt2", true),
-                        generateInstanceEvent("evt3", true),
-                        generateInstanceEvent("evt4", false),
-                        generateInstanceEvent("evt5", true)
-                    ),
-                    1,
-                    5,
-                    5
-                )
-            );
-
-        // test without predicate
-        Page<Map<String, String>> page = eventService.search(
-            GraviteeContext.getExecutionContext(),
-            Arrays.asList(io.gravitee.rest.api.model.EventType.GATEWAY_STARTED),
-            Collections.EMPTY_MAP,
-            0,
-            0,
-            1,
-            10,
-            evt -> {
-                Map<String, String> map = new HashMap<>();
-                map.put("id", evt.getId());
-                map.put("state", evt.getType().name());
-                return map;
-            },
-            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
-        );
-        assertNotNull(page);
-        assertNotNull(page.getContent());
-        assertEquals(5, page.getContent().size());
-
-        // test with predicate
-        page =
-            eventService.search(
-                GraviteeContext.getExecutionContext(),
-                Arrays.asList(io.gravitee.rest.api.model.EventType.GATEWAY_STARTED),
-                Collections.EMPTY_MAP,
-                0,
-                0,
-                1,
-                10,
-                evt -> {
-                    Map<String, String> map = new HashMap<>();
-                    map.put("id", evt.getId());
-                    map.put("state", evt.getType().name());
-                    return map;
-                },
-                map -> !map.get("state").equals(io.gravitee.rest.api.model.EventType.GATEWAY_STOPPED.name()),
-                Collections.singletonList(GraviteeContext.getCurrentEnvironment())
-            );
-        assertNotNull(page);
-        assertNotNull(page.getContent());
-        assertEquals(3, page.getContent().size());
-    }
-
-    @Test
     public void createDebugApiEvent_shouldCreateEvent_withoutPayload() throws TechnicalException {
         when(eventRepository.create(any())).thenAnswer(i -> i.getArguments()[0]);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3193
https://github.com/gravitee-io/issues/issues/9364

## Description

Look only for the latest event when deploying an API.

Also did some cleaning in the EventService interface

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-guexeturtd.chromatic.com)
<!-- Storybook placeholder end -->
