### PR TITLE
fix: defer some @Value resolution and bean instantiation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
@@ -32,6 +32,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -41,6 +42,7 @@ public class ApiManagementEndpoint implements Handler<RoutingContext>, Managemen
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApiManagementEndpoint.class);
 
+    @Lazy
     @Autowired
     private ApiManager apiManager;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -43,6 +44,7 @@ public class ApisManagementEndpoint implements Handler<RoutingContext>, Manageme
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApisManagementEndpoint.class);
 
+    @Lazy
     @Autowired
     private ApiManager apiManager;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 
 /**
@@ -77,6 +78,7 @@ public class ApiHandlerConfiguration {
     @Autowired
     private io.gravitee.node.api.configuration.Configuration configuration;
 
+    @Lazy
     @Bean
     public ApiManager apiManager(EventManager eventManager, GatewayConfiguration gatewayConfiguration, DataEncryptor dataEncryptor) {
         return new ApiManagerImpl(eventManager, gatewayConfiguration, dataEncryptor);
@@ -122,6 +124,7 @@ public class ApiHandlerConfiguration {
         return new SpringComponentProvider(applicationContext);
     }
 
+    @Lazy
     @Bean
     public DataEncryptor apiPropertiesEncryptor(Environment environment) {
         return new DataEncryptor(environment, "api.properties.encryption.secret", "vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
 
@@ -49,6 +50,7 @@ public class VertxReactorConfiguration {
 
     protected static final String SERVERS_PREFIX = "servers";
 
+    @Lazy
     @Bean
     public ServerManager serverManager(
         VertxServerFactory<VertxServer<?, VertxServerOptions>, VertxServerOptions> serverFactory,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
@@ -55,6 +55,11 @@
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/spring/IdentityProviderPluginConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/spring/IdentityProviderPluginConfiguration.java
@@ -40,7 +40,7 @@ public class IdentityProviderPluginConfiguration {
     }
 
     @Bean
-    public ReferenceSerializer referenceSerializer() {
-        return new ReferenceSerializer();
+    public ReferenceSerializer referenceSerializer(io.gravitee.node.api.configuration.Configuration configuration) {
+        return new ReferenceSerializer(configuration);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/WebNotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/WebNotifierServiceImpl.java
@@ -17,21 +17,15 @@ package io.gravitee.rest.api.service.notifiers.impl;
 
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notifiers.WebNotifierService;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.*;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import java.net.URI;
@@ -41,7 +35,6 @@ import java.util.concurrent.ExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -55,35 +48,11 @@ public class WebNotifierServiceImpl implements WebNotifierService {
 
     private static final String HTTPS_SCHEME = "https";
 
-    @Value("${httpClient.timeout:10000}")
-    private int httpClientTimeout;
+    private final Configuration configuration;
 
-    @Value("${httpClient.proxy.type:HTTP}")
-    private String httpClientProxyType;
-
-    @Value("${httpClient.proxy.http.host:#{systemProperties['http.proxyHost'] ?: 'localhost'}}")
-    private String httpClientProxyHttpHost;
-
-    @Value("${httpClient.proxy.http.port:#{systemProperties['http.proxyPort'] ?: 3128}}")
-    private int httpClientProxyHttpPort;
-
-    @Value("${httpClient.proxy.http.username:#{null}}")
-    private String httpClientProxyHttpUsername;
-
-    @Value("${httpClient.proxy.http.password:#{null}}")
-    private String httpClientProxyHttpPassword;
-
-    @Value("${httpClient.proxy.https.host:#{systemProperties['https.proxyHost'] ?: 'localhost'}}")
-    private String httpClientProxyHttpsHost;
-
-    @Value("${httpClient.proxy.https.port:#{systemProperties['https.proxyPort'] ?: 3128}}")
-    private int httpClientProxyHttpsPort;
-
-    @Value("${httpClient.proxy.https.username:#{null}}")
-    private String httpClientProxyHttpsUsername;
-
-    @Value("${httpClient.proxy.https.password:#{null}}")
-    private String httpClientProxyHttpsPassword;
+    public WebNotifierServiceImpl(Configuration configuration) {
+        this.configuration = configuration;
+    }
 
     @Autowired
     private Vertx vertx;
@@ -104,21 +73,21 @@ public class WebNotifierServiceImpl implements WebNotifierService {
             .setMaxPoolSize(1)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
-            .setConnectTimeout(httpClientTimeout);
+            .setConnectTimeout(httpClientTimeout());
 
         if (useSystemProxy) {
             ProxyOptions proxyOptions = new ProxyOptions();
-            proxyOptions.setType(ProxyType.valueOf(httpClientProxyType));
+            proxyOptions.setType(ProxyType.valueOf(httpClientProxyType()));
             if (HTTPS_SCHEME.equals(requestUri.getScheme())) {
-                proxyOptions.setHost(httpClientProxyHttpsHost);
-                proxyOptions.setPort(httpClientProxyHttpsPort);
-                proxyOptions.setUsername(httpClientProxyHttpsUsername);
-                proxyOptions.setPassword(httpClientProxyHttpsPassword);
+                proxyOptions.setHost(httpClientProxyHttpsHost());
+                proxyOptions.setPort(httpClientProxyHttpsPort());
+                proxyOptions.setUsername(httpClientProxyHttpsUsername());
+                proxyOptions.setPassword(httpClientProxyHttpsPassword());
             } else {
-                proxyOptions.setHost(httpClientProxyHttpHost);
-                proxyOptions.setPort(httpClientProxyHttpPort);
-                proxyOptions.setUsername(httpClientProxyHttpUsername);
-                proxyOptions.setPassword(httpClientProxyHttpPassword);
+                proxyOptions.setHost(httpClientProxyHttpHost());
+                proxyOptions.setPort(httpClientProxyHttpPort());
+                proxyOptions.setUsername(httpClientProxyHttpUsername());
+                proxyOptions.setPassword(httpClientProxyHttpPassword());
             }
             clientOptions.setProxyOptions(proxyOptions);
         }
@@ -132,7 +101,7 @@ public class WebNotifierServiceImpl implements WebNotifierService {
             .setHost(requestUri.getHost())
             .setPort(port)
             .setURI(requestUri.toString())
-            .setTimeout(httpClientTimeout);
+            .setTimeout(httpClientTimeout());
 
         //headers
         options.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
@@ -207,5 +176,53 @@ public class WebNotifierServiceImpl implements WebNotifierService {
 
     private static boolean isStatus2xx(HttpClientResponse httpResponse) {
         return httpResponse.statusCode() / 100 == 2;
+    }
+
+    private Integer httpClientTimeout() {
+        return configuration.getProperty("httpClient.timeout", Integer.class, 10000);
+    }
+
+    private String httpClientProxyType() {
+        return configuration.getProperty("httpClient.proxy.type", "HTTP");
+    }
+
+    private String httpClientProxyHttpHost() {
+        return configuration.getProperty("httpClient.proxy.http.host", System.getProperty("http.proxyHost", "localhost"));
+    }
+
+    private Integer httpClientProxyHttpPort() {
+        return configuration.getProperty(
+            "httpClient.proxy.http.port",
+            Integer.class,
+            Integer.valueOf(System.getProperty("http.proxyPort", "3128"))
+        );
+    }
+
+    private String httpClientProxyHttpUsername() {
+        return configuration.getProperty("httpClient.proxy.http.username");
+    }
+
+    private String httpClientProxyHttpPassword() {
+        return configuration.getProperty("httpClient.proxy.http.password");
+    }
+
+    private String httpClientProxyHttpsHost() {
+        return configuration.getProperty("httpClient.proxy.https.host", System.getProperty("https.proxyHost", "localhost"));
+    }
+
+    private Integer httpClientProxyHttpsPort() {
+        return configuration.getProperty(
+            "httpClient.proxy.https.port",
+            Integer.class,
+            Integer.valueOf(System.getProperty("https.proxyPort", "3128"))
+        );
+    }
+
+    private String httpClientProxyHttpsUsername() {
+        return configuration.getProperty("httpClient.proxy.https.username");
+    }
+
+    private String httpClientProxyHttpsPassword() {
+        return configuration.getProperty("httpClient.proxy.https.password");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertService_CreateTest.java
@@ -83,7 +83,7 @@ public class AlertService_CreateTest extends AlertServiceTest {
         when(alertTriggerProviderManager.findAll()).thenReturn(List.of(mock(TriggerProvider.class)));
         when(alertTriggerRepository.create(any())).thenReturn(alertTrigger);
 
-        alertService = getAlertService(null);
+        alertService = getAlertService();
         alertService.afterPropertiesSet();
         alertService.create(executionContext, alert);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.jetty;
 
+import io.gravitee.node.api.configuration.Configuration;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -23,223 +24,92 @@ import org.springframework.beans.factory.annotation.Value;
  */
 public class JettyConfiguration {
 
-    @Value("${jetty.host:0.0.0.0}")
-    private String httpHost;
+    private final Configuration configuration;
 
-    @Value("${jetty.port:8083}")
-    private int httpPort;
-
-    @Value("${jetty.idleTimeout:30000}")
-    private int idleTimeout;
-
-    @Value("${jetty.acceptors:-1}")
-    private int acceptors;
-
-    @Value("${jetty.selectors:-1}")
-    private int selectors;
-
-    @Value("${jetty.pool.minThreads:10}")
-    private int poolMinThreads;
-
-    @Value("${jetty.pool.maxThreads:200}")
-    private int poolMaxThreads;
-
-    @Value("${jetty.pool.idleTimeout:60000}")
-    private int poolIdleTimeout;
-
-    @Value("${jetty.pool.queueSize:6000}")
-    private int poolQueueSize;
-
-    @Value("${jetty.jmx:false}")
-    private boolean jmxEnabled;
-
-    @Value("${jetty.statistics:false}")
-    private boolean statisticsEnabled;
-
-    @Value("${jetty.accesslog.enabled:true}")
-    private boolean accessLogEnabled;
-
-    @Value("${jetty.accesslog.path:${gravitee.home}/logs/gravitee_accesslog_yyyy_mm_dd.log}")
-    private String accessLogPath;
-
-    @Value("${jetty.secured:false}")
-    private boolean secured;
-
-    @Value("${jetty.ssl.keystore.path:#{null}}")
-    private String keyStorePath;
-
-    @Value("${jetty.ssl.keystore.type:#{null}}")
-    private String keyStoreType;
-
-    @Value("${jetty.ssl.keystore.password:#{null}}")
-    private String keyStorePassword;
-
-    @Value("${jetty.ssl.truststore.path:#{null}}")
-    private String trustStorePath;
-
-    @Value("${jetty.ssl.truststore.type:#{null}}")
-    private String trustStoreType;
-
-    @Value("${jetty.ssl.truststore.password:#{null}}")
-    private String trustStorePassword;
-
-    public String getHttpHost() {
-        return httpHost;
+    public JettyConfiguration(Configuration configuration) {
+        this.configuration = configuration;
     }
 
-    public void setHttpHost(String httpHost) {
-        this.httpHost = httpHost;
+    public String getHttpHost() {
+        return configuration.getProperty("jetty.host", "0.0.0.0");
     }
 
     public int getHttpPort() {
-        return httpPort;
-    }
-
-    public void setHttpPort(int httpPort) {
-        this.httpPort = httpPort;
+        return configuration.getProperty("jetty.port", Integer.class, 8083);
     }
 
     public int getAcceptors() {
-        return acceptors;
-    }
-
-    public void setAcceptors(int acceptors) {
-        this.acceptors = acceptors;
+        return configuration.getProperty("jetty.acceptors", Integer.class, -1);
     }
 
     public int getSelectors() {
-        return selectors;
-    }
-
-    public void setSelectors(int selectors) {
-        this.selectors = selectors;
+        return configuration.getProperty("jetty.selectors", Integer.class, -1);
     }
 
     public int getPoolMinThreads() {
-        return poolMinThreads;
-    }
-
-    public void setPoolMinThreads(int poolMinThreads) {
-        this.poolMinThreads = poolMinThreads;
+        return configuration.getProperty("jetty.pool.minThreads", Integer.class, 10);
     }
 
     public int getPoolMaxThreads() {
-        return poolMaxThreads;
-    }
-
-    public void setPoolMaxThreads(int poolMaxThreads) {
-        this.poolMaxThreads = poolMaxThreads;
+        return configuration.getProperty("jetty.pool.maxThreads", Integer.class, 200);
     }
 
     public boolean isJmxEnabled() {
-        return jmxEnabled;
-    }
-
-    public void setJmxEnabled(boolean jmxEnabled) {
-        this.jmxEnabled = jmxEnabled;
+        return configuration.getProperty("jetty.jmx", Boolean.class, false);
     }
 
     public int getIdleTimeout() {
-        return idleTimeout;
-    }
-
-    public void setIdleTimeout(int idleTimeout) {
-        this.idleTimeout = idleTimeout;
+        return configuration.getProperty("jetty.idleTimeout", Integer.class, 30000);
     }
 
     public boolean isStatisticsEnabled() {
-        return statisticsEnabled;
-    }
-
-    public void setStatisticsEnabled(boolean statisticsEnabled) {
-        this.statisticsEnabled = statisticsEnabled;
+        return configuration.getProperty("jetty.statistics", Boolean.class, false);
     }
 
     public int getPoolIdleTimeout() {
-        return poolIdleTimeout;
-    }
-
-    public void setPoolIdleTimeout(int poolIdleTimeout) {
-        this.poolIdleTimeout = poolIdleTimeout;
+        return configuration.getProperty("jetty.pool.idleTimeout", Integer.class, 60000);
     }
 
     public int getPoolQueueSize() {
-        return poolQueueSize;
-    }
-
-    public void setPoolQueueSize(int poolQueueSize) {
-        this.poolQueueSize = poolQueueSize;
+        return configuration.getProperty("jetty.pool.queueSize", Integer.class, 6000);
     }
 
     public boolean isAccessLogEnabled() {
-        return accessLogEnabled;
-    }
-
-    public void setAccessLogEnabled(boolean accessLogEnabled) {
-        this.accessLogEnabled = accessLogEnabled;
+        return configuration.getProperty("jetty.accesslog.enabled", Boolean.class, true);
     }
 
     public String getAccessLogPath() {
-        return accessLogPath;
-    }
-
-    public void setAccessLogPath(String accessLogPath) {
-        this.accessLogPath = accessLogPath;
+        return configuration.getProperty(
+            "jetty.accesslog.path",
+            configuration.getProperty("gravitee.home") + "/logs/gravitee_accesslog_yyyy_mm_dd.log"
+        );
     }
 
     public boolean isSecured() {
-        return secured;
-    }
-
-    public void setSecured(boolean secured) {
-        this.secured = secured;
+        return configuration.getProperty("jetty.secured", Boolean.class, false);
     }
 
     public String getKeyStorePath() {
-        return keyStorePath;
-    }
-
-    public void setKeyStorePath(String keyStorePath) {
-        this.keyStorePath = keyStorePath;
+        return configuration.getProperty("jetty.ssl.keystore.path");
     }
 
     public String getKeyStorePassword() {
-        return keyStorePassword;
-    }
-
-    public void setKeyStorePassword(String keyStorePassword) {
-        this.keyStorePassword = keyStorePassword;
+        return configuration.getProperty("jetty.ssl.keystore.password");
     }
 
     public String getTrustStorePath() {
-        return trustStorePath;
-    }
-
-    public void setTrustStorePath(String trustStorePath) {
-        this.trustStorePath = trustStorePath;
+        return configuration.getProperty("jetty.ssl.truststore.path");
     }
 
     public String getTrustStorePassword() {
-        return trustStorePassword;
-    }
-
-    public void setTrustStorePassword(String trustStorePassword) {
-        this.trustStorePassword = trustStorePassword;
+        return configuration.getProperty("jetty.ssl.truststore.password");
     }
 
     public String getKeyStoreType() {
-        return keyStoreType;
-    }
-
-    public void setKeyStoreType(String keyStoreType) {
-        this.keyStoreType = keyStoreType;
+        return configuration.getProperty("jetty.ssl.keystore.type");
     }
 
     public String getTrustStoreType() {
-        return trustStoreType;
-    }
-
-    public void setTrustStoreType(String trustStoreType) {
-        this.trustStoreType = trustStoreType;
+        return configuration.getProperty("jetty.ssl.truststore.type");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyEmbeddedContainer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyEmbeddedContainer.java
@@ -53,8 +53,9 @@ import org.springframework.web.filter.DelegatingFilterProxy;
 public final class JettyEmbeddedContainer extends AbstractLifecycleComponent<JettyEmbeddedContainer> implements ApplicationContextAware {
 
     @Autowired
-    private Server server;
+    private JettyServerFactory jettyServerFactory;
 
+    private Server server;
     private ApplicationContext applicationContext;
 
     @Value("${http.api.management.enabled:true}")
@@ -71,6 +72,8 @@ public final class JettyEmbeddedContainer extends AbstractLifecycleComponent<Jet
 
     @Override
     protected void doStart() throws Exception {
+        server = jettyServerFactory.getObject();
+
         AbstractHandler noContentHandler = new NoContentOutputErrorHandler();
         // This part is needed to avoid WARN while starting container.
         noContentHandler.setServer(server);
@@ -150,7 +153,9 @@ public final class JettyEmbeddedContainer extends AbstractLifecycleComponent<Jet
 
     @Override
     protected void doStop() throws Exception {
-        server.stop();
+        if (server != null) {
+            server.stop();
+        }
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
@@ -81,6 +81,8 @@ public class JettyServerFactory implements FactoryBean<Server> {
             if (jettyConfiguration.getKeyStorePath() != null) {
                 sslContextFactory.setKeyStorePath(jettyConfiguration.getKeyStorePath());
                 sslContextFactory.setKeyStorePassword(jettyConfiguration.getKeyStorePassword());
+                // Force default keystore type to jks for backward compatibility (since jetty moved to pkcs12 by default https://github.com/jetty/jetty.project/pull/4489).
+                sslContextFactory.setKeyStoreType(KEYSTORE_TYPE_JKS);
 
                 if (KEYSTORE_TYPE_PKCS12.equalsIgnoreCase(jettyConfiguration.getKeyStoreType())) {
                     sslContextFactory.setKeyStoreType(KEYSTORE_TYPE_PKCS12);
@@ -90,6 +92,8 @@ public class JettyServerFactory implements FactoryBean<Server> {
             if (jettyConfiguration.getTrustStorePath() != null) {
                 sslContextFactory.setTrustStorePath(jettyConfiguration.getTrustStorePath());
                 sslContextFactory.setTrustStorePassword(jettyConfiguration.getTrustStorePassword());
+                // Force default truststore type to jks for backward compatibility (since jetty moved to pkcs12 by default https://github.com/jetty/jetty.project/pull/4489).
+                sslContextFactory.setTrustStoreType(KEYSTORE_TYPE_JKS);
 
                 if (KEYSTORE_TYPE_PKCS12.equalsIgnoreCase(jettyConfiguration.getTrustStoreType())) {
                     sslContextFactory.setTrustStoreType(KEYSTORE_TYPE_PKCS12);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -54,8 +54,8 @@ public class StandaloneConfiguration {
     }
 
     @Bean
-    public JettyConfiguration jettyConfiguration() {
-        return new JettyConfiguration();
+    public JettyConfiguration jettyConfiguration(io.gravitee.node.api.configuration.Configuration configuration) {
+        return new JettyConfiguration(configuration);
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.4.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>4.6.0</gravitee-node.version>
+        <gravitee-node.version>4.6.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>2.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-299

## Description

This PR defers some `@Value` resolutions that are susceptible to holding sensitive data and are eligible for secret injection. It also defers some bean instantiations for the same purpose (waiting for a proper global solution).

## Additional context

This PR can be tested by enabling and configuring a Kubernetes secret provider. It can be achieved by specifying the following environment variables on both management and gateway:

```properties
gravitee_secrets_kubernetes_enabled=true
gravitee_secrets_kubernetes_namespace=graviteeio
```

You can create a Kubernetes secret with several entries representing some "sensitive" information such as jwt secret, keystore password, ..., ex:

```bash
kubectl create secret -n graviteeio generic apim \
     --from-literal=jwt.secret=A_Very_Sensitive_JWT_Secret \
     --from-literal=api.properties.encryption.secret=A_Very_Sensitive_Api_Encryption_Secret \
     --from-literal=services.core.http.auth.basic.password=A_Very_Sensitive_Password \
     --from-literal=jetty.ssl.keystore.password=secret \
     --from-literal=http.ssl.keystore.password=secret \
     --dry-run=client -o yaml | k apply -f -
```

⚠️ This is not an exhaustive list, further tests can be made (ex: recaptcha, MongoDB password, ...)

Then for the management rest API, a couple of secrets can be configured via environment variables:

```properties
# Protect the jwt secret using a k8s secret.
gravitee_jwt_secret=secret://kubernetes/apim:jwt.secret

# Protect Api properties encryption secret.
gravitee_api_properties_encryption_secret=secret://kubernetes/apim:api.properties.encryption.secret

# Configure SSL on jetty and protect the password in a secret.
gravitee_jetty_secured=true
gravitee_jetty_ssl_keystore_password=secret://kubernetes/apim:jetty.ssl.keystore.password
gravitee_jetty_ssl_keystore_path=localhost.p12
gravitee_jetty_ssl_keystore_type=PKCS12
```

A similar configuration can be made for the gateway:

```properties
# Protect Api properties encryption secret.
gravitee_api_properties_encryption_secret=secret://kubernetes/apim:api.properties.encryption.secret

# Configure SSL on Vertx and protect the password in a secret.
gravitee_http_secured=true
gravitee_http_ssl_keystore_password=secret://kubernetes/apim:http.ssl.keystore.password
gravitee_http_ssl_keystore_path=localhost.p12
gravitee_http_ssl_keystore_type=PKCS12
```

You can use the following command to generate a localhost.p12 keystore:

```bash
openssl genrsa -out localhost.key 4096
openssl req -new -key localhost.key -out localhost.csr -sha256 -subj "/emailAddress=unit.tests@graviteesource.com/CN=localhost/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR"
openssl x509 -req -in localhost.csr -CA ca.pem -CAkey ca.key -set_serial 100 -extensions server -days 36500 -outform PEM -out localhost.cer -sha256 -passin pass:ca-secret
openssl pkcs12 -export -inkey localhost.key -in localhost.cer -out localhost.p12 -passout pass:secret -name localhost
```

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lsgoqckohz.chromatic.com)
<!-- Storybook placeholder end -->
