### PR TITLE
Apim 3103 console -- publish folder + handle if hidden

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
@@ -40,6 +40,7 @@ export interface Page {
   parentId?: string;
   parentPath?: string;
   contentRevision?: Revision;
+  hidden?: boolean;
 }
 
 export interface Breadcrumb {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
@@ -107,7 +107,10 @@ describe('ApiDocumentationV4', () => {
   describe('API has pages', () => {
     it('should show list of folders', async () => {
       await init(
-        [fakeFolder({ name: 'my first folder', visibility: 'PUBLIC' }), fakeFolder({ name: 'my private folder', visibility: 'PRIVATE' })],
+        [
+          fakeFolder({ name: 'my first folder', visibility: 'PUBLIC', hidden: false }),
+          fakeFolder({ name: 'my private folder', visibility: 'PRIVATE', hidden: true }),
+        ],
         [],
       );
 
@@ -116,6 +119,8 @@ describe('ApiDocumentationV4', () => {
       expect(await pageListHarness.getNameByRowIndex(1)).toEqual('my private folder');
       expect(await pageListHarness.getVisibilityByRowIndex(0)).toEqual('Public');
       expect(await pageListHarness.getVisibilityByRowIndex(1)).toEqual('Private');
+      expect(await pageListHarness.getStatusByRowIndex(0)).toEqual('');
+      expect(await pageListHarness.getStatusByRowIndex(1)).toEqual('Hidden');
     });
 
     it('should navigate to create page', async () => {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
@@ -152,7 +152,7 @@ describe('ApiDocumentationV4', () => {
       await dialogHarness.selectVisibility('PRIVATE');
       await dialogHarness.clickOnSave();
 
-      const page: Page = { type: 'FOLDER', name: 'folder', visibility: 'PRIVATE' };
+      const page: Page = { type: 'FOLDER', name: 'folder', visibility: 'PRIVATE', published: false };
       const req = httpTestingController.expectOne({
         method: 'POST',
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages`,
@@ -164,6 +164,15 @@ describe('ApiDocumentationV4', () => {
         visibility: 'PRIVATE',
         parentId: 'ROOT',
       });
+
+      page.published = true;
+
+      httpTestingController
+        .expectOne({
+          method: 'POST',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages/${page.id}/_publish`,
+        })
+        .flush(page);
 
       expectGetPages([page], []);
     });
@@ -178,7 +187,7 @@ describe('ApiDocumentationV4', () => {
       await dialogHarness.setName('subfolder');
       await dialogHarness.clickOnSave();
 
-      const page: Page = { type: 'FOLDER', name: 'subfolder', visibility: 'PUBLIC' };
+      const page: Page = { type: 'FOLDER', name: 'subfolder', visibility: 'PUBLIC', parentId: 'parent-folder-id', published: false };
       const req = httpTestingController.expectOne({
         method: 'POST',
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages`,
@@ -190,6 +199,15 @@ describe('ApiDocumentationV4', () => {
         visibility: 'PUBLIC',
         parentId: 'parent-folder-id',
       });
+
+      page.published = true;
+
+      httpTestingController
+        .expectOne({
+          method: 'POST',
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages/${page.id}/_publish`,
+        })
+        .flush(page);
 
       expectGetPages([page], [], 'parent-folder-id');
     });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -79,6 +79,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
             parentId: this.parentId,
           }),
         ),
+        switchMap((createdFolder) => this.apiDocumentationV2Service.publishDocumentationPage(this.ajsStateParams.apiId, createdFolder.id)),
         takeUntil(this.unsubscribe$),
       )
       .subscribe({

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
@@ -28,6 +28,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { MarkdownModule } from 'ngx-markdown';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { ApiDocumentationV4EmptyStateComponent } from './components/documentation-empty-state/api-documentation-v4-empty-state.component';
 import { ApiDocumentationV4ListNavigationHeaderComponent } from './components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component';
@@ -77,6 +78,7 @@ import { ApiDocumentationV4BreadcrumbComponent } from './components/api-document
     MatTableModule,
     MatSnackBarModule,
     MarkdownModule.forRoot(),
+    MatTooltipModule,
   ],
 })
 export class ApiDocumentationV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -42,6 +42,16 @@
           <span *ngIf="page.published" class="gio-badge-success"> Published </span>
           <span *ngIf="!page.published" class="gio-badge-neutral"> Unpublished </span>
         </ng-container>
+        <ng-container *ngIf="page.type === 'FOLDER'">
+          <span
+            *ngIf="page.hidden"
+            class="gio-badge-neutral"
+            matTooltip="Must contain published pages to be shown"
+            matTooltipPosition="after"
+          >
+            Hidden
+          </span>
+        </ng-container>
       </td>
     </ng-container>
     <ng-container matColumnDef="visibility">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
@@ -39,6 +39,10 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
     return this.getColumnTextByIndex('visibility', idx);
   }
 
+  public getStatusByRowIndex(idx: number): Promise<string> {
+    return this.getColumnTextByIndex('status', idx);
+  }
+
   public async clickAddNewPage() {
     return this.addNewPageButtonLocator().then((btn) => btn.click());
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3103

## Description

Waiting for backend PR: https://github.com/gravitee-io/gravitee-api-management/pull/5783

- Add badge `Hidden` to folders that do not appear on Portal

![Screenshot 2023-11-08 at 16 20 39](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/60568acd-86ff-437c-93d4-e720fe2acadc)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ffabejxlmy.chromatic.com)
<!-- Storybook placeholder end -->
