### PR TITLE
fix(console): keep url path when replacing env id for env hrid

### DIFF
--- a/gravitee-apim-console-webui/src/management/has-environment-permission.guard.ts
+++ b/gravitee-apim-console-webui/src/management/has-environment-permission.guard.ts
@@ -53,7 +53,8 @@ export class HasEnvironmentPermissionGuard implements CanActivate, CanActivateCh
         this.constants.org.currentEnv = currentEnvironment;
 
         if (paramEnv === currentEnvironment.id && currentEnvironment.hrids?.length > 0) {
-          this.router.navigate([currentEnvironment.hrids[0]]);
+          // Replace environment ID by hrid but keep url path
+          this.router.navigateByUrl(state.url.replace(currentEnvironment.id, currentEnvironment.hrids[0]));
         }
 
         return this.gioPermissionService.loadEnvironmentPermissions(paramEnv);

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -154,7 +154,7 @@ describe('API List feature', { defaultCommandTimeout: 10000 }, () => {
         cy.getByDataTestId('paginator-header').within(() => {
           cy.get('.mat-select-arrow-wrapper').click();
         });
-        cy.get('#mat-option-0').click();
+        cy.get('mat-option').contains('5').first().click();
         cy.url().should('include', 'size=5');
       });
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3385

## Description

- When an environment id is used in the url, we replace it with an hrid and keep the rest of the url.
- Small fix for e2e test of api list to select by value instead of id

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zusxpmklvb.chromatic.com)
<!-- Storybook placeholder end -->
