### PR TITLE
fix: ensure that groups of an API is a mutable set

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -323,7 +323,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 importedApi.getGroups().add(group.getId());
             }
         } else {
-            importedApi.setGroups(Collections.emptySet());
+            // Using a mutable Set, so we can add groups if necessary
+            importedApi.setGroups(new HashSet<>());
         }
 
         // Views & Categories

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -350,7 +350,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             groupEntityStream = groupEntityStream.filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()));
         }
 
-        return groupEntityStream.map(GroupEntity::getId).collect(Collectors.toSet());
+        return groupEntityStream.map(GroupEntity::getId).collect(Collectors.toCollection(HashSet::new)); // Using a mutable Set, so we can add groups if necessary
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -201,7 +201,7 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
                     .stream()
                     .flatMap(group -> groupService.findByName(executionContext.getEnvironmentId(), group).stream())
                     .map(GroupEntity::getId)
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(HashSet::new)); // Using a mutable Set, so we can add groups if necessary
                 apiEntity.setGroups(groupIdsToImport);
             }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3364

## Description

Ensure that groups of an API is a mutable set, so default groups can be added when importing an API with no `groups` field defined.