### PR TITLE
Apim 3390 clarify tooltip + pages list styling

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-tabs/api-navigation-tabs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-tabs/api-navigation-tabs.component.scss
@@ -30,6 +30,9 @@ $typography: map.get(gio.$mat-theme, typography);
 }
 
 .header {
+  display: flex;
+  gap: 4px;
+  flex-flow: column;
   margin-bottom: 24px;
 
   &__subtitle {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
@@ -20,15 +20,14 @@
     <h1>Documentation</h1>
     <div class="header__subtitle">Documentation pages appear in the Developer Portal and inform API consumers how to use your API</div>
   </div>
-  <div class="header__actions">
+  <div class="header__actions" *ngIf="api && apiPortalUrl">
     <a
       mat-raised-button
-      *ngIf="apiPortalUrl"
       class="header__actions__open-in-portal"
       [href]="apiPortalUrl"
       target="_blank"
       [disabled]="api.lifecycleState !== 'PUBLISHED'"
-      [matTooltip]="api.lifecycleState !== 'PUBLISHED' ? 'Publish your API to view' : undefined"
+      [matTooltip]="apiNotInPortalTooltip"
       >Open API in Developer Portal</a
     >
   </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="header">
   <div class="header__title">
-    <h1>Documentation</h1>
+    <div><span class="mat-h2">Documentation</span></div>
     <div class="header__subtitle">Documentation pages appear in the Developer Portal and inform API consumers how to use your API</div>
   </div>
   <div class="header__actions" *ngIf="api && apiPortalUrl">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.scss
@@ -10,6 +10,9 @@ $typography: map.get(gio.$mat-theme, typography);
 
   &__title {
     flex: 1 1 100%;
+    display: flex;
+    gap: 4px;
+    flex-flow: column;
   }
 
   &__subtitle {
@@ -18,6 +21,6 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 
   &__actions {
-    padding-top: 12px;
+    align-self: center;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-title/api-documentation-v4-page-title.component.ts
@@ -28,27 +28,46 @@ export class ApiDocumentationV4PageTitleComponent implements OnInit, OnChanges {
   api: Api;
 
   public apiPortalUrl: string;
+  public apiNotInPortalTooltip: string;
 
   constructor(@Inject('Constants') public readonly constants: Constants) {}
 
   ngOnInit(): void {
-    this.calculateApiPortalUrl();
+    if (this.api) {
+      this.calculateApiPortalUrl();
+      this.apiNotInPortalTooltip = this.getApiNotInPortalTooltip();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.api) {
       this.api = changes.api.currentValue;
-      this.calculateApiPortalUrl();
+      this.ngOnInit();
     }
   }
 
   private calculateApiPortalUrl(): void {
-    if (this.api?.id && this.constants?.env?.settings?.portal?.url) {
+    if (this.api.id && this.constants?.env?.settings?.portal?.url) {
       const root = this.constants.env.settings.portal.url;
       const apiPath = 'catalog/api/' + this.api.id;
       const connector = '/';
 
       this.apiPortalUrl = root.endsWith(connector) ? root + apiPath : root + connector + apiPath;
+    }
+  }
+
+  private getApiNotInPortalTooltip(): string {
+    switch (this.api.lifecycleState) {
+      case 'DEPRECATED':
+        return 'Deprecated APIs do not appear in the Developer Portal';
+      case 'ARCHIVED':
+        return 'Archived APIs do not appear in the Developer Portal';
+      case 'CREATED':
+      case 'UNPUBLISHED':
+        return "Activate the Developer Portal by publishing your API under 'General > Info'";
+      case 'PUBLISHED':
+      default:
+        return undefined;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.scss
@@ -6,7 +6,7 @@ $typography: map.get(gio.$mat-theme, typography);
 .header {
   border-bottom: 2px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');
 
-  padding: 8px;
+  padding: 12px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -14,8 +14,7 @@ $typography: map.get(gio.$mat-theme, typography);
   min-height: 54px;
 
   &__action {
-    &__button {
-      margin-right: 4px;
-    }
+    display: flex;
+    gap: 8px;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -49,7 +49,7 @@
     </ng-container>
     <ng-container matColumnDef="status">
       <th mat-header-cell *matHeaderCellDef>Status</th>
-      <td mat-cell *matCellDef="let page">
+      <td mat-cell *matCellDef="let page" class="documentation-pages-list__table__status">
         <ng-container *ngIf="page.type != 'FOLDER'">
           <span *ngIf="page.published" class="gio-badge-success"> Published </span>
           <span
@@ -67,7 +67,7 @@
     </ng-container>
     <ng-container matColumnDef="visibility">
       <th mat-header-cell *matHeaderCellDef>Visibility</th>
-      <td mat-cell *matCellDef="let page">
+      <td mat-cell *matCellDef="let page" class="documentation-pages-list__table__status">
         <span class="gio-badge-neutral"> {{ page.visibility | titlecase }} </span>
       </td>
     </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.scss
@@ -26,6 +26,13 @@
       }
     }
 
+    &__status {
+      flex: 1 1 100%;
+      span:first-child {
+        margin-left: 0;
+      }
+    }
+
     &__actions {
       display: flex;
       gap: 8px;
@@ -37,7 +44,7 @@
 }
 
 .empty-icon-button {
-  width: 40px;
+  min-width: 40px;
 }
 
 .no-pointer {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3390

## Description

- Refine tooltip for when `Open API in Developer Portal` button is disabled
- Add some styling to the pages list to make it prettier ✨ 

Tooltip on disabled -- CREATED:

![Screenshot 2023-11-23 at 10 00 17](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/3a1c5a5f-90c7-4e10-857f-eb9f57aca28b)


Tooltip on disabled -- DEPRECATED:

![Screenshot 2023-11-23 at 10 01 00](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/0265b4ba-8a0b-4351-a2b9-26a3ec848dda)


Prettification: 

![Screenshot 2023-11-22 at 17 57 58](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/b2933c60-b33b-4ad8-a6b4-f3df45b4711b)


Runtime logs improvement to match Documentation:

![Screenshot 2023-11-22 at 17 17 46](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/ffb6ea69-2913-4e5e-99c2-a78b6daebd9c)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ddgzqmvhtv.chromatic.com)
<!-- Storybook placeholder end -->
