### PR TITLE
refactor: use ApiType and DefinitionVersion enum from api definition

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.api.model;
 
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -155,16 +157,5 @@ public class Api {
         UNPUBLISHED,
         DEPRECATED,
         ARCHIVED,
-    }
-
-    public enum DefinitionVersion {
-        V1,
-        V2,
-        V4,
-    }
-
-    public enum ApiType {
-        PROXY,
-        MESSAGE,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiSearchCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiSearchCriteria.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api.model;
 
+import io.gravitee.definition.model.DefinitionVersion;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;
@@ -35,5 +36,5 @@ public class ApiSearchCriteria {
     private String environmentId;
     private List<String> environments;
     private String crossId;
-    private List<Api.DefinitionVersion> definitionVersion;
+    private List<DefinitionVersion> definitionVersion;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
@@ -15,14 +15,10 @@
  */
 package io.gravitee.apim.core.plan.query_service;
 
-import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.util.List;
 
 public interface PlanQueryService {
-    List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(
-        String apiId,
-        Api.DefinitionVersion definitionVersion,
-        String pageId
-    );
+    List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.infra.adapter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -56,10 +55,8 @@ public interface PlanAdapter {
     @Mapping(target = "security", expression = "java(computeBasePlanEntitySecurityV2(plan))")
     io.gravitee.rest.api.model.BasePlanEntity toEntityV2(Plan plan);
 
-    default GenericPlanEntity toGenericEntity(Plan plan, Api.DefinitionVersion definitionVersion) {
-        return definitionVersion == Api.DefinitionVersion.V4
-            ? PlanAdapter.INSTANCE.toEntityV4(plan)
-            : PlanAdapter.INSTANCE.toEntityV2(plan);
+    default GenericPlanEntity toGenericEntity(Plan plan, DefinitionVersion definitionVersion) {
+        return definitionVersion == DefinitionVersion.V4 ? PlanAdapter.INSTANCE.toEntityV4(plan) : PlanAdapter.INSTANCE.toEntityV2(plan);
     }
 
     @Named("computeBasePlanEntityMode")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plan/PlanQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plan/PlanQueryServiceImpl.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.apim.infra.query_service.plan;
 
-import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.infra.adapter.PlanAdapter;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
@@ -44,7 +43,7 @@ public class PlanQueryServiceImpl implements PlanQueryService {
     @Override
     public List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(
         String apiId,
-        Api.DefinitionVersion definitionVersion,
+        DefinitionVersion definitionVersion,
         String pageId
     ) {
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
@@ -17,6 +17,7 @@ package inmemory;
 
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
@@ -33,7 +34,7 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
     @Override
     public List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(
         String apiId,
-        Api.DefinitionVersion definitionVersion,
+        DefinitionVersion definitionVersion,
         String pageId
     ) {
         return storage

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.installation.model.RestrictedDomain;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.infra.adapter.GraviteeJacksonMapper;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -412,7 +413,7 @@ class VerifyApiPathDomainServiceTest {
             .builder()
             .id(apiId)
             .environmentId(environmentId)
-            .definitionVersion(Api.DefinitionVersion.V2)
+            .definitionVersion(DefinitionVersion.V2)
             .definition(objectMapper.writeValueAsString(apiDefV2))
             .build();
     }
@@ -437,7 +438,7 @@ class VerifyApiPathDomainServiceTest {
             .builder()
             .id(apiId)
             .environmentId(environmentId)
-            .definitionVersion(Api.DefinitionVersion.V4)
+            .definitionVersion(DefinitionVersion.V4)
             .definition(objectMapper.writeValueAsString(apiDefV4))
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/DeleteApiDocumentationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/DeleteApiDocumentationDomainServiceTest.java
@@ -29,8 +29,6 @@ import inmemory.PlanQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
-import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
-import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.PageAuditEvent;
 import io.gravitee.apim.core.documentation.exception.ApiFolderNotEmptyException;
@@ -38,10 +36,10 @@ import io.gravitee.apim.core.documentation.exception.ApiPageInvalidReferenceType
 import io.gravitee.apim.core.documentation.exception.ApiPageUsedAsGeneralConditionException;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
@@ -59,7 +57,7 @@ class DeleteApiDocumentationDomainServiceTest {
     private static final String ENVIRONMENT_ID = "environment-id";
     private static final String USER_ID = "user-id";
     private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
-    private static final Api API = Api.builder().id("api-id").definitionVersion(Api.DefinitionVersion.V4).build();
+    private static final Api API = Api.builder().id("api-id").definitionVersion(DefinitionVersion.V4).build();
     public static final String PAGE_ID = "page-id";
     public static final String FOLDER_ID = "folder-id";
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiDeleteDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiDeleteDocumentationPageUseCaseTest.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.documentation.domain_service.DeleteApiDocumentation
 import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import java.util.List;
 import java.util.stream.Stream;
@@ -46,7 +47,7 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ApiDeleteDocumentationPageUseCaseTest {
 
-    private static final Api API = Api.builder().id("api-id").definitionVersion(Api.DefinitionVersion.V4).build();
+    private static final Api API = Api.builder().id("api-id").definitionVersion(DefinitionVersion.V4).build();
     public static final String PAGE_ID = "page-id";
     private static final String ORGANIZATION_ID = "organization-id";
     private static final String ENVIRONMENT_ID = "environment-id";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/page/PlanQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/page/PlanQueryServiceImplTest.java
@@ -77,11 +77,7 @@ class PlanQueryServiceImplTest {
 
             when(planRepository.findByApi(eq(API_ID))).thenReturn(Set.of(plan_published, plan_closed, plan_staging, plan_different_page));
 
-            var res = service.findAllByApiIdAndGeneralConditionsAndIsActive(
-                API_ID,
-                io.gravitee.apim.core.api.model.Api.DefinitionVersion.V4,
-                PAGE_ID
-            );
+            var res = service.findAllByApiIdAndGeneralConditionsAndIsActive(API_ID, DefinitionVersion.V4, PAGE_ID);
             assertThat(res).hasSize(1);
             assertThat(res.get(0).getId()).isEqualTo("published-id");
             assertThat(res.get(0).getPlanSecurity()).isEqualTo(PlanSecurity.builder().type("api-key").build());
@@ -93,11 +89,7 @@ class PlanQueryServiceImplTest {
         void should_return_empty_list_if_no_results() {
             when(planRepository.findByApi(eq(API_ID))).thenReturn(Set.of());
 
-            var res = service.findAllByApiIdAndGeneralConditionsAndIsActive(
-                API_ID,
-                io.gravitee.apim.core.api.model.Api.DefinitionVersion.V4,
-                PAGE_ID
-            );
+            var res = service.findAllByApiIdAndGeneralConditionsAndIsActive(API_ID, DefinitionVersion.V4, PAGE_ID);
             assertThat(res).hasSize(0);
         }
     }


### PR DESCRIPTION
## Description

These 2 enums are already defined in the api-definition module. Instead of creating two new enum we can use the existing ones.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iujbqoiqsn.chromatic.com)
<!-- Storybook placeholder end -->
