### PR TITLE
ci: fix openjdk image version to 17.0.8 [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1554,6 +1554,7 @@ jobs:
     job-package-bundle:
         executor:
             name: openjdk
+            version: 17.0.8
             with_node: true
         environment:
             RELEASE_VERSION: << pipeline.parameters.graviteeio_version >>


### PR DESCRIPTION
## Issue

N/A

## Description

Starting from 17.0.9, node version included in the image becomes 20.9.0, which breaks the package bundle job.
