### PR TITLE
Fix regex used to check if a branch is support branch or master

### DIFF
--- a/.circleci/ci/src/utils/branch.ts
+++ b/.circleci/ci/src/utils/branch.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const supportBranchPattern = '\\d+\\.\\d+\\.x';
-
 export function sanitizeBranch(branch: string) {
   return branch
     .replaceAll(/[~^]+/g, '')
@@ -25,20 +23,19 @@ export function sanitizeBranch(branch: string) {
 }
 
 export function isE2EBranch(branch: string): boolean {
-  const regex = new RegExp('.*-run-e2e.*');
+  const regex = /.*-run-e2e.*/;
   return regex.test(branch);
 }
 
-export function isMasterBranch(branch: string) {
+export function isMasterBranch(branch: string): boolean {
   return branch === 'master';
 }
 
 export function isSupportBranch(branch: string): boolean {
-  const regex = new RegExp(supportBranchPattern);
+  const regex = /^\d+\.\d+\.x$/;
   return regex.test(branch);
 }
 
 export function isSupportBranchOrMaster(branch: string): boolean {
-  const branchPattern = new RegExp(`^(${supportBranchPattern})|master$`);
-  return branchPattern.test(branch);
+  return isMasterBranch(branch) || isSupportBranch(branch);
 }

--- a/.circleci/ci/src/utils/tests/branch.spec.ts
+++ b/.circleci/ci/src/utils/tests/branch.spec.ts
@@ -15,8 +15,8 @@
  */
 import { isMasterBranch, isSupportBranch, isSupportBranchOrMaster, sanitizeBranch } from '../branch';
 
-describe('branch', function () {
-  describe('sanitize', function () {
+describe('branch', () => {
+  describe('sanitize', () => {
     it.each`
       branchToSanitize                                                                                                  | sanitizedBranch
       ${'APIM-1234-my-custom-branch'}                                                                                   | ${'apim-1234-my-custom-branch'}
@@ -27,40 +27,51 @@ describe('branch', function () {
     });
   });
 
-  describe('isMaster', function () {
+  describe('isMaster', () => {
     it.each`
-      branch          | expected
-      ${'not-master'} | ${false}
-      ${'master'}     | ${true}
-    `('returns $expected is $branch is master', ({ branch, expected }) => {
+      branch               | expected
+      ${'not-master'}      | ${false}
+      ${'master-APIM-213'} | ${false}
+      ${'master'}          | ${true}
+    `('returns `$expected` for `$branch`', ({ branch, expected }) => {
       expect(isMasterBranch(branch)).toEqual(expected);
     });
   });
 
-  describe('isSupport', function () {
+  describe('isSupport', () => {
     it.each`
       branch                         | expected
       ${'APIM-1234-mycustom-branch'} | ${false}
       ${'master'}                    | ${false}
+      ${'1.2.x-master'}              | ${false}
+      ${'APIM-213-master'}           | ${false}
+      ${'master-APIM-213'}           | ${false}
       ${'1.2.3'}                     | ${false}
       ${'1.2.x'}                     | ${true}
+      ${'1.2.x-APIM-213'}            | ${false}
+      ${'APIM-213-1.2.x'}            | ${false}
       ${'1.x'}                       | ${false}
       ${'x'}                         | ${false}
-    `('returns $expected is $branch is support', ({ branch, expected }) => {
+    `('returns `$expected` for `$branch`', ({ branch, expected }) => {
       expect(isSupportBranch(branch)).toEqual(expected);
     });
   });
 
-  describe('isSupportOrMaster', function () {
+  describe('isSupportOrMaster', () => {
     it.each`
       branch                         | expected
       ${'APIM-1234-mycustom-branch'} | ${false}
       ${'master'}                    | ${true}
+      ${'1.2.x-master'}              | ${false}
+      ${'APIM-213-master'}           | ${false}
+      ${'master-APIM-213'}           | ${false}
       ${'1.2.3'}                     | ${false}
       ${'1.2.x'}                     | ${true}
+      ${'1.2.x-APIM-213'}            | ${false}
+      ${'APIM-213-1.2.x'}            | ${false}
       ${'1.x'}                       | ${false}
       ${'x'}                         | ${false}
-    `('returns $expected is $branch is support', ({ branch, expected }) => {
+    `('returns `$expected` for `$branch`', ({ branch, expected }) => {
       expect(isSupportBranchOrMaster(branch)).toEqual(expected);
     });
   });


### PR DESCRIPTION
## Issue

NA

## Description

There was an issue in the regexp used to check if a branch is a support branch or master, causing the wrong CI jobs to be run. 

Root cause of the extra images in Snyk:
<img width="1541" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4112568/b8492b8a-1873-4f9b-bbb6-61e9cbb6a0db">


