### PR TITLE
Add a browserlistrc file to configure Babel preset env

### DIFF
--- a/gravitee-apim-console-webui/.browserslistrc
+++ b/gravitee-apim-console-webui/.browserslistrc
@@ -1,0 +1,9 @@
+# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
+# For additional information regarding the format and rule options, please see:
+# https://github.com/browserslist/browserslist#queries
+
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
+> 0.5% and supports es6-module
+last 2 versions and supports es6-module


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The file is the same as the one in the Portal and will be automagically loaded by Babel to configure the `preset-env` preset
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qwtjjetbyd.chromatic.com)
<!-- Storybook placeholder end -->
