### PR TITLE
fix(console): keep documentation folder order on update

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
@@ -220,7 +220,9 @@ describe('ApiDocumentationV4', () => {
 
     it('should update folder', async () => {
       const ID = 'page-id';
-      await init([fakeFolder({ id: ID, name: 'my first folder', visibility: 'PUBLIC' })], []);
+      const FOLDER = fakeFolder({ id: ID, name: 'my first folder', visibility: 'PUBLIC', order: 1 });
+      const OTHER_FOLDER = fakeFolder({ id: 'top-folder', name: 'my top folder', visibility: 'PUBLIC', order: 0 });
+      await init([FOLDER, OTHER_FOLDER], []);
 
       const pageListHarness = await harnessLoader.getHarness(ApiDocumentationV4PagesListHarness);
       const editFolderButton = await pageListHarness.getEditFolderButtonByRowIndex(0);
@@ -240,7 +242,7 @@ describe('ApiDocumentationV4', () => {
       });
       req.flush(page);
       expect(req.request.body).toEqual({
-        type: 'FOLDER',
+        ...FOLDER,
         name: 'folder',
         visibility: 'PRIVATE',
       });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -133,7 +133,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         filter((updateFolder) => !!updateFolder),
         switchMap((updateFolder: EditDocumentationFolder) =>
           this.apiDocumentationV2Service.updateDocumentationPage(this.ajsStateParams.apiId, folder.id, {
-            type: 'FOLDER',
+            ...folder,
             name: updateFolder.name,
             visibility: updateFolder.visibility,
           }),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3349

## Description

Keep folder order when updating a folder.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yxcvbwbqnm.chromatic.com)
<!-- Storybook placeholder end -->
