### PR TITLE
fix(helm): AE system mail notification without keystore

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 3.20.25
 
 - Update regex for portal and console base_href
+- 'fix AE system mail notification without keystore'
 
 ### 3.20.23
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -20,3 +20,5 @@ annotations:
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
   artifacthub.io/changes: |
     - Update regex for portal and console base_href
+    - 'fix AE system mail notification without keystore'
+

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -384,8 +384,12 @@ data:
         {{- if .Values.notifiers.smtp.ssl }}
         ssl:
           trustAll: {{ .Values.notifiers.smtp.ssl.trustAll }}
+          {{- if .Values.notifiers.smtp.ssl.keyStore }}
           keyStore: {{ .Values.notifiers.smtp.ssl.keyStore }}
+          {{- end }}
+          {{- if .Values.notifiers.smtp.ssl.keyStorePassword }}
           keyStorePassword: {{ .Values.notifiers.smtp.ssl.keyStorePassword }}
+          {{- end }}
         {{- end }}
         {{- end }}
 

--- a/helm/tests/api/configmap_email_test.yaml
+++ b/helm/tests/api/configmap_email_test.yaml
@@ -104,3 +104,54 @@ tests:
       - matchRegex:
           path: data.[gravitee.yml]
           pattern: "keyStorePassword: TEST.keyStorePassword"
+
+  - it: Set notifiers smtp with SSL enabled but without keystore
+    template: api/api-configmap.yaml
+    set:
+      notifiers:
+        smtp:
+          enabled: true
+          host: TEST.host
+          subject: TEST.subject
+          port: 4242
+          from: TEST.from
+          username: TEST.username
+          password: TEST.password
+          starttlsEnabled: true
+          ssl:
+            trustAll: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *notifiers:\n
+                     *  email:\n
+                     *    enabled: true\n                                                                                                                                                                  
+                     *    host: TEST.host\n                                                                                                                                                            
+                     *    subject: \"TEST.subject\"\n
+                     *    port: 4242\n
+                     *    from: TEST.from\n
+                     *    username: TEST.username\n
+                     *    password: TEST.password\n
+                     *    starttls.enabled: true\n
+                     *    ssl:\n
+                     *      trustAll: true"
+      - notMatchRegex:
+          path: data.[gravitee.yml]
+          pattern: " *notifiers:\n
+                     *  email:\n
+                     *    enabled: true\n                                                                                                                                                                  
+                     *    host: TEST.host\n                                                                                                                                                            
+                     *    subject: \"TEST.subject\"\n
+                     *    port: 4242\n
+                     *    from: TEST.from\n
+                     *    username: TEST.username\n
+                     *    password: TEST.password\n
+                     *    starttls.enabled: true\n
+                     *    ssl:\n
+                     *      trustAll: true\n
+                     *      keyStore: \n
+                     *      keyStorePassword: "


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3449
https://gravitee.atlassian.net/browse/DV-329

## Description

In the case of setting up SSL in `.notifiers.smtp.ssl` with `trustAll`
to `true` and without `keystore`. The helm chart set a null value for
`keyStore` and `keyStorePassword` in the `gravitee.yml` which make the
application exception on startup:

```
ERROR i.g.notifier.email.EmailNotifier - An error occurs while sending email
io.vertx.core.file.FileSystemException: Unable to read file at path ''
```

We make these fields optionable.
