### PR TITLE
fix: use also parent class field to check synchronization

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.rest.api.model.BasePlanEntity;
 import io.gravitee.rest.api.model.NewPlanEntity;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanEntity;
@@ -289,7 +290,10 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
             flowService.save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
             PlanEntity newPlanEntity = convert(newPlan);
 
-            if (!synchronizationService.checkSynchronization(PlanEntity.class, oldPlanEntity, newPlanEntity)) {
+            if (
+                !synchronizationService.checkSynchronization(PlanEntity.class, oldPlanEntity, newPlanEntity) ||
+                !synchronizationService.checkSynchronization(BasePlanEntity.class, oldPlanEntity, newPlanEntity)
+            ) {
                 newPlan.setNeedRedeployAt(newPlan.getUpdatedAt());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -348,7 +348,10 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
                 flowService.save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
                 PlanEntity newPlanEntity = mapToEntity(newPlan);
 
-                if (!synchronizationService.checkSynchronization(PlanEntity.class, oldPlanEntity, newPlanEntity)) {
+                if (
+                    !synchronizationService.checkSynchronization(PlanEntity.class, oldPlanEntity, newPlanEntity) ||
+                    !synchronizationService.checkSynchronization(BasePlanEntity.class, oldPlanEntity, newPlanEntity)
+                ) {
                     newPlan.setNeedRedeployAt(newPlan.getUpdatedAt());
                 }
                 newPlan = planRepository.update(newPlan);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3287

## Description

PlanEntity fields annotated with `@DeploymentRequired` have been spread between PlanEntity and BasePlanEntity. As the synchronization check relies on Java Introspection, we need to also check fields of the parent class.

## Additional information
An internal improvement is planned to rely directly on APIM definition instead of java introspection and annotations.
https://gravitee.atlassian.net/browse/APIM-3534