### PR TITLE
feat(helm): allow installation api url override

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apim
 # Also update CHANGELOG.md
-version: 4.1.0
-appVersion: 4.1.0
+version: 4.2.0
+appVersion: 4.2.0
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io
 sources:

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -93,7 +93,11 @@ data:
     installation:
       type: {{ include "installation.type" . }}
       api:
+      {{- if .Values.installation.api.url }}
+        url: {{ .Values.installation.api.url }}
+      {{ else }}
         url: {{ .Values.api.ingress.management.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}
+      {{- end }}
         proxyPath:
           management: {{ regexFind "/[a-zA-Z-_.~]+" .Values.api.ingress.management.path }}
           portal: {{ regexFind "/[a-zA-Z-_.~]+" .Values.api.ingress.portal.path }}

--- a/helm/tests/api/configmap_test_installation.yaml
+++ b/helm/tests/api/configmap_test_installation.yaml
@@ -123,3 +123,14 @@ tests:
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "installation:[\\S\\s\\n]*multi-tenant:[\\S\\s\\n]*accessPoints:[\\S\\s\\n]*organization:[\\S\\s\\n]*console"
+  - it: Override installation.api.url
+    template: api/api-configmap.yaml
+    set:
+      installation:
+        type: multi-tenant
+        api:
+          url: https://mapi.example.com
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "installation:[\\S\\s\\n]*api:[\\S\\s\\n]*url: https://mapi.example.com"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,11 @@ extraObjects: []
   #  data:
   #    license.key: myLicenceInBase64==
 
+installation:
+  type:
+  api:
+    url:
+
 apim:
   name: apim
   # Whether this chart should self-manage its service account, role, and associated role binding.


### PR DESCRIPTION
When you difine ingress with wildcard dns eg: *.gravitee.xxx
You have to override the api url to: something.gravitee.xxx