### PR TITLE
add methods filter in API logs page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/apiLogsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/apiLogsResponse.ts
@@ -26,6 +26,7 @@ export interface ApiLogsParam {
   to?: number;
   applicationIds?: string;
   planIds?: string;
+  methods?: string;
 }
 
 export interface ApiLogsResponse {

--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -1439,7 +1439,7 @@ export const states: Ng2StateDeclaration[] = [
   },
   {
     name: 'management.apis.runtimeLogs',
-    url: '/runtime-logs?page&perPage&from&to&applicationIds&planIds',
+    url: '/runtime-logs?page&perPage&from&to&applicationIds&planIds&methods',
     data: {
       apiPermissions: {
         only: ['api-log-r'],
@@ -1473,6 +1473,10 @@ export const states: Ng2StateDeclaration[] = [
         dynamic: true,
       },
       planIds: {
+        type: 'string',
+        dynamic: true,
+      },
+      methods: {
         type: 'string',
         dynamic: true,
       },

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.harness.ts
@@ -241,4 +241,32 @@ export class ApiRuntimeLogsHarness extends ComponentHarness {
   async moreFiltersPeriodText() {
     return this.selectPeriodFromMoreFilters().then((select) => select.getValueText());
   }
+
+  async getSelectedMethods() {
+    return this.quickFiltersHarness()
+      .then((harness) => harness.getMethodsSelect())
+      .then((select) => select.getValueText());
+  }
+
+  async selectMethod(text: string) {
+    return this.quickFiltersHarness()
+      .then((harness) => harness.getMethodsSelect())
+      .then((select) => select.clickOptions({ text }));
+  }
+
+  async getMethodsChip() {
+    return this.quickFiltersHarness().then((harness) => harness.getMethodsChip());
+  }
+
+  async getMethodsChipText() {
+    return this.quickFiltersHarness()
+      .then((harness) => harness.getMethodsChip())
+      .then((chip) => chip.getText());
+  }
+
+  async removeMethodsChip() {
+    return this.getMethodsChip()
+      .then((chip) => chip.getRemoveButton())
+      .then((button) => button.click());
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/api-runtime-logs.component.ts
@@ -140,6 +140,7 @@ export class ApiRuntimeLogsComponent implements OnInit, OnDestroy {
               }) ?? undefined,
             from: this.ajsStateParams.from ? moment(this.ajsStateParams.from) : undefined,
             to: this.ajsStateParams.to ? moment(this.ajsStateParams.to) : undefined,
+            methods: this.ajsStateParams.methods?.split(',') ?? undefined,
           };
         }),
       )

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.html
@@ -25,6 +25,13 @@
         </mat-select>
       </mat-form-field>
 
+      <mat-form-field class="quick-filters__methods">
+        <mat-label>HTTP methods</mat-label>
+        <mat-select formControlName="methods" aria-label="Methods selection" [multiple]="true">
+          <mat-option *ngFor="let httpMethod of httpMethods" [value]="httpMethod">{{ httpMethod }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+
       <applications-filter
         formControlName="applications"
         class="quick-filters__applications"
@@ -47,7 +54,7 @@
           (applyMoreFiltersEvent)="applyMoreFilters($event)"
         ></api-runtime-logs-more-filters>
         <button mat-stroked-button type="button" class="action__button" [disabled]="loading" (click)="showMoreFilters = true">
-          <mat-icon svgIcon="gio:filter"></mat-icon> More
+          <mat-icon svgIcon="gio:filter"></mat-icon>More
         </button>
       </div>
       <div class="action">

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.scss
@@ -21,17 +21,28 @@ $typography: map.get(gio.$mat-theme, typography);
   &__selectors {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
   }
 
-  &__period,
   &__applications,
   &__plans {
     padding: 0;
     margin-right: 16px;
   }
 
+  &__period,
+  &__methods {
+    display: inline;
+    width: 132px;
+    padding: 0;
+    margin-right: 16px;
+  }
+
   .action {
-    margin-top: 0.25em;
+    // here we align the padding and margin of the button to angular mat-form-fields
+    padding-bottom: 1.34em;
+    margin: 0.25em 0;
+
     &__button {
       height: 48px;
       margin-right: 16px;

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
@@ -52,6 +52,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
 
   readonly periods = PERIODS;
   readonly defaultFilters = DEFAULT_FILTERS;
+  readonly httpMethods = ['CONNECT', 'DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'];
   isFiltering = false;
   quickFiltersForm: FormGroup;
   applicationsCache: CacheEntry[];
@@ -75,6 +76,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
         disabled: true,
       }),
       plans: new FormControl({ value: this.initialValues.plans?.map((plan) => plan.value) ?? DEFAULT_FILTERS.plans, disabled: true }),
+      methods: new FormControl({ value: this.initialValues.methods, disabled: true }),
     });
     this.onValuesChanges();
   }
@@ -132,7 +134,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
       if (values.period && values.period === DEFAULT_PERIOD) {
         this.moreFiltersValues = { ...this.moreFiltersValues, period: values.period };
       } else {
-        this.moreFiltersValues = { period: values.period, from: null, to: null };
+        this.moreFiltersValues = { ...this.moreFiltersValues, period: values.period, from: null, to: null };
       }
       this.quickFilterStore.next(this.mapFormValues(values, this.moreFiltersValues));
       this.currentFilters = this.quickFilterStore.getFilters();
@@ -147,11 +149,12 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
     };
   }
 
-  private mapQuickFiltersFormValues({ period, applications, plans }: LogFiltersForm) {
+  private mapQuickFiltersFormValues({ period, applications, plans, methods }: LogFiltersForm) {
     return {
       period,
       plans: this.plansFromValues(plans),
       applications: this.applicationsFromValues(applications),
+      methods,
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.harness.ts
@@ -36,6 +36,8 @@ export class ApiRuntimeLogsQuickFiltersHarness extends ComponentHarness {
   public getMoreButton = this.locatorFor(MatButtonHarness.with({ text: /More/ }));
   public getFromChip = this.locatorFor(MatChipHarness.with({ text: /^from:/ }));
   public getToChip = this.locatorFor(MatChipHarness.with({ text: /^to:/ }));
+  public getMethodsSelect = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="methods"]' }));
+  public getMethodsChip = this.locatorFor(MatChipHarness.with({ text: /^methods:/ }));
 
   public async getApplicationAutocomplete() {
     const applicationFormField = await this.getApplicationFormField();

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/pipes/chip-value.pipe.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/pipes/chip-value.pipe.spec.ts
@@ -32,4 +32,10 @@ describe('ChipValuePipe', () => {
       ]),
     ).toStrictEqual('foo, bar');
   });
+
+  it("should join values when it's a string array", () => {
+    const pipe = new ChipValuePipe();
+
+    expect(pipe.transform(['foo', 'bar'])).toStrictEqual('foo, bar');
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/pipes/chip-value.pipe.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/components/api-runtime-logs-quick-filters/pipes/chip-value.pipe.ts
@@ -19,7 +19,16 @@ import { MultiFilter, SimpleFilter } from '../../../models';
 
 @Pipe({ name: 'chipValue' })
 export class ChipValuePipe implements PipeTransform {
-  transform(filter: SimpleFilter | MultiFilter): string {
-    return Array.isArray(filter) ? filter.map((value) => value.label)?.join(', ') : filter.label;
+  transform(filter: SimpleFilter | MultiFilter | string[]): string {
+    return Array.isArray(filter)
+      ? filter
+          .map((value) => {
+            if (value.label) {
+              return value.label;
+            }
+            return value;
+          })
+          ?.join(', ')
+      : filter.label;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
@@ -30,9 +30,10 @@ export type LogFilters = {
   period?: SimpleFilter;
   applications?: MultiFilter;
   plans?: MultiFilter;
+  methods?: string[];
 };
 
-export type LogFiltersForm = { period: SimpleFilter; applications: string[]; plans: string[] };
+export type LogFiltersForm = { period: SimpleFilter; applications: string[]; plans: string[]; methods: string[] };
 
 export type MoreFiltersForm = { period: SimpleFilter; from: Moment; to: Moment };
 
@@ -41,6 +42,7 @@ export type LogFiltersInitialValues = {
   plans?: MultiFilter;
   from: Moment;
   to: Moment;
+  methods: string[];
 };
 
 export const DEFAULT_PERIOD = { label: 'None', value: '0' };
@@ -64,6 +66,7 @@ export const DEFAULT_FILTERS: LogFilters = {
   plans: undefined,
   from: undefined,
   to: undefined,
+  methods: undefined,
 };
 
 export const DATE_TIME_FORMATS = {

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/services/quick-filters-store.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs/services/quick-filters-store.service.ts
@@ -45,7 +45,8 @@ export class QuickFiltersStoreService {
       from: logFilters.from ? logFilters.from : from,
       to: logFilters.to ? logFilters.to : to,
       applicationIds: logFilters.applications?.length > 0 ? logFilters.applications?.map((app) => app.value).join(',') : null,
-      planIds: logFilters.plans?.length > 0 ? logFilters.plans?.map((app) => app.value).join(',') : null,
+      planIds: logFilters.plans?.length > 0 ? logFilters.plans?.map((plan) => plan.value).join(',') : null,
+      methods: logFilters.methods?.length > 0 ? logFilters.methods?.join(',') : null,
     };
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.spec.ts
@@ -50,6 +50,7 @@ describe('ApiLogsV2Service', () => {
       { queryParams: { applicationIds: '1,2' }, queryURL: '?page=1&perPage=10&applicationIds=1,2' },
       { queryParams: { planIds: '1,2' }, queryURL: '?page=1&perPage=10&planIds=1,2' },
       { queryParams: { applicationIds: '1,2', planIds: '1,2' }, queryURL: '?page=1&perPage=10&applicationIds=1,2&planIds=1,2' },
+      { queryParams: { methods: '1,2' }, queryURL: '?page=1&perPage=10&methods=1,2' },
     ])('call the service with: $queryParams should call API with: $queryURL', ({ queryParams, queryURL }: any, done: jest.DoneCallback) => {
       const fakeResponse: ApiLogsResponse = {
         data: [fakeConnectionLog({ apiId: API_ID })],

--- a/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-logs-v2.service.ts
@@ -47,6 +47,10 @@ export class ApiLogsV2Service {
       params = params.append('planIds', queryParam.planIds);
     }
 
+    if (queryParam?.methods) {
+      params = params.append('methods', queryParam.methods);
+    }
+
     return this.http.get<ApiLogsResponse>(`${this.constants.env.v2BaseURL}/apis/${apiId}/logs`, {
       params,
     });

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/ConnectionLogQuery.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.log.v4.model.connection;
 
+import io.gravitee.common.http.HttpMethod;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
@@ -40,5 +41,6 @@ public class ConnectionLogQuery {
         private Long to;
         private Set<String> applicationIds;
         private Set<String> planIds;
+        private Set<HttpMethod> methods;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.elasticsearch.v4.log.adapter.connection;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLogQuery;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -68,6 +69,10 @@ public class SearchConnectionLogQueryAdapter {
 
         if (!CollectionUtils.isEmpty(filter.getPlanIds())) {
             terms.add(JsonObject.of("terms", JsonObject.of("plan-id", filter.getPlanIds())));
+        }
+
+        if (!CollectionUtils.isEmpty(filter.getMethods())) {
+            terms.add(JsonObject.of("terms", JsonObject.of("http-method", filter.getMethods().stream().map(HttpMethod::code).toList())));
         }
 
         if (!terms.isEmpty()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
@@ -286,6 +286,29 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                     tuple("5fc3b3e5-7aa7-408e-83b3-e57aa7708ed4", today + "T06:54:30.047Z")
                 );
         }
+
+        @Test
+        void should_return_the_connection_logs_for_methods() {
+            var result = logV4Repository.searchConnectionLogs(
+                ConnectionLogQuery
+                    .builder()
+                    .page(1)
+                    .size(10)
+                    .filter(Filter.builder().methods(Set.of(HttpMethod.GET, HttpMethod.POST)).build())
+                    .build()
+            );
+            assertThat(result).isNotNull();
+            assertThat(result.total()).isEqualTo(5);
+            assertThat(result.data())
+                .extracting(ConnectionLog::getRequestId, ConnectionLog::getMethod)
+                .containsExactly(
+                    tuple("8d6d8bd5-bc42-4aea-ad8b-d5bc421aea48", HttpMethod.GET),
+                    tuple("26c61cfc-a4cc-4272-861c-fca4cc2272ab", HttpMethod.POST),
+                    tuple("ebaa9b08-eac8-490d-aa9b-08eac8590d3c", HttpMethod.POST),
+                    tuple("aed3a207-d5c0-4073-93a2-07d5c0007336", HttpMethod.GET),
+                    tuple("3aa93e93-eaa3-4fcd-a93e-93eaa3bfcd41", HttpMethod.GET)
+                );
+        }
     }
 
     @Nested

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchConnectionLogQueryAdapterTest.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.log.adapter.connection;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLogQuery;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -327,6 +328,36 @@ class SearchConnectionLogQueryAdapterTest {
                                  }
                               }
                              """
+            ),
+            Arguments.of(
+                ConnectionLogQuery.Filter.builder().apiId("1").methods(Set.of(HttpMethod.GET, HttpMethod.CONNECT)).build(),
+                """
+                                     {
+                                         "from": 0,
+                                         "size": 20,
+                                         "query": {
+                                             "bool": {
+                                                 "must": [
+                                                     {
+                                                         "term": {
+                                                             "api-id": "1"
+                                                         }
+                                                     },
+                                                     {
+                                                         "terms": {
+                                                             "http-method": [3, 1]
+                                                         }
+                                                     }
+                                                 ]
+                                             }
+                                         },
+                                         "sort": {
+                                             "@timestamp": {
+                                                 "order": "desc"
+                                             }
+                                         }
+                                     }
+                                     """
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/param/SearchLogsParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/param/SearchLogsParam.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api.log.param;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.rest.api.management.v2.rest.resource.api.log.param.validation.IntervalParamConstraint;
 import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.QueryParam;
@@ -29,6 +30,7 @@ public class SearchLogsParam {
     public static final String TO_QUERY_PARAM_NAME = "to";
     public static final String APPLICATION_IDS_QUERY_PARAM_NAME = "applicationIds";
     public static final String PLAN_IDS_QUERY_PARAM_NAME = "planIds";
+    public static final String METHODS_QUERY_PARAM_NAME = "methods";
 
     @QueryParam(FROM_QUERY_PARAM_NAME)
     @Min(0)
@@ -43,4 +45,7 @@ public class SearchLogsParam {
 
     @QueryParam(PLAN_IDS_QUERY_PARAM_NAME)
     Set<String> planIds;
+
+    @QueryParam(METHODS_QUERY_PARAM_NAME)
+    Set<HttpMethod> methods;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -1589,6 +1589,7 @@ paths:
                 - $ref: "#/components/parameters/to"
                 - $ref: "#/components/parameters/applicationIds"
                 - $ref: "#/components/parameters/planIds"
+                - $ref: "#/components/parameters/methods"
             tags:
                 - Analytics - Logs
             summary: Get API logs
@@ -6133,6 +6134,15 @@ components:
         planIds:
             name: planIds
             description: List of plan ids to filter on.
+            in: query
+            explode: false
+            schema:
+                type: array
+                items:
+                    type: string
+        methods:
+            name: methods
+            description: List of HTTP request methods to filter on.
             in: query
             explode: false
             schema:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -395,6 +395,47 @@ public class ApiLogsResourceTest extends ApiResourceTest {
                         .build()
                 );
         }
+
+        @Test
+        public void should_return_connection_logs_filtered_by_methods() {
+            connectionLogStorageService.initWith(
+                List.of(
+                    connectionLogFixtures.aConnectionLog("req1").toBuilder().method(io.gravitee.common.http.HttpMethod.POST).build(),
+                    connectionLogFixtures.aConnectionLog("req2").toBuilder().method(io.gravitee.common.http.HttpMethod.GET).build(),
+                    connectionLogFixtures.aConnectionLog("req3").toBuilder().method(io.gravitee.common.http.HttpMethod.POST).build()
+                )
+            );
+
+            connectionLogsTarget = connectionLogsTarget.queryParam(SearchLogsParam.METHODS_QUERY_PARAM_NAME, HttpMethod.GET);
+            final Response response = connectionLogsTarget.request().get();
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ApiLogsResponse.class)
+                .isEqualTo(
+                    ApiLogsResponse
+                        .builder()
+                        .data(
+                            List.of(
+                                ApiLog
+                                    .builder()
+                                    .application(BaseApplication.builder().id("app1").name(APPLICATION.getName()).build())
+                                    .plan(BasePlan.builder().id(PLAN_1.getId()).name(PLAN_1.getName()).apiId(API).build())
+                                    .method(HttpMethod.GET)
+                                    .status(200)
+                                    .clientIdentifier("client-identifier")
+                                    .requestEnded(true)
+                                    .transactionId("transaction-id")
+                                    .timestamp(Instant.parse("2020-02-01T20:00:00.00Z").atOffset(ZoneOffset.UTC))
+                                    .requestId("req2")
+                                    .build()
+                            )
+                        )
+                        .pagination(Pagination.builder().page(1).perPage(10).pageCount(1).pageItemsCount(1).totalCount(1L).build())
+                        .links(Links.builder().self(connectionLogsTarget.getUri().toString()).build())
+                        .build()
+                );
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.rest.api.model.analytics;
 
+import io.gravitee.common.http.HttpMethod;
 import java.util.Set;
 import lombok.Builder;
 
 @Builder
-public record SearchLogsFilters(Long from, Long to, Set<String> applicationIds, Set<String> planIds) {}
+public record SearchLogsFilters(Long from, Long to, Set<String> applicationIds, Set<String> planIds, Set<HttpMethod> methods) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -58,6 +58,7 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
                             .to(logsFilters.to())
                             .applicationIds(logsFilters.applicationIds())
                             .planIds(logsFilters.planIds())
+                            .methods(logsFilters.methods())
                             .build()
                     )
                     .page(pageable.getPageNumber())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
@@ -50,6 +50,10 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
             predicate = predicate.and(connectionLog -> logsFilters.planIds().contains(connectionLog.getPlanId()));
         }
 
+        if (!CollectionUtils.isEmpty(logsFilters.methods())) {
+            predicate = predicate.and(connectionLog -> logsFilters.methods().contains(connectionLog.getMethod()));
+        }
+
         var pageNumber = pageable.getPageNumber();
         var pageSize = pageable.getPageSize();
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2481

## Description

Add methods filter in API V4 logs page.


https://github.com/gravitee-io/gravitee-api-management/assets/25704259/90847e71-dbf5-46aa-818a-ad344263e759



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kthhmwtugc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/5833/console](https://pr.team-apim.gravitee.dev/5833/console)
      Portal: [https://pr.team-apim.gravitee.dev/5833/portal](https://pr.team-apim.gravitee.dev/5833/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/5833/api/management](https://pr.team-apim.gravitee.dev/5833/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/5833](https://pr.team-apim.gravitee.dev/5833)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/5833](https://pr.gateway-v3.team-apim.gravitee.dev/5833)

<!-- Environment placeholder end -->
