### PR TITLE
APIM 3321 - add publish action to list of pages

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
@@ -29,6 +29,7 @@
     (onGoToFolder)="navigateTo($event)"
     (onEditPage)="editPage($event)"
     (onEditFolder)="editFolder($event)"
+    (onPublishPage)="publishPage($event)"
     (onMoveUp)="moveUp($event)"
     (onMoveDown)="moveDown($event)"
   ></api-documentation-v4-pages-list>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -20,7 +20,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { StateService } from '@uirouter/angularjs';
 import { filter, switchMap, takeUntil } from 'rxjs/operators';
 import { StateParams } from '@uirouter/core';
-import { GIO_DIALOG_WIDTH } from '@gravitee/ui-particles-angular';
+import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 
 import {
   ApiDocumentationV4EditFolderDialog,
@@ -147,6 +147,31 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         },
         error: (error) => {
           this.snackBarService.error(error?.error?.message ?? 'Error while updating folder');
+        },
+      });
+  }
+
+  publishPage(pageId: string) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Publish your page',
+          content: 'Your page will be published to the Portal. Are you sure?',
+          confirmButton: 'Publish',
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirmed) => !!confirmed),
+        switchMap((_) => this.apiDocumentationV2Service.publishDocumentationPage(this.ajsStateParams.apiId, pageId)),
+      )
+      .subscribe({
+        next: (_) => {
+          this.snackBarService.success('Page published successfully');
+          this.ngOnInit();
+        },
+        error: (error) => {
+          this.snackBarService.error(error?.error?.message ?? 'Error while publishing page');
         },
       });
   }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -75,6 +75,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           mode: 'create',
+          existingNames: this.pages.filter((page) => page.type === 'FOLDER').map((page) => page.name.toLowerCase().trim()),
         },
       })
       .afterClosed()
@@ -122,6 +123,9 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
           mode: 'edit',
           name: folder.name,
           visibility: folder.visibility,
+          existingNames: this.pages
+            .filter((page) => page.type === 'FOLDER' && page.id !== folder.id)
+            .map((page) => page.name.toLowerCase().trim()),
         },
       })
       .afterClosed()

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.html
@@ -25,6 +25,8 @@
   <mat-form-field>
     <mat-label>Name</mat-label>
     <input matInput formControlName="name" placeholder="Name" />
+    <mat-error *ngIf="formGroup.controls.name?.errors?.required">Name is required</mat-error>
+    <mat-error *ngIf="formGroup.controls.name?.errors?.unique">Name already exists in this folder</mat-error>
   </mat-form-field>
   <api-documentation-visibility [showSubtitle]="data.mode === 'create'" formControlName="visibility"></api-documentation-visibility>
   <div class="new-folder-form__actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.spec.ts
@@ -68,7 +68,8 @@ describe('ApiDocumentationV4EditFolderDialog', () => {
   };
 
   describe('Create Folder', () => {
-    beforeEach(async () => await init({ mode: 'create' }));
+    const EXISTING_FOLDER = 'folder-1';
+    beforeEach(async () => await init({ mode: 'create', existingNames: [EXISTING_FOLDER] }));
 
     it('should show name input and public / private radio buttons', async () => {
       const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
@@ -86,10 +87,19 @@ describe('ApiDocumentationV4EditFolderDialog', () => {
       await addFolderDialogHarness.getSaveButton().then((btn) => btn.click());
       expect(fixture.componentInstance.result).toEqual({ name: 'folder', visibility: 'PRIVATE' });
     });
+    it('should not allow same name folder', async () => {
+      const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
+      expect(addFolderDialogHarness).toBeDefined();
+      const input = await addFolderDialogHarness.getNameInput();
+      expect(input).toBeDefined();
+      await input.setValue('Folder-1 ');
+
+      expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(true);
+    });
   });
 
   describe('Update Folder', () => {
-    beforeEach(async () => await init({ mode: 'edit', visibility: 'PUBLIC', name: 'folder-name' }));
+    beforeEach(async () => await init({ mode: 'edit', visibility: 'PUBLIC', name: 'folder-name', existingNames: ['existing-folder'] }));
 
     it('should not be able to submit after opening dialog', async () => {
       const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
@@ -121,6 +131,16 @@ describe('ApiDocumentationV4EditFolderDialog', () => {
       expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(true);
     });
 
+    it('should not allow same name as existing page', async () => {
+      const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
+      expect(addFolderDialogHarness).toBeDefined();
+
+      const input = await addFolderDialogHarness.getNameInput();
+      expect(await input.getValue()).toEqual('folder-name');
+      await input.setValue(' Existing-folder ');
+      expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(true);
+    });
+
     it('should update with name change', async () => {
       const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
       expect(addFolderDialogHarness).toBeDefined();
@@ -144,6 +164,27 @@ describe('ApiDocumentationV4EditFolderDialog', () => {
       expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(false);
       await addFolderDialogHarness.getSaveButton().then((btn) => btn.click());
       expect(fixture.componentInstance.result).toEqual({ name: 'folder-name', visibility: 'PRIVATE' });
+    });
+  });
+
+  describe('Empty parent folder', () => {
+    it('should allow creation', async () => {
+      await init({ mode: 'create', existingNames: [] });
+
+      const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
+      const input = await addFolderDialogHarness.getNameInput();
+      await input.setValue('folder');
+
+      expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(false);
+    });
+    it('should allow update', async () => {
+      await init({ mode: 'edit', visibility: 'PUBLIC', name: 'folder-name', existingNames: [] });
+
+      const addFolderDialogHarness = await harnessLoader.getHarness(ApiDocumentationV4EditFolderDialogHarness);
+      const input = await addFolderDialogHarness.getNameInput();
+      await input.setValue('folder');
+
+      expect(await addFolderDialogHarness.getSaveButton().then((btn) => btn.isDisabled())).toEqual(false);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { tap } from 'rxjs/operators';
 
 import { Visibility } from '../../../../../entities/management-api-v2/documentation/visibility';
@@ -24,6 +24,7 @@ export interface ApiDocumentationV4EditFolderDialogData {
   mode: 'create' | 'edit';
   name?: string;
   visibility?: Visibility;
+  existingNames?: string[];
 }
 
 @Component({
@@ -52,7 +53,7 @@ export class ApiDocumentationV4EditFolderDialog implements OnInit {
     this.submitButtonText = this.data.mode === 'create' ? 'Add folder' : 'Save';
 
     this.formGroup = this.formBuilder.group({
-      name: this.formBuilder.control(this.data?.name ?? '', [Validators.required]),
+      name: this.formBuilder.control(this.data?.name ?? '', [Validators.required, this.folderNameUniqueValidator()]),
       visibility: this.formBuilder.control(this.data?.visibility ?? 'PUBLIC', [Validators.required]),
     });
 
@@ -70,5 +71,10 @@ export class ApiDocumentationV4EditFolderDialog implements OnInit {
   }
   cancel() {
     this.dialogRef.close(null);
+  }
+
+  private folderNameUniqueValidator(): ValidatorFn {
+    return (nameControl: AbstractControl): ValidationErrors | null =>
+      this.data.existingNames?.includes(nameControl.value?.toLowerCase().trim()) ? { unique: true } : null;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -39,6 +39,8 @@
               <mat-form-field>
                 <mat-label>Name</mat-label>
                 <input matInput formControlName="name" placeholder="Name" autofocus />
+                <mat-error *ngIf="stepOneForm.controls.name?.errors?.required">Name is required</mat-error>
+                <mat-error *ngIf="stepOneForm.controls.name?.errors?.unique">Name already exists in this folder</mat-error>
               </mat-form-field>
               <api-documentation-visibility formControlName="visibility"></api-documentation-visibility>
             </form>
@@ -82,6 +84,7 @@
           <div class="stepper__content">
             <ng-container>
               <api-documentation-content formControlName="content" [published]="page?.published"></api-documentation-content>
+              <mat-error *ngIf="stepOneForm.controls.content?.errors?.required">Page content cannot be empty</mat-error>
             </ng-container>
           </div>
           <div class="stepper__actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
@@ -97,9 +97,11 @@ describe('ApiDocumentationV4EditPageComponent', () => {
 
   describe('Create page', () => {
     describe('In the root folder of the API', () => {
+      const EXISTING_PAGE = fakeMarkdown({ id: 'page-id', name: 'page-name' });
+
       beforeEach(async () => {
         await init('ROOT', undefined);
-        initPageServiceRequests({ pages: [], breadcrumb: [], parentId: 'ROOT' });
+        initPageServiceRequests({ pages: [EXISTING_PAGE], breadcrumb: [], parentId: 'ROOT' });
       });
 
       it('should have 3 steps', async () => {
@@ -144,6 +146,12 @@ describe('ApiDocumentationV4EditPageComponent', () => {
           });
 
           expect(getPageTitle()).toEqual('New page');
+        });
+
+        it('should not allow duplicate name', async () => {
+          const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiDocumentationV4EditPageHarness);
+          await harness.setName(EXISTING_PAGE.name);
+          expect(await harness.getNextButton().then((btn) => btn.isDisabled())).toEqual(true);
         });
       });
 
@@ -366,11 +374,18 @@ describe('ApiDocumentationV4EditPageComponent', () => {
   describe('Edit page', () => {
     describe('In the root folder', () => {
       describe('with published page', () => {
-        const PAGE = fakeMarkdown({ id: 'page-id', content: 'my content', visibility: 'PUBLIC', published: true });
+        const PAGE = fakeMarkdown({ id: 'page-id', name: 'page-name', content: 'my content', visibility: 'PUBLIC', published: true });
+        const OTHER_PAGE = fakeMarkdown({
+          id: 'other-page',
+          name: 'other-page-name',
+          content: 'my other content',
+          visibility: 'PUBLIC',
+          published: true,
+        });
 
         beforeEach(async () => {
           await init(undefined, PAGE.id);
-          initPageServiceRequests({ pages: [PAGE], breadcrumb: [], parentId: undefined, mode: 'edit' }, PAGE);
+          initPageServiceRequests({ pages: [PAGE, OTHER_PAGE], breadcrumb: [], parentId: undefined, mode: 'edit' }, PAGE);
         });
 
         it('should load step one with existing name and visibility', async () => {
@@ -387,6 +402,12 @@ describe('ApiDocumentationV4EditPageComponent', () => {
         it('should not have Next button clickable with name blank', async () => {
           const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiDocumentationV4EditPageHarness);
           await harness.setName('');
+          expect(await harness.getNextButton().then((btn) => btn.isDisabled())).toEqual(true);
+        });
+
+        it('should not have Next button clickable with duplicate name', async () => {
+          const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiDocumentationV4EditPageHarness);
+          await harness.setName(' Other-page-Name  ');
           expect(await harness.getNextButton().then((btn) => btn.isDisabled())).toEqual(true);
         });
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -70,12 +70,31 @@
       <th mat-header-cell *matHeaderCellDef>Actions</th>
       <td mat-cell *matCellDef="let page; let i = index">
         <div class="documentation-pages-list__table__actions">
-          <button *ngIf="page.type === 'FOLDER'" mat-icon-button (click)="onEditFolder.emit(page)" aria-label="Edit folder">
-            <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-          </button>
-          <button *ngIf="page.type !== 'FOLDER'" mat-icon-button (click)="onEditPage.emit(page.id)" aria-label="Edit page">
-            <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-          </button>
+          <ng-container *ngIf="page.type === 'FOLDER'">
+            <button mat-icon-button (click)="onEditFolder.emit(page)" aria-label="Edit folder">
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <div *ngIf="pagesIncludeNonFolders" class="empty-icon-button"></div>
+          </ng-container>
+
+          <ng-container *ngIf="page.type !== 'FOLDER'">
+            <button mat-icon-button (click)="onEditPage.emit(page.id)" aria-label="Edit page">
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <button
+              *ngIf="!page.published"
+              mat-icon-button
+              (click)="onPublishPage.emit(page.id)"
+              matTooltip="Publish page"
+              aria-label="Publish page"
+            >
+              <mat-icon svgIcon="gio:upload-cloud"></mat-icon>
+            </button>
+            <button *ngIf="page.published" disabled mat-icon-button matTooltip="Unpublish page" aria-label="Unpublish page">
+              <mat-icon svgIcon="gio:cloud-unpublished"></mat-icon>
+            </button>
+          </ng-container>
+
           <button mat-icon-button (click)="onMoveUp.emit(page)" [disabled]="i === 0 || page.order === 0" aria-label="Move page up">
             <mat-icon svgIcon="gio:arrow-up"></mat-icon>
           </button>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
@@ -28,3 +28,7 @@
     }
   }
 }
+
+.empty-icon-button {
+  width: 40px;
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 
 import { Page } from '../../../../entities/management-api-v2/documentation/page';
@@ -24,7 +24,7 @@ import { Page } from '../../../../entities/management-api-v2/documentation/page'
   template: require('./api-documentation-v4-pages-list.component.html'),
   styles: [require('./api-documentation-v4-pages-list.component.scss')],
 })
-export class ApiDocumentationV4PagesListComponent implements OnChanges {
+export class ApiDocumentationV4PagesListComponent implements OnInit, OnChanges {
   @Input()
   pages: Page[];
 
@@ -33,6 +33,9 @@ export class ApiDocumentationV4PagesListComponent implements OnChanges {
 
   @Output()
   onEditPage = new EventEmitter<string>();
+
+  @Output()
+  onPublishPage = new EventEmitter<string>();
 
   @Output()
   onDeletePage = new EventEmitter<string>();
@@ -51,6 +54,11 @@ export class ApiDocumentationV4PagesListComponent implements OnChanges {
 
   public displayedColumns = ['name', 'status', 'visibility', 'lastUpdated', 'actions'];
   public dataSource: MatTableDataSource<Page>;
+  public pagesIncludeNonFolders: boolean;
+
+  ngOnInit(): void {
+    this.pagesIncludeNonFolders = this.pages.some((page) => page.type !== 'FOLDER');
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.pages) {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
@@ -25,6 +25,7 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
   protected tableLocator = this.locatorFor(MatTableHarness);
   protected addNewPageButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add new page' }));
   protected allEditFolderButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit folder"]' }));
+  protected allPublishPageButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Publish page"]' }));
   protected allMovePageDownButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page down"]' }));
   protected allMovePageUpButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page up"]' }));
 
@@ -48,6 +49,10 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
 
   public getEditFolderButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
     return this.allEditFolderButtons().then((buttonList) => buttonList[idx]);
+  }
+
+  public getPublishPageButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
+    return this.allPublishPageButtons().then((buttonList) => buttonList[idx]);
   }
 
   public getMovePageDownButtonByRowIndex(idx: number): Promise<MatButtonHarness> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3321

## Description

- Add the publish action to the list of documents
- Add rules for naming pages and folders

With pages + folders in view:

![Screenshot 2023-11-15 at 11 19 43](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/4b27a759-447e-41f2-becd-77d416f4766d)

With just folders in view:

![Screenshot 2023-11-15 at 11 19 54](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/228c54a8-5569-47fe-a024-004c320ef91e)

Publish dialog:

![Screenshot 2023-11-15 at 11 46 36](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/ac77fe25-66b5-4816-9368-602f7e08aba2)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wbxfkrqvxr.chromatic.com)
<!-- Storybook placeholder end -->
