### PR TITLE
fix(console): hide create page button in api documentation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.html
@@ -19,6 +19,7 @@
 <mat-card>
   <api-documentation-list-navigation-header
     [breadcrumbs]="breadcrumbs || []"
+    [hasPages]="pages && pages.length > 0"
     (onAddFolder)="addFolder()"
     (onAddPage)="addPage()"
     (onNavigateTo)="navigateTo($event)"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
@@ -199,6 +199,13 @@ describe('ApiDocumentationV4', () => {
       });
     });
 
+    it('should hide create page button when folder is empty', async () => {
+      await init([], []);
+      const headerHarness = await harnessLoader.getHarness(ApiDocumentationV4ListNavigationHeaderHarness);
+
+      expect(await headerHarness.getNewPageButton()).toBeNull();
+    });
+
     it('should navigate to folder when click in the list', async () => {
       await init([fakeFolder({ name: 'my first folder', id: 'my-first-folder', visibility: 'PUBLIC' })], []);
       const pageListHarness = await harnessLoader.getHarness(ApiDocumentationV4PagesListHarness);

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.html
@@ -26,14 +26,16 @@
     >
       Add new folder
     </button>
-    <button
-      class="header__action__button"
-      mat-flat-button
-      color="primary"
-      (click)="onAddPage.emit()"
-      *gioPermission="{ anyOf: ['api-documentation-c'] }"
-    >
-      Add new page
-    </button>
+    <ng-container *ngIf="hasPages">
+      <button
+        class="header__action__button"
+        mat-flat-button
+        color="primary"
+        (click)="onAddPage.emit()"
+        *gioPermission="{ anyOf: ['api-documentation-c'] }"
+      >
+        Add new page
+      </button>
+    </ng-container>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component.ts
@@ -26,6 +26,8 @@ import { Breadcrumb } from '../../../../../entities/management-api-v2/documentat
 export class ApiDocumentationV4ListNavigationHeaderComponent {
   @Input()
   breadcrumbs: Breadcrumb[];
+  @Input()
+  hasPages: boolean;
   @Output()
   onAddFolder = new EventEmitter<void>();
   @Output()

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.harness.ts
@@ -21,7 +21,7 @@ import { ApiDocumentationV4BreadcrumbHarness } from '../api-documentation-v4-bre
 
 export class ApiDocumentationV4ListNavigationHeaderHarness extends ComponentHarness {
   public static hostSelector = 'api-documentation-list-navigation-header';
-  private addNewPageButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add new page' }));
+  private addNewPageButtonLocator = this.locatorForOptional(MatButtonHarness.with({ text: 'Add new page' }));
 
   private addNewFolderButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Add new folder' }));
   public async clickAddNewFolder() {
@@ -40,5 +40,9 @@ export class ApiDocumentationV4ListNavigationHeaderHarness extends ComponentHarn
 
   async clickAddNewPage() {
     return this.addNewPageButtonLocator().then((btn) => btn.click());
+  }
+
+  async getNewPageButton() {
+    return this.addNewPageButtonLocator();
   }
 }


### PR DESCRIPTION
…r is empty

## Issue

https://gravitee.atlassian.net/browse/APIM-3407

## Description

hide create page button in api documentation when folder is empty

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jqyvmifdxm.chromatic.com)
<!-- Storybook placeholder end -->
