### PR TITLE
feat(console): add save and publish button to edit unpublished page view

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -83,15 +83,37 @@
             </ng-container>
 
             <ng-container *ngIf="mode === 'edit' && page">
-              <button
-                *gioPermission="{ anyOf: ['api-documentation-u'] }"
-                mat-flat-button
-                color="primary"
-                [disabled]="form.invalid || form.pristine || formUnchanged"
-                (click)="update()"
-              >
-                {{ page.published ? 'Publish changes' : 'Save' }}
-              </button>
+              <ng-container *ngIf="!page.published">
+                <button
+                  *gioPermission="{ anyOf: ['api-documentation-u'] }"
+                  mat-flat-button
+                  color="primary"
+                  [disabled]="form.invalid || form.pristine || formUnchanged"
+                  (click)="updateAndPublish()"
+                >
+                  Save and publish
+                </button>
+                <button
+                  *gioPermission="{ anyOf: ['api-documentation-u'] }"
+                  mat-stroked-button
+                  [disabled]="form.invalid || form.pristine || formUnchanged"
+                  (click)="update()"
+                >
+                  Save
+                </button>
+              </ng-container>
+
+              <ng-container *ngIf="page.published">
+                <button
+                  *gioPermission="{ anyOf: ['api-documentation-u'] }"
+                  mat-flat-button
+                  color="primary"
+                  [disabled]="form.invalid || form.pristine || formUnchanged"
+                  (click)="update()"
+                >
+                  Publish changes
+                </button>
+              </ng-container>
             </ng-container>
 
             <button mat-stroked-button matStepperPrevious>Previous</button>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -158,6 +158,22 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
       });
   }
 
+  updateAndPublish() {
+    this.updatePage()
+      .pipe(
+        switchMap((page) => this.apiDocumentationService.publishDocumentationPage(this.api.id, page.id)),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe({
+        next: () => {
+          this.goBackToPageList();
+        },
+        error: (error) => {
+          this.snackBarService.error(error?.error?.message ?? 'Cannot publish page');
+        },
+      });
+  }
+
   private updatePage(): Observable<Page> {
     const formValue = this.form.getRawValue();
     return this.apiDocumentationService.getApiPage(this.api.id, this.ajsStateParams.pageId).pipe(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3414

## Description

Add a button for Save and publish if a page is unpublished and being edited.

![Screenshot 2023-11-24 at 10 27 23](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/090b719f-c475-4a08-8efa-6faa5e4f092d)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qthxiauchc.chromatic.com)
<!-- Storybook placeholder end -->
