### PR TITLE
feat(console): refer to portal as Developer Portal in documentation

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-top-nav/gio-top-nav.component.html
@@ -30,7 +30,7 @@
     <gio-top-bar-link
       *ngIf="constants?.env?.settings?.portal?.url"
       [url]="constants.env.settings.portal.url"
-      name="Developers Portal"
+      name="Developer Portal"
     ></gio-top-bar-link>
     <gio-top-bar-menu>
       <button

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
@@ -18,7 +18,7 @@
 <div class="header">
   <div class="header__title">
     <h1>Documentation</h1>
-    <div class="header__subtitle">Documentation pages appear in the portal and inform API consumers how to use your API</div>
+    <div class="header__subtitle">Documentation pages appear in the Developer Portal and inform API consumers how to use your API</div>
   </div>
   <div class="header__actions">
     <a

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -61,14 +61,7 @@
           <span *ngIf="!page.published" class="gio-badge-neutral"> Unpublished </span>
         </ng-container>
         <ng-container *ngIf="page.type === 'FOLDER'">
-          <span
-            *ngIf="page.hidden"
-            class="gio-badge-neutral"
-            matTooltip="Must contain published pages to be shown"
-            matTooltipPosition="after"
-          >
-            Hidden
-          </span>
+          <span *ngIf="page.hidden" class="gio-badge-neutral" matTooltip="Must contain published pages to be shown"> Hidden </span>
         </ng-container>
       </td>
     </ng-container>
@@ -127,7 +120,7 @@
                 (click)="onUnpublishPage.emit(page.id)"
                 [disabled]="page.generalConditions"
                 mat-icon-button
-                [matTooltip]="page.generalConditions ? 'Cannot be unpublished if used by active plans' : 'Unpublish page'"
+                [matTooltip]="page.generalConditions ? 'Cannot unpublish if used as General Conditions' : 'Unpublish page'"
                 aria-label="Unpublish page"
               >
                 <mat-icon svgIcon="gio:cloud-unpublished"></mat-icon>
@@ -163,7 +156,7 @@
             aria-label="Delete page"
             [matTooltip]="
               page.generalConditions
-                ? 'Cannot delete page used as General Conditions'
+                ? 'Cannot delete if used as General Conditions'
                 : page.type === 'FOLDER'
                 ? 'Delete folder'
                 : 'Delete page'


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3384

## Description

Rename portal to Developer Portal in Documentation as well as in the top bar.

![Screenshot 2023-11-22 at 16 32 20](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/6a59dab0-935b-4723-a2be-ed7f3f786a07)

![Screenshot 2023-11-22 at 16 32 31](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/db9602dd-b765-4660-b3f3-2d02bc4c445e)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nmruvswjsx.chromatic.com)
<!-- Storybook placeholder end -->
