### PR TITLE
apim 3103 control if page folder has published children

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
@@ -42,4 +42,6 @@ public interface PageRepository extends FindAllRepository<Page> {
     Integer findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, PageReferenceType referenceType) throws TechnicalException;
 
     io.gravitee.common.data.domain.Page<Page> findAll(Pageable pageable) throws TechnicalException;
+
+    long countByParentIdAndIsPublished(String parentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
@@ -17,6 +17,8 @@ package io.gravitee.repository.jdbc.management;
 
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.createPagingClause;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
+import static io.gravitee.repository.jdbc.management.JdbcHelper.AND_CLAUSE;
+import static io.gravitee.repository.jdbc.management.JdbcHelper.WHERE_CLAUSE;
 import static io.gravitee.repository.jdbc.orm.JdbcColumn.getDBName;
 import static java.lang.String.format;
 
@@ -432,6 +434,25 @@ public class JdbcPageRepository extends JdbcAbstractCrudRepository<Page, String>
         } catch (final Exception ex) {
             LOGGER.error("Failed to find page by id:", ex);
             throw new TechnicalException("Failed to find page by id", ex);
+        }
+    }
+
+    @Override
+    public long countByParentIdAndIsPublished(String parentId) throws TechnicalException {
+        try {
+            final List<Object> args = new ArrayList<>();
+
+            String builder =
+                "select count(*) from " + this.tableName + " p " + WHERE_CLAUSE + "parent_id = ?" + AND_CLAUSE + "published = ?";
+            args.add(parentId);
+            args.add(true);
+
+            LOGGER.debug("SQL: {}", builder);
+            LOGGER.debug("Args: {}", args);
+            return jdbcTemplate.queryForObject(builder, args.toArray(), Long.class);
+        } catch (final Exception e) {
+            LOGGER.error("Failed to count page by parent_id:", e);
+            throw new TechnicalException("Failed to count page by parentId", e);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
@@ -183,6 +183,16 @@ public class MongoPageRepository implements PageRepository {
         }
     }
 
+    @Override
+    public long countByParentIdAndIsPublished(String parentId) throws TechnicalException {
+        try {
+            return internalPageRepo.countByParentIdAndIsPublished(parentId);
+        } catch (Exception e) {
+            logger.error("An error occurred when counting page by parent_id {}", parentId, e);
+            throw new TechnicalException("An error occurred when counting page by parentId");
+        }
+    }
+
     private PageSourceMongo convert(PageSource pageSource) {
         PageSourceMongo pageSourceMongo = new PageSourceMongo();
         pageSourceMongo.setType(pageSource.getType());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryCustom.java
@@ -20,7 +20,6 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.PageMongo;
 import java.util.List;
-import java.util.List;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -33,4 +32,6 @@ public interface PageMongoRepositoryCustom {
     int findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, String referenceType);
 
     Page<PageMongo> findAll(Pageable pageable);
+
+    long countByParentIdAndIsPublished(String parentId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
@@ -110,4 +110,12 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
 
         return new Page<>(pages, pageable.pageNumber(), pages.size(), total);
     }
+
+    @Override
+    public long countByParentIdAndIsPublished(String parentId) {
+        Query query = new Query();
+        query.addCriteria(where("parentId").is(parentId));
+        query.addCriteria(where("published").is(true));
+        return mongoTemplate.count(query, PageMongo.class);
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRepositoryTest.java
@@ -387,6 +387,18 @@ public class PageRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldCountExistingParentIdAndIsPublished() throws TechnicalException {
+        var count = pageRepository.countByParentIdAndIsPublished("2");
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void shouldCountNonExistingParentId() throws TechnicalException {
+        var count = pageRepository.countByParentIdAndIsPublished("does-not-exist");
+        assertEquals(0, count);
+    }
+
+    @Test
     public void shouldUpdateFolderPage() throws Exception {
         Optional<Page> optionalBefore = pageRepository.findById("updatePageFolder");
         assertTrue("Page to update not found", optionalBefore.isPresent());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/page-tests/pages.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/page-tests/pages.json
@@ -82,6 +82,8 @@
       "content": "Content of the page 3",
       "order": 1,
       "type": "MARKDOWN",
+      "parentId": "2",
+      "published": true,
       "createdAt": 1439022010883,
       "updatedAt": 1439022010883
    },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -5622,6 +5622,9 @@ components:
                         $ref: "#/components/schemas/Page"
                 contentRevision:
                     $ref: "#/components/schemas/Revision"
+                hidden:
+                    type: boolean
+                    description: If folder is published but not shown in Portal.
         PageMedia:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -188,6 +188,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
+                            .hidden(true)
                             .build()
                     )
                 );
@@ -243,6 +244,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
+                            .hidden(true)
                             .build()
                     )
                 );
@@ -309,6 +311,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                             .configuration(Map.of())
                             .metadata(Map.of())
                             .excludedAccessControls(false)
+                            .hidden(true)
                             .build()
                     )
                 );
@@ -368,6 +371,68 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                         .excludedAccessControls(false)
                         .parentId("parent-id")
                         .build()
+                );
+        }
+
+        @Test
+        void should_return_folder_with_published_children() {
+            Page child = Page
+                .builder()
+                .referenceType(Page.ReferenceType.API)
+                .referenceId("api-id")
+                .type(Page.Type.MARKDOWN)
+                .id("page-1")
+                .name("page-1")
+                .parentId("parent-id")
+                .published(true)
+                .build();
+            Page page = Page
+                .builder()
+                .referenceType(Page.ReferenceType.API)
+                .referenceId("api-id")
+                .type(Page.Type.FOLDER)
+                .id("parent-id")
+                .name("folder 2")
+                .parentId("")
+                .build();
+            givenApiPagesQuery(List.of(child, page));
+            final Response response = rootTarget().request().get();
+            assertThat(response.getStatus()).isEqualTo(200);
+
+            var body = response.readEntity(ApiDocumentationPagesResponse.class);
+            assertThat(body.getPages())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    List.of(
+                        io.gravitee.rest.api.management.v2.rest.model.Page
+                            .builder()
+                            .id("page-1")
+                            .type(PageType.MARKDOWN)
+                            .name("page-1")
+                            .order(0)
+                            .published(false)
+                            .homepage(false)
+                            .configuration(Map.of())
+                            .metadata(Map.of())
+                            .excludedAccessControls(false)
+                            .parentId("parent-id")
+                            .published(true)
+                            .build(),
+                        io.gravitee.rest.api.management.v2.rest.model.Page
+                            .builder()
+                            .id(page.getId())
+                            .type(PageType.FOLDER)
+                            .name(page.getName())
+                            .order(page.getOrder())
+                            .published(page.isPublished())
+                            .homepage(page.isHomepage())
+                            .configuration(Map.of())
+                            .metadata(Map.of())
+                            .excludedAccessControls(false)
+                            .parentId(page.getParentId())
+                            .hidden(false)
+                            .build()
+                    )
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
@@ -34,10 +34,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,6 +80,9 @@ public class ApiPagesResource extends AbstractResource {
                 )
                 .stream()
                 .filter(page -> accessControlService.canAccessPageFromPortal(executionContext, apiId, page))
+                .filter(pageEntity ->
+                    !Objects.equals(pageEntity.getType(), "FOLDER") || pageService.folderHasPublishedChildren(pageEntity.getId())
+                )
                 .map(pageMapper::convert)
                 .map(page -> this.addPageLink(apiId, page));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainService.java
@@ -64,4 +64,12 @@ public class ApiDocumentationDomainService {
             throw new ValidationDomainException("Name already exists with the same parent and type: " + name);
         }
     }
+
+    public Boolean pageIsHidden(Page page) {
+        if (page.isFolder()) {
+            var publishedChildren = this.pageQueryService.countByParentIdAndIsPublished(page.getId());
+            return publishedChildren <= 0;
+        }
+        return null;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/CreateApiDocumentationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/domain_service/CreateApiDocumentationDomainService.java
@@ -23,7 +23,6 @@ import io.gravitee.apim.core.audit.model.event.PageAuditEvent;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.crud_service.PageRevisionCrudService;
 import io.gravitee.apim.core.documentation.model.Page;
-import io.gravitee.apim.core.documentation.query_service.PageQueryService;
 import java.time.ZoneId;
 import java.util.Map;
 
@@ -65,7 +64,6 @@ public class CreateApiDocumentationDomainService {
                 .newValue(page)
                 .build()
         );
-
         return createdPage;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/Page.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/Page.java
@@ -47,6 +47,9 @@ public class Page {
     private Date updatedAt;
     private String parentId;
 
+    @With
+    private Boolean hidden;
+
     private String content;
     private boolean homepage;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/query_service/PageQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/query_service/PageQueryService.java
@@ -24,4 +24,5 @@ public interface PageQueryService {
     Optional<Page> findHomepageByApiId(String apiId);
     List<Page> searchByApiIdAndParentId(String apiId, String parentId);
     Optional<Page> findByApiIdAndParentIdAndNameAndType(String apiId, String parentId, String name, Page.Type type);
+    long countByParentIdAndIsPublished(String parentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCase.java
@@ -71,6 +71,10 @@ public class ApiCreateDocumentationPageUseCase {
             this.homepageDomainService.setPreviousHomepageToFalse(createdPage.getReferenceId(), createdPage.getId());
         }
 
+        if (createdPage.isFolder()) {
+            createdPage.setHidden(true);
+        }
+
         return new Output(createdPage);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCase.java
@@ -42,6 +42,8 @@ public class ApiGetDocumentationPageUseCase {
         var page = this.pageCrudService.get(input.pageId);
         this.apiDocumentationDomainService.validatePageAssociatedToApi(page, input.apiId);
 
+        page = page.withHidden(this.apiDocumentationDomainService.pageIsHidden(page));
+
         return new Output(page);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCase.java
@@ -61,7 +61,11 @@ public class ApiGetDocumentationPagesUseCase {
             }
         }
 
-        var pages = apiDocumentationDomainService.getApiPages(input.apiId, input.parentId);
+        var pages = apiDocumentationDomainService
+            .getApiPages(input.apiId, input.parentId)
+            .stream()
+            .map(page -> page.withHidden(this.apiDocumentationDomainService.pageIsHidden(page)))
+            .toList();
 
         return new Output(pages, breadcrumbList);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCase.java
@@ -55,8 +55,11 @@ public class ApiPublishDocumentationPageUseCase {
         }
 
         var newPage = page.toBuilder().published(true).updatedAt(new Date()).build();
+        var updatedPage = this.updateApiDocumentationDomainService.updatePage(newPage, page, input.auditInfo);
 
-        return new Output(this.updateApiDocumentationDomainService.updatePage(newPage, page, input.auditInfo));
+        updatedPage = updatedPage.withHidden(this.apiDocumentationDomainService.pageIsHidden(updatedPage));
+
+        return new Output(updatedPage);
     }
 
     public record Input(String apiId, String pageId, AuditInfo auditInfo) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCase.java
@@ -85,6 +85,8 @@ public class ApiUpdateDocumentationPageUseCase {
             this.updatePageOrders(oldPage.getOrder(), updatedPage, input.auditInfo);
         }
 
+        updatedPage = updatedPage.withHidden(this.apiDocumentationDomainService.pageIsHidden(updatedPage));
+
         return new Output(updatedPage);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/documentation/PageQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/documentation/PageQueryServiceImpl.java
@@ -100,6 +100,16 @@ public class PageQueryServiceImpl implements PageQueryService {
         return this.search(pageCriteriaBuilder, apiId).stream().findFirst();
     }
 
+    @Override
+    public long countByParentIdAndIsPublished(String parentId) {
+        try {
+            return this.pageRepository.countByParentIdAndIsPublished(parentId);
+        } catch (TechnicalException e) {
+            logger.error("An error occurred while counting Pages by parentId {}", parentId, e);
+            throw new TechnicalDomainException("Error during repository search", e);
+        }
+    }
+
     private List<Page> search(PageCriteria.Builder pageCriteriaBuilder, String apiId) {
         try {
             return PageAdapter.INSTANCE.toEntityList(pageRepository.search(pageCriteriaBuilder.build()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -117,4 +117,6 @@ public interface PageService {
     boolean shouldHaveRevision(String pageType);
 
     Optional<PageEntity> attachMedia(String pageId, String mediaId, String mediaName);
+
+    boolean folderHasPublishedChildren(String folderId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2676,6 +2676,17 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     @Override
+    public boolean folderHasPublishedChildren(String folderId) {
+        try {
+            var count = pageRepository.countByParentIdAndIsPublished(folderId);
+            return count > 0;
+        } catch (TechnicalException e) {
+            logger.error("An error occurs while trying to count Pages with parentId {}", folderId, e);
+            throw new TechnicalManagementException("An error occurred while evaluating if folder has children");
+        }
+    }
+
+    @Override
     public PageEntity createWithDefinition(final ExecutionContext executionContext, String apiId, String pageDefinition) {
         try {
             final NewPageEntity newPage = convertToEntity(pageDefinition);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
@@ -85,6 +85,11 @@ public class PageQueryServiceInMemory implements InMemoryAlternative<Page>, Page
     }
 
     @Override
+    public long countByParentIdAndIsPublished(String parentId) {
+        return pages.stream().filter(page -> Objects.equals(page.getParentId(), parentId) && page.isPublished()).count();
+    }
+
+    @Override
     public void initWith(List<Page> items) {
         pages = List.copyOf(items);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCaseTest.java
@@ -454,7 +454,8 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .hasFieldOrPropertyWithValue("homepage", false)
                 .hasFieldOrPropertyWithValue("visibility", Page.Visibility.PRIVATE)
                 .hasFieldOrPropertyWithValue("parentId", "parent-id")
-                .hasFieldOrPropertyWithValue("order", 0);
+                .hasFieldOrPropertyWithValue("order", 0)
+                .hasFieldOrPropertyWithValue("hidden", true);
 
             var savedPage = pageCrudService
                 .storage()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
@@ -65,7 +65,43 @@ class ApiGetDocumentationPageUseCaseTest {
             List.of(Page.builder().id(PAGE_ID).referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.MARKDOWN).build())
         );
         var res = useCase.execute(new ApiGetDocumentationPageUseCase.Input(API_ID, PAGE_ID)).page();
-        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID);
+        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID).hasFieldOrPropertyWithValue("hidden", null);
+    }
+
+    @Test
+    void should_return_folder_without_children() {
+        initApiServices(List.of(Api.builder().id(API_ID).build()));
+        initPageServices(
+            List.of(Page.builder().id(PAGE_ID).referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build())
+        );
+        var res = useCase.execute(new ApiGetDocumentationPageUseCase.Input(API_ID, PAGE_ID)).page();
+        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID).hasFieldOrPropertyWithValue("hidden", true);
+    }
+
+    @Test
+    void should_return_folder_with_published_children() {
+        initApiServices(List.of(Api.builder().id(API_ID).build()));
+        initPageServices(
+            List.of(
+                Page.builder().id(PAGE_ID).referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build(),
+                Page.builder().id("one-child").parentId(PAGE_ID).published(true).build()
+            )
+        );
+        var res = useCase.execute(new ApiGetDocumentationPageUseCase.Input(API_ID, PAGE_ID)).page();
+        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID).hasFieldOrPropertyWithValue("hidden", false);
+    }
+
+    @Test
+    void should_return_folder_with_unpublished_children() {
+        initApiServices(List.of(Api.builder().id(API_ID).build()));
+        initPageServices(
+            List.of(
+                Page.builder().id(PAGE_ID).referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build(),
+                Page.builder().id("one-child").parentId(PAGE_ID).published(false).build()
+            )
+        );
+        var res = useCase.execute(new ApiGetDocumentationPageUseCase.Input(API_ID, PAGE_ID)).page();
+        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID).hasFieldOrPropertyWithValue("hidden", true);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
@@ -75,6 +75,45 @@ class ApiGetDocumentationPagesUseCaseTest {
         }
 
         @Test
+        void should_calculate_if_folders_are_hidden() {
+            initApiServices(List.of(Api.builder().id(API_ID).build()));
+            initPageServices(
+                List.of(
+                    Page
+                        .builder()
+                        .id("page#1")
+                        .referenceType(Page.ReferenceType.API)
+                        .referenceId(API_ID)
+                        .type(Page.Type.MARKDOWN)
+                        .parentId("folder#1")
+                        .published(true)
+                        .build(),
+                    Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.MARKDOWN).build(),
+                    Page
+                        .builder()
+                        .id("page#3")
+                        .referenceType(Page.ReferenceType.API)
+                        .referenceId(API_ID)
+                        .type(Page.Type.MARKDOWN)
+                        .parentId("folder#2")
+                        .published(false)
+                        .build(),
+                    Page.builder().id("folder#1").referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build(),
+                    Page.builder().id("folder#2").referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build(),
+                    Page.builder().id("folder#3").referenceType(Page.ReferenceType.API).referenceId(API_ID).type(Page.Type.FOLDER).build()
+                )
+            );
+            var res = useCase.execute(new ApiGetDocumentationPagesUseCase.Input(API_ID, null)).pages();
+            assertThat(res).hasSize(6);
+            assertThat(res.get(0)).hasFieldOrPropertyWithValue("id", "page#1").hasFieldOrPropertyWithValue("hidden", null);
+            assertThat(res.get(1)).hasFieldOrPropertyWithValue("id", "page#2").hasFieldOrPropertyWithValue("hidden", null);
+            assertThat(res.get(2)).hasFieldOrPropertyWithValue("id", "page#3").hasFieldOrPropertyWithValue("hidden", null);
+            assertThat(res.get(3)).hasFieldOrPropertyWithValue("id", "folder#1").hasFieldOrPropertyWithValue("hidden", false);
+            assertThat(res.get(4)).hasFieldOrPropertyWithValue("id", "folder#2").hasFieldOrPropertyWithValue("hidden", true);
+            assertThat(res.get(5)).hasFieldOrPropertyWithValue("id", "folder#3").hasFieldOrPropertyWithValue("hidden", true);
+        }
+
+        @Test
         void should_throw_error_if_api_not_found() {
             initApiServices(List.of(Api.builder().id("not-my-api").build()));
             assertThatThrownBy(() -> useCase.execute(new ApiGetDocumentationPagesUseCase.Input(API_ID, null)))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCaseTest.java
@@ -115,7 +115,36 @@ class ApiPublishDocumentationPageUseCaseTest {
             )
         );
         var res = useCase.execute(new ApiPublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO)).page();
-        assertThat(res).isNotNull().hasFieldOrPropertyWithValue("id", PAGE_ID).hasFieldOrPropertyWithValue("published", true);
+        assertThat(res)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("id", PAGE_ID)
+            .hasFieldOrPropertyWithValue("published", true)
+            .hasFieldOrPropertyWithValue("hidden", true);
+    }
+
+    @Test
+    void should_publish_folder_and_has_published_children() {
+        initApiServices(List.of(Api.builder().id(API_ID).build()));
+        initPageServices(
+            List.of(
+                Page
+                    .builder()
+                    .id(PAGE_ID)
+                    .referenceType(Page.ReferenceType.API)
+                    .referenceId(API_ID)
+                    .type(Page.Type.FOLDER)
+                    .published(false)
+                    .createdAt(DATE)
+                    .build(),
+                Page.builder().id("child").parentId(PAGE_ID).published(true).build()
+            )
+        );
+        var res = useCase.execute(new ApiPublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO)).page();
+        assertThat(res)
+            .isNotNull()
+            .hasFieldOrPropertyWithValue("id", PAGE_ID)
+            .hasFieldOrPropertyWithValue("published", true)
+            .hasFieldOrPropertyWithValue("hidden", false);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCaseTest.java
@@ -396,7 +396,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
         @Test
         void should_update_folder() {
             initApiServices(List.of(Api.builder().id(API_ID).build()));
-            initPageServices(List.of(PARENT_FOLDER, OLD_FOLDER_PAGE));
+            initPageServices(List.of(PARENT_FOLDER, OLD_FOLDER_PAGE, Page.builder().id("child").parentId(PAGE_ID).published(true).build()));
 
             var res = apiUpdateDocumentationPageUsecase.execute(
                 ApiUpdateDocumentationPageUseCase.Input
@@ -419,9 +419,16 @@ class ApiUpdateDocumentationPageUseCaseTest {
                 .hasFieldOrPropertyWithValue("homepage", false)
                 .hasFieldOrPropertyWithValue("visibility", Page.Visibility.PRIVATE)
                 .hasFieldOrPropertyWithValue("parentId", PARENT_ID)
-                .hasFieldOrPropertyWithValue("order", 24);
+                .hasFieldOrPropertyWithValue("order", 24)
+                .hasFieldOrPropertyWithValue("hidden", false);
 
-            var savedPage = pageCrudService.storage().stream().filter(page -> page.getId().equals(res.page().getId())).toList().get(0);
+            var savedPage = pageCrudService
+                .storage()
+                .stream()
+                .filter(page -> page.getId().equals(res.page().getId()))
+                .toList()
+                .get(0)
+                .withHidden(false);
             assertThat(savedPage).isEqualTo(res.page());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/documentation/PageQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/documentation/PageQueryServiceImplTest.java
@@ -132,7 +132,15 @@ class PageQueryServiceImplTest {
             String PARENT_ID = "parent-id";
             String PAGE_ID = "page-id";
 
-            var page = aPage(API_ID, PAGE_ID, "duplicate name");
+            var repositoryPage = aPage(API_ID, PAGE_ID, "duplicate name");
+            var expectedPage = io.gravitee.apim.core.documentation.model.Page
+                .builder()
+                .id(PAGE_ID)
+                .referenceId(API_ID)
+                .referenceType(io.gravitee.apim.core.documentation.model.Page.ReferenceType.API)
+                .name(repositoryPage.getName())
+                .build();
+
             givenMatchingPages(
                 new PageCriteria.Builder()
                     .referenceId(API_ID)
@@ -140,7 +148,7 @@ class PageQueryServiceImplTest {
                     .parent(PARENT_ID)
                     .type("MARKDOWN")
                     .name("duplicate name"),
-                List.of(page)
+                List.of(repositoryPage)
             );
 
             var res = service.findByApiIdAndParentIdAndNameAndType(
@@ -150,7 +158,7 @@ class PageQueryServiceImplTest {
                 io.gravitee.apim.core.documentation.model.Page.Type.MARKDOWN
             );
 
-            assertThat(res.get()).usingRecursiveComparison().isEqualTo(page);
+            assertThat(res.get()).usingRecursiveComparison().isEqualTo(expectedPage);
         }
 
         @Test
@@ -159,7 +167,15 @@ class PageQueryServiceImplTest {
             String PARENT_ID = null;
             String PAGE_ID = "page-id";
 
-            var page = aPage(API_ID, PAGE_ID, "duplicate name");
+            var repositoryPage = aPage(API_ID, PAGE_ID, "duplicate name");
+            var expectedPage = io.gravitee.apim.core.documentation.model.Page
+                .builder()
+                .id(PAGE_ID)
+                .referenceId(API_ID)
+                .referenceType(io.gravitee.apim.core.documentation.model.Page.ReferenceType.API)
+                .name(repositoryPage.getName())
+                .build();
+
             givenMatchingPages(
                 new PageCriteria.Builder()
                     .referenceId(API_ID)
@@ -167,7 +183,7 @@ class PageQueryServiceImplTest {
                     .rootParent(true)
                     .type("MARKDOWN")
                     .name("duplicate name"),
-                List.of(page)
+                List.of(repositoryPage)
             );
 
             var res = service.findByApiIdAndParentIdAndNameAndType(
@@ -177,7 +193,7 @@ class PageQueryServiceImplTest {
                 io.gravitee.apim.core.documentation.model.Page.Type.MARKDOWN
             );
 
-            assertThat(res.get()).usingRecursiveComparison().isEqualTo(page);
+            assertThat(res.get()).usingRecursiveComparison().isEqualTo(expectedPage);
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3103

## Description

- For MAPI v2 -- Return page with a boolean: `hidden` to indicate if it should not appear on Portal
- For Portal -- Do not return folders if there are no published children

Next step: 
- Console -- Add badge if a folder is not shown on the Portal -- https://github.com/gravitee-io/gravitee-api-management/pull/5788

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

