### PR TITLE
Extend flow name column to 256 for JDBC

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_24/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_24/schema.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.20.24
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}flows
+            columnName: name
+            newDataType: nvarchar(256)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -151,3 +151,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_20_4/schema.yml
   - include:
       - file: liquibase/changelogs/v3_20_22/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_20_24/schema.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
@@ -119,6 +119,38 @@ public class FlowRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void shouldCreateWithBigValues() throws TechnicalException {
+        Flow flow = new Flow();
+        // Mandatory fields
+        flow.setId("flow-create-big-values");
+        flow.setOrder(1);
+        flow.setCreatedAt(new Date(1470157767000L));
+        flow.setReferenceId("my-orga");
+        flow.setReferenceType(FlowReferenceType.ORGANIZATION);
+
+        // Fields with big capacities
+        flow.setName(
+            "A big name with 256 characters-A big name with 256 characters-A big name with 256 characters-A big name with 256 characters-A big name with 256 characters-A big name with 256 characters-A big name with 256 characters-A big name with 256 characters---------"
+        );
+        flow.setCondition(
+            "A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters-A huge condition with 512 characters--------------------------------"
+        );
+        flow.setPath(
+            "A big path with 256 characters-A big path with 256 characters-A big path with 256 characters-A big path with 256 characters-A big path with 256 characters-A big path with 256 characters-A big path with 256 characters-A big path with 256 characters---------"
+        );
+
+        Flow flowCreated = flowRepository.create(flow);
+        assertEquals(flowCreated.getId(), flow.getId());
+        assertEquals(flowCreated.getName(), flow.getName());
+        assertEquals(flowCreated.getCondition(), flow.getCondition());
+        assertEquals(flowCreated.getPath(), flow.getPath());
+        assertEquals(flowCreated.getOrder(), flow.getOrder());
+        assertEquals(flowCreated.getCreatedAt(), flow.getCreatedAt());
+        assertEquals(flowCreated.getReferenceId(), flow.getReferenceId());
+        assertEquals(flowCreated.getReferenceType(), flow.getReferenceType());
+    }
+
+    @Test
     public void shouldUpdate() throws TechnicalException {
         Flow flow = new Flow();
         flow.setId("tag-updated");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3282

## Description

This PR extends flow name column to 256 for JDBC and add a unit test for big values.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xdhcldvkam.chromatic.com)
<!-- Storybook placeholder end -->
