### PR TITLE
feat(console): update visibility radio subtitle for documentation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -72,7 +72,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
   addFolder() {
     this.matDialog
       .open<ApiDocumentationV4EditFolderDialog, ApiDocumentationV4EditFolderDialogData>(ApiDocumentationV4EditFolderDialog, {
-        width: GIO_DIALOG_WIDTH.MEDIUM,
+        width: GIO_DIALOG_WIDTH.LARGE,
         data: {
           mode: 'create',
           existingNames: this.pages.filter((page) => page.type === 'FOLDER').map((page) => page.name.toLowerCase().trim()),
@@ -118,7 +118,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
   editFolder(folder: Page) {
     this.matDialog
       .open<ApiDocumentationV4EditFolderDialog, ApiDocumentationV4EditFolderDialogData>(ApiDocumentationV4EditFolderDialog, {
-        width: GIO_DIALOG_WIDTH.MEDIUM,
+        width: GIO_DIALOG_WIDTH.LARGE,
         data: {
           mode: 'edit',
           name: folder.name,

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.component.html
@@ -22,13 +22,23 @@
   <mat-radio-button value="PUBLIC" class="gio-radio-button">
     <gio-radio-button-content icon="gio:language">
       <gio-radio-button-title>Public</gio-radio-button-title>
-      <gio-radio-button-subtitle>Requires no subscription to view</gio-radio-button-subtitle>
+      <gio-radio-button-subtitle *ngIf="documentationType === 'page'"
+        >Anonymous users browsing the API in the Developer Portal can view the page</gio-radio-button-subtitle
+      >
+      <gio-radio-button-subtitle *ngIf="documentationType === 'folder'"
+        >Anonymous users browsing the API in the Developer Portal can view the contents of the folder</gio-radio-button-subtitle
+      >
     </gio-radio-button-content>
   </mat-radio-button>
   <mat-radio-button value="PRIVATE" class="gio-radio-button">
     <gio-radio-button-content icon="gio:lock">
       <gio-radio-button-title>Private</gio-radio-button-title>
-      <gio-radio-button-subtitle>Requires approved subscription to view</gio-radio-button-subtitle>
+      <gio-radio-button-subtitle *ngIf="documentationType === 'page'"
+        >Users must be authenticated in the Developer Portal to view the page</gio-radio-button-subtitle
+      >
+      <gio-radio-button-subtitle *ngIf="documentationType === 'folder'"
+        >Users must be authenticated in the Developer Portal to view the contents of the folder</gio-radio-button-subtitle
+      >
     </gio-radio-button-content>
   </mat-radio-button>
 </mat-radio-group>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.component.ts
@@ -32,6 +32,9 @@ export class ApiDocumentationV4VisibilityComponent implements ControlValueAccess
   @Input()
   public showSubtitle: boolean;
 
+  @Input()
+  public documentationType: 'page' | 'folder' = 'page';
+
   _value: string;
   protected _onChange: (_selection: 'PUBLIC' | 'PRIVATE') => void = () => ({});
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-visibility/api-documentation-v4-visibility.harness.ts
@@ -20,8 +20,8 @@ export class ApiDocumentationV4VisibilityHarness extends ComponentHarness {
   public static hostSelector = 'api-documentation-visibility';
 
   private radioGroupLocator = this.locatorFor(MatRadioGroupHarness);
-  private publicRadioLocator = this.locatorFor(MatRadioButtonHarness.with({ label: 'PublicRequires no subscription to view' }));
-  private privateRadioLocator = this.locatorFor(MatRadioButtonHarness.with({ label: 'PrivateRequires approved subscription to view' }));
+  private publicRadioLocator = this.locatorFor(MatRadioButtonHarness.with({ selector: '[value="PUBLIC"]' }));
+  private privateRadioLocator = this.locatorFor(MatRadioButtonHarness.with({ selector: '[value="PRIVATE"]' }));
 
   public getPublicRadioOption() {
     return this.publicRadioLocator();

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/dialog/documentation-edit-folder-dialog/api-documentation-v4-edit-folder-dialog.component.html
@@ -28,7 +28,11 @@
     <mat-error *ngIf="formGroup.controls.name?.errors?.required">Name is required</mat-error>
     <mat-error *ngIf="formGroup.controls.name?.errors?.unique">Name already exists in this folder</mat-error>
   </mat-form-field>
-  <api-documentation-visibility [showSubtitle]="data.mode === 'create'" formControlName="visibility"></api-documentation-visibility>
+  <api-documentation-visibility
+    [showSubtitle]="data.mode === 'create'"
+    documentationType="folder"
+    formControlName="visibility"
+  ></api-documentation-visibility>
   <div class="new-folder-form__actions">
     <button mat-stroked-button type="button" (click)="cancel()">Cancel</button>
     <button type="submit" mat-flat-button color="primary" [disabled]="formGroup.invalid || formGroup.pristine || !formValueChanged">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3285

## Description

- Change the text to be more pertinent to the real definition of Private / Public.
- Differentiate the text between `folder` vs `page`.


Page:

![Screenshot 2023-11-20 at 17 35 40](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/aa9a3560-0a23-4d22-a1e4-b7ce96145005)


Folder:

![Screenshot 2023-11-20 at 17 38 22](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/91514ae4-f9c9-4cac-8676-ac63e7e15835)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xvqizkscgr.chromatic.com)
<!-- Storybook placeholder end -->
