### PR TITLE
feat: add requestTimeout and requestTimeoutGraceDelay in helm charts

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 4.0.13
 
 - "fix 'gravitee.yml' > 'services.metrics' definition from helm `values.yaml`"
+- Add requestTimeout and requestTimeoutGraceDelay in gateway
 
 ### 4.0.9
 

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -35,6 +35,8 @@ data:
     #  tcpKeepAlive: true
     #  compressionSupported: false
     #  instances: 0
+      requestTimeout: {{ .Values.gateway.http.requestTimeout }}
+      requestTimeoutGraceDelay: {{ .Values.gateway.http.requestTimeoutGraceDelay }}
       maxHeaderSize: {{ .Values.gateway.http.maxHeaderSize }}
       maxChunkSize: {{ .Values.gateway.http.maxChunkSize }}
       maxInitialLineLength: {{ .Values.gateway.http.maxInitialLineLength }}

--- a/helm/tests/gateway/configmap_http_test.yaml
+++ b/helm/tests/gateway/configmap_http_test.yaml
@@ -45,3 +45,40 @@ tests:
           path: data.[gravitee.yml]
           pattern: |
             alpn: false
+
+  - it: Default timeouts (30 000 & 30)
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            requestTimeout: 30000
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            requestTimeoutGraceDelay: 30
+
+  - it: Custom timeouts
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        http:
+          requestTimeout: 60000
+          requestTimeoutGraceDelay: 60
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            requestTimeout: 60000
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            requestTimeoutGraceDelay: 60

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -724,6 +724,8 @@ gateway:
     maxInitialLineLength: 4096
     maxFormAttributeSize: 2048
     alpn: "true"
+    requestTimeout: 30000
+    requestTimeoutGraceDelay: 30
   logging:
     debug: false
     stdout:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3402

## Description

Add `requestTimeout` and `requestTimeoutGraceDelay` in helm charts