### PR TITLE
test: [4.1.x] refactoring of API workflow creation test

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
@@ -22,60 +22,55 @@ describe('API creation workflow', () => {
   const apiName = faker.commerce.productName();
   let apiId: string;
 
-  describe('Create a V4 Proxy REST API', { testIsolation: false }, function () {
+  describe('Create a V4 Proxy REST API', function () {
     before(() => {
       cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
       cy.visit('/#!/environments/default/apis/new');
+      cy.getByDataTestId('api_create_v4_button').should('be.visible');
     });
 
-    it(`should initiate V4 API workflow by clicking Create button`, () => {
+    it(`should create V4 API using the default API creation workflow`, () => {
       cy.getByDataTestId('api_create_v4_button').click();
-      cy.contains('Step 1');
-    });
 
-    it(`should successfully complete step 1`, () => {
+      // Step 1
+      cy.contains('Step 1');
       cy.getByDataTestId('api_creation_v4_validate_button').should('be.disabled');
       cy.getByDataTestId('api_creation_v4_name_input').type(apiName);
       cy.getByDataTestId('api_creation_v4_validate_button').should('be.disabled');
       cy.getByDataTestId('api_creation_v4_version_input').type(apiVersion);
       cy.getByDataTestId('api_creation_v4_validate_button').click();
+
+      // Select Proxy Upstream Protocol option (entrypoints)`
       cy.contains('Step 2');
       cy.contains('Select how you want your backend service exposed');
-    });
-
-    it(`should select Proxy Upstream Protocol option (entrypoints)`, () => {
       cy.getByDataTestId('select_architecture_button').should('be.disabled');
       cy.getByDataTestId('api_creation_proxy_checkbox').click();
       cy.getByDataTestId('select_architecture_button').click();
+
+      // Step 2 (entrypoints)
       cy.contains('Step 2');
       cy.contains('Configure your API entrypoints');
-    });
-
-    it(`should successfully complete step 2 (entrypoints)`, () => {
       cy.getByDataTestId('validate_entrypoints_button').should('be.disabled');
-      cy.get('input[formcontrolname=path]').type(apiPath);
+      cy.get('input[formcontrolname=path]').clear().type(apiPath);
       cy.getByDataTestId('validate_entrypoints_button').click();
-      cy.contains('Step 3');
-    });
 
-    it(`should successfully complete step 3 (endpoints)`, () => {
+      // Step 3 (endpoints)
+      cy.contains('Step 3');
       const targetUrl = `${Cypress.env('wiremockUrl')}/hello`;
       cy.getByDataTestId('validate_endpoint_button').should('be.disabled');
       cy.get('input[id*=target]').should('be.enabled').type(targetUrl);
       cy.getByDataTestId('validate_endpoint_button').click();
       cy.contains('Step 4');
-    });
 
-    it(`should successfully complete step 4 (plans)`, () => {
+      // Step 4 (plans)
       cy.getByDataTestId('validate_plans_button').click();
       cy.contains('Review your API configuration');
-    });
 
-    it(`should successfully complete final step (summary)`, () => {
+      // Final step (summary)
       cy.intercept('POST', '**/apis').as('createApi');
       cy.getByDataTestId('deploy_api_button').click();
 
-      // retrieve API-id for clean-up
+      // Retrieve API-id for clean-up
       cy.wait('@createApi').then((interception) => {
         expect(interception.response.statusCode).to.eq(201);
         expect(interception.response.body).to.have.property('id');
@@ -83,15 +78,14 @@ describe('API creation workflow', () => {
         expect(interception.response.body).to.have.property('apiVersion', apiVersion);
         apiId = interception.response.body.id;
         cy.contains(`${apiName} has been created`);
+
+        // open new API in API Management
+        cy.getByDataTestId('open_api_in_api_management_button').click();
+        cy.url().should('include', `/${apiId}/general`);
       });
     });
 
-    it(`should open new API in API Management`, () => {
-      cy.getByDataTestId('open_api_in_api_management_button').click();
-      cy.url().should('include', `/${apiId}/general`);
-    });
-
-    it('should successfully connect to created API', function () {
+    it('should successfully connect to created API via Gateway', function () {
       cy.callGateway(`${apiPath}`).then((response) => {
         expect(response.body.message).to.eq('Hello, World!'); // from wiremock
       });


### PR DESCRIPTION
## Description
This API workflow creation test has been refactored to comply with testing best practices of test isolation (no need to have many separated tests if there are linked together and build upon each other anyway). Getting rid of unnecessary tests also matter for the Cypress Cloud where we have a limited contingent of monthly tests.

## Additional context
This change is already implemented on master (https://github.com/gravitee-io/gravitee-api-management/pull/5752).



