### PR TITLE
refactor: create plan core model

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.log.model.MessageLogFixtures;
+import fixtures.core.model.PlanFixtures;
 import fixtures.repository.ConnectionLogDetailFixtures;
 import fixtures.repository.ConnectionLogFixtures;
 import inmemory.ApplicationCrudServiceInMemory;
@@ -32,6 +33,7 @@ import inmemory.InMemoryAlternative;
 import inmemory.MessageLogCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.apim.core.log.model.MessageOperation;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLog;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLogRequestContent;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLogResponse;
@@ -51,7 +53,6 @@ import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
-import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
@@ -69,8 +70,8 @@ import org.junit.jupiter.api.Test;
 
 public class ApiLogsResourceTest extends ApiResourceTest {
 
-    private static final BasePlanEntity PLAN_1 = BasePlanEntity.builder().id("plan1").name("1st plan").apiId(API).build();
-    private static final BasePlanEntity PLAN_2 = BasePlanEntity.builder().id("plan2").name("2nd plan").apiId(API).build();
+    private static final Plan PLAN_1 = Plan.builder().id("plan1").name("1st plan").apiId(API).build();
+    private static final Plan PLAN_2 = Plan.builder().id("plan2").name("2nd plan").apiId(API).build();
     private static final BaseApplicationEntity APPLICATION = BaseApplicationEntity.builder().id("app1").name("an application name").build();
     public static final String REQUEST_ID = "request-id";
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import assertions.MAPIAssertions;
+import fixtures.core.model.PlanFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
@@ -490,7 +491,16 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .build();
             givenApiPagesQuery(List.of(page1, page2));
             planQueryServiceInMemory.initWith(
-                List.of(PlanEntity.builder().id("plan-1").apiId("api-id").generalConditions("page-1").status(PlanStatus.PUBLISHED).build())
+                List.of(
+                    PlanFixtures
+                        .aPlanV4()
+                        .toBuilder()
+                        .id("plan-1")
+                        .apiId("api-id")
+                        .generalConditions("page-1")
+                        .status(PlanStatus.PUBLISHED)
+                        .build()
+                )
             );
 
             final Response response = rootTarget().request().get();
@@ -1237,7 +1247,9 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             givenApiPagesQuery(List.of(page1));
 
             planQueryServiceInMemory.initWith(
-                List.of(PlanEntity.builder().id("plan-id").status(planStatus).apiId(API_ID).generalConditions(PAGE_ID).build())
+                List.of(
+                    PlanFixtures.aPlanV4().toBuilder().id("plan-id").status(planStatus).apiId(API_ID).generalConditions(PAGE_ID).build()
+                )
             );
 
             final Response response = rootTarget().path(PATH).request().delete();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/crud_service/PlanCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/crud_service/PlanCrudService.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.apim.core.plan.crud_service;
 
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.apim.core.plan.model.Plan;
 
 public interface PlanCrudService {
-    GenericPlanEntity findById(String planId);
+    Plan findById(String planId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.model;
+
+import io.gravitee.definition.model.Rule;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Define a Plan for API.
+ *
+ * <p>⚠️ It is a merged definition of V2 and V4 plans.</p>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+// Implement GenericPlanEntity to ease transition but it should be removed once core elements only use Plan instead of GenericPlanEntity
+public class Plan implements GenericPlanEntity {
+
+    private String id;
+    /**
+     * The plan crossId uniquely identifies a plan across environments.
+     * Plans promoted between environments will share the same crossId.
+     */
+    private String crossId;
+    private String name;
+    private String description;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+    private ZonedDateTime publishedAt;
+    private ZonedDateTime closedAt;
+
+    private Date needRedeployAt; // java.util.Date required to implement GenericPlanEntity
+
+    /** The way to validate subscriptions */
+    private PlanValidationType validation;
+
+    @Builder.Default
+    private PlanType type = PlanType.API;
+
+    @Builder.Default
+    private PlanMode mode = PlanMode.STANDARD;
+
+    private PlanSecurity security;
+
+    private String selectionRule;
+
+    @Builder.Default
+    private Set<String> tags = new HashSet<>();
+
+    private PlanStatus status;
+
+    private String apiId;
+
+    private int order;
+
+    @Builder.Default
+    private List<String> characteristics = new ArrayList<>();
+
+    @Builder.Default
+    private List<String> excludedGroups = new ArrayList<>();
+
+    private boolean commentRequired;
+    private String commentMessage;
+    private String generalConditions;
+
+    /** Use only for V2 plans */
+    private Map<String, List<Rule>> paths;
+
+    @Override
+    public io.gravitee.rest.api.model.v4.plan.PlanType getPlanType() {
+        return io.gravitee.rest.api.model.v4.plan.PlanType.valueOf(type.name());
+    }
+
+    @Override
+    public PlanSecurity getPlanSecurity() {
+        return this.security;
+    }
+
+    @Override
+    public PlanStatus getPlanStatus() {
+        return this.status;
+    }
+
+    @Override
+    public io.gravitee.rest.api.model.v4.plan.PlanMode getPlanMode() {
+        return io.gravitee.rest.api.model.v4.plan.PlanMode.valueOf(mode.name());
+    }
+
+    @Override
+    public io.gravitee.rest.api.model.v4.plan.PlanValidationType getPlanValidation() {
+        return io.gravitee.rest.api.model.v4.plan.PlanValidationType.valueOf(validation.name());
+    }
+
+    public enum PlanValidationType {
+        /** Subscription is automatically validated without any human action. */
+        AUTO,
+
+        /** Subscription requires a human validation. */
+        MANUAL,
+    }
+
+    public enum PlanType {
+        API,
+        CATALOG,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/query_service/PlanQueryService.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.apim.core.plan.query_service;
 
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.util.List;
 
 public interface PlanQueryService {
-    List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId);
+    List<Plan> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plan/PlanQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plan/PlanQueryServiceImpl.java
@@ -16,13 +16,12 @@
 package io.gravitee.apim.infra.query_service.plan;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.infra.adapter.PlanAdapter;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
-import io.gravitee.repository.management.model.Plan;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.util.List;
 import java.util.Objects;
 import org.slf4j.Logger;
@@ -41,20 +40,19 @@ public class PlanQueryServiceImpl implements PlanQueryService {
     }
 
     @Override
-    public List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(
-        String apiId,
-        DefinitionVersion definitionVersion,
-        String pageId
-    ) {
+    public List<Plan> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId) {
         try {
             return planRepository
                 .findByApi(apiId)
                 .stream()
                 .filter(plan ->
                     Objects.equals(plan.getGeneralConditions(), pageId) &&
-                    !(Plan.Status.CLOSED == plan.getStatus() || Plan.Status.STAGING == plan.getStatus())
+                    !(
+                        io.gravitee.repository.management.model.Plan.Status.CLOSED == plan.getStatus() ||
+                        io.gravitee.repository.management.model.Plan.Status.STAGING == plan.getStatus()
+                    )
                 )
-                .map(plan -> PlanAdapter.INSTANCE.toGenericEntity(plan, definitionVersion))
+                .map(PlanAdapter.INSTANCE::fromRepository)
                 .toList();
         } catch (TechnicalException e) {
             logger.error("An error occurred while finding plans by API ID {}", apiId, e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+public class PlanFixtures {
+
+    private PlanFixtures() {}
+
+    private static final Supplier<Plan.PlanBuilder> BASE = () ->
+        Plan
+            .builder()
+            .id("my-plan")
+            .apiId("my-api")
+            .name("My plan")
+            .description("Description")
+            .order(1)
+            .characteristics(List.of("characteristic1", "characteristic2"))
+            .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .needRedeployAt(Date.from(Instant.parse("2051-02-01T20:22:02.00Z")))
+            .commentMessage("Comment message")
+            .crossId("my-plan-crossId")
+            .generalConditions("General conditions")
+            .tags(Set.of("tag1", "tag2"))
+            .status(PlanStatus.PUBLISHED)
+            .security(PlanSecurity.builder().type(PlanSecurityType.KEY_LESS.getLabel()).configuration("{\"nice\": \"config\"}").build())
+            .type(Plan.PlanType.API)
+            .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+            .validation(Plan.PlanValidationType.AUTO)
+            .selectionRule("{#request.attribute['selectionRule'] != null}");
+
+    public static Plan aPlanV4() {
+        return BASE.get().build();
+    }
+
+    public static Plan aPlanV2() {
+        return BASE.get().paths(Map.of("/", List.of())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
@@ -16,19 +16,19 @@
 package inmemory;
 
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlternative<GenericPlanEntity> {
+public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlternative<Plan> {
 
-    private final List<GenericPlanEntity> storage = new ArrayList<>();
+    private final List<Plan> storage = new ArrayList<>();
 
     @Override
-    public GenericPlanEntity findById(String planId) {
+    public Plan findById(String planId) {
         if (planId == null) {
             throw new TechnicalManagementException("planId should not be null");
         }
@@ -40,7 +40,7 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlterna
     }
 
     @Override
-    public void initWith(List<GenericPlanEntity> items) {
+    public void initWith(List<Plan> items) {
         storage.addAll(items);
     }
 
@@ -50,7 +50,7 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlterna
     }
 
     @Override
-    public List<GenericPlanEntity> storage() {
+    public List<Plan> storage() {
         return Collections.unmodifiableList(storage);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
@@ -15,28 +15,21 @@
  */
 package inmemory;
 
-import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlternative<GenericPlanEntity> {
+public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlternative<Plan> {
 
-    private final List<GenericPlanEntity> storage = new ArrayList<>();
+    private final List<Plan> storage = new ArrayList<>();
 
     @Override
-    public List<GenericPlanEntity> findAllByApiIdAndGeneralConditionsAndIsActive(
-        String apiId,
-        DefinitionVersion definitionVersion,
-        String pageId
-    ) {
+    public List<Plan> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId) {
         return storage
             .stream()
             .filter(plan ->
@@ -48,7 +41,7 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
     }
 
     @Override
-    public void initWith(List<GenericPlanEntity> items) {
+    public void initWith(List<Plan> items) {
         storage.addAll(items);
     }
 
@@ -58,7 +51,7 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
     }
 
     @Override
-    public List<GenericPlanEntity> storage() {
+    public List<Plan> storage() {
         return Collections.unmodifiableList(storage);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/DeleteApiDocumentationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/DeleteApiDocumentationDomainServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.PlanFixtures;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PageCrudServiceInMemory;
@@ -38,7 +39,6 @@ import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.Date;
 import java.util.List;
@@ -116,7 +116,14 @@ class DeleteApiDocumentationDomainServiceTest {
             );
             planQueryService.initWith(
                 List.of(
-                    PlanEntity.builder().id("plan-1").apiId(API.getId()).status(PlanStatus.PUBLISHED).generalConditions(PAGE_ID).build()
+                    PlanFixtures
+                        .aPlanV4()
+                        .toBuilder()
+                        .id("plan-1")
+                        .apiId(API.getId())
+                        .status(PlanStatus.PUBLISHED)
+                        .generalConditions(PAGE_ID)
+                        .build()
                 )
             );
             assertThatThrownBy(() -> cut.delete(API, PAGE_ID, AUDIT_INFO)).isInstanceOf(ApiPageUsedAsGeneralConditionException.class);
@@ -143,7 +150,14 @@ class DeleteApiDocumentationDomainServiceTest {
             pageQueryService.initWith(List.of(folder, page));
             planQueryService.initWith(
                 List.of(
-                    PlanEntity.builder().id("plan-1").apiId(API.getId()).status(PlanStatus.PUBLISHED).generalConditions(PAGE_ID).build()
+                    PlanFixtures
+                        .aPlanV4()
+                        .toBuilder()
+                        .id("plan-1")
+                        .apiId(API.getId())
+                        .status(PlanStatus.PUBLISHED)
+                        .generalConditions(PAGE_ID)
+                        .build()
                 )
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.documentation.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import fixtures.core.model.PlanFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
@@ -26,9 +27,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.List;
@@ -82,7 +81,16 @@ class ApiGetDocumentationPageUseCaseTest {
         );
 
         planQueryService.initWith(
-            List.of(PlanEntity.builder().id("plan-1").status(PlanStatus.PUBLISHED).apiId(API_ID).generalConditions(PAGE_ID).build())
+            List.of(
+                PlanFixtures
+                    .aPlanV4()
+                    .toBuilder()
+                    .id("plan-1")
+                    .status(PlanStatus.PUBLISHED)
+                    .apiId(API_ID)
+                    .generalConditions(PAGE_ID)
+                    .build()
+            )
         );
 
         var res = useCase.execute(new ApiGetDocumentationPageUseCase.Input(API_ID, PAGE_ID)).page();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.documentation.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import fixtures.core.model.PlanFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
@@ -27,11 +28,7 @@ import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomain
 import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
 import io.gravitee.apim.core.documentation.model.Breadcrumb;
 import io.gravitee.apim.core.documentation.model.Page;
-import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
-import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.ArrayList;
@@ -139,7 +136,16 @@ class ApiGetDocumentationPagesUseCaseTest {
             );
 
             planQueryService.initWith(
-                List.of(PlanEntity.builder().id("plan-1").apiId(API_ID).status(PlanStatus.PUBLISHED).generalConditions("page#1").build())
+                List.of(
+                    PlanFixtures
+                        .aPlanV4()
+                        .toBuilder()
+                        .id("plan-1")
+                        .apiId(API_ID)
+                        .status(PlanStatus.PUBLISHED)
+                        .generalConditions("page#1")
+                        .build()
+                )
             );
 
             var res = useCase.execute(new ApiGetDocumentationPagesUseCase.Input(API_ID, null)).pages();
@@ -176,7 +182,7 @@ class ApiGetDocumentationPagesUseCaseTest {
             assertThat(pages.get(0).getId()).isEqualTo("page#1");
             assertThat(pages.get(1).getId()).isEqualTo("page#2");
 
-            assertThat(res.breadcrumbList()).isNotNull().hasSize(0);
+            assertThat(res.breadcrumbList()).isEmpty();
         }
     }
 
@@ -209,7 +215,7 @@ class ApiGetDocumentationPagesUseCaseTest {
             assertThat(pages.get(0).getId()).isEqualTo("result-1");
             assertThat(pages.get(1).getId()).isEqualTo("result-2");
 
-            assertThat(res.breadcrumbList()).isNotNull().hasSize(3);
+            assertThat(res.breadcrumbList()).hasSize(3);
             assertThat(res.breadcrumbList().get(0))
                 .isNotNull()
                 .isEqualTo(Breadcrumb.builder().position(1).id(parentIdPos1).name(parentIdPos1 + "-name").build());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUnpublishDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUnpublishDocumentationPageUseCaseTest.java
@@ -19,7 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.AuditInfoFixtures;
-import inmemory.*;
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
+import inmemory.PageQueryServiceInMemory;
+import inmemory.PageRevisionCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -28,10 +35,7 @@ import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentation
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
-import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
-import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.Date;
@@ -143,7 +147,7 @@ class ApiUnpublishDocumentationPageUseCaseTest {
                     .build()
             )
         );
-        useCase.execute(new ApiUnpublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO)).page();
+        useCase.execute(new ApiUnpublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO));
         assertThat(auditCrudService.storage().get(0)).isNotNull().hasFieldOrPropertyWithValue("event", "PAGE_UPDATED");
     }
 
@@ -184,7 +188,16 @@ class ApiUnpublishDocumentationPageUseCaseTest {
             )
         );
         planQueryService.initWith(
-            List.of(PlanEntity.builder().id("plan-id").apiId(API_ID).generalConditions(PAGE_ID).status(PlanStatus.PUBLISHED).build())
+            List.of(
+                PlanFixtures
+                    .aPlanV4()
+                    .toBuilder()
+                    .id("plan-id")
+                    .apiId(API_ID)
+                    .generalConditions(PAGE_ID)
+                    .status(PlanStatus.PUBLISHED)
+                    .build()
+            )
         );
         assertThatThrownBy(() -> useCase.execute(new ApiUnpublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO)))
             .isInstanceOf(ValidationDomainException.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCaseTest.java
@@ -19,12 +19,14 @@ import static io.gravitee.apim.core.log.use_case.SearchConnectionLogsUseCase.UNK
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import fixtures.core.model.PlanFixtures;
 import fixtures.repository.ConnectionLogFixtures;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PlanCrudServiceInMemory;
 import io.gravitee.apim.core.log.use_case.SearchConnectionLogsUseCase.Input;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
@@ -45,8 +47,8 @@ import org.junit.jupiter.api.Test;
 public class SearchConnectionLogsUseCaseTest {
 
     private static final String API_ID = "f1608475-dd77-4603-a084-75dd775603e9";
-    private static final BasePlanEntity PLAN_1 = BasePlanEntity.builder().id("plan1").name("1st plan").build();
-    private static final BasePlanEntity PLAN_2 = BasePlanEntity.builder().id("plan2").name("2nd plan").build();
+    private static final Plan PLAN_1 = PlanFixtures.aPlanV4().toBuilder().id("plan1").name("1st plan").build();
+    private static final Plan PLAN_2 = PlanFixtures.aPlanV4().toBuilder().id("plan2").name("2nd plan").build();
     private static final BaseApplicationEntity APPLICATION_1 = BaseApplicationEntity
         .builder()
         .id("app1")
@@ -266,9 +268,9 @@ public class SearchConnectionLogsUseCaseTest {
         assertThat(result.data())
             .extracting(ConnectionLogModel::getRequestId, ConnectionLogModel::getPlan)
             .containsExactlyInAnyOrder(
-                tuple("req1", BasePlanEntity.builder().id(PLAN_1.getId()).name(PLAN_1.getName()).build()),
-                tuple("req2", BasePlanEntity.builder().id(PLAN_1.getId()).name(PLAN_1.getName()).build()),
-                tuple("req3", BasePlanEntity.builder().id(PLAN_2.getId()).name(PLAN_2.getName()).build())
+                tuple("req1", PlanFixtures.aPlanV4().toBuilder().id(PLAN_1.getId()).name(PLAN_1.getName()).build()),
+                tuple("req2", PlanFixtures.aPlanV4().toBuilder().id(PLAN_1.getId()).name(PLAN_1.getName()).build()),
+                tuple("req3", PlanFixtures.aPlanV4().toBuilder().id(PLAN_2.getId()).name(PLAN_2.getName()).build())
             );
     }
 
@@ -312,7 +314,7 @@ public class SearchConnectionLogsUseCaseTest {
         );
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(result.total()).isEqualTo(1);
+            soft.assertThat(result.total()).isOne();
             soft
                 .assertThat(result.data())
                 .extracting(ConnectionLogModel::getRequestId, ConnectionLogModel::getTimestamp)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.PlanFixtures;
 import fixtures.core.model.SubscriptionFixtures;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
@@ -38,7 +39,6 @@ import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
-import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
@@ -97,8 +97,8 @@ public class RejectSubscriptionDomainServiceTest {
             );
         planCrudService.initWith(
             List.of(
-                BasePlanEntity.builder().id(PLAN_CLOSED).status(PlanStatus.CLOSED).build(),
-                BasePlanEntity.builder().id(PLAN_PUBLISHED).status(PlanStatus.PUBLISHED).build()
+                PlanFixtures.aPlanV4().toBuilder().id(PLAN_CLOSED).status(PlanStatus.CLOSED).build(),
+                PlanFixtures.aPlanV4().toBuilder().id(PLAN_PUBLISHED).status(PlanStatus.PUBLISHED).build()
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 import fixtures.core.model.ApiKeyFixtures;
 import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.PlanFixtures;
 import fixtures.core.model.SubscriptionFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
@@ -39,6 +40,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApiHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApplicationHookContext;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -47,7 +49,6 @@ import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
-import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import java.time.Instant;
@@ -189,7 +190,7 @@ class CloseSubscriptionUseCaseTest {
     @Test
     void should_reject_pending_subscription() {
         // Given
-        var plan = givenExistingPlan(BasePlanEntity.builder().id("plan-id").status(PlanStatus.PUBLISHED).build());
+        var plan = givenExistingPlan(PlanFixtures.aPlanV4().toBuilder().id("plan-id").status(PlanStatus.PUBLISHED).build());
         givenExistingSubscription(
             SubscriptionFixtures
                 .aSubscription()
@@ -379,7 +380,7 @@ class CloseSubscriptionUseCaseTest {
         return subscription;
     }
 
-    private BasePlanEntity givenExistingPlan(BasePlanEntity plan) {
+    private Plan givenExistingPlan(Plan plan) {
         planCrudService.initWith(List.of(plan));
         return plan;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
@@ -17,18 +17,24 @@ package io.gravitee.apim.infra.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PlanFixtures;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.Policy;
 import io.gravitee.definition.model.Rule;
-import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.BasePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
-import java.util.ArrayList;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -40,6 +46,222 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PlanAdapterTest {
+
+    @Nested
+    class CoreModel {
+
+        @Test
+        void should_convert_from_v4_repository_to_core_model() {
+            var repository = planV4().build();
+
+            var plan = PlanAdapter.INSTANCE.fromRepository(repository);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getApiId()).isEqualTo("my-api");
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
+                soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("general-conditions");
+                soft.assertThat(plan.getId()).isEqualTo("my-id");
+                soft.assertThat(plan.getMode()).isEqualTo(io.gravitee.definition.model.v4.plan.PlanMode.STANDARD);
+                soft.assertThat(plan.getName()).isEqualTo("plan-name");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft
+                    .assertThat(plan.getSecurity())
+                    .isEqualTo(PlanSecurity.builder().type("api-key").configuration("security-definition").build());
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
+                soft.assertThat(plan.getStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
+                soft.assertThat(plan.getType()).isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanType.API);
+                soft.assertThat(plan.getValidation()).isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanValidationType.AUTO);
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.isCommentRequired()).isTrue();
+            });
+        }
+
+        @Test
+        void should_convert_from_v2_repository_to_core_model() {
+            var repository = planV2().build();
+
+            var plan = PlanAdapter.INSTANCE.fromRepository(repository);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getApiId()).isEqualTo("my-api");
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
+                soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("general-conditions");
+                soft.assertThat(plan.getId()).isEqualTo("my-id");
+                soft.assertThat(plan.getName()).isEqualTo("plan-name");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPaths()).isEqualTo(Map.of("/", List.of()));
+                soft.assertThat(plan.getMode()).isEqualTo(io.gravitee.definition.model.v4.plan.PlanMode.STANDARD);
+                soft
+                    .assertThat(plan.getSecurity())
+                    .isEqualTo(PlanSecurity.builder().type("api-key").configuration("security-definition").build());
+                soft.assertThat(plan.getStatus()).isEqualTo(PlanStatus.PUBLISHED);
+                soft.assertThat(plan.getType()).isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanType.API);
+                soft.assertThat(plan.getValidation()).isEqualTo(io.gravitee.apim.core.plan.model.Plan.PlanValidationType.AUTO);
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneOffset.UTC));
+                soft.assertThat(plan.isCommentRequired()).isTrue();
+            });
+        }
+
+        @Test
+        void should_convert_v4_plan_to_repository() {
+            var model = PlanFixtures
+                .aPlanV4()
+                .toBuilder()
+                .closedAt(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC))
+                .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+                .publishedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC))
+                .build();
+
+            var plan = PlanAdapter.INSTANCE.toRepository(model);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getApi()).isEqualTo("my-api");
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic1", "characteristic2");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("Comment message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCrossId()).isEqualTo("my-plan-crossId");
+                soft.assertThat(plan.getDescription()).isEqualTo("Description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excludedGroup1", "excludedGroup2");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("General conditions");
+                soft.assertThat(plan.getId()).isEqualTo("my-plan");
+                soft.assertThat(plan.getMode()).isEqualTo(Plan.PlanMode.STANDARD);
+                soft.assertThat(plan.getName()).isEqualTo("My plan");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getSecurity()).isEqualTo(Plan.PlanSecurityType.KEY_LESS);
+                soft.assertThat(plan.getSecurityDefinition()).isEqualTo("{\"nice\": \"config\"}");
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("{#request.attribute['selectionRule'] != null}");
+                soft.assertThat(plan.getStatus()).isEqualTo(Plan.Status.PUBLISHED);
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag1", "tag2"));
+                soft.assertThat(plan.getType()).isEqualTo(Plan.PlanType.API);
+                soft.assertThat(plan.getValidation()).isEqualTo(Plan.PlanValidationType.AUTO);
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.isCommentRequired()).isFalse();
+            });
+        }
+
+        @Test
+        void should_convert_v2_plan_to_repository() {
+            var model = PlanFixtures
+                .aPlanV2()
+                .toBuilder()
+                .paths(Map.of("/", List.of()))
+                .closedAt(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC))
+                .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+                .publishedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC))
+                .build();
+
+            var plan = PlanAdapter.INSTANCE.toRepository(model);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getApi()).isEqualTo("my-api");
+                soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic1", "characteristic2");
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getCommentMessage()).isEqualTo("Comment message");
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCrossId()).isEqualTo("my-plan-crossId");
+                soft.assertThat(plan.getDefinition()).isEqualTo("{\"/\":[]}");
+                soft.assertThat(plan.getDescription()).isEqualTo("Description");
+                soft.assertThat(plan.getExcludedGroups()).containsExactly("excludedGroup1", "excludedGroup2");
+                soft.assertThat(plan.getGeneralConditions()).isEqualTo("General conditions");
+                soft.assertThat(plan.getId()).isEqualTo("my-plan");
+                soft.assertThat(plan.getMode()).isEqualTo(Plan.PlanMode.STANDARD);
+                soft.assertThat(plan.getName()).isEqualTo("My plan");
+                soft.assertThat(plan.getNeedRedeployAt()).isEqualTo(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")));
+                soft.assertThat(plan.getOrder()).isOne();
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getSecurity()).isEqualTo(Plan.PlanSecurityType.KEY_LESS);
+                soft.assertThat(plan.getSecurityDefinition()).isEqualTo("{\"nice\": \"config\"}");
+                soft.assertThat(plan.getSelectionRule()).isEqualTo("{#request.attribute['selectionRule'] != null}");
+                soft.assertThat(plan.getStatus()).isEqualTo(Plan.Status.PUBLISHED);
+                soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag1", "tag2"));
+                soft.assertThat(plan.getType()).isEqualTo(Plan.PlanType.API);
+                soft.assertThat(plan.getValidation()).isEqualTo(Plan.PlanValidationType.AUTO);
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.isCommentRequired()).isFalse();
+            });
+        }
+
+        private Plan.PlanBuilder planV4() {
+            return Plan
+                .builder()
+                .id("my-id")
+                .api("my-api")
+                .crossId("cross-id")
+                .name("plan-name")
+                .description("plan-description")
+                .security(Plan.PlanSecurityType.API_KEY)
+                .securityDefinition("security-definition")
+                .selectionRule("selection-rule")
+                .validation(Plan.PlanValidationType.AUTO)
+                .mode(Plan.PlanMode.STANDARD)
+                .order(1)
+                .type(Plan.PlanType.API)
+                .status(Plan.Status.PUBLISHED)
+                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                .publishedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+                .closedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")))
+                .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+                .characteristics(List.of("characteristic-1"))
+                .excludedGroups(List.of("excluded-group-1"))
+                .commentRequired(true)
+                .commentMessage("comment-message")
+                .generalConditions("general-conditions")
+                .tags(Set.of("tag-1"));
+        }
+
+        private Plan.PlanBuilder planV2() {
+            return Plan
+                .builder()
+                .id("my-id")
+                .api("my-api")
+                .crossId("cross-id")
+                .name("plan-name")
+                .description("plan-description")
+                .security(Plan.PlanSecurityType.API_KEY)
+                .securityDefinition("security-definition")
+                .selectionRule("selection-rule")
+                .validation(Plan.PlanValidationType.AUTO)
+                .mode(Plan.PlanMode.STANDARD)
+                .order(1)
+                .type(Plan.PlanType.API)
+                .status(Plan.Status.PUBLISHED)
+                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                .publishedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+                .closedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")))
+                .needRedeployAt(Date.from(Instant.parse("2020-02-05T20:22:02.00Z")))
+                .definition("{\"/\":[]}")
+                .characteristics(List.of("characteristic-1"))
+                .excludedGroups(List.of("excluded-group-1"))
+                .commentRequired(true)
+                .commentMessage("comment-message")
+                .generalConditions("general-conditions")
+                .tags(Set.of("tag-1"));
+        }
+    }
 
     @Nested
     class ToEntityV4 {
@@ -160,7 +382,7 @@ class PlanAdapterTest {
                    """
             );
 
-            GenericPlanEntity planEntity = PlanAdapter.INSTANCE.toEntityV2(plan);
+            BasePlanEntity planEntity = PlanAdapter.INSTANCE.toEntityV2(plan);
 
             assertThat(planEntity.getId()).isEqualTo(plan.getId());
             assertThat(planEntity.getName()).isEqualTo(plan.getName());
@@ -170,8 +392,7 @@ class PlanAdapterTest {
             assertThat(planEntity.getApiId()).isEqualTo(plan.getApi());
             assertThat(planEntity.getGeneralConditions()).isEqualTo(plan.getGeneralConditions());
             assertThat(planEntity.getPlanSecurity().getType()).isEqualTo(io.gravitee.rest.api.model.PlanSecurityType.KEY_LESS.name());
-            BasePlanEntity planV2 = (BasePlanEntity) planEntity;
-            assertThat(planV2.getPaths().get("/"))
+            assertThat(planEntity.getPaths().get("/"))
                 .hasSize(1)
                 .containsExactly(
                     Rule

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/plan/PlanCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/plan/PlanCrudServiceImplTest.java
@@ -29,13 +29,13 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
-import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanType;
 import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +58,7 @@ public class PlanCrudServiceImplTest {
         planRepository = mock(PlanRepository.class);
         apiRepository = mock(ApiRepository.class);
 
-        service = new PlanCrudServiceImpl(planRepository, apiRepository);
+        service = new PlanCrudServiceImpl(planRepository);
     }
 
     @Nested
@@ -77,18 +77,15 @@ public class PlanCrudServiceImplTest {
                 );
 
             // When
-            var result = service.findById(planId);
+            var plan = service.findById(planId);
 
             // Then
             SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result).isInstanceOf(BasePlanEntity.class);
-                BasePlanEntity plan = (BasePlanEntity) result;
-
                 soft.assertThat(plan.getApiId()).isEqualTo(apiId);
                 soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
-                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
-                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
                 soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
@@ -104,10 +101,10 @@ public class PlanCrudServiceImplTest {
                 soft.assertThat(plan.getPlanStatus()).isEqualTo(PlanStatus.PUBLISHED);
                 soft.assertThat(plan.getPlanType()).isEqualTo(PlanType.API);
                 soft.assertThat(plan.getPlanValidation()).isEqualTo(PlanValidationType.AUTO);
-                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
                 soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
-                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.isCommentRequired()).isTrue();
             });
         }
@@ -125,18 +122,15 @@ public class PlanCrudServiceImplTest {
                 );
 
             // When
-            var result = service.findById(planId);
+            var plan = service.findById(planId);
 
             // Then
             SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result).isInstanceOf(io.gravitee.rest.api.model.BasePlanEntity.class);
-                io.gravitee.rest.api.model.BasePlanEntity plan = (io.gravitee.rest.api.model.BasePlanEntity) result;
-
                 soft.assertThat(plan.getApiId()).isEqualTo(apiId);
                 soft.assertThat(plan.getCharacteristics()).containsExactly("characteristic-1");
-                soft.assertThat(plan.getClosedAt()).isEqualTo(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
+                soft.assertThat(plan.getClosedAt()).isEqualTo(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getCommentMessage()).isEqualTo("comment-message");
-                soft.assertThat(plan.getCreatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")));
+                soft.assertThat(plan.getCreatedAt()).isEqualTo(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(plan.getDescription()).isEqualTo("plan-description");
                 soft.assertThat(plan.getExcludedGroups()).containsExactly("excluded-group-1");
@@ -149,14 +143,14 @@ public class PlanCrudServiceImplTest {
                 soft.assertThat(plan.getPlanMode()).isEqualTo(PlanMode.STANDARD);
                 soft
                     .assertThat(plan.getPlanSecurity())
-                    .isEqualTo(PlanSecurity.builder().type("API_KEY").configuration("security-definition").build());
+                    .isEqualTo(PlanSecurity.builder().type("api-key").configuration("security-definition").build());
                 soft.assertThat(plan.getPlanStatus()).isEqualTo(PlanStatus.PUBLISHED);
                 soft.assertThat(plan.getPlanType()).isEqualTo(PlanType.API);
                 soft.assertThat(plan.getPlanValidation()).isEqualTo(PlanValidationType.AUTO);
-                soft.assertThat(plan.getPublishedAt()).isEqualTo(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+                soft.assertThat(plan.getPublishedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.getSelectionRule()).isEqualTo("selection-rule");
                 soft.assertThat(plan.getTags()).isEqualTo(Set.of("tag-1"));
-                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+                soft.assertThat(plan.getUpdatedAt()).isEqualTo(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneOffset.UTC));
                 soft.assertThat(plan.isCommentRequired()).isTrue();
             });
         }
@@ -187,21 +181,6 @@ public class PlanCrudServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalManagementException.class)
                 .hasMessage("An error occurs while trying to find a plan by id: " + planId);
-        }
-
-        @Test
-        void should_throw_when_technical_exception_occurs_while_fetching_api() throws TechnicalException {
-            // Given
-            when(planRepository.findById(any(String.class))).thenReturn(Optional.of(planV4().api("api-id").build()));
-            when(apiRepository.findById(any(String.class))).thenThrow(TechnicalException.class);
-
-            // When
-            Throwable throwable = catchThrowable(() -> service.findById("plan-id"));
-
-            // Then
-            assertThat(throwable)
-                .isInstanceOf(TechnicalManagementException.class)
-                .hasMessage("An error occurs while trying to find an API using its ID: api-id");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/page/PlanQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/page/PlanQueryServiceImplTest.java
@@ -16,21 +16,16 @@
 package io.gravitee.apim.infra.query_service.page;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.apim.core.exception.NotFoundDomainException;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.infra.query_service.plan.PlanQueryServiceImpl;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
-import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
-import java.util.Optional;
 import java.util.Set;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +85,7 @@ class PlanQueryServiceImplTest {
             when(planRepository.findByApi(eq(API_ID))).thenReturn(Set.of());
 
             var res = service.findAllByApiIdAndGeneralConditionsAndIsActive(API_ID, DefinitionVersion.V4, PAGE_ID);
-            assertThat(res).hasSize(0);
+            assertThat(res).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a new type of Plan in the core package.

This model merges PlanV2 and PlanV4 attributes. For now, the code in `core` does not care about specificity as it relies on the `GenericPlanEntity` interface.

Dealing with 2 objects for Plans is a pain, especially when we only care about "common" attributes. When we will migrate code needing to work on v2 and v4 plans, we should be able to write adapters to create specific V2 or V4 plan objects.

I would need this change to help me write domain services related to plan updates. I can eventually keep the work in another branch, but as the work is "siloed" it can be merged and it would prevent me some pain in rebasing a long life branch 🙈 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cwdtzbdwjo.chromatic.com)
<!-- Storybook placeholder end -->
