### PR TITLE
fix: disable documentation on application startup if OEM

### DIFF
--- a/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
+++ b/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
@@ -23,7 +23,12 @@ class ContextualDocController implements IOnInit, IOnDestroy {
 
   private openContextualDocumentationListener: () => void;
 
-  constructor(private $transitions, private $http, public $state, private $window, private $rootScope) {
+  constructor(private $transitions, private $http, public $state, private $window, private $rootScope, private $Constants) {
+    if ($Constants.isOEM) {
+      // For OEM, documentation is hidden
+      this.isOpen = false;
+      return;
+    }
     if (window.pendo && window.pendo.isReady()) {
       // Do nothing, Pendo provide documentation
       this.isOpen = false;
@@ -84,6 +89,6 @@ class ContextualDocController implements IOnInit, IOnDestroy {
     this.$rootScope.helpDisplayed = this.isOpen;
   }
 }
-ContextualDocController.$inject = ['$transitions', '$http', '$state', '$window', '$rootScope'];
+ContextualDocController.$inject = ['$transitions', '$http', '$state', '$window', '$rootScope', 'Constants'];
 
 export default ContextualDocController;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3317

## Description

In the first PR, only the button in the top bar was hidden. But we need to make the documentation panel hidden by default if we don't want it to be opened on application startup

![Screenshot 2023-11-21 at 08 28 28](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/3b596b26-46f9-4709-92e4-49574d8d4802)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iwilhwckcj.chromatic.com)
<!-- Storybook placeholder end -->
