### PR TITLE
Test/fix flaky create-and-modify-flow-tests

### DIFF
--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -39,7 +39,7 @@
         "@types/node": "16.10.9",
         "@types/node-fetch": "2.6.1",
         "ansi-regex": "6.0.1",
-        "cypress": "13.3.3",
+        "cypress": "13.5.1",
         "dotenv": "16.0.0",
         "har-validator": "5.1.5",
         "jest": "27.5.1",

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -48,7 +48,7 @@ declare global {
 }
 export {};
 
-Cypress.Commands.add('callGateway', (contextPath, checkConditionFn?, maxRetries = 5, retryDelay = 1500) => {
+Cypress.Commands.add('callGateway', (contextPath, checkConditionFn?, maxRetries = 15, retryDelay = 1500) => {
   const defaultCheckFunction = (response: Cypress.Response<any>) => response.status === 200;
   const isResponseValid = checkConditionFn || defaultCheckFunction;
   const url = `${Cypress.env('gatewayServer')}${contextPath}`;


### PR DESCRIPTION
## Description
Some of the Policy Studio test ran on error because it was tried to reach the Gateway before the deployment happened. So, the number of retries were increased to make sure that it tries to reach the API for longer while keeping the waiting time as short as possible.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ladexrgpkm.chromatic.com)
<!-- Storybook placeholder end -->
