### PR TITLE
fix: generate rest api v2 models from openapi-apis.yaml file

### DIFF
--- a/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
+++ b/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
@@ -14,10 +14,10 @@
 # limitations under the License.
 
 mkdir -p .tmp
-sed s/'uniqueItems: true'/'uniqueItems: false'/g ../gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml > .tmp/management-openapi-v2.yaml
+sed s/'uniqueItems: true'/'uniqueItems: false'/g ../gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml > .tmp/openapi-apis.yaml
 
 npx @openapitools/openapi-generator-cli@2.6.0 generate \
-  -i .tmp/management-openapi-v2.yaml \
+  -i .tmp/openapi-apis.yaml \
   -g typescript-fetch \
   -o lib/management-v2-webclient-sdk/src/lib/ \
   -puseSingleRequestParameter=true \


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The open api yaml file has been renamed but the e2e tests tries to  generates the models from the old one. Here is a pr to update the file name

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gdvbkqrgcd.chromatic.com)
<!-- Storybook placeholder end -->
