### PR TITLE
Bump `gravitee-policy-generate-jwt` to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <gravitee-policy-callout-http.version>2.0.1</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.3</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>
-        <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>
+        <gravitee-policy-generate-jwt.version>1.7.1</gravitee-policy-generate-jwt.version>
         <gravitee-policy-groovy.version>2.4.1</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.5.0</gravitee-policy-http-signature.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3245

## Description

Bump `gravitee-policy-generate-jwt` to 1.7.1
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xkaxxtfvjz.chromatic.com)
<!-- Storybook placeholder end -->
