### PR TITLE
Apim 3391 fix doc long name

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -27,7 +27,7 @@
         "@fontsource/libre-franklin": "4.4.5",
         "@gravitee/ui-analytics": "7.40.0",
         "@gravitee/ui-components": "3.45.2",
-        "@gravitee/ui-particles-angular": "7.49.2",
+        "@gravitee/ui-particles-angular": "7.50.0",
         "@gravitee/ui-policy-studio-angular": "7.40.0",
         "@highcharts/map-collection": "1.1.4",
         "@ngx-formly/core": "6.1.8",
@@ -4826,9 +4826,9 @@
       }
     },
     "node_modules/@gravitee/ui-particles-angular": {
-      "version": "7.49.2",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-7.49.2.tgz",
-      "integrity": "sha512-DA/+xGEofYozA2HSY1vpnAenQvX3Bq9QLQ2Jsgk19DIUR2k1HP1ya2k1QmT6m40h0Uh4q2mvJRN+Nbx0x7XOVA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-7.50.0.tgz",
+      "integrity": "sha512-y6TUQr7vz5cU/74NhHbic1ipxUg2GtZZJY+fTj6+rkmu/LaUqUADvfWxEq96WSoEVP73NULl0q1Uw5Cu+sI8Wg==",
       "dependencies": {
         "@fontsource/fira-mono": "4.5.0",
         "@fontsource/golos-ui": "^4.5.1",
@@ -39826,9 +39826,9 @@
       }
     },
     "@gravitee/ui-particles-angular": {
-      "version": "7.49.2",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-7.49.2.tgz",
-      "integrity": "sha512-DA/+xGEofYozA2HSY1vpnAenQvX3Bq9QLQ2Jsgk19DIUR2k1HP1ya2k1QmT6m40h0Uh4q2mvJRN+Nbx0x7XOVA==",
+      "version": "7.50.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-7.50.0.tgz",
+      "integrity": "sha512-y6TUQr7vz5cU/74NhHbic1ipxUg2GtZZJY+fTj6+rkmu/LaUqUADvfWxEq96WSoEVP73NULl0q1Uw5Cu+sI8Wg==",
       "requires": {
         "@fontsource/fira-mono": "4.5.0",
         "@fontsource/golos-ui": "^4.5.1",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -21,7 +21,7 @@
     "@fontsource/libre-franklin": "4.4.5",
     "@gravitee/ui-analytics": "7.40.0",
     "@gravitee/ui-components": "3.45.2",
-    "@gravitee/ui-particles-angular": "7.49.2",
+    "@gravitee/ui-particles-angular": "7.50.0",
     "@gravitee/ui-policy-studio-angular": "7.40.0",
     "@highcharts/map-collection": "1.1.4",
     "@ngx-formly/core": "6.1.8",

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.component.html
@@ -24,13 +24,13 @@
   <div
     [class.clickable]="canNavigate && breadcrumbs?.length > 0"
     (click)="doNavigate('ROOT', !breadcrumbs || breadcrumbs.length === 0)"
-    class="header__breadcrumb__item"
+    class="breadcrumb__item"
   >
     Home
   </div>
   <ng-container *ngFor="let breadcrumb of breadcrumbs; last as isLast">
-    <div class="header__breadcrumb__separator">></div>
-    <div class="header__breadcrumb__item" [class.clickable]="canNavigate && !isLast" (click)="doNavigate(breadcrumb.id, isLast)">
+    <div class="breadcrumb__separator">></div>
+    <div class="breadcrumb__item" [class.clickable]="canNavigate && !isLast" (click)="doNavigate(breadcrumb.id, isLast)">
       {{ breadcrumb.name }}
     </div>
   </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.component.scss
@@ -14,12 +14,17 @@ $typography: map.get(gio.$mat-theme, typography);
   &__item {
     @include mat.typography-level($typography, 'body-2');
     color: mat.get-color-from-palette(gio.$mat-space-palette, 'default');
+    max-width: 250px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   &__item:last-of-type:not(:only-of-type) {
     @include mat.typography-level($typography, 'body-2');
     color: mat.get-color-from-palette(gio.$mat-space-palette, 'default');
     background-color: mat.get-color-from-palette(gio.$mat-dove-palette, 'default');
+    max-width: none;
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component.html
@@ -28,6 +28,7 @@
     [(ngModel)]="_value"
     [languageConfig]="{ language: 'markdown' }"
     (ngModelChange)="_onChange(_value)"
+    [disableMiniMap]="true"
   ></gio-monaco-editor>
   <markdown *ngIf="preview" [data]="_value"> </markdown>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -18,16 +18,22 @@
 <api-documentation-page-title [api]="api"></api-documentation-page-title>
 <mat-card>
   <div class="header">
-    <div>
-      <h3>{{ pageTitle }}</h3>
-      <div class="header__location">
-        In
-        <api-documentation-breadcrumb [breadcrumbs]="breadcrumbs" [canNavigate]="false"></api-documentation-breadcrumb>
-      </div>
+    <h3 class="header__title">{{ pageTitle }}</h3>
+    <div class="header__location">
+      In
+      <api-documentation-breadcrumb [breadcrumbs]="breadcrumbs" [canNavigate]="false"></api-documentation-breadcrumb>
     </div>
     <div class="header__actions">
-      <button mat-stroked-button *ngIf="mode === 'edit'" (click)="deletePage()" [disabled]="!!page?.generalConditions">Delete page</button>
-      <button mat-stroked-button (click)="goBackToPageList()">Exit without saving</button>
+      <button
+        class="header__delete"
+        mat-stroked-button
+        *ngIf="mode === 'edit'"
+        (click)="deletePage()"
+        [disabled]="!!page?.generalConditions"
+      >
+        Delete page
+      </button>
+      <button class="header__exit" mat-stroked-button (click)="goBackToPageList()">Exit without saving</button>
     </div>
   </div>
   <div class="stepper">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.scss
@@ -9,22 +9,37 @@ $typography: map.get(gio.$mat-theme, typography);
 }
 
 .header {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 6fr 1fr;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    'title actions'
+    'location actions';
+  grid-column-gap: 8px;
   padding: 20px 24px;
   border-bottom: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+
+  &__title {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    grid-area: title;
+  }
 
   &__location {
     display: flex;
     flex-direction: row;
     align-items: flex-end;
     gap: 2px;
+    grid-area: location;
   }
 
   &__actions {
+    grid-area: actions;
+
     display: flex;
+    justify-items: center;
+    align-items: center;
     gap: 8px;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -81,7 +81,7 @@
     <ng-container matColumnDef="lastUpdated">
       <th mat-header-cell *matHeaderCellDef>Last Updated</th>
       <td mat-cell *matCellDef="let page">
-        {{ page.updatedAt | date : 'medium' }}
+        {{ page.updatedAt | date: 'medium' }}
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">
@@ -172,6 +172,8 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
   </table>
   <div class="documentation-pages-list__footer">
-    <button mat-flat-button (click)="onAddPage.emit()" *gioPermission="{ anyOf: ['api-documentation-c'] }">Add new page</button>
+    <button mat-flat-button color="primary" (click)="onAddPage.emit()" *gioPermission="{ anyOf: ['api-documentation-c'] }">
+      Add new page
+    </button>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -81,7 +81,7 @@
     <ng-container matColumnDef="lastUpdated">
       <th mat-header-cell *matHeaderCellDef>Last Updated</th>
       <td mat-cell *matCellDef="let page">
-        {{ page.updatedAt | date: 'medium' }}
+        {{ page.updatedAt | date : 'medium' }}
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
@@ -14,17 +14,29 @@
   &__table {
     &__name {
       display: flex;
+      max-width: 450px;
       cursor: pointer;
       gap: 8px;
       align-items: center;
+
       p {
         margin-bottom: 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
+
+      mat-icon {
+        flex: 0 0 24px;
       }
     }
 
     &__actions {
       display: flex;
       gap: 8px;
+    }
+    .mat-column-actions {
+      max-width: 232px;
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3391

## Description

- Upgrade particles to disable minimap on monaco editor
- Handle display of long names in page edition and in page list

![Screenshot 2023-11-22 at 15 12 50](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/e6c98abf-3e1f-4cc8-a7bc-747591efa219)
![Screenshot 2023-11-22 at 15 13 03](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/70ff4f2e-f636-4c62-9e3e-c291a3d8a331)

![Screenshot 2023-11-22 at 15 41 10](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/64d55a1c-c26e-4228-8a7c-14fe0ac5c6c3)
![Screenshot 2023-11-22 at 15 41 15](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/13d2fced-91dc-49ef-b116-a47a5b592128)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kzqcwkpnei.chromatic.com)
<!-- Storybook placeholder end -->
