### PR TITLE
feat(console): add arrows to change documentation order

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
@@ -17,7 +17,7 @@ import { Visibility } from './visibility';
 import { PageType } from './pageType';
 
 export interface BaseEditDocumentation {
-  type: PageType;
+  type?: PageType;
   name?: string;
   order?: number;
   visibility?: Visibility;

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
@@ -29,6 +29,8 @@
     (onGoToFolder)="navigateTo($event)"
     (onEditPage)="editPage($event)"
     (onEditFolder)="editFolder($event)"
+    (onMoveUp)="moveUp($event)"
+    (onMoveDown)="moveDown($event)"
   ></api-documentation-v4-pages-list>
   <ng-template #emptyState>
     <api-documentation-empty-state (onAddPage)="addPage()"></api-documentation-empty-state>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -146,4 +146,29 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         },
       });
   }
+
+  moveUp(page: Page) {
+    this.changeOrder(page, page.order - 1);
+  }
+
+  moveDown(page: Page) {
+    this.changeOrder(page, page.order + 1);
+  }
+
+  private changeOrder(page: Page, order: number): void {
+    this.apiDocumentationV2Service
+      .updateDocumentationPage(this.ajsStateParams.apiId, page.id, {
+        ...page,
+        order,
+      })
+      .subscribe({
+        next: () => {
+          this.snackBarService.success('Order updated successfully');
+          this.ngOnInit();
+        },
+        error: (error) => {
+          this.snackBarService.error(error?.error?.message ?? 'Error while changing order');
+        },
+      });
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
@@ -425,12 +425,14 @@ describe('ApiDocumentationV4EditPageComponent', () => {
           expect(await saveBtn.isDisabled()).toEqual(false);
           await saveBtn.click();
 
+          expectGetPage(PAGE);
+
           const req = httpTestingController.expectOne({
             method: 'PUT',
             url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages/${PAGE.id}`,
           });
           expect(req.request.body).toEqual({
-            type: 'MARKDOWN',
+            ...PAGE,
             name: 'New name',
             visibility: 'PRIVATE',
             content: 'New content',
@@ -471,13 +473,15 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             expect(await saveBtn.isDisabled()).toEqual(false);
             await saveBtn.click();
 
+            expectGetPage(PAGE);
+
             const req = httpTestingController.expectOne({
               method: 'PUT',
               url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages/${PAGE.id}`,
             });
 
             expect(req.request.body).toEqual({
-              type: 'MARKDOWN',
+              ...PAGE,
               name: 'New name',
               visibility: 'PUBLIC',
               content: PAGE.content,

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -138,19 +138,20 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
 
   private updatePage(): Observable<Page> {
     const formValue = this.form.getRawValue();
-    return this.apiDocumentationService
-      .updateDocumentationPage(this.ajsStateParams.apiId, this.ajsStateParams.pageId, {
-        name: formValue.stepOne.name,
-        visibility: formValue.stepOne.visibility,
-        content: formValue.content,
-        type: this.page.type,
-      })
-      .pipe(
-        catchError((err) => {
-          this.snackBarService.error(err?.error?.message ?? 'Cannot update page');
-          return EMPTY;
+    return this.apiDocumentationService.getApiPage(this.ajsStateParams.apiId, this.ajsStateParams.pageId).pipe(
+      switchMap((page) =>
+        this.apiDocumentationService.updateDocumentationPage(this.ajsStateParams.apiId, this.ajsStateParams.pageId, {
+          ...page,
+          name: formValue.stepOne.name,
+          visibility: formValue.stepOne.visibility,
+          content: formValue.content,
         }),
-      );
+      ),
+      catchError((err) => {
+        this.snackBarService.error(err?.error?.message ?? 'Cannot update page');
+        return EMPTY;
+      }),
+    );
   }
 
   private createPage(): Observable<Page> {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -68,13 +68,19 @@
     </ng-container>
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>Actions</th>
-      <td mat-cell *matCellDef="let page">
+      <td mat-cell *matCellDef="let page; let i = index">
         <div class="documentation-pages-list__table__actions">
           <button *ngIf="page.type === 'FOLDER'" mat-icon-button (click)="onEditFolder.emit(page)" aria-label="Edit folder">
             <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
           </button>
           <button *ngIf="page.type !== 'FOLDER'" mat-icon-button (click)="onEditPage.emit(page.id)" aria-label="Edit page">
             <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+          </button>
+          <button mat-icon-button (click)="onMoveUp.emit(page)" [disabled]="i === 0 || page.order === 0" aria-label="Move page up">
+            <mat-icon svgIcon="gio:arrow-up"></mat-icon>
+          </button>
+          <button mat-icon-button (click)="onMoveDown.emit(page)" [disabled]="i === dataSource.data.length - 1" aria-label="Move page down">
+            <mat-icon svgIcon="gio:arrow-down"></mat-icon>
           </button>
           <button mat-icon-button (click)="onDeletePage.emit(page.id)" disabled="true">
             <mat-icon svgIcon="gio:trash"></mat-icon>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
@@ -43,6 +43,12 @@ export class ApiDocumentationV4PagesListComponent implements OnChanges {
   @Output()
   onEditFolder = new EventEmitter<Page>();
 
+  @Output()
+  onMoveDown = new EventEmitter<Page>();
+
+  @Output()
+  onMoveUp = new EventEmitter<Page>();
+
   public displayedColumns = ['name', 'status', 'visibility', 'lastUpdated', 'actions'];
   public dataSource: MatTableDataSource<Page>;
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
@@ -25,6 +25,8 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
   protected tableLocator = this.locatorFor(MatTableHarness);
   protected addNewPageButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add new page' }));
   protected allEditFolderButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit folder"]' }));
+  protected allMovePageDownButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page down"]' }));
+  protected allMovePageUpButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page up"]' }));
 
   public async getNameDivByRowIndex(idx: number): Promise<DivHarness> {
     const table = await this.tableLocator();
@@ -46,6 +48,14 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
 
   public getEditFolderButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
     return this.allEditFolderButtons().then((buttonList) => buttonList[idx]);
+  }
+
+  public getMovePageDownButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
+    return this.allMovePageDownButtons().then((buttonList) => buttonList[idx]);
+  }
+
+  public getMovePageUpButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
+    return this.allMovePageUpButtons().then((buttonList) => buttonList[idx]);
   }
 
   public async clickAddNewPage() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3248

## Description

Add arrows to change order of docs per parentId

![Screenshot 2023-11-13 at 15 52 37](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/af573b04-a7f2-4090-b429-595fac660174)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ctntwxyszp.chromatic.com)
<!-- Storybook placeholder end -->
