### PR TITLE
fix(import): use group name in plan excluded groups

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -240,6 +240,35 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                             .filter(pageEntity -> !pageEntity.getType().equals(PageType.ASCIIDOC.name()))
                             .collect(Collectors.toList());
                 }
+
+                // Replace group id by group name in access control list
+                final Map<String, String> pageGroupEntities = new HashMap<>();
+                pages.forEach(pageEntity -> {
+                    if (pageEntity.getAccessControls() != null) {
+                        pageEntity.setAccessControls(
+                            pageEntity
+                                .getAccessControls()
+                                .stream()
+                                .filter(accessControlEntity ->
+                                    accessControlEntity.getReferenceType().equals(AccessControlReferenceType.GROUP.name())
+                                )
+                                .peek(accessControlEntity ->
+                                    accessControlEntity.setReferenceId(
+                                        pageGroupEntities.computeIfAbsent(
+                                            accessControlEntity.getReferenceId(),
+                                            key ->
+                                                applicationContext
+                                                    .getBean(GroupService.class)
+                                                    .findById(GraviteeContext.getExecutionContext(), key)
+                                                    .getName()
+                                        )
+                                    )
+                                )
+                                .collect(Collectors.toSet())
+                        );
+                    }
+                });
+
                 jsonGenerator.writeObjectField("pages", pages == null ? Collections.emptyList() : pages);
                 List<MediaEntity> apiMedia = applicationContext.getBean(MediaService.class).findAllByApiId(apiEntity.getId());
                 if (apiMedia != null && !apiMedia.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -170,10 +170,14 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
         List<String> filteredFieldsList = (List<String>) apiEntity.getMetadata().get(METADATA_FILTERED_FIELDS_LIST);
 
         if (filteredFieldsList != null) {
+            Set<GroupEntity> apiGroupEntities = null;
             if (!filteredFieldsList.contains("groups")) {
                 if (apiEntity.getGroups() != null && !apiEntity.getGroups().isEmpty()) {
-                    Set<GroupEntity> groupEntities = applicationContext.getBean(GroupService.class).findByIds(apiEntity.getGroups());
-                    jsonGenerator.writeObjectField("groups", groupEntities.stream().map(GroupEntity::getName).collect(Collectors.toSet()));
+                    apiGroupEntities = applicationContext.getBean(GroupService.class).findByIds(apiEntity.getGroups());
+                    jsonGenerator.writeObjectField(
+                        "groups",
+                        apiGroupEntities.stream().map(GroupEntity::getName).collect(Collectors.toSet())
+                    );
                 }
             }
 
@@ -251,6 +255,16 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                 Set<PlanEntity> plansToAdd = plans == null
                     ? Collections.emptySet()
                     : plans.stream().filter(p -> !PlanStatus.CLOSED.equals(p.getStatus())).collect(Collectors.toSet());
+                if (!filteredFieldsList.contains("groups") && apiGroupEntities != null) {
+                    Map<String, String> apiGroupNameByIds = apiGroupEntities
+                        .stream()
+                        .collect(Collectors.toMap(GroupEntity::getId, GroupEntity::getName));
+                    plansToAdd.forEach(p -> {
+                        if (p.getExcludedGroups() != null) {
+                            p.setExcludedGroups(p.getExcludedGroups().stream().map(apiGroupNameByIds::get).collect(Collectors.toList()));
+                        }
+                    });
+                }
                 jsonGenerator.writeObjectField("plans", plansToAdd);
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -416,6 +417,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         Api api = new Api();
         api.setId(API_ID);
         apiEntity.setId(API_ID);
+        apiEntity.setGroups(Set.of("my_group_id"));
         when(apiService.createWithApiDefinition(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(apiEntity);
 
         UserEntity admin = new UserEntity();
@@ -426,6 +428,11 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setId("user");
         user.setSource(SOURCE);
         user.setSourceId(API_ID);
+
+        GroupEntity knownGroup = new GroupEntity();
+        knownGroup.setId("my_group_id");
+        knownGroup.setName("MY Group");
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "My Group")).thenReturn(List.of(knownGroup));
 
         apiDuplicatorService.createWithImportedDefinition(GraviteeContext.getExecutionContext(), toBeImport);
 
@@ -447,13 +454,18 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 })
             );
 
+        verify(groupService, times(2)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "My Group");
+
         // check find plans by API has been called once to remove potential pre-existing plans on target API
         verify(planService, times(2)).findByApi(eq(GraviteeContext.getExecutionContext()), any());
         // check planService has been called twice to create 2 plans, with same IDs as API definition
         verify(planService, times(1))
             .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals(plan1newId)));
         verify(planService, times(1))
-            .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals(plan2newId)));
+            .createOrUpdatePlan(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(plan -> plan.getId().equals(plan2newId) && plan.getExcludedGroups().contains(knownGroup.getId()))
+            );
         // check that plan service verifies we are not updated a plan that does not belong to us
         verify(planService, times(1)).anyPlanMismatchWithApi(eq(List.of(plan1newId, plan2newId)), any(String.class));
         verifyNoMoreInteractions(planService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -34,9 +34,12 @@ import com.google.common.io.Resources;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import io.gravitee.rest.api.model.AccessControlEntity;
+import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
@@ -306,11 +309,39 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setSource(SOURCE);
         user.setSourceId("ref-user");
 
+        GroupEntity knownGroup = new GroupEntity();
+        knownGroup.setId("known_group_id");
+        knownGroup.setName("known group name");
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "known group name"))
+            .thenReturn(List.of(knownGroup));
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "group_id")).thenReturn(List.of());
+
         apiDuplicatorService.createWithImportedDefinition(GraviteeContext.getExecutionContext(), toBeImport);
 
         verify(apiService, times(1)).createWithApiDefinition(eq(GraviteeContext.getExecutionContext()), any(), eq("admin"), any());
+        verify(groupService, times(1)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "known group name");
+        verify(groupService, times(1)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "group_id");
         verify(pageService, times(1))
-            .createOrUpdatePages(eq(GraviteeContext.getExecutionContext()), argThat(pagesList -> pagesList.size() == 2), eq(API_ID));
+            .createOrUpdatePages(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(pagesList -> {
+                    boolean pageSizeOk = pagesList.size() == 4;
+                    boolean accessControlOk = true;
+                    for (PageEntity pageEntity : pagesList) {
+                        if (pageEntity.getOrder() == 3) {
+                            accessControlOk =
+                                accessControlOk &&
+                                pageEntity.getAccessControls().contains(new AccessControlEntity("known_group_id", "GROUP"));
+                        } else if (pageEntity.getOrder() == 4) {
+                            accessControlOk =
+                                accessControlOk && pageEntity.getAccessControls().contains(new AccessControlEntity("group_id", "GROUP"));
+                        }
+                    }
+
+                    return pageSizeOk && accessControlOk;
+                }),
+                eq(API_ID)
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -224,12 +224,19 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
     }
 
     private ApiEntity prepareUpdateImportApiWithMembers(String apiId, UserEntity admin, UserEntity user) {
+        return prepareUpdateImportApiWithMembersAndGroups(apiId, admin, user, null);
+    }
+
+    private ApiEntity prepareUpdateImportApiWithMembersAndGroups(String apiId, UserEntity admin, UserEntity user, String groupId) {
         ApiEntity apiEntity = new ApiEntity();
         Api api = new Api();
         api.setId(apiId);
         api.setApiLifecycleState(ApiLifecycleState.CREATED);
         apiEntity.setId(apiId);
         apiEntity.setLifecycleState(io.gravitee.rest.api.model.api.ApiLifecycleState.CREATED);
+        if (groupId != null) {
+            apiEntity.setGroups(Set.of(groupId));
+        }
         when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any())).thenReturn(apiEntity);
 
         RoleEntity poRole = new RoleEntity();
@@ -447,7 +454,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         String toBeImport = Resources.toString(url, Charsets.UTF_8);
         UserEntity admin = new UserEntity();
         UserEntity user = new UserEntity();
-        ApiEntity apiEntity = prepareUpdateImportApiWithMembers(API_ID, admin, user);
+        ApiEntity apiEntity = prepareUpdateImportApiWithMembersAndGroups(API_ID, admin, user, "my_group_id");
         apiEntity.setId("id-api");
         apiEntity.setCrossId("api-cross-id");
         // plan1 is present both in existing api and in imported api definition
@@ -468,14 +475,24 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(planService.findByApi(GraviteeContext.getExecutionContext(), apiEntity.getId()))
             .thenReturn(Set.of(plan1, plan2, plan3, plan4));
 
+        GroupEntity knownGroup = new GroupEntity();
+        knownGroup.setId("my_group_id");
+        knownGroup.setName("MY Group");
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "My Group")).thenReturn(List.of(knownGroup));
+
         apiDuplicatorService.updateWithImportedDefinition(GraviteeContext.getExecutionContext(), apiEntity.getId(), toBeImport);
+
+        verify(groupService, times(2)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "My Group");
 
         verify(planService, times(2)).findByApi(GraviteeContext.getExecutionContext(), apiEntity.getId());
         // plan1, plan2 and plan4 has to be created or updated
         verify(planService, times(1))
             .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals("plan-id1")));
         verify(planService, times(1))
-            .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals("plan-id2")));
+            .createOrUpdatePlan(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(plan -> plan.getId().equals("plan-id2") && plan.getExcludedGroups().contains(knownGroup.getId()))
+            );
         verify(planService, times(1))
             .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals("plan-id4")));
         // plan3 has to be deleted cause no more in imported file

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -418,13 +418,41 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Collections.singletonList(poRole));
 
+        GroupEntity knownGroup = new GroupEntity();
+        knownGroup.setId("known_group_id");
+        knownGroup.setName("known group name");
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "known group name"))
+            .thenReturn(List.of(knownGroup));
+        when(groupService.findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "group_id")).thenReturn(List.of());
+
         apiDuplicatorService.updateWithImportedDefinition(GraviteeContext.getExecutionContext(), apiEntity.getId(), toBeImport);
 
         verify(pageService, times(1))
-            .createOrUpdatePages(eq(GraviteeContext.getExecutionContext()), argThat(pagesList -> pagesList.size() == 2), eq(API_ID));
+            .createOrUpdatePages(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(pagesList -> {
+                    boolean pageSizeOk = pagesList.size() == 4;
+                    boolean accessControlOk = true;
+                    for (PageEntity pageEntity : pagesList) {
+                        if (pageEntity.getOrder() == 3) {
+                            accessControlOk =
+                                accessControlOk &&
+                                pageEntity.getAccessControls().contains(new AccessControlEntity("known_group_id", "GROUP"));
+                        } else if (pageEntity.getOrder() == 4) {
+                            accessControlOk =
+                                accessControlOk && pageEntity.getAccessControls().contains(new AccessControlEntity("group_id", "GROUP"));
+                        }
+                    }
+
+                    return pageSizeOk && accessControlOk;
+                }),
+                eq(API_ID)
+            );
         verify(membershipService, never()).addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
         verify(apiService, times(1)).update(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any());
         verify(apiService, never()).create(eq(GraviteeContext.getExecutionContext()), any(), any());
+        verify(groupService, times(1)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "known group name");
+        verify(groupService, times(1)).findByName(GraviteeContext.getExecutionContext().getEnvironmentId(), "group_id");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
@@ -283,6 +283,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
         publishedPlan.setSecurity(PlanSecurityType.API_KEY);
         publishedPlan.setValidation(PlanValidationType.AUTO);
         publishedPlan.setStatus(PlanStatus.PUBLISHED);
+        publishedPlan.setExcludedGroups(List.of("my-group"));
         Map<String, List<Rule>> paths = new HashMap<>();
         io.gravitee.definition.model.Rule rule = new io.gravitee.definition.model.Rule();
         rule.setEnabled(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
@@ -199,6 +199,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
         markdownPage.setType(PageType.MARKDOWN.toString());
         markdownPage.setContent("Read the doc");
         markdownPage.setVisibility(Visibility.PUBLIC);
+        markdownPage.setAccessControls(Set.of(new AccessControlEntity("my-group", "GROUP")));
         PageEntity asideFolder = new PageEntity();
         asideFolder.setName("Aside");
         asideFolder.setOrder(1);
@@ -273,6 +274,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
         groupEntity.setId("my-group");
         groupEntity.setName("My Group");
         when(groupService.findByIds(apiEntity.getGroups())).thenReturn(Collections.singleton(groupEntity));
+        when(groupService.findById(GraviteeContext.getExecutionContext(), "my-group")).thenReturn(groupEntity);
 
         PlanEntity publishedPlan = new PlanEntity();
         publishedPlan.setId("plan-id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
@@ -306,6 +306,7 @@ public class ApiExportService_gRPC_ExportAsJsonTestSetup {
         publishedPlan.setSecurity(PlanSecurityType.API_KEY);
         publishedPlan.setValidation(PlanValidationType.AUTO);
         publishedPlan.setStatus(PlanStatus.PUBLISHED);
+        publishedPlan.setExcludedGroups(List.of("my-group"));
         Map<String, List<Rule>> paths = new HashMap<>();
         Rule rule = new Rule();
         rule.setEnabled(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
@@ -228,6 +228,7 @@ public class ApiExportService_gRPC_ExportAsJsonTestSetup {
         markdownPage.setType(PageType.MARKDOWN.toString());
         markdownPage.setContent("Read the doc");
         markdownPage.setVisibility(Visibility.PUBLIC);
+        markdownPage.setAccessControls(Set.of(new AccessControlEntity("my-group", "GROUP")));
         PageEntity asideFolder = new PageEntity();
         asideFolder.setName("Aside");
         asideFolder.setOrder(1);
@@ -296,6 +297,7 @@ public class ApiExportService_gRPC_ExportAsJsonTestSetup {
         groupEntity.setId("my-group");
         groupEntity.setName("My Group");
         when(groupService.findByIds(apiEntity.getGroups())).thenReturn(Collections.singleton(groupEntity));
+        when(groupService.findById(GraviteeContext.getExecutionContext(), "my-group")).thenReturn(groupEntity);
 
         PlanEntity publishedPlan = new PlanEntity();
         publishedPlan.setId("plan-id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "metadata":[

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
@@ -29,7 +29,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
@@ -64,7 +64,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "metadata":[

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
@@ -112,7 +112,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
@@ -122,7 +122,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
@@ -132,7 +132,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
@@ -132,7 +132,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
@@ -132,7 +132,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
@@ -132,7 +132,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithouGroup.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithouGroup.json
@@ -33,7 +33,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
@@ -24,7 +24,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
@@ -59,7 +59,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
@@ -60,7 +60,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
@@ -25,7 +25,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
@@ -60,7 +60,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
@@ -25,7 +25,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
@@ -103,7 +103,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
@@ -32,7 +32,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
@@ -113,7 +113,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
@@ -32,7 +32,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
@@ -123,7 +123,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
@@ -32,7 +32,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "proxy": {
     "context_path": "/test",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "proxy": {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
@@ -29,7 +29,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
@@ -64,7 +64,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "proxy": {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
@@ -112,7 +112,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "path_mappings": [],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
@@ -122,7 +122,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "id": "id-api",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
@@ -132,7 +132,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "id": "id-api",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_15.json
@@ -32,7 +32,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_20.json
@@ -33,7 +33,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-1_25.json
@@ -34,7 +34,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_0.json
@@ -52,7 +52,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_7.json
@@ -52,7 +52,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
@@ -52,7 +52,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_15.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_20.json
@@ -29,7 +29,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_25.json
@@ -30,7 +30,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_7.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "metadata":[
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
@@ -28,7 +28,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
@@ -63,7 +63,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "metadata":[

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
@@ -29,7 +29,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
@@ -64,7 +64,10 @@
         "enabled" : true
       } ]
     },
-    "comment_required" : false
+    "comment_required" : false,
+    "excluded_groups": [
+      "My Group"
+    ]
   } ],
   "path_mappings":[],
   "metadata":[

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
@@ -112,7 +112,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
@@ -112,7 +112,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_7.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_7.json
@@ -41,7 +41,13 @@
       "visibility": "PUBLIC",
       "published" : false,
       "homepage" : false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name" : "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
@@ -36,7 +36,13 @@
       "published": false,
       "visibility": "PUBLIC",
       "homepage": false,
-      "excludedAccessControls": false
+      "excludedAccessControls": false,
+      "accessControls": [
+        {
+          "referenceId":"My Group",
+          "referenceType":"GROUP"
+        }
+      ]
     },
     {
       "name": "My Swagger",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
@@ -127,7 +127,10 @@
         ]
       },
       "flows": [],
-      "comment_required": false
+      "comment_required": false,
+      "excluded_groups": [
+        "My Group"
+      ]
     }
   ],
   "metadata": [

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api-update.definition+plans.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api-update.definition+plans.json
@@ -147,7 +147,10 @@
           },
           "enabled" : true
         } ]
-      }
+      },
+      "excluded_groups": [
+        "My Group"
+      ]
     },
     {
       "id" : "plan-id4",
@@ -173,5 +176,6 @@
         } ]
       }
     }
-  ]
+  ],
+  "groups": ["My Group"]
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+pages.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+pages.json
@@ -118,6 +118,34 @@
       "visibility": "PUBLIC",
       "lastContributor": "admin",
       "published": false
+    },
+    {
+      "name": "page with group name in access control",
+      "type": "MARKDOWN",
+      "order": 3,
+      "visibility": "PUBLIC",
+      "lastContributor": "admin",
+      "published": false,
+      "accessControls": [
+        {
+          "referenceId": "known group name",
+          "referenceType": "GROUP"
+        }
+      ]
+    },
+    {
+      "name": "page with group id in access control",
+      "type": "MARKDOWN",
+      "order": 4,
+      "visibility": "PUBLIC",
+      "lastContributor": "admin",
+      "published": false,
+      "accessControls": [
+        {
+          "referenceId": "group_id",
+          "referenceType": "GROUP"
+        }
+      ]
     }
   ]
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+plans.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+plans.json
@@ -144,7 +144,11 @@
           },
           "enabled" : true
         } ]
-      }
+      },
+      "excluded_groups": [
+        "My Group"
+      ]
     }
-  ]
+  ],
+  "groups" : ["My Group"]
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2139

## Description

Use group name in plan's excluded groups during the export and replace group name by new group id when importing.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fvhwisbmun.chromatic.com)
<!-- Storybook placeholder end -->
