### PR TITLE
Add miscellaneous Babel plugins to have `swagger-ui-dist` working fine

### DIFF
--- a/gravitee-apim-console-webui/babel.config.js
+++ b/gravitee-apim-console-webui/babel.config.js
@@ -15,4 +15,14 @@
  */
 module.exports = {
   presets: ['@babel/preset-env'],
+  plugins: [
+    // Some extra plugins required to have `swagger-ui-dist` properly working
+    '@babel/plugin-transform-nullish-coalescing-operator',
+    '@babel/plugin-transform-class-properties',
+    '@babel/plugin-transform-private-methods',
+    '@babel/plugin-transform-private-property-in-object',
+    '@babel/plugin-transform-optional-chaining',
+    '@babel/plugin-transform-logical-assignment-operators',
+    '@babel/plugin-transform-class-static-block',
+  ],
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3401
https://github.com/gravitee-io/issues/issues/9391

## Description

Add miscellaneous Babel plugins to have `swagger-ui-dist` working fine
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ykwsxwkcnv.chromatic.com)
<!-- Storybook placeholder end -->
