### PR TITLE
Look only for the latest event when deploying an API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
@@ -95,30 +95,5 @@ public interface EventService {
         final List<String> environments
     );
 
-    <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        final List<String> environmentsIds
-    );
-
-    <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        Predicate<T> filter,
-        final List<String> environmentsIds
-    );
-
     Collection<EventEntity> search(ExecutionContext executionContext, EventQuery query);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
@@ -345,43 +345,6 @@ public class EventServiceImpl extends TransactionalService implements EventServi
     }
 
     @Override
-    public <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        final List<String> environmentsIds
-    ) {
-        return search(executionContext, eventTypes, properties, from, to, page, size, mapper, (T t) -> true, environmentsIds);
-    }
-
-    @Override
-    public <T> Page<T> search(
-        ExecutionContext executionContext,
-        List<EventType> eventTypes,
-        Map<String, Object> properties,
-        long from,
-        long to,
-        int page,
-        int size,
-        Function<EventEntity, T> mapper,
-        Predicate<T> filter,
-        final List<String> environmentsIds
-    ) {
-        Page<EventEntity> result = search(executionContext, eventTypes, properties, from, to, page, size, environmentsIds);
-        return new Page<>(
-            result.getContent().stream().map(mapper).filter(filter).collect(Collectors.toList()),
-            page,
-            size,
-            result.getTotalElements()
-        );
-    }
-
-    @Override
     public Collection<EventEntity> search(ExecutionContext executionContext, final EventQuery query) {
         LOGGER.debug("Search APIs by {}", query);
         return convert(executionContext, eventRepository.search(queryToCriteria(executionContext, query).build()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
@@ -414,69 +414,6 @@ public class EventServiceTest {
     }
 
     @Test
-    public void shouldFilterEvent() throws TechnicalException {
-        when(eventRepository.search(any(), any()))
-            .thenReturn(
-                new Page<>(
-                    Arrays.asList(
-                        generateInstanceEvent("evt1", false),
-                        generateInstanceEvent("evt2", true),
-                        generateInstanceEvent("evt3", true),
-                        generateInstanceEvent("evt4", false),
-                        generateInstanceEvent("evt5", true)
-                    ),
-                    1,
-                    5,
-                    5
-                )
-            );
-
-        // test without predicate
-        Page<Map<String, String>> page = eventService.search(
-            GraviteeContext.getExecutionContext(),
-            List.of(io.gravitee.rest.api.model.EventType.GATEWAY_STARTED),
-            Collections.EMPTY_MAP,
-            0,
-            0,
-            1,
-            10,
-            evt -> {
-                Map<String, String> map = new HashMap<>();
-                map.put("id", evt.getId());
-                map.put("state", evt.getType().name());
-                return map;
-            },
-            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
-        );
-        assertNotNull(page);
-        assertNotNull(page.getContent());
-        assertEquals(5, page.getContent().size());
-
-        // test with predicate
-        page =
-            eventService.search(
-                GraviteeContext.getExecutionContext(),
-                List.of(io.gravitee.rest.api.model.EventType.GATEWAY_STARTED),
-                Collections.EMPTY_MAP,
-                0,
-                0,
-                1,
-                10,
-                evt -> {
-                    Map<String, String> map = new HashMap<>();
-                    map.put("id", evt.getId());
-                    map.put("state", evt.getType().name());
-                    return map;
-                },
-                map -> !map.get("state").equals(io.gravitee.rest.api.model.EventType.GATEWAY_STOPPED.name()),
-                Collections.singletonList(GraviteeContext.getCurrentEnvironment())
-            );
-        assertNotNull(page);
-        assertNotNull(page.getContent());
-        assertEquals(3, page.getContent().size());
-    }
-
-    @Test
     public void createDebugApiEvent_shouldCreateEvent_withoutPayload() throws TechnicalException {
         when(eventRepository.create(any())).thenAnswer(i -> i.getArguments()[0]);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -20,14 +20,11 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,6 +32,7 @@ import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.EventLatestRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.Event;
@@ -53,7 +51,6 @@ import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiNotificationService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
-import io.gravitee.rest.api.service.v4.ApiService;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
@@ -66,8 +63,6 @@ import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apiguardian.api.API;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -113,6 +108,9 @@ public class ApiStateServiceImplTest {
 
     @Mock
     private EventService eventService;
+
+    @Mock
+    private EventLatestRepository eventLatestRepository;
 
     @Mock
     private FlowService flowService;
@@ -185,6 +183,7 @@ public class ApiStateServiceImplTest {
                 primaryOwnerService,
                 auditService,
                 eventService,
+                eventLatestRepository,
                 objectMapper,
                 apiMetadataService,
                 apiValidationService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -31,9 +31,8 @@ import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.api.EventLatestRepository;
 import io.gravitee.rest.api.model.EventEntity;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -42,17 +41,14 @@ import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
-import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.*;
-import io.gravitee.rest.api.service.v4.ApiService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
 import io.gravitee.rest.api.service.v4.mapper.CategoryMapper;
 import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
-import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -97,6 +93,9 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
 
     @Mock
     private EventService eventService;
+
+    @Mock
+    private EventLatestRepository eventLatestRepository;
 
     @Mock
     private FlowService flowService;
@@ -172,6 +171,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
                 primaryOwnerService,
                 auditService,
                 eventService,
+                eventLatestRepository,
                 objectMapper,
                 apiMetadataService,
                 apiValidationService,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3193
https://github.com/gravitee-io/issues/issues/9364

## Description

Same as https://github.com/gravitee-io/gravitee-api-management/pull/5746 but on 4.0.x

Look only for the latest event when deploying an API.

Also did some cleaning in the EventService interface
