### PR TITLE
fix: ignore empty argument

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
@@ -161,14 +161,16 @@ public class Bootstrap {
 
         try {
             for (String arg : args) {
-                String[] argument = arg.split("=");
-                if (argument.length != 2) {
-                    throw new RuntimeException(String.format("Wrong argument was passed %s", arg));
-                } else {
-                    if (argument[0].startsWith("--")) {
-                        argument[0] = argument[0].substring(2);
+                if (arg != null && !arg.isEmpty()) {
+                    String[] argument = arg.split("=");
+                    if (argument.length != 2) {
+                        throw new RuntimeException(String.format("Wrong argument was passed %s", arg));
+                    } else {
+                        if (argument[0].startsWith("--")) {
+                            argument[0] = argument[0].substring(2);
+                        }
+                        System.getProperties().put(argument[0], argument[1]);
                     }
-                    System.getProperties().put(argument[0], argument[1]);
                 }
             }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3146

## Description

With windows, when using `gravitee.bat` to start APIM Rest API, an empty argument is added. We should ignore it.

Note: CI is skipped because this part of the code is not used in the build & test process.