### PR TITLE
Apim 3399 only published pages can be general conditions

### DIFF
--- a/gravitee-apim-console-webui/src/entities/page/Page.ts
+++ b/gravitee-apim-console-webui/src/entities/page/Page.ts
@@ -19,6 +19,7 @@ export class Page {
   name?: string;
   parentId?: string;
   type?: PageType;
+  published?: boolean;
 }
 
 export enum PageType {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -60,6 +60,7 @@ export class PlanEditGeneralStepComponent implements OnInit, OnDestroy {
         api: api.id,
       }),
     ),
+    map((pages) => pages.filter((page) => page.published)),
   );
   shardingTags$ = this.api$.pipe(
     // Only load tags if api is defined

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -150,7 +150,7 @@ describe('ApiPlanFormComponent', () => {
       it('should be added', async () => {
         const planForm = await loader.getHarness(ApiPlanFormHarness);
 
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
         planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
@@ -228,7 +228,7 @@ describe('ApiPlanFormComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
@@ -375,7 +375,7 @@ describe('ApiPlanFormComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
@@ -524,7 +524,7 @@ describe('ApiPlanFormComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
@@ -641,7 +641,7 @@ describe('ApiPlanFormComponent', () => {
 
       const planForm = await loader.getHarness(ApiPlanFormHarness);
 
-      planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       fixture.detectChanges();
 
       expect(testComponent.planControl.touched).toEqual(false);
@@ -756,7 +756,7 @@ describe('ApiPlanFormComponent', () => {
 
       const planForm = await loader.getHarness(ApiPlanFormHarness);
 
-      planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, []);
       planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
       planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
@@ -875,7 +875,7 @@ describe('ApiPlanFormComponent', () => {
 
     const planForm = await loader.getHarness(ApiPlanFormHarness);
 
-    planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+    planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     fixture.detectChanges();
 
     expect(testComponent.planControl.touched).toEqual(false);
@@ -908,7 +908,7 @@ describe('ApiPlanFormComponent', () => {
       planForm
         .httpRequest(httpTestingController)
         .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-      planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
       planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
       fixture.detectChanges();
@@ -993,7 +993,7 @@ describe('ApiPlanFormComponent', () => {
       planForm
         .httpRequest(httpTestingController)
         .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-      planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
       planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
       fixture.detectChanges();
@@ -1052,7 +1052,7 @@ describe('ApiPlanFormComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
@@ -1134,7 +1134,7 @@ describe('ApiPlanFormComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', fakeApiKeySchema);

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -229,7 +229,9 @@ describe('ApiPlanFormComponent', () => {
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
+        planForm
+          .httpRequest(httpTestingController)
+          .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
 
@@ -376,7 +378,9 @@ describe('ApiPlanFormComponent', () => {
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
+        planForm
+          .httpRequest(httpTestingController)
+          .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
 
@@ -525,7 +529,9 @@ describe('ApiPlanFormComponent', () => {
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
+        planForm
+          .httpRequest(httpTestingController)
+          .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
 
@@ -909,7 +915,9 @@ describe('ApiPlanFormComponent', () => {
         .httpRequest(httpTestingController)
         .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
       planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-      planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
+      planForm
+        .httpRequest(httpTestingController)
+        .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
       planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
       fixture.detectChanges();
 
@@ -1053,7 +1061,9 @@ describe('ApiPlanFormComponent', () => {
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
-        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
+        planForm
+          .httpRequest(httpTestingController)
+          .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
         fixture.detectChanges();
 
@@ -1109,6 +1119,27 @@ describe('ApiPlanFormComponent', () => {
           generalConditions: 'doc-1',
           selectionRule: undefined,
         } as PlanV4);
+      });
+
+      it('should only show published pages for general conditions', async () => {
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+        planForm
+          .httpRequest(httpTestingController)
+          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [
+          { id: 'doc-1', name: 'Doc 1', published: true },
+          { id: 'doc-2', name: 'Doc 2', published: false },
+        ]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+
+        const generalConditionsInput = await planForm.getGeneralConditionsInput();
+        await generalConditionsInput.open();
+        const options = await generalConditionsInput.getOptions();
+        expect(options.length).toEqual(2);
+        expect(await options[0].getText()).toEqual(''); // First option is blank so user can choose not to have general conditions
+        expect(await options[1].getText()).toEqual('Doc 1');
       });
     });
     describe('API Key plan', () => {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -71,7 +71,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
         .flush(tags);
     }
 
-    function expectGroupLisRequest(groups: Group[] = []) {
+    function expectGroupListRequest(groups: Group[] = []) {
       httpTestingController
         .expectOne({
           method: 'GET',
@@ -80,13 +80,13 @@ export class ApiPlanFormHarness extends ComponentHarness {
         .flush(groups);
     }
 
-    function expectDocumentationSearchRequest(apiId: string, groups: Page[] = []) {
+    function expectDocumentationSearchRequest(apiId: string, pages: Page[] = []) {
       httpTestingController
         .expectOne({
           method: 'GET',
           url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/pages?type=MARKDOWN&api=${apiId}`,
         })
-        .flush(groups);
+        .flush(pages);
     }
 
     function expectCurrentUserTagsRequest(tags: string[]) {
@@ -110,7 +110,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
 
     return {
       expectTagsListRequest,
-      expectGroupLisRequest,
+      expectGroupListRequest,
       expectDocumentationSearchRequest,
       expectCurrentUserTagsRequest,
       expectPolicySchemaGetRequest,

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -76,7 +76,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
 
     const apiPlanFormHarness = await this.locatorFor(ApiPlanFormHarness)();
 
-    apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+    apiPlanFormHarness.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(planName));
 
     apiPlanFormHarness.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {});
@@ -98,7 +98,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
 
     const apiPlanFormHarness = await this.locatorFor(ApiPlanFormHarness)();
 
-    apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+    apiPlanFormHarness.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     // Change plan name
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(newPlanName));
 

--- a/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/plans/edit/api-general-plan-edit.component.spec.ts
@@ -107,7 +107,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',
@@ -190,7 +190,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',
@@ -283,7 +283,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',
@@ -324,7 +324,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',
@@ -375,7 +375,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',
@@ -415,7 +415,7 @@ describe('ApiGeneralPlanEditComponent', () => {
         planForm
           .httpRequest(httpTestingController)
           .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupLisRequest([
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
           fakeGroup({
             id: 'group-a',
             name: 'Group A',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3399

## Description

- Fix typo for method name in plan form harness
- Only show published plans to user to add as general conditions

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zqlirlmsws.chromatic.com)
<!-- Storybook placeholder end -->
