### PR TITLE
fix: we should allow verification for update permission

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -403,7 +403,9 @@ public class ApisResource extends AbstractResource {
         content = @Content(mediaType = "text/plain", schema = @Schema(type = "string"))
     )
     @ApiResponse(responseCode = "400", description = "API already exist with the following criteria")
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE) })
+    @Permissions(
+        { @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.CREATE, RolePermissionAction.UPDATE }) }
+    )
     public Response verifyApi(@Valid VerifyApiParam verifyApiParam) {
         // TODO : create verify service to query repository with criteria
         virtualHostService.sanitizeAndValidate(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3264

## Description

When a user as only the right to update an API, he should still be able to verify that the contextPath is not already use when he wants to change it.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hwfswvotzh.chromatic.com)
<!-- Storybook placeholder end -->
