### PR TITLE
fix: set back path size to 256

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_24/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_24/schema.yml
@@ -7,3 +7,7 @@ databaseChangeLog:
             tableName: ${gravitee_prefix}flows
             columnName: name
             newDataType: nvarchar(256)
+        - modifyDataType:
+            tableName: ${gravitee_prefix}flows
+            columnName: path
+            newDataType: nvarchar(256)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3282

## Description
Before 3.18.0, column `path` of table `flows` was 64 characters long.
In 3.18.0, it has been increased to 256.
In 3.19.0, `dropNotNullConstraint` command set the size back to 64 for MariaDB, MySQL and SQLServer.

This PR sets this value back to 256.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-amgylcrjmd.chromatic.com)
<!-- Storybook placeholder end -->
