### PR TITLE
ci: fix openjdk image version to 17.0.8 [skip ci]

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -52,7 +52,7 @@ const executor = {
   },
   openjdk: {
     image: 'cimg/openjdk',
-    version: '17.0',
+    version: '17.0.8', // starting with 17.0.9, node version becomes 20.9.0, which breaks the build.
   },
   node: {
     image: 'cimg/node',

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -122,7 +122,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -138,7 +138,7 @@ jobs:
           jobName: job-validate
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -172,7 +172,7 @@ jobs:
             - ./gateway-docker-context
   job-e2e-generate-sdk:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: small
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
             git push --tags  origin 4.2.x
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:
@@ -579,7 +579,7 @@ jobs:
             }
   job-nexus-staging:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
             git push --tags --dry-run origin 4.2.x
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:
@@ -565,7 +565,7 @@ jobs:
           working_directory: ./release
   job-nexus-staging:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
             git push --tags  origin 4.2.x
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:
@@ -579,7 +579,7 @@ jobs:
             }
   job-nexus-staging:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -373,7 +373,7 @@ jobs:
             git push --tags  origin 4.2.x
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:
@@ -579,7 +579,7 @@ jobs:
             }
   job-nexus-staging:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
@@ -85,7 +85,7 @@ jobs:
             - .gravitee.settings.xml
   job-nexus-staging:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: xlarge
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-dry-run.yml
@@ -28,7 +28,7 @@ parameters:
 jobs:
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-prerelease-no-dry-run.yml
@@ -28,7 +28,7 @@ parameters:
 jobs:
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-dry-run.yml
@@ -28,7 +28,7 @@ parameters:
 jobs:
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:

--- a/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/package-bundle/package-bundle-release-no-dry-run.yml
@@ -28,7 +28,7 @@ parameters:
 jobs:
   job-package-bundle:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: medium
     steps:
       - keeper/env-export:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -183,7 +183,7 @@ jobs:
             - .gravitee.settings.xml
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -217,7 +217,7 @@ jobs:
             - ./gateway-docker-context
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -150,7 +150,7 @@ jobs:
             - .gravitee.settings.xml
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -184,7 +184,7 @@ jobs:
             - ./gateway-docker-context
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -183,7 +183,7 @@ jobs:
             - .gravitee.settings.xml
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -217,7 +217,7 @@ jobs:
             - ./gateway-docker-context
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -202,7 +202,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -230,7 +230,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -264,7 +264,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -295,7 +295,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -346,7 +346,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -689,7 +689,7 @@ jobs:
       - cmd-notify-on-failure
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -727,7 +727,7 @@ jobs:
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: small
     steps:
       - checkout
@@ -869,7 +869,7 @@ jobs:
       - cmd-notify-on-failure
   job-community-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -901,7 +901,7 @@ jobs:
           working_directory: ./helm
   job-publish-on-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -917,7 +917,7 @@ jobs:
           jobName: job-publish-on-artifactory
   job-publish-on-nexus:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -83,7 +83,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -111,7 +111,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -145,7 +145,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -176,7 +176,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -227,7 +227,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -169,7 +169,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -197,7 +197,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -231,7 +231,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -262,7 +262,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -313,7 +313,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -202,7 +202,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -230,7 +230,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -264,7 +264,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -295,7 +295,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -346,7 +346,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -689,7 +689,7 @@ jobs:
       - cmd-notify-on-failure
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -727,7 +727,7 @@ jobs:
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: small
     steps:
       - checkout
@@ -869,7 +869,7 @@ jobs:
       - cmd-notify-on-failure
   job-community-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -901,7 +901,7 @@ jobs:
           working_directory: ./helm
   job-publish-on-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -917,7 +917,7 @@ jobs:
           jobName: job-publish-on-artifactory
   job-publish-on-nexus:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -169,7 +169,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -197,7 +197,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -231,7 +231,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -262,7 +262,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -313,7 +313,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -169,7 +169,7 @@ jobs:
             - .gravitee.settings.xml
   job-validate:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -197,7 +197,7 @@ jobs:
           command: cd .circleci/danger && yarn run danger
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout
@@ -231,7 +231,7 @@ jobs:
             - ./gateway-docker-context
   job-test-definition:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -262,7 +262,7 @@ jobs:
             - gravitee-apim-definition/gravitee-apim-definition-coverage/target/site/jacoco-aggregate/
   job-test-gateway:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -313,7 +313,7 @@ jobs:
     parallelism: 4
   job-test-rest-api:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: small
     steps:
       - checkout
@@ -664,7 +664,7 @@ jobs:
           command: echo "Congratulations! If you can read this, everything is OK"
   job-build-images:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: medium
     steps:
       - checkout
@@ -687,7 +687,7 @@ jobs:
       - cmd-docker-azure-logout
   job-e2e-generate-sdk:
     docker:
-      - image: cimg/openjdk:17.0-node
+      - image: cimg/openjdk:17.0.8-node
     resource_class: small
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -294,7 +294,7 @@ jobs:
       ARTIFACTORY_URL: https://odbxikk7vo-artifactory.services.clever-cloud.com
   job-backend-build-and-publish-artifactory:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -83,7 +83,7 @@ jobs:
             - .gravitee.settings.xml
   job-build:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/openjdk:17.0.8
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
## Issue

N/A

## Description

Starting from 17.0.9, node version included in the image becomes 20.9.0, which breaks the package bundle job.
