### PR TITLE
Point to latest documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Download API Management to document, discover, and publish your APIs.
 
 ## 📚 Documentation
 
-You can find Gravitee.io API Management's documentation on the [dedicated website](https://docs.gravitee.io/).
+You can find Gravitee.io API Management's documentation on the [dedicated website](https://documentation.gravitee.io/).
 
 ## 👥 Community
 


### PR DESCRIPTION
The Github readme was pointing to the old (<4.0) documentation website. 

This PR updates the link to point to the new documentation website. 

If this PR makes sense, then I can also do it on the other repositories where it makes sense. 

