### PR TITLE
Apim 3057 unpublish markdown page in UI

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
@@ -41,6 +41,7 @@ export interface Page {
   parentPath?: string;
   contentRevision?: Revision;
   hidden?: boolean;
+  generalConditions?: boolean;
 }
 
 export interface Breadcrumb {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
@@ -30,6 +30,7 @@
     (onEditPage)="editPage($event)"
     (onEditFolder)="editFolder($event)"
     (onPublishPage)="publishPage($event)"
+    (onUnpublishPage)="unpublishPage($event)"
     (onMoveUp)="moveUp($event)"
     (onMoveDown)="moveDown($event)"
   ></api-documentation-v4-pages-list>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -176,6 +176,31 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
       });
   }
 
+  unpublishPage(pageId: string) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Unpublish your page',
+          content: 'Your page will be unpublished from Portal. Are you sure?',
+          confirmButton: 'Unpublish',
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirmed) => !!confirmed),
+        switchMap((_) => this.apiDocumentationV2Service.unpublishDocumentationPage(this.ajsStateParams.apiId, pageId)),
+      )
+      .subscribe({
+        next: (_) => {
+          this.snackBarService.success('Page unpublished successfully');
+          this.ngOnInit();
+        },
+        error: (error) => {
+          this.snackBarService.error(error?.error?.message ?? 'Error while unpublishing page');
+        },
+      });
+  }
+
   moveUp(page: Page) {
     this.changeOrder(page, page.order - 1);
   }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -164,6 +164,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
       .pipe(
         filter((confirmed) => !!confirmed),
         switchMap((_) => this.apiDocumentationV2Service.publishDocumentationPage(this.ajsStateParams.apiId, pageId)),
+        takeUntil(this.unsubscribe$),
       )
       .subscribe({
         next: (_) => {
@@ -189,6 +190,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
       .pipe(
         filter((confirmed) => !!confirmed),
         switchMap((_) => this.apiDocumentationV2Service.unpublishDocumentationPage(this.ajsStateParams.apiId, pageId)),
+        takeUntil(this.unsubscribe$),
       )
       .subscribe({
         next: (_) => {
@@ -215,6 +217,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         ...page,
         order,
       })
+      .pipe(takeUntil(this.unsubscribe$))
       .subscribe({
         next: () => {
           this.snackBarService.success('Order updated successfully');

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -40,6 +40,12 @@
       <td mat-cell *matCellDef="let page">
         <ng-container *ngIf="page.type != 'FOLDER'">
           <span *ngIf="page.published" class="gio-badge-success"> Published </span>
+          <span
+            *ngIf="page.published && page.generalConditions"
+            class="gio-badge-neutral"
+            matTooltip="Used by at least one plan as General Conditions"
+            ><mat-icon svgIcon="gio:book-open"></mat-icon
+          ></span>
           <span *ngIf="!page.published" class="gio-badge-neutral"> Unpublished </span>
         </ng-container>
         <ng-container *ngIf="page.type === 'FOLDER'">
@@ -90,7 +96,14 @@
             >
               <mat-icon svgIcon="gio:upload-cloud"></mat-icon>
             </button>
-            <button *ngIf="page.published" disabled mat-icon-button matTooltip="Unpublish page" aria-label="Unpublish page">
+            <button
+              *ngIf="page.published"
+              (click)="onUnpublishPage.emit(page.id)"
+              [disabled]="page.generalConditions"
+              mat-icon-button
+              [matTooltip]="page.generalConditions ? 'Cannot be unpublished if used by active plans' : 'Unpublish page'"
+              aria-label="Unpublish page"
+            >
               <mat-icon svgIcon="gio:cloud-unpublished"></mat-icon>
             </button>
           </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
@@ -38,6 +38,9 @@ export class ApiDocumentationV4PagesListComponent implements OnInit, OnChanges {
   onPublishPage = new EventEmitter<string>();
 
   @Output()
+  onUnpublishPage = new EventEmitter<string>();
+
+  @Output()
   onDeletePage = new EventEmitter<string>();
 
   @Output()

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.harness.ts
@@ -26,6 +26,7 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
   protected addNewPageButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add new page' }));
   protected allEditFolderButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit folder"]' }));
   protected allPublishPageButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Publish page"]' }));
+  protected allUnpublishPageButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Unpublish page"]' }));
   protected allMovePageDownButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page down"]' }));
   protected allMovePageUpButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Move page up"]' }));
 
@@ -53,6 +54,10 @@ export class ApiDocumentationV4PagesListHarness extends ComponentHarness {
 
   public getPublishPageButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
     return this.allPublishPageButtons().then((buttonList) => buttonList[idx]);
+  }
+
+  public getUnpublishPageButtonByRowIndex(idx: number): Promise<MatButtonHarness> {
+    return this.allUnpublishPageButtons().then((buttonList) => buttonList[idx]);
   }
 
   public getMovePageDownButtonByRowIndex(idx: number): Promise<MatButtonHarness> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.spec.ts
@@ -188,4 +188,21 @@ describe('ApiDocumentationV2Service', () => {
       req.flush(fakeResponse);
     });
   });
+
+  describe('unpublishPage', () => {
+    const PAGE_ID = 'page-id';
+    it('should call the API to unpublish page', (done) => {
+      const fakeResponse: Page = fakeMarkdown();
+      service.unpublishDocumentationPage(API_ID, PAGE_ID).subscribe((response) => {
+        expect(response).toEqual(fakeResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages/${PAGE_ID}/_unpublish`,
+        method: 'POST',
+      });
+      req.flush(fakeResponse);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.ts
@@ -58,4 +58,8 @@ export class ApiDocumentationV2Service {
   publishDocumentationPage(apiId: string, pageId: string): Observable<Page> {
     return this.http.post<Page>(`${this.constants.env.v2BaseURL}/apis/${apiId}/pages/${pageId}/_publish`, {});
   }
+
+  unpublishDocumentationPage(apiId: any, pageId: string): Observable<Page> {
+    return this.http.post<Page>(`${this.constants.env.v2BaseURL}/apis/${apiId}/pages/${pageId}/_unpublish`, {});
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3057

## Description

- User can unpublish a page in the list of pages
- A page is marked as `General Conditions` in the view of the page list

Will use back-end endpoint created in https://github.com/gravitee-io/gravitee-api-management/pull/5876.

TODO: 
- add `generalConditions: boolean` to back-end response for `GET /{pageId}` and `GET /pages`

Normal list:

![Screenshot 2023-11-17 at 17 32 06](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/3edaa147-e9f7-424e-89b3-bb55f2398bdc)


Page used as General Conditions:

![Screenshot 2023-11-17 at 16 37 08](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/3967f902-d4a3-401d-8ca4-774e3fa665a9)

![Screenshot 2023-11-17 at 16 37 21](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/64b74685-e2d7-4d90-b17e-5a5ef7c1ff43)


Unpublish page dialog:

![Screenshot 2023-11-17 at 16 38 36](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/8cb7ed1f-36ca-4076-9004-d8f0763bc8b7)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqbwvpdwep.chromatic.com)
<!-- Storybook placeholder end -->
