### PR TITLE
fix(console): resolve parentId query param for documentation v2

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/documentation-management.component.ts
@@ -45,7 +45,7 @@ export class DocumentationManagementComponent extends UpgradeComponent {
 
   ngOnInit() {
     const apiId = this.activatedRoute.snapshot.params.apiId;
-    const parent = this.activatedRoute.snapshot.queryParams.parent;
+    const parent = this.activatedRoute.snapshot.queryParams.parent ?? '';
 
     Promise.all([
       this.ajsDocumentationService.search(isEmpty(parent) ? { root: true } : { parent: parent }, apiId).then((response) => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3385

## Description

System folders were not appearing in the documentation table because the `parentId` was not resolved correctly via the new angular routing.

![Screenshot 2023-12-07 at 14 38 45](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/fb909427-f3fc-40b0-80d5-37d957d7f425)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ovsqnussez.chromatic.com)
<!-- Storybook placeholder end -->
