### PR TITLE
fix(helm): license deleted after helm upgrade

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -19,7 +19,4 @@ annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
-    - Add unknownExpireAfter in management-api configuration
-    - Allow users to define extra manifests
-    - Make optional HTTP2 request processing via `gateway.http.alpn` set at `true` by default.
-    - "fix 'gravitee.yml' > 'services.metrics' definition from helm `values.yaml`"
+    - 'fix: license deleted after helm upgrade https://github.com/gravitee-io/issues/issues/9411'

--- a/helm/templates/common/licenses-secrets.yaml
+++ b/helm/templates/common/licenses-secrets.yaml
@@ -1,4 +1,3 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace .Values.license.name) }}
 {{- with .Values.license }}
 {{- if .key }}
 apiVersion: v1
@@ -8,6 +7,5 @@ metadata:
 type: Opaque
 data:
   licensekey: {{ .key }}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1521,5 +1521,5 @@ initContainers:
 
 # For enterprise plugin only, you will need a license
 license:
-  name: licensekey
+  name: licensekey-apim
 #  key: <put here your license.key file encoded in base64>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/DV-330
https://gravitee.atlassian.net/browse/APIM-3511

## Description

During an helm upgrade, the secret with gravitee license created
from `values.yml` entry: `license.key` is deleted.

It seems that the lookup implies the the ressource is not re-created,
however during the helm upgrade rotation it is deleted.

The fix consist on removing this lookup and by default name the secret
with component suffix. We set this suffix to allow specific use case
with multiple gravitee component on the same namespace (eg: APIM+AE).

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yroaujrnsq.chromatic.com)
<!-- Storybook placeholder end -->
