### PR TITLE
fix: allow to convert a deprecated V1 API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1350,8 +1350,15 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     private void checkLifecycleState(final UpdateApiEntity updateApiEntity, final ApiEntity existingAPI) {
         if (io.gravitee.rest.api.model.api.ApiLifecycleState.DEPRECATED.equals(existingAPI.getLifecycleState())) {
-            throw new LifecycleStateChangeNotAllowedException(updateApiEntity.getLifecycleState().name());
+            // We can update a DEPRECATED API only if the definition version has changed AND the updateApiEntity is also DEPRECATED (used when converting from v1 to v2)
+            if (
+                updateApiEntity.getGraviteeDefinitionVersion().equals(existingAPI.getGraviteeDefinitionVersion()) ||
+                updateApiEntity.getLifecycleState() != existingAPI.getLifecycleState()
+            ) {
+                throw new LifecycleStateChangeNotAllowedException(updateApiEntity.getLifecycleState().name());
+            }
         }
+
         if (existingAPI.getLifecycleState().name().equals(updateApiEntity.getLifecycleState().name())) {
             return;
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3474

## Description

Allow to convert a deprecated V1 API