### PR TITLE
test: fix policy studio test

### DIFF
--- a/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
+++ b/gravitee-apim-e2e/ui-test/support/PageObjects/Apis/PolicyStudio.ts
@@ -16,7 +16,7 @@
 
 export default class PolicyStudio {
   static openPolicyStudio(apiId: string) {
-    cy.visit(`/#!/environments/default/apis/${apiId}/policy-studio`);
+    cy.visit(`/#!/environments/default/apis/ng/${apiId}/policy-studio`);
     cy.url().should('include', '/policy-studio');
     cy.contains('.list__flowsGroup__header__label', 'Common flows', { timeout: 60000 });
     return new PolicyStudio();


### PR DESCRIPTION
## Description
A tiny change to fix the Policy Studio URL. 
After cherry-picking a commit done on master it was forgotten to add 'ng' string to the URL for the 4.1 branch. This PR will fix that.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fwjihvgyha.chromatic.com)
<!-- Storybook placeholder end -->
