### PR TITLE
feat(mapi-v2): order in page update must be positive int

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -5747,6 +5747,7 @@ components:
                     description: Page's order.
                     example: 1
                     default: 0
+                    minimum: 0
                 visibility:
                     $ref: "#/components/schemas/Visibility"
             required:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3235

## Description

Add control for input to be greater than 0 for page order update

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

