### PR TITLE
feat(helm): improve metrics configuration in helm charts

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.2.0
+
+- Add unknownExpireAfter in management-api configuration
+- Allow users to define extra manifests
+- Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.
+- "fix 'gravitee.yml' > 'services.metrics' definition from helm `values.yaml`"
+
 ### 4.1.0
 
 - Avoid empty user when disabling admin user

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -19,13 +19,7 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
-    - Avoid empty user when disabling admin user
-    - Add revision history limit on portal
-    - Add podSecurityContext
-    - Add support for DB less mode on gateway
-    - Add nodePort value to all services
-    - Remove smtp default example values
-    - Allow wildcard in ingress host
     - Add unknownExpireAfter in management-api configuration
     - Allow users to define extra manifests
     - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.
+    - "fix 'gravitee.yml' > 'services.metrics' definition from helm `values.yaml`"

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -147,8 +147,8 @@ data:
           {{- end }}
       {{- end }}
 
-      {{- if .Values.api.services.metrics.enabled }}
-      metrics: {{- toYaml .Values.api.services.metrics | nindent 10 }}
+      {{- if .Values.api.services.metrics }}
+      metrics: {{- toYaml .Values.api.services.metrics | nindent 8 }}
       {{- end }}
       {{- if .Values.api.services.subscription.enabled }}
       subscription:

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -373,8 +373,8 @@ data:
           {{- end }}
       {{- end }}
 
-      {{- if .Values.gateway.services.metrics.enabled }}
-      metrics: {{- toYaml .Values.gateway.services.metrics | nindent 10 }}
+      {{- if .Values.gateway.services.metrics }}
+      metrics: {{- toYaml .Values.gateway.services.metrics | nindent 8 }}
       {{- end }}
 
       {{- if .Values.gateway.services.tracing.enabled }}

--- a/helm/tests/api/configmap_metrics_test.yaml
+++ b/helm/tests/api/configmap_metrics_test.yaml
@@ -5,9 +5,12 @@ tests:
   - it: Disable metrics service by default
     template: api/api-configmap.yaml
     asserts:
-      - notMatchRegex:
+      - matchRegex:
           path: data.[gravitee.yml]
-          pattern: "metrics:\n"
+          pattern: " *metrics:\n
+                     *  enabled: false\n
+                     *  prometheus:\n
+                     *    enabled: true"
   - it: Enable metrics service and set `labels`
     template: api/api-configmap.yaml
     set:

--- a/helm/tests/gateway/configmap_metrics_test.yaml
+++ b/helm/tests/gateway/configmap_metrics_test.yaml
@@ -5,9 +5,12 @@ tests:
   - it: Disable metrics service by default
     template: gateway/gateway-configmap.yaml
     asserts:
-      - notMatchRegex:
+      - matchRegex:
           path: data.[gravitee.yml]
-          pattern: "metrics:\n"
+          pattern: " *metrics:\n
+                     *  enabled: false\n
+                     *  prometheus:\n
+                     *    enabled: true"
   - it: Enable metrics service and set `labels`
     template: gateway/gateway-configmap.yaml
     set:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/DEVOPS-52

## Description

Now, when defined, we use the full definition of
`.Values.gateway.services.metrics` as it is in helm `values.yml`.

Same for `.Values.api.services.metrics`.

This made update from `gravitee.yml` easier to map from `values.yml`.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gvovvyylbb.chromatic.com)
<!-- Storybook placeholder end -->
