### PR TITLE
fix(console): go to sub-folder when exiting edit documentation page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -26,7 +26,7 @@
       </div>
     </div>
     <div class="header__actions">
-      <button mat-stroked-button (click)="exitWithoutSaving()">Exit without saving</button>
+      <button mat-stroked-button (click)="goBackToPageList()">Exit without saving</button>
     </div>
   </div>
   <div class="stepper">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
@@ -459,6 +459,8 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             content: 'New content',
           });
           req.flush(PAGE);
+
+          expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.documentationV4', { apiId: API_ID, parentId: 'ROOT' });
         });
       });
       describe('with unpublished page', () => {
@@ -513,7 +515,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
       });
     });
     describe('In parent folder', () => {
-      const PAGE = fakeMarkdown({ id: 'page-id', content: 'my content', visibility: 'PUBLIC' });
+      const PAGE = fakeMarkdown({ id: 'page-id', content: 'my content', visibility: 'PUBLIC', parentId: 'parent-folder-id' });
 
       beforeEach(async () => {
         await init('parent-folder-id', PAGE.id);
@@ -531,6 +533,15 @@ describe('ApiDocumentationV4EditPageComponent', () => {
       it('should show breadcrumb', async () => {
         const harness = await harnessLoader.getHarness(ApiDocumentationV4BreadcrumbHarness);
         expect(await harness.getContent()).toEqual('Home>Parent Folder');
+      });
+
+      it('should exit without saving', async () => {
+        const exitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Exit without saving' }));
+        await exitBtn.click();
+        expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.documentationV4', {
+          apiId: API_ID,
+          parentId: PAGE.parentId,
+        });
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -91,11 +91,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
     }
 
     this.loadPage$
-      .pipe(
-        switchMap((page) =>
-          this.apiDocumentationService.getApiPages(this.ajsStateParams.apiId, this.ajsStateParams.parentId ?? page?.parentId ?? 'ROOT'),
-        ),
-      )
+      .pipe(switchMap((_) => this.apiDocumentationService.getApiPages(this.ajsStateParams.apiId, this.getParentId())))
       .subscribe({
         next: (pagesResponse) => {
           this.breadcrumbs = pagesResponse.breadcrumb;
@@ -115,7 +111,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
 
   create() {
     this.createPage().subscribe(() => {
-      this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
+      this.goBackToPageList();
     });
   }
 
@@ -124,7 +120,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
       .pipe(switchMap((page) => this.apiDocumentationService.publishDocumentationPage(this.ajsStateParams.apiId, page.id)))
       .subscribe({
         next: () => {
-          this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
+          this.goBackToPageList();
         },
         error: (error) => {
           this.snackBarService.error(error?.error?.message ?? 'Cannot publish page');
@@ -135,7 +131,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
   update() {
     this.updatePage().subscribe({
       next: () => {
-        this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
+        this.goBackToPageList();
       },
     });
   }
@@ -158,8 +154,8 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
     );
   }
 
-  exitWithoutSaving() {
-    this.ajsState.go('management.apis.documentationV4', this.ajsStateParams);
+  goBackToPageList() {
+    this.ajsState.go('management.apis.documentationV4', { apiId: this.ajsStateParams.apiId, parentId: this.getParentId() });
   }
 
   private createPage(): Observable<Page> {
@@ -195,5 +191,9 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
   private pageNameUniqueValidator(): ValidatorFn {
     return (nameControl: AbstractControl): ValidationErrors | null =>
       this.existingNames.includes(nameControl.value?.toLowerCase().trim()) ? { unique: true } : null;
+  }
+
+  private getParentId(): string {
+    return this.ajsStateParams.parentId ?? this.page?.parentId ?? 'ROOT';
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3343

## Description

Redirect users to the page's subfolder when exiting the edit documentation page

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dyuuvmsjcs.chromatic.com)
<!-- Storybook placeholder end -->
