### PR TITLE
test: deactivate cypress cloud recording for 4.2.x branch

### DIFF
--- a/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
+++ b/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "cypress";
 import { unlinkSync } from "fs";
 
 export default defineConfig({
-    projectId: "88vnc3",
     env: {
         failOnStatusCode: false,
         api_publisher_user_login: "api1",

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -20,7 +20,7 @@ services:
   cypress:
     image: cypress/included:13.3.3
     working_dir: /test
-    command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts' --record"
+    command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts'"
     volumes:
       - ./:/test
       - ./docker/ui-tests/conf/cypress-ui-config.ts:/test/cypress-ui-config.ts


### PR DESCRIPTION
## Description
Since we have to respect a certain quota for test results in Cypress Cloud we want to limit this Cloud service to track the master branch only. However, when we created the 4.2.x branch the cloud recording was not disabled, so this PR will correct that.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fymwfvjlyh.chromatic.com)
<!-- Storybook placeholder end -->
