### PR TITLE
Remove MongoDB 7.1 from repository tests and update APIM version in Bridge tests

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -311,9 +311,9 @@ workflows:
               database:
                 - bridge
               apim_client_tag:
+                - 4.2.x-latest
+                - 4.1.x-latest
                 - 4.0.x-latest
-                - 3.20.x-latest
-                - 3.19.x-latest
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -302,7 +302,6 @@ workflows:
                 - "5.0"
                 - "6.0"
                 - "7.0"
-                - "7.1"
       - job-elastic-test-container:
           name: Analytics repository tests - ElasticSearch << matrix.engineVersion >>
           context:

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -61,7 +61,7 @@ export class BridgeCompatibilityTestsWorkflow {
         matrix: {
           execution_mode: ['v3', 'v4-emulation-engine'],
           database: ['bridge'],
-          apim_client_tag: ['4.0.x-latest', '3.20.x-latest', '3.19.x-latest'],
+          apim_client_tag: ['4.2.x-latest', '4.1.x-latest', '4.0.x-latest'],
         },
       }),
     ];

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -74,7 +74,7 @@ export class RepositoriesTestsWorkflow {
         context: ['cicd-orchestrator'],
         requires: [buildJobName],
         matrix: {
-          mongoVersion: ['4.4', '5.0', '6.0', '7.0', '7.1'],
+          mongoVersion: ['4.4', '5.0', '6.0', '7.0'],
         },
       }),
       new workflow.WorkflowJob(elasticTestContainerJob, {


### PR DESCRIPTION
## Issue

NA

## Description

Remove MongoDB 7.1 from repository tests and update APIM version in Bridge tests
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-frfvivmbur.chromatic.com)
<!-- Storybook placeholder end -->
