### PR TITLE
Bump gravitee-policy-generate-jwt to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <gravitee-policy-data-logging-masking.version>3.1.0</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.12.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.2.1</gravitee-policy-generate-http-signature.version>
-        <gravitee-policy-generate-jwt.version>1.6.1</gravitee-policy-generate-jwt.version>
+        <gravitee-policy-generate-jwt.version>1.7.1</gravitee-policy-generate-jwt.version>
         <gravitee-policy-geoip-filtering.version>2.0.2</gravitee-policy-geoip-filtering.version>
         <gravitee-policy-groovy.version>2.5.2</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.2</gravitee-policy-html-json.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3245

## Description

Bump `gravitee-policy-generate-jwt` to 1.7.1