### PR TITLE
Apim 3247 add button to open api in portal

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<api-documentation-page-title></api-documentation-page-title>
+<api-documentation-page-title [api]="api"></api-documentation-page-title>
 <mat-card>
   <api-documentation-list-navigation-header
     [breadcrumbs]="breadcrumbs || []"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,20 @@
 
 -->
 <div class="header">
-  <h1>Documentation</h1>
-  <div class="header__subtitle">Documentation pages appear in the portal and inform API consumers how to use your API</div>
+  <div class="header__title">
+    <h1>Documentation</h1>
+    <div class="header__subtitle">Documentation pages appear in the portal and inform API consumers how to use your API</div>
+  </div>
+  <div class="header__actions">
+    <a
+      mat-raised-button
+      *ngIf="apiPortalUrl"
+      class="header__actions__open-in-portal"
+      [href]="apiPortalUrl"
+      target="_blank"
+      [disabled]="api.lifecycleState !== 'PUBLISHED'"
+      [matTooltip]="api.lifecycleState !== 'PUBLISHED' ? 'Publish your API to view' : undefined"
+      >Open API in Developer Portal</a
+    >
+  </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.scss
@@ -5,9 +5,19 @@ $typography: map.get(gio.$mat-theme, typography);
 
 .header {
   margin-bottom: 24px;
+  display: flex;
+  gap: 12px;
+
+  &__title {
+    flex: 1 1 100%;
+  }
 
   &__subtitle {
     color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
     @include mat.typography-level($typography, 'body-1');
+  }
+
+  &__actions {
+    padding-top: 12px;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.ts
@@ -13,11 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Inject, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+
+import { Constants } from '../../../../../entities/Constants';
+import { Api } from '../../../../../entities/management-api-v2';
 
 @Component({
   selector: 'api-documentation-page-title',
   template: require('./api-documentation-v4-page-title.component.html'),
   styles: [require('./api-documentation-v4-page-title.component.scss')],
 })
-export class ApiDocumentationV4PageTitleComponent {}
+export class ApiDocumentationV4PageTitleComponent implements OnInit, OnChanges {
+  @Input()
+  api: Api;
+
+  public apiPortalUrl: string;
+
+  constructor(@Inject('Constants') public readonly constants: Constants) {}
+
+  ngOnInit(): void {
+    this.calculateApiPortalUrl();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.api) {
+      this.api = changes.api.currentValue;
+      this.calculateApiPortalUrl();
+    }
+  }
+
+  private calculateApiPortalUrl(): void {
+    if (this.api?.id && this.constants?.env?.settings?.portal?.url) {
+      const root = this.constants.env.settings.portal.url;
+      const apiPath = 'catalog/api/' + this.api.id;
+      const connector = '/';
+
+      this.apiPortalUrl = root.endsWith(connector) ? root + apiPath : root + connector + apiPath;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.harness.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class ApiDocumentationV4PageTitleHarness extends ComponentHarness {
+  public static hostSelector = 'api-documentation-page-title';
+
+  protected locateOpenInPortalBtn = this.locatorForOptional(MatButtonHarness.with({ text: 'Open API in Developer Portal' }));
+
+  public getOpenInPortalBtn() {
+    return this.locateOpenInPortalBtn();
+  }
+
+  public getApiPortalUrl(): Promise<string> {
+    return this.locateOpenInPortalBtn()
+      .then((btn) => btn.host())
+      .then((host) => host.getAttribute('href'));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<api-documentation-page-title></api-documentation-page-title>
+<api-documentation-page-title [api]="api"></api-documentation-page-title>
 <mat-card>
   <div class="header">
     <div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -167,6 +167,6 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
   <div class="documentation-pages-list__footer">
-    <button mat-stroked-button (click)="onAddPage.emit()" *gioPermission="{ anyOf: ['api-documentation-c'] }">Add new page</button>
+    <button mat-flat-button (click)="onAddPage.emit()" *gioPermission="{ anyOf: ['api-documentation-c'] }">Add new page</button>
   </div>
 </div>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3247

## Description

Add button to Documentation title that opens the Api in the Portal in a different window.

Page list:

![Screenshot 2023-11-20 at 17 15 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/e42c179a-cc09-417d-a3be-03a66236c76b)


Edit page:

![Screenshot 2023-11-20 at 17 15 33](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/6e3cb221-fa97-4c67-aa6a-a9e6b6aec40d)


When API is not published:

![Screenshot 2023-11-21 at 16 06 03](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/9b4dd636-4673-4319-aae8-4e8b8bf47dd4)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yojmvhbeuv.chromatic.com)
<!-- Storybook placeholder end -->
