### PR TITLE
refactor(test): refactor inmemory tests to be able to share storage

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -32,6 +32,7 @@ import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.MessageLogCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.log.model.MessageOperation;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLog;
@@ -102,8 +103,8 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
         GraviteeContext.setCurrentOrganization(ORGANIZATION);
 
-        planStorageService.initWith(List.of(PLAN_1, PLAN_2));
-        applicationStorageService.initWith(List.of(APPLICATION));
+        planStorageService.initWith(Storage.of(PLAN_1, PLAN_2));
+        applicationStorageService.initWith(Storage.of(APPLICATION));
     }
 
     @Override
@@ -147,7 +148,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
 
         @Test
         public void should_return_connection_logs() {
-            connectionLogStorageService.initWith(List.of(connectionLogFixtures.aConnectionLog("req1")));
+            connectionLogStorageService.initWith(Storage.of(connectionLogFixtures.aConnectionLog("req1")));
 
             final Response response = connectionLogsTarget.request().get();
 
@@ -184,7 +185,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             var total = 20L;
             var pageSize = 5;
             connectionLogStorageService.initWithConnectionLogs(
-                LongStream.range(0, total).mapToObj(i -> connectionLogFixtures.aConnectionLog()).toList()
+                Storage.from(LongStream.range(0, total).mapToObj(i -> connectionLogFixtures.aConnectionLog()).toList())
             );
 
             connectionLogsTarget =
@@ -206,7 +207,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             var page = 2;
             var pageSize = 5;
             connectionLogStorageService.initWithConnectionLogs(
-                LongStream.range(0, total).mapToObj(i -> connectionLogFixtures.aConnectionLog()).toList()
+                Storage.from(LongStream.range(0, total).mapToObj(i -> connectionLogFixtures.aConnectionLog()).toList())
             );
 
             final Response response = connectionLogsTarget
@@ -276,7 +277,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         public void should_return_connection_logs_filtered_by_interval() {
             connectionLogStorageService.initWith(
-                List.of(
+                Storage.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
                     connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
                     connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
@@ -326,7 +327,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         public void should_return_connection_logs_filtered_by_applications() {
             connectionLogStorageService.initWith(
-                List.of(
+                Storage.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().applicationId("app1").build(),
                     connectionLogFixtures.aConnectionLog("req2").toBuilder().applicationId("app1").build(),
                     connectionLogFixtures.aConnectionLog("req3").toBuilder().applicationId("app2").build()
@@ -363,7 +364,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         public void should_return_connection_logs_filtered_by_plans() {
             connectionLogStorageService.initWith(
-                List.of(
+                Storage.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().planId(PLAN_1.getId()).build(),
                     connectionLogFixtures.aConnectionLog("req2").toBuilder().planId(PLAN_1.getId()).build(),
                     connectionLogFixtures.aConnectionLog("req3").toBuilder().planId(PLAN_2.getId()).build()
@@ -400,7 +401,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         public void should_return_connection_logs_filtered_by_methods() {
             connectionLogStorageService.initWith(
-                List.of(
+                Storage.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().method(io.gravitee.common.http.HttpMethod.POST).build(),
                     connectionLogFixtures.aConnectionLog("req2").toBuilder().method(io.gravitee.common.http.HttpMethod.GET).build(),
                     connectionLogFixtures.aConnectionLog("req3").toBuilder().method(io.gravitee.common.http.HttpMethod.POST).build()
@@ -441,7 +442,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         public void should_return_connection_logs_filtered_by_statuses() {
             connectionLogStorageService.initWith(
-                List.of(
+                Storage.of(
                     connectionLogFixtures.aConnectionLog("req1").toBuilder().status(200).build(),
                     connectionLogFixtures.aConnectionLog("req2").toBuilder().status(202).build(),
                     connectionLogFixtures.aConnectionLog("req3").toBuilder().status(200).build()
@@ -506,7 +507,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
 
         @Test
         public void should_return_message_logs() {
-            messageLogStorageService.initWith(List.of(MessageLogFixtures.aMessageLog(API, REQUEST_ID)));
+            messageLogStorageService.initWith(Storage.of(MessageLogFixtures.aMessageLog(API, REQUEST_ID)));
 
             final Response response = messageLogsTarget.request().get();
 
@@ -560,10 +561,12 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             var total = 20L;
             var pageSize = 5;
             messageLogStorageService.initWith(
-                LongStream
-                    .range(0, total)
-                    .mapToObj(i -> MessageLogFixtures.aMessageLog(API, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
-                    .toList()
+                Storage.from(
+                    LongStream
+                        .range(0, total)
+                        .mapToObj(i -> MessageLogFixtures.aMessageLog(API, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
+                        .toList()
+                )
             );
 
             messageLogsTarget =
@@ -585,10 +588,12 @@ public class ApiLogsResourceTest extends ApiResourceTest {
             var page = 2;
             var pageSize = 5;
             messageLogStorageService.initWith(
-                LongStream
-                    .range(0, total)
-                    .mapToObj(i -> MessageLogFixtures.aMessageLog(API, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
-                    .toList()
+                Storage.from(
+                    LongStream
+                        .range(0, total)
+                        .mapToObj(i -> MessageLogFixtures.aMessageLog(API, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
+                        .toList()
+                )
             );
 
             final Response response = messageLogsTarget
@@ -641,7 +646,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         void should_return_connection_log() {
             final ConnectionLogDetail connectionLogDetail = new ConnectionLogDetailFixtures(API, REQUEST_ID).aConnectionLogDetail();
-            connectionLogStorageService.initWithConnectionLogDetails(List.of(connectionLogDetail));
+            connectionLogStorageService.initWithConnectionLogDetails(Storage.of(connectionLogDetail));
 
             final Response response = connectionLogTarget.request().get();
 
@@ -693,7 +698,7 @@ public class ApiLogsResourceTest extends ApiResourceTest {
         @Test
         void should_return_404_if_no_connection_log() {
             final ConnectionLogDetail connectionLogDetail = new ConnectionLogDetailFixtures(API, "other-request-id").aConnectionLogDetail();
-            connectionLogStorageService.initWithConnectionLogDetails(List.of(connectionLogDetail));
+            connectionLogStorageService.initWithConnectionLogDetails(Storage.of(connectionLogDetail));
 
             final Response response = connectionLogTarget.request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_CloseTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
@@ -76,7 +77,7 @@ public class ApiSubscriptionsResource_CloseTest extends AbstractResourceTest {
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
         GraviteeContext.setCurrentOrganization(ORGANIZATION);
 
-        applicationCrudServiceInMemory.initWith(List.of(BaseApplicationEntity.builder().id(APPLICATION).build()));
+        applicationCrudServiceInMemory.initWith(Storage.of(BaseApplicationEntity.builder().id(APPLICATION).build()));
     }
 
     @AfterEach
@@ -93,7 +94,7 @@ public class ApiSubscriptionsResource_CloseTest extends AbstractResourceTest {
     @Test
     public void should_return_404_if_subscription_associated_to_another_api() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 SubscriptionEntity
                     .builder()
                     .id(SUBSCRIPTION)
@@ -128,7 +129,7 @@ public class ApiSubscriptionsResource_CloseTest extends AbstractResourceTest {
     @Test
     public void should_return_subscription_when_subscription_closed() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 SubscriptionEntity
                     .builder()
                     .id(SUBSCRIPTION)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_RevokeApiKeyTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_RevokeApiKeyTest.java
@@ -28,6 +28,7 @@ import fixtures.core.model.ApiKeyFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.rest.api.management.v2.rest.model.ApiKey;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -75,7 +76,7 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
         GraviteeContext.setCurrentOrganization(ORGANIZATION);
 
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
     }
 
@@ -91,7 +92,7 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
     @Test
     public void should_return_404_if_subscription_not_found() {
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures.anApiKey().toBuilder().id(API_KEY_ID).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
             )
         );
@@ -104,10 +105,10 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
     @Test
     public void should_return_404_if_subscription_associated_to_another_api() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(fixtures.core.model.SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION).apiId("another-api").build())
+            Storage.of(fixtures.core.model.SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION).apiId("another-api").build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures.anApiKey().toBuilder().id(API_KEY_ID).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
             )
         );
@@ -127,10 +128,10 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
     @Test
     public void should_return_404_if_api_key_associated_to_another_subscription() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(fixtures.core.model.SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION).apiId(API).build())
+            Storage.of(fixtures.core.model.SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION).apiId(API).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -149,7 +150,7 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
     @Test
     public void should_return_400_if_application_is_in_shared_api_key_mode() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 fixtures.core.model.SubscriptionFixtures
                     .aSubscription()
                     .toBuilder()
@@ -160,10 +161,10 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
             )
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.SHARED).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.SHARED).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures.anApiKey().toBuilder().id(API_KEY_ID).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
             )
         );
@@ -196,7 +197,7 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
     @Test
     public void should_revoke_api_key() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 fixtures.core.model.SubscriptionFixtures
                     .aSubscription()
                     .toBuilder()
@@ -207,10 +208,10 @@ public class ApiSubscriptionsResource_RevokeApiKeyTest extends ApiSubscriptionsR
             )
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures.anApiKey().toBuilder().id(API_KEY_ID).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/boostrap/ManagementUIResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/boostrap/ManagementUIResourceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import inmemory.ParametersDomainServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.license.NodeLicenseService;
 import io.gravitee.repository.management.model.Parameter;
@@ -46,7 +47,7 @@ class ManagementUIResourceTest extends AbstractResourceTest {
         GraviteeContext.fromExecutionContext(new ExecutionContext(ORGANIZATION));
 
         parametersDomainServiceInMemory.initWith(
-            List.of(Parameter.builder().key(Key.CONSOLE_CUSTOMIZATION_TITLE.key()).value("title").build())
+            Storage.of(Parameter.builder().key(Key.CONSOLE_CUSTOMIZATION_TITLE.key()).value("title").build())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/documentation/ApiPagesResourceTest.java
@@ -33,6 +33,7 @@ import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PageRevisionCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -133,7 +134,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @BeforeEach
         void setUp() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id("api-id").build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id("api-id").build()));
         }
 
         @Test
@@ -491,7 +492,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
                 .build();
             givenApiPagesQuery(List.of(page1, page2));
             planQueryServiceInMemory.initWith(
-                List.of(
+                Storage.of(
                     PlanFixtures
                         .aPlanV4()
                         .toBuilder()
@@ -573,7 +574,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @BeforeEach
         void setUp() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id("api-id").build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id("api-id").build()));
         }
 
         @Test
@@ -700,7 +701,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             when(
                 permissionService.hasPermission(
@@ -736,7 +737,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_404_if_page_does_not_exist() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             final Response response = rootTarget().path(PAGE_ID).request().get();
 
@@ -750,7 +751,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_get_page() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -792,7 +793,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @BeforeEach
         void setUp() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
         }
 
         @Test
@@ -1003,7 +1004,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             when(
                 permissionService.hasPermission(
@@ -1039,7 +1040,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_404_if_page_does_not_exist() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             final Response response = rootTarget().path(PATH).request().post(Entity.json(""));
 
@@ -1053,7 +1054,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_publish_page() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -1080,7 +1081,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_403_if_incorrect_permissions() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             when(
                 permissionService.hasPermission(
@@ -1116,7 +1117,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         public void should_return_404_if_page_does_not_exist() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             final Response response = rootTarget().path(PATH).request().post(Entity.json(""));
 
@@ -1130,7 +1131,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_unpublish_page() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -1157,7 +1158,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_403_if_incorrect_permissions() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             when(
                 permissionService.hasPermission(
@@ -1193,7 +1194,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_404_if_page_does_not_exist() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             final Response response = rootTarget().path(PATH).request().delete();
 
@@ -1207,7 +1208,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_400_if_page_is_not_api_page() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -1233,7 +1234,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
         @ParameterizedTest
         @EnumSource(value = PlanStatus.class, names = { "PUBLISHED", "DEPRECATED" })
         void should_return_400_if_page_is_used_as_general_condition(PlanStatus planStatus) {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -1247,7 +1248,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
             givenApiPagesQuery(List.of(page1));
 
             planQueryServiceInMemory.initWith(
-                List.of(
+                Storage.of(
                     PlanFixtures.aPlanV4().toBuilder().id("plan-id").status(planStatus).apiId(API_ID).generalConditions(PAGE_ID).build()
                 )
             );
@@ -1264,7 +1265,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_400_if_page_is_a_non_empty_folder() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page folder = Page
                 .builder()
@@ -1299,7 +1300,7 @@ class ApiPagesResourceTest extends AbstractResourceTest {
 
         @Test
         void should_delete_page() {
-            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+            apiCrudServiceInMemory.initWith(Storage.of(Api.builder().id(API_ID).build()));
 
             Page page1 = Page
                 .builder()
@@ -1322,7 +1323,6 @@ class ApiPagesResourceTest extends AbstractResourceTest {
     }
 
     private void givenApiPagesQuery(List<Page> pages) {
-        pageQueryServiceInMemory.initWith(pages);
-        pageCrudServiceInMemory.initWith(pages);
+        pageCrudServiceInMemory.syncStorageWith(pageQueryServiceInMemory.initWith(Storage.from(pages)));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.management.v2.rest.spring;
 
-import inmemory.AccessPointQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
@@ -25,7 +24,6 @@ import inmemory.AuditCrudServiceInMemory;
 import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
 import inmemory.EventCrudInMemory;
-import inmemory.InstallationAccessQueryServiceInMemory;
 import inmemory.InstanceQueryServiceInMemory;
 import inmemory.MessageLogCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
@@ -36,13 +34,15 @@ import inmemory.PlanCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import stub.AccessPointQueryServiceStub;
+import stub.InstallationAccessQueryServiceStub;
+import stub.TriggerNotificationDomainServiceStub;
 
 @Configuration
 public class InMemoryConfiguration {
@@ -108,15 +108,13 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    public SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory(
-        SubscriptionCrudServiceInMemory subscriptionCrudServiceInMemory
-    ) {
-        return new SubscriptionQueryServiceInMemory(subscriptionCrudServiceInMemory);
+    public SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory() {
+        return new SubscriptionQueryServiceInMemory();
     }
 
     @Bean
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainServiceInMemory() {
-        return new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainServiceInMemory() {
+        return new TriggerNotificationDomainServiceStub();
     }
 
     @Bean
@@ -140,13 +138,13 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    public AccessPointQueryServiceInMemory accessPointQueryServiceInMemory() {
-        return new AccessPointQueryServiceInMemory();
+    public AccessPointQueryServiceStub accessPointQueryServiceInMemory() {
+        return new AccessPointQueryServiceStub();
     }
 
     @Bean
     public InstallationAccessQueryService installationAccessServiceInMemory() {
-        return new InstallationAccessQueryServiceInMemory();
+        return new InstallationAccessQueryServiceStub();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceDebugTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceDebugTest.java
@@ -28,6 +28,7 @@ import fixtures.core.model.ApiFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.InstanceQueryServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.gateway.model.Instance;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.Proxy;
@@ -114,9 +115,9 @@ public class ApiResourceDebugTest extends AbstractResourceTest {
     @Test
     public void shouldDebugApi() {
         when(nodeLicenseService.isFeatureMissing("apim-debug-mode")).thenReturn(false);
-        apiCrudServiceInMemory.initWith(List.of(ApiFixtures.aProxyApiV2().toBuilder().id(API).build()));
+        apiCrudServiceInMemory.initWith(Storage.of(ApiFixtures.aProxyApiV2().toBuilder().id(API).build()));
         instanceQueryServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 Instance
                     .builder()
                     .id("gateway")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeyResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeyResourceTest.java
@@ -32,6 +32,7 @@ import fixtures.core.model.SubscriptionFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
@@ -95,13 +96,13 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
     @Test
     public void delete_should_revoke_and_return_http_204() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -115,7 +116,7 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
         Response response = envTarget().request().delete();
 
         Assertions
-            .assertThat(apiKeyCrudServiceInMemory.storage())
+            .assertThat(apiKeyCrudServiceInMemory.data())
             .extracting(
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::getId,
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::isRevoked
@@ -127,13 +128,13 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
     @Test
     public void delete_should_return_http_404_when_apikey_on_another_subscription() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -147,7 +148,7 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
         Assertions
-            .assertThat(apiKeyCrudServiceInMemory.storage())
+            .assertThat(apiKeyCrudServiceInMemory.data())
             .extracting(
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::getId,
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::isRevoked
@@ -158,13 +159,13 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
     @Test
     public void delete_should_return_http_500_on_exception() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).apiId(API_ID).build())
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResourceTest.java
@@ -23,6 +23,7 @@ import fixtures.core.model.ApiKeyFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -70,10 +71,10 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
     @Test
     public void revoke_should_return_http_400_if_application_doesnt_use_shared_api_key() {
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(ApiKeyFixtures.anApiKey().toBuilder().id(APIKEY_ID).key("my-api-key-value").applicationId(APPLICATION_ID).build())
+            Storage.of(ApiKeyFixtures.anApiKey().toBuilder().id(APIKEY_ID).key("my-api-key-value").applicationId(APPLICATION_ID).build())
         );
 
         Response response = envTarget().request().delete();
@@ -84,10 +85,10 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
     @Test
     public void revoke_should_return_http_400_if_application_doesnt_match_api_key() {
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(ApiKeyFixtures.anApiKey().toBuilder().id(APIKEY_ID).key("my-api-key-value").applicationId("another-app").build())
+            Storage.of(ApiKeyFixtures.anApiKey().toBuilder().id(APIKEY_ID).key("my-api-key-value").applicationId("another-app").build())
         );
 
         Response response = envTarget().request().delete();
@@ -98,10 +99,10 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
     @Test
     public void revoke_should_revoke_and_return_http_204() {
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -116,7 +117,7 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
         Response response = envTarget().request().delete();
 
         Assertions
-            .assertThat(apiKeyCrudServiceInMemory.storage())
+            .assertThat(apiKeyCrudServiceInMemory.data())
             .extracting(
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::getId,
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::isRevoked

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApikeyResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApikeyResourceTest.java
@@ -26,6 +26,7 @@ import fixtures.core.model.SubscriptionFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -76,13 +77,13 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
     @Test
     public void delete_should_revoke_and_return_http_204() {
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION_ID).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION_ID).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -97,7 +98,7 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
         Response response = envTarget().request().delete();
 
         Assertions
-            .assertThat(apiKeyCrudServiceInMemory.storage())
+            .assertThat(apiKeyCrudServiceInMemory.data())
             .extracting(
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::getId,
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::isRevoked
@@ -109,13 +110,13 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
     @Test
     public void delete_should_return_http_400_when_apikey_on_another_subscription() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -130,7 +131,7 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
 
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
         Assertions
-            .assertThat(apiKeyCrudServiceInMemory.storage())
+            .assertThat(apiKeyCrudServiceInMemory.data())
             .extracting(
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::getId,
                 io.gravitee.apim.core.api_key.model.ApiKeyEntity::isRevoked
@@ -141,13 +142,13 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
     @Test
     public void delete_should_return_http_500_on_exception() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.EXCLUSIVE).id(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()
@@ -174,13 +175,13 @@ public class ApplicationSubscriptionApikeyResourceTest extends AbstractResourceT
     @Test
     public void delete_should_return_http_400_if_application_found_has_shared_apiKey_mode() {
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
+            Storage.of(BaseApplicationEntity.builder().apiKeyMode(ApiKeyMode.SHARED).id(APPLICATION_ID).build())
         );
         subscriptionCrudServiceInMemory.initWith(
-            List.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
+            Storage.of(SubscriptionFixtures.aSubscription().toBuilder().id(SUBSCRIPTION_ID).applicationId(APPLICATION_ID).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 ApiKeyFixtures
                     .anApiKey()
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import stub.TriggerNotificationDomainServiceStub;
 
 @Configuration
 public class InMemoryConfiguration {
@@ -80,10 +81,8 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    public SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory(
-        SubscriptionCrudServiceInMemory subscriptionCrudServiceInMemory
-    ) {
-        return new SubscriptionQueryServiceInMemory(subscriptionCrudServiceInMemory);
+    public SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory() {
+        return new SubscriptionQueryServiceInMemory();
     }
 
     @Bean
@@ -97,8 +96,8 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    public TriggerNotificationDomainServiceInMemory triggerNotificationDomainServiceInMemory() {
-        return new TriggerNotificationDomainServiceInMemory();
+    public TriggerNotificationDomainServiceStub triggerNotificationDomainServiceInMemory() {
+        return new TriggerNotificationDomainServiceStub();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionKeysResourceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import fixtures.core.model.ApiKeyFixtures;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
@@ -192,7 +193,7 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
     @Test
     public void should_revoke_key() {
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 fixtures.core.model.SubscriptionFixtures
                     .aSubscription()
                     .toBuilder()
@@ -203,10 +204,12 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
             )
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build())
+            Storage.of(
+                ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
+            )
         );
 
         final Response response = target(SUBSCRIPTION).path("keys/" + KEY + "/_revoke").request().post(null);
@@ -260,7 +263,7 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
             );
 
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 fixtures.core.model.SubscriptionFixtures
                     .aSubscription()
                     .toBuilder()
@@ -271,10 +274,12 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
             )
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build())
+            Storage.of(
+                ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
+            )
         );
 
         assertThat(target(SUBSCRIPTION).path("keys/" + KEY + "/_revoke").request().post(null).getStatus())
@@ -303,7 +308,7 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
             );
 
         subscriptionCrudServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 fixtures.core.model.SubscriptionFixtures
                     .aSubscription()
                     .toBuilder()
@@ -314,10 +319,12 @@ public class SubscriptionKeysResourceTest extends AbstractResourceTest {
             )
         );
         applicationCrudServiceInMemory.initWith(
-            List.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
+            Storage.of(BaseApplicationEntity.builder().id(APPLICATION).apiKeyMode(ApiKeyMode.EXCLUSIVE).build())
         );
         apiKeyCrudServiceInMemory.initWith(
-            List.of(ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build())
+            Storage.of(
+                ApiKeyFixtures.anApiKey().toBuilder().key(KEY).applicationId(APPLICATION).subscriptions(List.of(SUBSCRIPTION)).build()
+            )
         );
 
         assertThat(target(SUBSCRIPTION).path("keys/" + KEY + "/_revoke").request().post(null).getStatus())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import stub.TriggerNotificationDomainServiceStub;
 
 @Configuration
 public class InMemoryConfiguration {
@@ -81,8 +82,8 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory(SubscriptionCrudServiceInMemory subscriptionCrudServiceInMemory) {
-        return new SubscriptionQueryServiceInMemory(subscriptionCrudServiceInMemory);
+    SubscriptionQueryServiceInMemory subscriptionQueryServiceInMemory() {
+        return new SubscriptionQueryServiceInMemory();
     }
 
     @Bean
@@ -96,8 +97,8 @@ public class InMemoryConfiguration {
     }
 
     @Bean
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainServiceInMemory() {
-        return new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainServiceInMemory() {
+        return new TriggerNotificationDomainServiceStub();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -355,6 +355,7 @@
 						<configuration>
 							<includes>
 								<include>inmemory/**</include>
+								<include>stub/**</include>
 								<include>fixtures/**</include>
 							</includes>
 						</configuration>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
@@ -18,39 +18,36 @@ package inmemory;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 
 public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternative<Api> {
 
-    final ArrayList<Api> apis = new ArrayList<>();
+    Storage<Api> apisStorage = new Storage<>();
 
     @Override
     public Api get(String id) {
-        var foundApi = apis.stream().filter(api -> id.equals(api.getId())).findFirst();
+        var foundApi = apisStorage.data().stream().filter(api -> id.equals(api.getId())).findFirst();
         return foundApi.orElseThrow(() -> new ApiNotFoundException(id));
     }
 
     @Override
     public boolean existsById(String id) {
-        return apis.stream().anyMatch(api -> id.equals(api.getId()));
-    }
-
-    @Override
-    public void initWith(List<Api> items) {
-        apis.clear();
-        apis.addAll(items);
+        return apisStorage.data().stream().anyMatch(api -> id.equals(api.getId()));
     }
 
     @Override
     public void reset() {
-        apis.clear();
+        apisStorage.clear();
     }
 
     @Override
-    public List<Api> storage() {
-        return Collections.unmodifiableList(apis);
+    public Storage<Api> storage() {
+        return apisStorage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Api> other) {
+        apisStorage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyCrudServiceInMemory.java
@@ -15,6 +15,7 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.crud_service.ApiKeyCrudService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
 import java.util.ArrayList;
@@ -24,23 +25,17 @@ import java.util.OptionalInt;
 
 public class ApiKeyCrudServiceInMemory implements ApiKeyCrudService, InMemoryAlternative<ApiKeyEntity> {
 
-    final ArrayList<ApiKeyEntity> storage = new ArrayList<>();
+    Storage<ApiKeyEntity> storage = new Storage<>();
 
     @Override
     public ApiKeyEntity update(ApiKeyEntity entity) {
-        OptionalInt index = this.findIndex(this.storage, apiKey -> apiKey.getId().equals(entity.getId()));
+        OptionalInt index = this.findIndex(this.storage.data(), apiKey -> apiKey.getId().equals(entity.getId()));
         if (index.isPresent()) {
-            storage.set(index.getAsInt(), entity);
+            storage.data().set(index.getAsInt(), entity);
             return entity;
         }
 
         throw new IllegalStateException("ApiKey not found");
-    }
-
-    @Override
-    public void initWith(List<ApiKeyEntity> items) {
-        storage.clear();
-        storage.addAll(items);
     }
 
     @Override
@@ -49,7 +44,12 @@ public class ApiKeyCrudServiceInMemory implements ApiKeyCrudService, InMemoryAlt
     }
 
     @Override
-    public List<ApiKeyEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<ApiKeyEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<ApiKeyEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
@@ -15,6 +15,7 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
 import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
 import java.util.ArrayList;
@@ -25,10 +26,10 @@ import java.util.stream.Stream;
 
 public class ApiKeyQueryServiceInMemory implements ApiKeyQueryService, InMemoryAlternative<ApiKeyEntity> {
 
-    private final ArrayList<ApiKeyEntity> storage;
+    private Storage<ApiKeyEntity> storage;
 
     public ApiKeyQueryServiceInMemory() {
-        storage = new ArrayList<>();
+        storage = new Storage<>();
     }
 
     public ApiKeyQueryServiceInMemory(ApiKeyCrudServiceInMemory apiKeyCrudServiceInMemory) {
@@ -37,23 +38,17 @@ public class ApiKeyQueryServiceInMemory implements ApiKeyQueryService, InMemoryA
 
     @Override
     public Optional<ApiKeyEntity> findById(String apiKeyId) {
-        return storage.stream().filter(apiKey -> apiKey.getId().equals(apiKeyId)).findFirst();
+        return storage.data().stream().filter(apiKey -> apiKey.getId().equals(apiKeyId)).findFirst();
     }
 
     @Override
     public Optional<ApiKeyEntity> findByKeyAndApiId(String key, String apiId) {
-        return storage.stream().filter(apiKey -> apiKey.getKey().equals(key)).findFirst();
+        return storage.data().stream().filter(apiKey -> apiKey.getKey().equals(key)).findFirst();
     }
 
     @Override
     public Stream<ApiKeyEntity> findBySubscription(String subscriptionId) {
-        return storage.stream().filter(apiKey -> apiKey.getSubscriptions().contains(subscriptionId));
-    }
-
-    @Override
-    public void initWith(List<ApiKeyEntity> items) {
-        storage.clear();
-        storage.addAll(items);
+        return storage.data().stream().filter(apiKey -> apiKey.getSubscriptions().contains(subscriptionId));
     }
 
     @Override
@@ -62,7 +57,12 @@ public class ApiKeyQueryServiceInMemory implements ApiKeyQueryService, InMemoryA
     }
 
     @Override
-    public List<ApiKeyEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<ApiKeyEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<ApiKeyEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiMetadataQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiMetadataQueryServiceInMemory.java
@@ -23,20 +23,22 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ApiMetadataQueryServiceInMemory implements ApiMetadataQueryService, InMemoryAlternative<Map.Entry<String, List<ApiMetadata>>> {
 
-    Map<String, List<ApiMetadata>> storage = new HashMap<>();
+    MapStorage<String, List<ApiMetadata>> storage = new MapStorage<>();
 
     @Override
     public Map<String, ApiMetadata> findApiMetadata(String apiId) {
-        return storage.get(apiId).stream().collect(toMap(ApiMetadata::getKey, Function.identity()));
+        return storage.data().get(apiId).stream().collect(toMap(ApiMetadata::getKey, Function.identity()));
     }
 
     @Override
-    public void initWith(List<Map.Entry<String, List<ApiMetadata>>> items) {
+    public ApiMetadataQueryServiceInMemory initWith(Storage<Map.Entry<String, List<ApiMetadata>>> items) {
         storage.clear();
-        items.forEach(entry -> storage.put(entry.getKey(), entry.getValue()));
+        items.data().forEach(entry -> storage.data().put(entry.getKey(), entry.getValue()));
+        return this;
     }
 
     @Override
@@ -45,7 +47,13 @@ public class ApiMetadataQueryServiceInMemory implements ApiMetadataQueryService,
     }
 
     @Override
-    public List<Map.Entry<String, List<ApiMetadata>>> storage() {
-        return storage.entrySet().stream().toList();
+    public Storage<Map.Entry<String, List<ApiMetadata>>> storage() {
+        // FIXME ugly
+        return Storage.from(storage.data().entrySet().stream().toList());
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Map.Entry<String, List<ApiMetadata>>> other) {
+        // FIXME: to implement
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
@@ -28,24 +28,23 @@ import java.util.stream.Stream;
 
 public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlternative<Api> {
 
-    private final List<Api> storage = new ArrayList<>();
+    private Storage<Api> storage = new Storage<>();
 
     /**
      * WARNING: this implementation doesn't actually filter the API present in the storage. Instead, it will return all applications from storage.
      */
     @Override
     public Stream<Api> search(ApiSearchCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter) {
-        return this.storage().stream();
+        return this.storage().data().stream();
     }
 
     @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) {
-        return storage.stream().filter(api -> api.getEnvironmentId().equals(environmentId) && api.getCrossId().equals(crossId)).findFirst();
-    }
-
-    @Override
-    public void initWith(List<Api> items) {
-        storage.addAll(items);
+        return storage
+            .data()
+            .stream()
+            .filter(api -> api.getEnvironmentId().equals(environmentId) && api.getCrossId().equals(crossId))
+            .findFirst();
     }
 
     @Override
@@ -54,7 +53,12 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
     }
 
     @Override
-    public List<Api> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<Api> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Api> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApplicationCrudServiceInMemory.java
@@ -25,21 +25,16 @@ import java.util.List;
 
 public class ApplicationCrudServiceInMemory implements ApplicationCrudService, InMemoryAlternative<BaseApplicationEntity> {
 
-    private final List<BaseApplicationEntity> storage = new ArrayList<>();
+    private Storage<BaseApplicationEntity> storage = new Storage<>();
 
     @Override
     public BaseApplicationEntity findById(ExecutionContext executionContext, String applicationId) {
         return storage
+            .data()
             .stream()
             .filter(application -> applicationId.equals(application.getId()))
             .findFirst()
             .orElseThrow(() -> new ApplicationNotFoundException(applicationId));
-    }
-
-    @Override
-    public void initWith(List<BaseApplicationEntity> items) {
-        storage.clear();
-        storage.addAll(items);
     }
 
     @Override
@@ -48,7 +43,12 @@ public class ApplicationCrudServiceInMemory implements ApplicationCrudService, I
     }
 
     @Override
-    public List<BaseApplicationEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<BaseApplicationEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<BaseApplicationEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EnvironmentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EnvironmentCrudServiceInMemory.java
@@ -24,12 +24,7 @@ import java.util.List;
 
 public class EnvironmentCrudServiceInMemory implements EnvironmentCrudService, InMemoryAlternative<Environment> {
 
-    private final List<Environment> storage = new ArrayList<>();
-
-    @Override
-    public void initWith(List<Environment> items) {
-        storage.addAll(items);
-    }
+    private Storage<Environment> storage = new Storage<>();
 
     @Override
     public void reset() {
@@ -37,16 +32,22 @@ public class EnvironmentCrudServiceInMemory implements EnvironmentCrudService, I
     }
 
     @Override
-    public List<Environment> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<Environment> storage() {
+        return storage;
     }
 
     @Override
     public Environment get(String environmentId) {
         return storage
+            .data()
             .stream()
             .filter(env -> environmentId.equals(env.getId()))
             .findFirst()
             .orElseThrow(() -> new EnvironmentNotFoundException(environmentId));
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Environment> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventCrudInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EventCrudInMemory.java
@@ -29,7 +29,7 @@ import lombok.SneakyThrows;
 
 public class EventCrudInMemory implements EventCrudService, InMemoryAlternative<Event> {
 
-    private final List<Event> storage = new ArrayList<>();
+    private Storage<Event> storage = new Storage<>();
 
     @SneakyThrows
     @Override
@@ -48,14 +48,8 @@ public class EventCrudInMemory implements EventCrudService, InMemoryAlternative<
             .properties(new EnumMap<>(properties))
             .payload(GraviteeJacksonMapper.getInstance().writeValueAsString(content))
             .build();
-        storage.add(event);
+        storage.data().add(event);
         return event;
-    }
-
-    @Override
-    public void initWith(List<Event> items) {
-        reset();
-        storage.addAll(items);
     }
 
     @Override
@@ -64,7 +58,12 @@ public class EventCrudInMemory implements EventCrudService, InMemoryAlternative<
     }
 
     @Override
-    public List<Event> storage() {
+    public Storage<Event> storage() {
         return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Event> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryAlternative.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InMemoryAlternative.java
@@ -24,15 +24,25 @@ import java.util.stream.IntStream;
 public interface InMemoryAlternative<T> {
     /**
      * Init the storage with the given items
-     * @param items the items to store
+     * @param storage the items to store
      */
-    void initWith(List<T> items);
+    default InMemoryAlternative<T> initWith(Storage<T> storage) {
+        reset();
+        storage().addAll(storage);
+        return this;
+    }
+
+    void syncStorageWith(InMemoryAlternative<T> other);
 
     /** Reset the storage */
     void reset();
 
     /** @return the storage */
-    List<T> storage();
+    Storage<T> storage();
+
+    default List<T> data() {
+        return storage().unmodifiableData();
+    }
 
     default OptionalInt findIndex(List<T> storage, Predicate<T> predicate) {
         IntPredicate intPredicate = i -> predicate.test(storage.get(i));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InstanceQueryServiceInMemory.java
@@ -23,17 +23,11 @@ import java.util.List;
 
 public class InstanceQueryServiceInMemory implements InstanceQueryService, InMemoryAlternative<Instance> {
 
-    private final List<Instance> storage = new ArrayList<>();
+    private Storage<Instance> storage = new Storage<>();
 
     @Override
     public List<Instance> findAllStarted(String organizationId, String environmentId) {
-        return storage.stream().filter(instance -> instance.getStartedAt() != null).toList();
-    }
-
-    @Override
-    public void initWith(List<Instance> items) {
-        reset();
-        storage.addAll(items);
+        return storage.data().stream().filter(instance -> instance.getStartedAt() != null).toList();
     }
 
     @Override
@@ -42,7 +36,12 @@ public class InstanceQueryServiceInMemory implements InstanceQueryService, InMem
     }
 
     @Override
-    public List<Instance> storage() {
+    public Storage<Instance> storage() {
         return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Instance> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MapStorage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MapStorage.java
@@ -15,33 +15,37 @@
  */
 package inmemory;
 
-import io.gravitee.apim.core.audit.crud_service.AuditCrudService;
-import io.gravitee.apim.core.audit.model.AuditEntity;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class AuditCrudServiceInMemory implements AuditCrudService, InMemoryAlternative<AuditEntity> {
+public class MapStorage<K, V> {
 
-    private Storage<AuditEntity> storage = new Storage<>();
+    private Map<K, V> data = new HashMap<>();
 
-    @Override
-    public void create(AuditEntity auditEntity) {
-        storage.data().add(auditEntity);
+    public MapStorage() {}
+
+    public Map<K, V> unmodifiableData() {
+        return Collections.unmodifiableMap(data);
     }
 
-    @Override
-    public void reset() {
-        storage.clear();
+    Map<K, V> data() {
+        return data;
     }
 
-    @Override
-    public Storage<AuditEntity> storage() {
+    void clear() {
+        data.clear();
+    }
+
+    public static <K, V> MapStorage<K, V> from(Map<K, V> map) {
+        final MapStorage<K, V> storage = new MapStorage<>();
+        storage.data = map;
         return storage;
     }
 
-    @Override
-    public void syncStorageWith(InMemoryAlternative<AuditEntity> other) {
-        storage = other.storage();
+    public static <K, V> MapStorage<K, V> of() {
+        return MapStorage.from(Map.of());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MessageLogCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MessageLogCrudServiceInMemory.java
@@ -27,7 +27,7 @@ import java.util.function.Predicate;
 
 public class MessageLogCrudServiceInMemory implements MessageLogCrudService, InMemoryAlternative<AggregatedMessageLog> {
 
-    private final List<AggregatedMessageLog> storage = new ArrayList<>();
+    private Storage<AggregatedMessageLog> storage = new Storage<>();
 
     @Override
     public SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(String apiId, String requestId, Pageable pageable) {
@@ -37,6 +37,7 @@ public class MessageLogCrudServiceInMemory implements MessageLogCrudService, InM
         var pageSize = pageable.getPageSize();
 
         var matches = storage()
+            .data()
             .stream()
             .filter(predicate)
             .sorted(Comparator.comparing(AggregatedMessageLog::getTimestamp).reversed())
@@ -48,17 +49,17 @@ public class MessageLogCrudServiceInMemory implements MessageLogCrudService, InM
     }
 
     @Override
-    public void initWith(List<AggregatedMessageLog> items) {
-        storage.addAll(items);
-    }
-
-    @Override
     public void reset() {
         storage.clear();
     }
 
     @Override
-    public List<AggregatedMessageLog> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<AggregatedMessageLog> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<AggregatedMessageLog> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageRevisionCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageRevisionCrudServiceInMemory.java
@@ -30,28 +30,27 @@ import java.util.Optional;
 
 public class PageRevisionCrudServiceInMemory implements InMemoryAlternative<PageRevision>, PageRevisionCrudService {
 
-    List<PageRevision> pageRevisions = new ArrayList<>();
-
-    @Override
-    public void initWith(List<PageRevision> items) {
-        this.reset();
-        this.pageRevisions.addAll(items);
-    }
+    Storage<PageRevision> pageRevisions = new Storage<>();
 
     @Override
     public void reset() {
-        pageRevisions = new ArrayList<>();
+        pageRevisions.clear();
     }
 
     @Override
-    public List<PageRevision> storage() {
-        return ImmutableList.copyOf(pageRevisions);
+    public Storage<PageRevision> storage() {
+        return pageRevisions;
     }
 
     @Override
     public PageRevision create(Page page) {
         var pageRevisionToAdd = PageAdapter.INSTANCE.toPageRevision(page);
-        pageRevisions.add(pageRevisionToAdd);
+        pageRevisions.data().add(pageRevisionToAdd);
         return pageRevisionToAdd;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<PageRevision> other) {
+        pageRevisions = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersDomainServiceInMemory.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 
 public class ParametersDomainServiceInMemory implements ParametersDomainService, InMemoryAlternative<Parameter> {
 
-    final ArrayList<Parameter> parameters = new ArrayList<>();
+    Storage<Parameter> parameters = new Storage<>();
 
     @Override
     public Map<Key, String> getSystemParameters(List<Key> keys) {
@@ -35,15 +35,10 @@ public class ParametersDomainServiceInMemory implements ParametersDomainService,
         }
 
         return parameters
+            .data()
             .stream()
             .filter(parameter -> keys.contains(Key.findByKey(parameter.getKey())))
             .collect(Collectors.toMap(parameter -> Key.findByKey(parameter.getKey()), Parameter::getValue));
-    }
-
-    @Override
-    public void initWith(List<Parameter> items) {
-        parameters.clear();
-        parameters.addAll(items);
     }
 
     @Override
@@ -52,7 +47,12 @@ public class ParametersDomainServiceInMemory implements ParametersDomainService,
     }
 
     @Override
-    public List<Parameter> storage() {
-        return Collections.unmodifiableList(parameters);
+    public Storage<Parameter> storage() {
+        return parameters;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Parameter> other) {
+        parameters = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlternative<Plan> {
 
-    private final List<Plan> storage = new ArrayList<>();
+    private Storage<Plan> storage = new Storage<>();
 
     @Override
     public Plan findById(String planId) {
@@ -33,15 +33,11 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlterna
             throw new TechnicalManagementException("planId should not be null");
         }
         return storage
+            .data()
             .stream()
             .filter(plan -> planId.equals(plan.getId()))
             .findFirst()
             .orElseThrow(() -> new PlanNotFoundException(planId));
-    }
-
-    @Override
-    public void initWith(List<Plan> items) {
-        storage.addAll(items);
     }
 
     @Override
@@ -50,7 +46,12 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlterna
     }
 
     @Override
-    public List<Plan> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<Plan> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Plan> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanQueryServiceInMemory.java
@@ -26,11 +26,12 @@ import java.util.Objects;
 
 public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlternative<Plan> {
 
-    private final List<Plan> storage = new ArrayList<>();
+    private Storage<Plan> storage = new Storage<>();
 
     @Override
     public List<Plan> findAllByApiIdAndGeneralConditionsAndIsActive(String apiId, DefinitionVersion definitionVersion, String pageId) {
         return storage
+            .data()
             .stream()
             .filter(plan ->
                 Objects.equals(apiId, plan.getApiId()) &&
@@ -41,17 +42,17 @@ public class PlanQueryServiceInMemory implements PlanQueryService, InMemoryAlter
     }
 
     @Override
-    public void initWith(List<Plan> items) {
-        storage.addAll(items);
-    }
-
-    @Override
     public void reset() {
         storage.clear();
     }
 
     @Override
-    public List<Plan> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<Plan> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Plan> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PrimaryOwnerDomainServiceInMemory.java
@@ -20,19 +20,17 @@ import io.gravitee.apim.core.application.domain_service.ApplicationPrimaryOwnerD
 import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.exception.ApplicationPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class PrimaryOwnerDomainServiceInMemory
     implements
         ApiPrimaryOwnerDomainService, ApplicationPrimaryOwnerDomainService, InMemoryAlternative<Map.Entry<String, PrimaryOwnerEntity>> {
 
-    Map<String, PrimaryOwnerEntity> storage = new HashMap<>();
+    MapStorage<String, PrimaryOwnerEntity> storage = new MapStorage<>();
 
     @Override
     public PrimaryOwnerEntity getApiPrimaryOwner(String organizationId, String apiId) throws ApiPrimaryOwnerNotFoundException {
-        PrimaryOwnerEntity primaryOwnerEntity = storage.get(apiId);
+        PrimaryOwnerEntity primaryOwnerEntity = storage.data().get(apiId);
         if (primaryOwnerEntity == null) {
             throw new ApiPrimaryOwnerNotFoundException(apiId);
         }
@@ -42,7 +40,7 @@ public class PrimaryOwnerDomainServiceInMemory
     @Override
     public PrimaryOwnerEntity getApplicationPrimaryOwner(String organizationId, String applicationId)
         throws ApplicationPrimaryOwnerNotFoundException {
-        PrimaryOwnerEntity primaryOwnerEntity = storage.get(applicationId);
+        PrimaryOwnerEntity primaryOwnerEntity = storage.data().get(applicationId);
         if (primaryOwnerEntity == null) {
             throw new ApplicationPrimaryOwnerNotFoundException(applicationId);
         }
@@ -50,13 +48,10 @@ public class PrimaryOwnerDomainServiceInMemory
     }
 
     @Override
-    public void initWith(List<Map.Entry<String, PrimaryOwnerEntity>> items) {
+    public PrimaryOwnerDomainServiceInMemory initWith(Storage<Map.Entry<String, PrimaryOwnerEntity>> items) {
         storage.clear();
-        items.forEach(entry -> storage.put(entry.getKey(), entry.getValue()));
-    }
-
-    public void add(String id, PrimaryOwnerEntity primaryOwnerEntity) {
-        storage.put(id, primaryOwnerEntity);
+        items.data().forEach(entry -> storage.data().put(entry.getKey(), entry.getValue()));
+        return this;
     }
 
     @Override
@@ -65,7 +60,13 @@ public class PrimaryOwnerDomainServiceInMemory
     }
 
     @Override
-    public List<Map.Entry<String, PrimaryOwnerEntity>> storage() {
-        return storage.entrySet().stream().toList();
+    public Storage<Map.Entry<String, PrimaryOwnerEntity>> storage() {
+        // FIXME ugly
+        return Storage.from(storage.data().entrySet().stream().toList());
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<Map.Entry<String, PrimaryOwnerEntity>> other) {
+        // FIXME: to implement
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/Storage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/Storage.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import org.jetbrains.annotations.NotNull;
+
+public class Storage<T> {
+
+    private List<T> data = new ArrayList<>();
+
+    public Storage() {}
+
+    public List<T> unmodifiableData() {
+        return Collections.unmodifiableList(data);
+    }
+
+    List<T> data() {
+        return data;
+    }
+
+    void clear() {
+        data.clear();
+    }
+
+    boolean addAll(Storage<? extends T> items) {
+        return data.addAll(items.data);
+    }
+
+    public static <T> Storage<T> from(List<T> list) {
+        final Storage<T> storage = new Storage<>();
+        storage.data = list;
+        return storage;
+    }
+
+    public static <T> Storage<T> of() {
+        return Storage.from(List.of());
+    }
+
+    public static <T> Storage<T> of(T element) {
+        return Storage.from(List.of(element));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2) {
+        return Storage.from(List.of(e1, e2));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3) {
+        return Storage.from(List.of(e1, e2, e3));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4) {
+        return Storage.from(List.of(e1, e2, e3, e4));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5, T e6) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5, e6));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5, T e6, T e7) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5, e6, e7));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5, T e6, T e7, T e8) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5, e6, e7, e8));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5, T e6, T e7, T e8, T e9) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5, e6, e7, e8, e9));
+    }
+
+    public static <T> Storage<T> of(T e1, T e2, T e3, T e4, T e5, T e6, T e7, T e8, T e9, T e10) {
+        return Storage.from(List.of(e1, e2, e3, e4, e5, e6, e7, e8, e9, e10));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionCrudServiceInMemory.java
@@ -25,11 +25,12 @@ import java.util.OptionalInt;
 
 public class SubscriptionCrudServiceInMemory implements SubscriptionCrudService, InMemoryAlternative<SubscriptionEntity> {
 
-    final ArrayList<SubscriptionEntity> storage = new ArrayList<>();
+    Storage<SubscriptionEntity> storage = new Storage<>();
 
     @Override
     public SubscriptionEntity get(String subscriptionId) {
         return storage
+            .data()
             .stream()
             .filter(subscription -> subscriptionId.equals(subscription.getId()))
             .findFirst()
@@ -38,19 +39,13 @@ public class SubscriptionCrudServiceInMemory implements SubscriptionCrudService,
 
     @Override
     public SubscriptionEntity update(SubscriptionEntity subscriptionEntity) {
-        OptionalInt index = this.findIndex(this.storage, subscription -> subscription.getId().equals(subscriptionEntity.getId()));
+        OptionalInt index = this.findIndex(this.storage.data(), subscription -> subscription.getId().equals(subscriptionEntity.getId()));
         if (index.isPresent()) {
-            storage.set(index.getAsInt(), subscriptionEntity);
+            storage.data().set(index.getAsInt(), subscriptionEntity);
             return subscriptionEntity;
         }
 
         throw new IllegalStateException("Subscription not found");
-    }
-
-    @Override
-    public void initWith(List<SubscriptionEntity> items) {
-        storage.clear();
-        storage.addAll(items);
     }
 
     @Override
@@ -59,7 +54,12 @@ public class SubscriptionCrudServiceInMemory implements SubscriptionCrudService,
     }
 
     @Override
-    public List<SubscriptionEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<SubscriptionEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<SubscriptionEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
@@ -24,19 +24,12 @@ import java.util.List;
 
 public class SubscriptionQueryServiceInMemory implements SubscriptionQueryService, InMemoryAlternative<SubscriptionEntity> {
 
-    private final ArrayList<SubscriptionEntity> storage;
-
-    public SubscriptionQueryServiceInMemory() {
-        storage = new ArrayList<>();
-    }
-
-    public SubscriptionQueryServiceInMemory(SubscriptionCrudServiceInMemory subscriptionCrudServiceInMemory) {
-        storage = subscriptionCrudServiceInMemory.storage;
-    }
+    private Storage<SubscriptionEntity> storage = new Storage<>();
 
     @Override
     public List<SubscriptionEntity> findExpiredSubscriptions() {
         return storage
+            .data()
             .stream()
             .filter(subscription ->
                 subscription.getStatus().equals(SubscriptionEntity.Status.ACCEPTED) &&
@@ -46,18 +39,17 @@ public class SubscriptionQueryServiceInMemory implements SubscriptionQueryServic
     }
 
     @Override
-    public void initWith(List<SubscriptionEntity> items) {
-        storage.clear();
-        storage.addAll(items);
-    }
-
-    @Override
     public void reset() {
         storage.clear();
     }
 
     @Override
-    public List<SubscriptionEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<SubscriptionEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<SubscriptionEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
@@ -27,30 +27,26 @@ import java.util.stream.Collectors;
 
 public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlternative<BaseUserEntity> {
 
-    private final List<BaseUserEntity> storage = new ArrayList<>();
+    private Storage<BaseUserEntity> storage = new Storage<>();
 
     @Override
     public Optional<BaseUserEntity> findBaseUserById(String userId) {
-        return storage.stream().filter(user -> userId.equals(user.getId())).findFirst();
+        return storage.data().stream().filter(user -> userId.equals(user.getId())).findFirst();
     }
 
     @Override
     public Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds) {
-        return storage.stream().filter(user -> userIds.contains(user.getId())).collect(Collectors.toSet());
+        return storage.data().stream().filter(user -> userIds.contains(user.getId())).collect(Collectors.toSet());
     }
 
     @Override
     public BaseUserEntity getBaseUser(String userId) {
         return storage
+            .data()
             .stream()
             .filter(user -> userId.equals(user.getId()))
             .findFirst()
             .orElseThrow(() -> new UserNotFoundException(userId));
-    }
-
-    @Override
-    public void initWith(List<BaseUserEntity> items) {
-        storage.addAll(items);
     }
 
     @Override
@@ -59,7 +55,12 @@ public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlterna
     }
 
     @Override
-    public List<BaseUserEntity> storage() {
-        return Collections.unmodifiableList(storage);
+    public Storage<BaseUserEntity> storage() {
+        return storage;
+    }
+
+    @Override
+    public void syncStorageWith(InMemoryAlternative<BaseUserEntity> other) {
+        storage = other.storage();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 
-import inmemory.ApiHostValidatorDomainServiceGoogleImpl;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiFieldFilter;
@@ -50,6 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import stub.ApiHostValidatorDomainServiceGoogleStub;
 
 @ExtendWith(MockitoExtension.class)
 class VerifyApiPathDomainServiceTest {
@@ -88,7 +88,7 @@ class VerifyApiPathDomainServiceTest {
     @BeforeEach
     void setup() {
         service =
-            new VerifyApiPathDomainService(apiSearchService, installationAccessQueryService, new ApiHostValidatorDomainServiceGoogleImpl());
+            new VerifyApiPathDomainService(apiSearchService, installationAccessQueryService, new ApiHostValidatorDomainServiceGoogleStub());
     }
 
     @AfterEach

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
@@ -24,8 +24,8 @@ import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import stub.TriggerNotificationDomainServiceStub;
 
 class RevokeApiKeyDomainServiceTest {
 
@@ -70,7 +71,7 @@ class RevokeApiKeyDomainServiceTest {
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
     RevokeApiKeyDomainService service;
 
     @BeforeEach
@@ -113,7 +114,7 @@ class RevokeApiKeyDomainServiceTest {
             );
 
             // Then
-            assertThat(auditCrudService.storage()).isEmpty();
+            assertThat(auditCrudService.data()).isEmpty();
         }
 
         @Test
@@ -146,7 +147,7 @@ class RevokeApiKeyDomainServiceTest {
 
             // Then
             // No modification
-            assertThat(auditCrudService.storage()).isEmpty();
+            assertThat(auditCrudService.data()).isEmpty();
         }
 
         @Test
@@ -180,7 +181,7 @@ class RevokeApiKeyDomainServiceTest {
             assertThat(revokedKey.get().isRevoked()).isTrue();
             assertThat(revokedKey.get().getRevokedAt()).isAfterOrEqualTo(now);
 
-            assertThat(auditCrudService.storage())
+            assertThat(auditCrudService.data())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
                 .containsExactly(
                     AuditEntity
@@ -221,7 +222,7 @@ class RevokeApiKeyDomainServiceTest {
             );
 
             // Then
-            assertThat(auditCrudService.storage())
+            assertThat(auditCrudService.data())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
                 .containsExactly(
                     AuditEntity
@@ -251,7 +252,7 @@ class RevokeApiKeyDomainServiceTest {
             var result = service.revoke(apiKey, AUDIT_INFO);
 
             // Then
-            assertThat(auditCrudService.storage()).isEmpty();
+            assertThat(auditCrudService.data()).isEmpty();
             assertThat(result).isSameAs(apiKey);
         }
 
@@ -264,7 +265,7 @@ class RevokeApiKeyDomainServiceTest {
             var result = service.revoke(apiKey, AUDIT_INFO);
 
             // Then
-            assertThat(auditCrudService.storage()).isEmpty();
+            assertThat(auditCrudService.data()).isEmpty();
             assertThat(result).isSameAs(apiKey);
         }
 
@@ -301,7 +302,7 @@ class RevokeApiKeyDomainServiceTest {
             var result = service.revoke(apiKey, AUDIT_INFO);
 
             // Then
-            assertThat(auditCrudService.storage())
+            assertThat(auditCrudService.data())
                 .hasSize(2)
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
                 .contains(
@@ -354,17 +355,17 @@ class RevokeApiKeyDomainServiceTest {
 
     @SneakyThrows
     private void givenApiKeys(List<ApiKeyEntity> keys) {
-        apiKeyCrudService.initWith(keys);
+        apiKeyCrudService.initWith(Storage.from(keys));
     }
 
     @SneakyThrows
     private ApiKeyEntity givenApiKey(ApiKeyEntity key) {
-        apiKeyCrudService.initWith(List.of(key));
+        apiKeyCrudService.initWith(Storage.of(key));
         return key;
     }
 
     private List<SubscriptionEntity> givenSubscriptions(List<SubscriptionEntity> subscriptions) {
-        subscriptionCrudService.initWith(subscriptions);
+        subscriptionCrudService.initWith(Storage.from(subscriptions));
         return subscriptions;
     }
 
@@ -387,7 +388,7 @@ class RevokeApiKeyDomainServiceTest {
                 .planId(PLAN_ID_2)
                 .build()
         );
-        subscriptionCrudService.initWith(subscriptions);
+        subscriptionCrudService.initWith(Storage.from(subscriptions));
         return subscriptions;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
@@ -27,8 +27,8 @@ import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import stub.TriggerNotificationDomainServiceStub;
 
 class RevokeApiSubscriptionApiKeyUseCaseTest {
 
@@ -77,7 +78,7 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
     ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
     SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
     RevokeApiSubscriptionApiKeyUseCase usecase;
 
     @BeforeAll
@@ -231,7 +232,7 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
         var result = usecase.execute(new Input(API_KEY_ID, API_ID, SUBSCRIPTION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(auditCrudService.storage())
+        assertThat(auditCrudService.data())
             .hasSize(1)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
             .contains(
@@ -281,7 +282,7 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
     }
 
     private SubscriptionEntity givenASubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
+        subscriptionCrudService.initWith(Storage.of(subscription));
         return subscription;
     }
 
@@ -290,12 +291,12 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
     }
 
     private BaseApplicationEntity givenAnApplication(BaseApplicationEntity application) {
-        applicationCrudService.initWith(List.of(application));
+        applicationCrudService.initWith(Storage.of(application));
         return application;
     }
 
     private ApiKeyEntity givenAnApiKey(ApiKeyEntity apiKey) {
-        apiKeyCrudService.initWith(List.of(apiKey));
+        apiKeyCrudService.initWith(Storage.of(apiKey));
         return apiKey;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
@@ -27,8 +27,8 @@ import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
@@ -58,6 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import stub.TriggerNotificationDomainServiceStub;
 
 class RevokeApplicationApiKeyUseCaseTest {
 
@@ -79,7 +80,7 @@ class RevokeApplicationApiKeyUseCaseTest {
     ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
     SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
     RevokeApplicationApiKeyUseCase usecase;
 
     @BeforeAll
@@ -200,7 +201,7 @@ class RevokeApplicationApiKeyUseCaseTest {
         var result = usecase.execute(new Input(API_KEY_ID, APPLICATION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(auditCrudService.storage())
+        assertThat(auditCrudService.data())
             .hasSize(2)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
             .contains(
@@ -260,12 +261,12 @@ class RevokeApplicationApiKeyUseCaseTest {
     }
 
     private BaseApplicationEntity givenAnApplication(BaseApplicationEntity application) {
-        applicationCrudService.initWith(List.of(application));
+        applicationCrudService.initWith(Storage.of(application));
         return application;
     }
 
     private ApiKeyEntity givenAnApiKey(ApiKeyEntity apiKey) {
-        apiKeyCrudService.initWith(List.of(apiKey));
+        apiKeyCrudService.initWith(Storage.of(apiKey));
         return apiKey;
     }
 
@@ -288,7 +289,7 @@ class RevokeApplicationApiKeyUseCaseTest {
                 .planId(PLAN_2)
                 .build()
         );
-        subscriptionCrudService.initWith(subscriptions);
+        subscriptionCrudService.initWith(Storage.from(subscriptions));
         return subscriptions;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
@@ -27,8 +27,8 @@ import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import stub.TriggerNotificationDomainServiceStub;
 
 class RevokeApplicationSubscriptionApiKeyUseCaseTest {
 
@@ -77,7 +78,7 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
     ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
     SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
     RevokeApplicationSubscriptionApiKeyUseCase usecase;
 
     @BeforeAll
@@ -233,7 +234,7 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
         var result = usecase.execute(new Input(API_KEY_ID, APPLICATION_ID, SUBSCRIPTION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(auditCrudService.storage())
+        assertThat(auditCrudService.data())
             .hasSize(1)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
             .contains(
@@ -283,7 +284,7 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
     }
 
     private SubscriptionEntity givenASubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
+        subscriptionCrudService.initWith(Storage.of(subscription));
         return subscription;
     }
 
@@ -292,12 +293,12 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
     }
 
     private BaseApplicationEntity givenAnApplication(BaseApplicationEntity application) {
-        applicationCrudService.initWith(List.of(application));
+        applicationCrudService.initWith(Storage.of(application));
         return application;
     }
 
     private ApiKeyEntity givenAnApiKey(ApiKeyEntity apiKey) {
-        apiKeyCrudService.initWith(List.of(apiKey));
+        apiKeyCrudService.initWith(Storage.of(apiKey));
         return apiKey;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
@@ -27,8 +27,8 @@ import inmemory.ApiKeyQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import stub.TriggerNotificationDomainServiceStub;
 
 class RevokeSubscriptionApiKeyUseCaseTest {
 
@@ -77,7 +78,7 @@ class RevokeSubscriptionApiKeyUseCaseTest {
     ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
     SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
     AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
     RevokeSubscriptionApiKeyUseCase usecase;
 
     @BeforeAll
@@ -221,7 +222,7 @@ class RevokeSubscriptionApiKeyUseCaseTest {
         var result = usecase.execute(new Input(SUBSCRIPTION_ID, KEY, AUDIT_INFO));
 
         // Then
-        assertThat(auditCrudService.storage())
+        assertThat(auditCrudService.data())
             .hasSize(1)
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
             .contains(
@@ -271,7 +272,7 @@ class RevokeSubscriptionApiKeyUseCaseTest {
     }
 
     private SubscriptionEntity givenASubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
+        subscriptionCrudService.initWith(Storage.of(subscription));
         return subscription;
     }
 
@@ -280,12 +281,12 @@ class RevokeSubscriptionApiKeyUseCaseTest {
     }
 
     private BaseApplicationEntity givenAnApplication(BaseApplicationEntity application) {
-        applicationCrudService.initWith(List.of(application));
+        applicationCrudService.initWith(Storage.of(application));
         return application;
     }
 
     private ApiKeyEntity givenAnApiKey(ApiKeyEntity apiKey) {
-        apiKeyCrudService.initWith(List.of(apiKey));
+        apiKeyCrudService.initWith(Storage.of(apiKey));
         return apiKey;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/audit/domain_service/AuditDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/audit/domain_service/AuditDomainServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.audit.domain_service;
 
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
 import io.gravitee.apim.core.audit.model.ApplicationAuditLogEntity;
@@ -97,7 +98,7 @@ public class AuditDomainServiceTest {
                 .patch("[]")
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).containsOnly(expectedAudit);
         }
 
         @Test
@@ -140,12 +141,12 @@ public class AuditDomainServiceTest {
                 )
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).containsOnly(expectedAudit);
         }
 
         @Test
         void should_fetch_user_display_name_when_using_a_token() {
-            userCrudService.initWith(List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").build()));
+            userCrudService.initWith(Storage.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").build()));
 
             var audit = ApiAuditLogEntity
                 .builder()
@@ -174,7 +175,7 @@ public class AuditDomainServiceTest {
                 .patch("[]")
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).containsOnly(expectedAudit);
         }
     }
 
@@ -212,7 +213,7 @@ public class AuditDomainServiceTest {
                 .patch("[]")
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).hasSize(1).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).hasSize(1).containsOnly(expectedAudit);
         }
 
         @Test
@@ -255,12 +256,12 @@ public class AuditDomainServiceTest {
                 )
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).containsOnly(expectedAudit);
         }
 
         @Test
         void should_fetch_user_display_name_when_using_a_token() {
-            userCrudService.initWith(List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").build()));
+            userCrudService.initWith(Storage.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").build()));
 
             var audit = ApplicationAuditLogEntity
                 .builder()
@@ -289,7 +290,7 @@ public class AuditDomainServiceTest {
                 .patch("[]")
                 .build();
 
-            Assertions.assertThat(auditCrudService.storage()).containsOnly(expectedAudit);
+            Assertions.assertThat(auditCrudService.data()).containsOnly(expectedAudit);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/console/use_case/GetConsoleCustomizationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/console/use_case/GetConsoleCustomizationUseCaseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import inmemory.ParametersDomainServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.console.model.ConsoleCustomization;
 import io.gravitee.apim.core.console.model.ConsoleTheme;
 import io.gravitee.apim.core.console.model.CtaConfiguration;
@@ -51,7 +52,7 @@ class GetConsoleCustomizationUseCaseTest {
     @Test
     void should_return_console_customization() {
         parametersDomainServiceInMemory.initWith(
-            List.of(
+            Storage.of(
                 Parameter.builder().key(Key.CONSOLE_CUSTOMIZATION_TITLE.key()).value("title").build(),
                 Parameter.builder().key(Key.CONSOLE_CUSTOMIZATION_FAVICON.key()).value("favicon").build(),
                 Parameter.builder().key(Key.CONSOLE_CUSTOMIZATION_LOGO.key()).value("logo").build(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/ApiDocumentationDomainServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import java.util.List;
@@ -44,7 +45,7 @@ class ApiDocumentationDomainServiceTest {
         @Test
         void should_return_all_pages_with_null_parent_id() {
             pageQueryService.initWith(
-                List.of(
+                Storage.of(
                     Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#3").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("not-root").build()
@@ -60,7 +61,7 @@ class ApiDocumentationDomainServiceTest {
         @Test
         void should_return_all_pages_with_empty_parent_id() {
             pageQueryService.initWith(
-                List.of(
+                Storage.of(
                     Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#3").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("not-root").build()
@@ -80,7 +81,7 @@ class ApiDocumentationDomainServiceTest {
         @Test
         void should_return_all_root_pages() {
             pageQueryService.initWith(
-                List.of(
+                Storage.of(
                     Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("not-root").build(),
                     Page.builder().id("page#3").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("").build()
@@ -99,7 +100,7 @@ class ApiDocumentationDomainServiceTest {
         @Test
         void should_return_all_pages_with_parent_id() {
             pageQueryService.initWith(
-                List.of(
+                Storage.of(
                     Page.builder().id("page#1").referenceType(Page.ReferenceType.API).referenceId("api-id").build(),
                     Page.builder().id("page#2").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("not-root").build(),
                     Page.builder().id("page#3").referenceType(Page.ReferenceType.API).referenceId("api-id").parentId("parent-id").build(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/CreateApiDocumentationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/domain_service/CreateApiDocumentationDomainServiceTest.java
@@ -72,7 +72,7 @@ public class CreateApiDocumentationDomainServiceTest {
                 .parentId("")
                 .name("parent")
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             var res = createApiDocumentationDomainService.createPage(
                 Page
@@ -127,7 +127,7 @@ public class CreateApiDocumentationDomainServiceTest {
                     .build(),
                 AUDIT_INFO
             );
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -155,7 +155,7 @@ public class CreateApiDocumentationDomainServiceTest {
                 AUDIT_INFO
             );
 
-            var pageRevision = pageRevisionCrudService.storage().get(0);
+            var pageRevision = pageRevisionCrudService.data().get(0);
             assertThat(pageRevision)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("pageId", PAGE_ID)
@@ -178,7 +178,7 @@ public class CreateApiDocumentationDomainServiceTest {
                 .parentId("")
                 .name("parent")
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             var res = createApiDocumentationDomainService.createPage(
                 Page
@@ -210,9 +210,9 @@ public class CreateApiDocumentationDomainServiceTest {
 
             assertThat(res.getCreatedAt()).isNotNull().isEqualTo(res.getUpdatedAt());
 
-            assertThat(pageRevisionCrudService.storage().size()).isEqualTo(0);
+            assertThat(pageRevisionCrudService.data().size()).isEqualTo(0);
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -238,7 +238,7 @@ public class CreateApiDocumentationDomainServiceTest {
                 AUDIT_INFO
             );
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -264,7 +264,7 @@ public class CreateApiDocumentationDomainServiceTest {
                 AUDIT_INFO
             );
 
-            assertThat(pageRevisionCrudService.storage().size()).isEqualTo(0);
+            assertThat(pageRevisionCrudService.data()).isEmpty();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiCreateDocumentationPageUseCaseTest.java
@@ -34,7 +34,6 @@ import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.PageContentUnsafeException;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -110,7 +109,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .name("parent")
                 .type(Page.Type.FOLDER)
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             var res = apiCreateDocumentationPageUsecase.execute(
                 ApiCreateDocumentationPageUseCase.Input
@@ -144,12 +143,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .hasFieldOrPropertyWithValue("parentId", "parent-id")
                 .hasFieldOrPropertyWithValue("order", 0);
 
-            var savedPage = pageCrudService
-                .storage()
-                .stream()
-                .filter(page -> page.getId().equals(res.createdPage().getId()))
-                .toList()
-                .get(0);
+            var savedPage = pageCrudService.data().stream().filter(page -> page.getId().equals(res.createdPage().getId())).toList().get(0);
             assertThat(savedPage).isEqualTo(res.createdPage());
         }
 
@@ -176,7 +170,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -206,7 +200,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var pageRevision = pageRevisionCrudService.storage().get(0);
+            var pageRevision = pageRevisionCrudService.data().get(0);
             assertThat(pageRevision)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("pageId", PAGE_ID)
@@ -227,8 +221,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .name("existing homepage")
                 .homepage(true)
                 .build();
-            pageCrudService.initWith(List.of(existingHomepage));
-            pageQueryService.initWith(List.of(existingHomepage));
+            pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.of(existingHomepage)));
 
             var res = apiCreateDocumentationPageUsecase.execute(
                 ApiCreateDocumentationPageUseCase.Input
@@ -253,7 +246,7 @@ class ApiCreateDocumentationPageUseCaseTest {
 
             assertThat(res.createdPage()).isNotNull().hasFieldOrPropertyWithValue("homepage", true);
 
-            var formerHomepage = pageCrudService.storage().stream().filter(p -> p.getId().equals(EXISTING_PAGE_ID)).toList().get(0);
+            var formerHomepage = pageCrudService.data().stream().filter(p -> p.getId().equals(EXISTING_PAGE_ID)).toList().get(0);
             assertThat(formerHomepage).isNotNull().hasFieldOrPropertyWithValue("homepage", false);
         }
 
@@ -281,8 +274,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .homepage(true)
                 .order(99)
                 .build();
-            pageCrudService.initWith(List.of(existingPage, existingParent));
-            pageQueryService.initWith(List.of(existingPage, existingParent));
+            pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.of(existingPage, existingParent)));
 
             var res = apiCreateDocumentationPageUsecase.execute(
                 ApiCreateDocumentationPageUseCase.Input
@@ -395,7 +387,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .parentId("")
                 .name("parent")
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             assertThatThrownBy(() ->
                     apiCreateDocumentationPageUsecase.execute(
@@ -433,7 +425,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .name("parent")
                 .type(Page.Type.FOLDER)
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             assertThatThrownBy(() ->
                     apiCreateDocumentationPageUsecase.execute(
@@ -478,8 +470,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .parentId(PARENT_ID)
                 .name("sub-page")
                 .build();
-            pageCrudService.initWith(List.of(parentFolder, subPage));
-            pageQueryService.initWith(List.of(parentFolder, subPage));
+            pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.of(parentFolder, subPage)));
 
             assertThatThrownBy(() ->
                     apiCreateDocumentationPageUsecase.execute(
@@ -520,7 +511,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .name("parent")
                 .type(Page.Type.FOLDER)
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             var res = apiCreateDocumentationPageUsecase.execute(
                 ApiCreateDocumentationPageUseCase.Input
@@ -552,12 +543,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .hasFieldOrPropertyWithValue("order", 0)
                 .hasFieldOrPropertyWithValue("hidden", true);
 
-            var savedPage = pageCrudService
-                .storage()
-                .stream()
-                .filter(page -> page.getId().equals(res.createdPage().getId()))
-                .toList()
-                .get(0);
+            var savedPage = pageCrudService.data().stream().filter(page -> page.getId().equals(res.createdPage().getId())).toList().get(0);
             assertThat(savedPage).isEqualTo(res.createdPage());
         }
 
@@ -582,7 +568,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -599,7 +585,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .parentId("")
                 .name("parent")
                 .build();
-            pageCrudService.initWith(List.of(parentPage));
+            pageCrudService.initWith(Storage.of(parentPage));
 
             assertThatThrownBy(() ->
                     apiCreateDocumentationPageUsecase.execute(
@@ -644,8 +630,7 @@ class ApiCreateDocumentationPageUseCaseTest {
                 .parentId(PARENT_ID)
                 .name("sub-page")
                 .build();
-            pageCrudService.initWith(List.of(parentFolder, subFolder));
-            pageQueryService.initWith(List.of(parentFolder, subFolder));
+            pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.of(parentFolder, subFolder)));
 
             assertThatThrownBy(() ->
                     apiCreateDocumentationPageUsecase.execute(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiDeleteDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiDeleteDocumentationPageUseCaseTest.java
@@ -26,6 +26,7 @@ import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PageRevisionCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -36,7 +37,6 @@ import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,9 +104,8 @@ class ApiDeleteDocumentationPageUseCaseTest {
             .referenceType(Page.ReferenceType.API)
             .type(Page.Type.MARKDOWN)
             .build();
-        pageCrudService.initWith(List.of(page));
-        pageQueryService.initWith(List.of(page));
-        apiCrudService.initWith(List.of(API));
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.of(page)));
+        apiCrudService.initWith(Storage.of(API));
         assertThat(pageCrudService.findById(PAGE_ID)).isPresent();
         cut.execute(new ApiDeleteDocumentationPageUseCase.Input(API.getId(), PAGE_ID, AUDIT_INFO));
         assertThat(pageCrudService.findById(PAGE_ID)).isEmpty();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPageUseCaseTest.java
@@ -23,6 +23,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -81,7 +82,7 @@ class ApiGetDocumentationPageUseCaseTest {
         );
 
         planQueryService.initWith(
-            List.of(
+            Storage.of(
                 PlanFixtures
                     .aPlanV4()
                     .toBuilder()
@@ -202,11 +203,10 @@ class ApiGetDocumentationPageUseCaseTest {
     }
 
     private void initPageServices(List<Page> pages) {
-        pageCrudService.initWith(pages);
-        pageQueryService.initWith(pages);
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.from(pages)));
     }
 
     private void initApiServices(List<Api> apis) {
-        apiCrudService.initWith(apis);
+        apiCrudService.initWith(Storage.from(apis));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiGetDocumentationPagesUseCaseTest.java
@@ -23,6 +23,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
@@ -136,7 +137,7 @@ class ApiGetDocumentationPagesUseCaseTest {
             );
 
             planQueryService.initWith(
-                List.of(
+                Storage.of(
                     PlanFixtures
                         .aPlanV4()
                         .toBuilder()
@@ -254,12 +255,11 @@ class ApiGetDocumentationPagesUseCaseTest {
     }
 
     private void initPageServices(List<Page> pages) {
-        pageQueryService.initWith(pages);
-        pageCrudService.initWith(pages);
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.from(pages)));
     }
 
     private void initApiServices(List<Api> apis) {
-        apiCrudService.initWith(apis);
+        apiCrudService.initWith(Storage.from(apis));
     }
 
     private Page basicPageWithParent(String id, String parentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiPublishDocumentationPageUseCaseTest.java
@@ -28,7 +28,6 @@ import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentation
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
-import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.Date;
@@ -165,7 +164,7 @@ class ApiPublishDocumentationPageUseCaseTest {
             )
         );
         useCase.execute(new ApiPublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO)).page();
-        assertThat(auditCrudService.storage().get(0)).isNotNull().hasFieldOrPropertyWithValue("event", "PAGE_UPDATED");
+        assertThat(auditCrudService.data().get(0)).isNotNull().hasFieldOrPropertyWithValue("event", "PAGE_UPDATED");
     }
 
     @Test
@@ -260,11 +259,10 @@ class ApiPublishDocumentationPageUseCaseTest {
     }
 
     private void initPageServices(List<Page> pages) {
-        pageCrudService.initWith(pages);
-        pageQueryService.initWith(pages);
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.from(pages)));
     }
 
     private void initApiServices(List<Api> apis) {
-        apiCrudService.initWith(apis);
+        apiCrudService.initWith(Storage.from(apis));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUnpublishDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUnpublishDocumentationPageUseCaseTest.java
@@ -26,6 +26,7 @@ import inmemory.PageCrudServiceInMemory;
 import inmemory.PageQueryServiceInMemory;
 import inmemory.PageRevisionCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.Storage;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -148,7 +149,7 @@ class ApiUnpublishDocumentationPageUseCaseTest {
             )
         );
         useCase.execute(new ApiUnpublishDocumentationPageUseCase.Input(API_ID, PAGE_ID, AUDIT_INFO));
-        assertThat(auditCrudService.storage().get(0)).isNotNull().hasFieldOrPropertyWithValue("event", "PAGE_UPDATED");
+        assertThat(auditCrudService.data().get(0)).isNotNull().hasFieldOrPropertyWithValue("event", "PAGE_UPDATED");
     }
 
     @Test
@@ -188,7 +189,7 @@ class ApiUnpublishDocumentationPageUseCaseTest {
             )
         );
         planQueryService.initWith(
-            List.of(
+            Storage.of(
                 PlanFixtures
                     .aPlanV4()
                     .toBuilder()
@@ -275,11 +276,10 @@ class ApiUnpublishDocumentationPageUseCaseTest {
     }
 
     private void initPageServices(List<Page> pages) {
-        pageCrudService.initWith(pages);
-        pageQueryService.initWith(pages);
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.from(pages)));
     }
 
     private void initApiServices(List<Api> apis) {
-        apiCrudService.initWith(apis);
+        apiCrudService.initWith(Storage.from(apis));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/documentation/use_case/ApiUpdateDocumentationPageUseCaseTest.java
@@ -194,7 +194,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", API_ID)
@@ -219,7 +219,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var pageRevision = pageRevisionCrudService.storage().get(0);
+            var pageRevision = pageRevisionCrudService.data().get(0);
             assertThat(pageRevision)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("pageId", PAGE_ID)
@@ -246,7 +246,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var pageRevision = pageRevisionCrudService.storage().get(0);
+            var pageRevision = pageRevisionCrudService.data().get(0);
             assertThat(pageRevision)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("pageId", PAGE_ID)
@@ -273,7 +273,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            assertThat(pageRevisionCrudService.storage()).hasSize(0);
+            assertThat(pageRevisionCrudService.data()).hasSize(0);
         }
 
         @Test
@@ -308,7 +308,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
 
             assertThat(res.page()).isNotNull().hasFieldOrPropertyWithValue("homepage", true);
 
-            var formerHomepage = pageCrudService.storage().stream().filter(p -> p.getId().equals(EXISTING_PAGE_ID)).toList().get(0);
+            var formerHomepage = pageCrudService.data().stream().filter(p -> p.getId().equals(EXISTING_PAGE_ID)).toList().get(0);
             assertThat(formerHomepage).isNotNull().hasFieldOrPropertyWithValue("homepage", false);
         }
 
@@ -476,7 +476,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            var audit = auditCrudService.storage().get(0);
+            var audit = auditCrudService.data().get(0);
             assertThat(audit)
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("referenceId", "api-id")
@@ -500,7 +500,7 @@ class ApiUpdateDocumentationPageUseCaseTest {
                     .build()
             );
 
-            assertThat(pageRevisionCrudService.storage()).hasSize(0);
+            assertThat(pageRevisionCrudService.data()).hasSize(0);
         }
 
         @Test
@@ -713,12 +713,11 @@ class ApiUpdateDocumentationPageUseCaseTest {
     }
 
     private void initPageServices(List<Page> pages) {
-        pageQueryService.initWith(pages);
-        pageCrudService.initWith(pages);
+        pageQueryService.syncStorageWith(pageCrudService.initWith(Storage.from(pages)));
     }
 
     private void initApiServices(List<Api> apis) {
-        apiCrudService.initWith(apis);
+        apiCrudService.initWith(Storage.from(apis));
     }
 
     private String getNotSafe() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import fixtures.repository.ConnectionLogDetailFixtures;
 import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.Storage;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.Instant;
@@ -59,7 +60,7 @@ class SearchConnectionLogUseCaseTest {
     @Test
     void should_return_connection_log_for_a_request_on_api() {
         final ConnectionLogDetail connectionLogDetail = connectionLogDetailFixtures.aConnectionLogDetail().toBuilder().build();
-        logStorageService.initWithConnectionLogDetails(List.of(connectionLogDetail));
+        logStorageService.initWithConnectionLogDetails(Storage.of(connectionLogDetail));
 
         var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
 
@@ -69,7 +70,7 @@ class SearchConnectionLogUseCaseTest {
     @Test
     void should_return_empty_connection_log_for_non_existing_request() {
         logStorageService.initWithConnectionLogDetails(
-            List.of(connectionLogDetailFixtures.aConnectionLogDetail("other-req").toBuilder().build())
+            Storage.of(connectionLogDetailFixtures.aConnectionLogDetail("other-req").toBuilder().build())
         );
 
         var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
@@ -80,7 +81,7 @@ class SearchConnectionLogUseCaseTest {
     @Test
     void should_return_empty_connection_log_for_non_existing_api() {
         logStorageService.initWithConnectionLogDetails(
-            List.of(connectionLogDetailFixtures.aConnectionLogDetail().toBuilder().apiId("other-api").build())
+            Storage.of(connectionLogDetailFixtures.aConnectionLogDetail().toBuilder().apiId("other-api").build())
         );
 
         var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCaseTest.java
@@ -25,6 +25,7 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PlanCrudServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.log.use_case.SearchConnectionLogsUseCase.Input;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpMethod;
@@ -76,8 +77,8 @@ public class SearchConnectionLogsUseCaseTest {
     void setUp() {
         usecase = new SearchConnectionLogsUseCase(logStorageService, planStorageService, applicationStorageService);
 
-        planStorageService.initWith(List.of(PLAN_1, PLAN_2));
-        applicationStorageService.initWith(List.of(APPLICATION_1, APPLICATION_2));
+        planStorageService.initWith(Storage.of(PLAN_1, PLAN_2));
+        applicationStorageService.initWith(Storage.of(APPLICATION_1, APPLICATION_2));
     }
 
     @AfterEach
@@ -90,7 +91,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_connection_logs_of_an_api() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog("req1").toBuilder().build(),
                 connectionLogFixtures.aConnectionLog().toBuilder().apiId("other-api").planId("other-plan").build()
             )
@@ -128,7 +129,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_sorted_by_desc_timestamp() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
@@ -159,7 +160,7 @@ public class SearchConnectionLogsUseCaseTest {
         var pageNumber = 2;
         var pageSize = 5;
         logStorageService.initWithConnectionLogs(
-            IntStream.range(0, expectedTotal).mapToObj(i -> connectionLogFixtures.aConnectionLog(String.valueOf(i))).toList()
+            Storage.from(IntStream.range(0, expectedTotal).mapToObj(i -> connectionLogFixtures.aConnectionLog(String.valueOf(i))).toList())
         );
 
         var result = usecase.execute(
@@ -181,7 +182,9 @@ public class SearchConnectionLogsUseCaseTest {
     void should_return_api_connection_logs_with_only_plan_id_if_plan_cannot_be_found() {
         var unknownPlan = "unknown";
 
-        logStorageService.initWithConnectionLogs(List.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(unknownPlan).build()));
+        logStorageService.initWithConnectionLogs(
+            Storage.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(unknownPlan).build())
+        );
 
         var result = usecase.execute(
             GraviteeContext.getExecutionContext(),
@@ -195,7 +198,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_with_only_available_info() {
         logStorageService.initWithConnectionLogs(
-            List.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(null).clientIdentifier(null).applicationId("1").build())
+            Storage.of(connectionLogFixtures.aConnectionLog().toBuilder().planId(null).clientIdentifier(null).applicationId("1").build())
         );
 
         var result = usecase.execute(
@@ -212,7 +215,7 @@ public class SearchConnectionLogsUseCaseTest {
         var unknownApp = "unknown";
 
         logStorageService.initWithConnectionLogs(
-            List.of(connectionLogFixtures.aConnectionLog().toBuilder().applicationId(unknownApp).build())
+            Storage.of(connectionLogFixtures.aConnectionLog().toBuilder().applicationId(unknownApp).build())
         );
 
         var result = usecase.execute(
@@ -227,7 +230,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_for_applications() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").applicationId("app1").build(),
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req2").applicationId("app1").build(),
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req3").applicationId("app2").build(),
@@ -252,7 +255,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_for_plans() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req1").planId("plan1").build(),
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req2").planId("plan1").build(),
                 connectionLogFixtures.aConnectionLog().toBuilder().requestId("req3").planId("plan2").build(),
@@ -277,7 +280,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_filtered_by_timestamp_date_range() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
@@ -301,7 +304,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_from_timestamp() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()
@@ -325,7 +328,7 @@ public class SearchConnectionLogsUseCaseTest {
     @Test
     void should_return_api_connection_logs_to_timestamp() {
         logStorageService.initWithConnectionLogs(
-            List.of(
+            Storage.of(
                 connectionLogFixtures.aConnectionLog("req1").toBuilder().timestamp("2020-02-01T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req2").toBuilder().timestamp("2020-02-02T20:00:00.00Z").build(),
                 connectionLogFixtures.aConnectionLog("req3").toBuilder().timestamp("2020-02-04T20:00:00.00Z").build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCaseTest.java
@@ -19,6 +19,7 @@ import static fixtures.core.log.model.MessageLogFixtures.aMessageLog;
 import static org.assertj.core.api.Assertions.tuple;
 
 import inmemory.MessageLogCrudServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.log.model.AggregatedMessageLog;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -55,7 +56,7 @@ class SearchMessageLogsUseCaseTest {
     void should_return_messages_logs_of_an_api() {
         var expectedMessageLog = aMessageLog(API_ID, REQUEST_ID);
         messageLogStorageService.initWith(
-            List.of(
+            Storage.of(
                 expectedMessageLog,
                 aMessageLog("other-api", "a-request-id"),
                 aMessageLog(API_ID, "other-request-id"),
@@ -92,7 +93,7 @@ class SearchMessageLogsUseCaseTest {
     @Test
     void should_return_api_message_logs_sorted_by_desc_timestamp() {
         messageLogStorageService.initWith(
-            List.of(
+            Storage.of(
                 aMessageLog(API_ID, REQUEST_ID).toBuilder().correlationId("correlation-1").timestamp("2020-02-01T20:00:00.00Z").build(),
                 aMessageLog(API_ID, REQUEST_ID).toBuilder().correlationId("correlation-2").timestamp("2020-02-02T20:00:00.00Z").build(),
                 aMessageLog(API_ID, REQUEST_ID).toBuilder().correlationId("correlation-3").timestamp("2020-02-04T20:00:00.00Z").build()
@@ -120,10 +121,12 @@ class SearchMessageLogsUseCaseTest {
         var pageNumber = 2;
         var pageSize = 5;
         messageLogStorageService.initWith(
-            IntStream
-                .range(0, expectedTotal)
-                .mapToObj(i -> aMessageLog(API_ID, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
-                .toList()
+            Storage.from(
+                IntStream
+                    .range(0, expectedTotal)
+                    .mapToObj(i -> aMessageLog(API_ID, REQUEST_ID).toBuilder().correlationId(String.valueOf(i)).build())
+                    .toList()
+            )
         );
 
         var result = usecase.execute(new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID, new PageableImpl(pageNumber, pageSize)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
@@ -24,9 +24,8 @@ import fixtures.core.model.SubscriptionFixtures;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PlanCrudServiceInMemory;
+import inmemory.Storage;
 import inmemory.SubscriptionCrudServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory;
-import inmemory.TriggerNotificationDomainServiceInMemory.ApplicationNotification;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditEntity;
@@ -58,6 +57,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import stub.TriggerNotificationDomainServiceStub;
+import stub.TriggerNotificationDomainServiceStub.ApplicationNotification;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class RejectSubscriptionDomainServiceTest {
@@ -73,7 +74,7 @@ public class RejectSubscriptionDomainServiceTest {
 
     AuditCrudServiceInMemory auditCrudServiceInMemory;
     PlanCrudServiceInMemory planCrudService;
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService;
+    TriggerNotificationDomainServiceStub triggerNotificationDomainService;
     UserCrudServiceInMemory userCrudService;
     RejectSubscriptionDomainService cut;
 
@@ -81,7 +82,7 @@ public class RejectSubscriptionDomainServiceTest {
     void setUp() {
         UuidString.overrideGenerator(() -> "audit-id");
 
-        triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
+        triggerNotificationDomainService = new TriggerNotificationDomainServiceStub();
 
         auditCrudServiceInMemory = new AuditCrudServiceInMemory();
         planCrudService = new PlanCrudServiceInMemory();
@@ -96,7 +97,7 @@ public class RejectSubscriptionDomainServiceTest {
                 userCrudService
             );
         planCrudService.initWith(
-            List.of(
+            Storage.of(
                 PlanFixtures.aPlanV4().toBuilder().id(PLAN_CLOSED).status(PlanStatus.CLOSED).build(),
                 PlanFixtures.aPlanV4().toBuilder().id(PLAN_PUBLISHED).status(PlanStatus.PUBLISHED).build()
             )
@@ -157,7 +158,7 @@ public class RejectSubscriptionDomainServiceTest {
                 .build();
             givenExistingSubscription(subscription);
             if (shouldTriggerEmailNotification) {
-                userCrudService.initWith(List.of(BaseUserEntity.builder().id("subscriber").email("subscriber@mail.fake").build()));
+                userCrudService.initWith(Storage.of(BaseUserEntity.builder().id("subscriber").email("subscriber@mail.fake").build()));
             }
 
             // When
@@ -192,7 +193,7 @@ public class RejectSubscriptionDomainServiceTest {
                     );
             }
 
-            assertThat(auditCrudServiceInMemory.storage())
+            assertThat(auditCrudServiceInMemory.data())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
                 .containsExactly(
                     new AuditEntity(
@@ -275,7 +276,7 @@ public class RejectSubscriptionDomainServiceTest {
                     .build()
             );
             if (shouldTriggerEmailNotification) {
-                userCrudService.initWith(List.of(BaseUserEntity.builder().id("subscriber").email("subscriber@mail.fake").build()));
+                userCrudService.initWith(Storage.of(BaseUserEntity.builder().id("subscriber").email("subscriber@mail.fake").build()));
             }
 
             // When
@@ -310,7 +311,7 @@ public class RejectSubscriptionDomainServiceTest {
                     );
             }
 
-            assertThat(auditCrudServiceInMemory.storage())
+            assertThat(auditCrudServiceInMemory.data())
                 .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
                 .containsExactly(
                     new AuditEntity(
@@ -342,6 +343,6 @@ public class RejectSubscriptionDomainServiceTest {
     }
 
     private void givenExistingSubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
+        subscriptionCrudService.initWith(Storage.of(subscription));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/membership/PrimaryOwnerDomainServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import inmemory.Storage;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.exception.ApplicationPrimaryOwnerNotFoundException;
@@ -486,7 +487,7 @@ public class PrimaryOwnerDomainServiceImplTest {
     }
 
     private void givenExistingUsers(List<BaseUserEntity> users) {
-        userRepository.initWith(users);
+        userRepository.initWith(Storage.from(users));
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 
 import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.PrimaryOwnerDomainServiceInMemory;
+import inmemory.Storage;
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
@@ -133,9 +134,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_api_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             // When
@@ -181,13 +194,30 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_api_notification_data_with_metadata() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build(),
-                List.of(
-                    ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build(),
+                            List.of(
+                                ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                                ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
+                                ApiMetadata
+                                    .builder()
+                                    .key("email-support")
+                                    .value("${(api.primaryOwner.email)!''}")
+                                    .format(MetadataFormat.STRING)
+                                    .build()
+                            )
+                        )
+                    )
                 )
             );
 
@@ -234,23 +264,41 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_application_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
-            );
-            givenExistingApplication(
-                Application
-                    .builder()
-                    .id("application-id")
-                    .name("application-name")
-                    .type(ApplicationType.SIMPLE)
-                    .status(ApplicationStatus.ACTIVE)
-                    .description("application-description")
-                    .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
-                    .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
-                    .apiKeyMode(ApiKeyMode.SHARED)
-                    .build(),
-                PrimaryOwnerEntity.builder().id("user-2").displayName("Jen Doe").email("jen.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        ),
+                        givenExistingApplication(
+                            Application
+                                .builder()
+                                .id("application-id")
+                                .name("application-name")
+                                .type(ApplicationType.SIMPLE)
+                                .status(ApplicationStatus.ACTIVE)
+                                .description("application-description")
+                                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                                .apiKeyMode(ApiKeyMode.SHARED)
+                                .build(),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-2")
+                                .displayName("Jen Doe")
+                                .email("jen.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             // When
@@ -297,9 +345,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_plan_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingPlan(
@@ -359,9 +419,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_push_plan_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingPlan(
@@ -419,9 +491,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_subscription_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingSubscription(Subscription.builder().id("subscription-id").request("my-request").reason("my-reason").build());
@@ -474,19 +558,31 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_application_notification_data() {
             // Given
-            givenExistingApplication(
-                Application
-                    .builder()
-                    .id("application-id")
-                    .name("application-name")
-                    .type(ApplicationType.SIMPLE)
-                    .status(ApplicationStatus.ACTIVE)
-                    .description("application-description")
-                    .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
-                    .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
-                    .apiKeyMode(ApiKeyMode.SHARED)
-                    .build(),
-                PrimaryOwnerEntity.builder().id("user-2").displayName("Jen Doe").email("jen.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApplication(
+                            Application
+                                .builder()
+                                .id("application-id")
+                                .name("application-name")
+                                .type(ApplicationType.SIMPLE)
+                                .status(ApplicationStatus.ACTIVE)
+                                .description("application-description")
+                                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                                .apiKeyMode(ApiKeyMode.SHARED)
+                                .build(),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-2")
+                                .displayName("Jen Doe")
+                                .email("jen.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             // When
@@ -531,23 +627,41 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_api_notification_data() {
             // Given
-            givenExistingApplication(
-                Application
-                    .builder()
-                    .id("application-id")
-                    .name("application-name")
-                    .description("application-description")
-                    .type(ApplicationType.SIMPLE)
-                    .status(ApplicationStatus.ACTIVE)
-                    .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
-                    .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
-                    .apiKeyMode(ApiKeyMode.SHARED)
-                    .build(),
-                PrimaryOwnerEntity.builder().id("user-2").displayName("Jen Doe").email("jen.doe@gravitee.io").type("USER").build()
-            );
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApplication(
+                            Application
+                                .builder()
+                                .id("application-id")
+                                .name("application-name")
+                                .description("application-description")
+                                .type(ApplicationType.SIMPLE)
+                                .status(ApplicationStatus.ACTIVE)
+                                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                                .apiKeyMode(ApiKeyMode.SHARED)
+                                .build(),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-2")
+                                .displayName("Jen Doe")
+                                .email("jen.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        ),
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             // When
@@ -597,13 +711,30 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_api_notification_data_with_metadata() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build(),
-                List.of(
-                    ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build(),
+                            List.of(
+                                ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                                ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
+                                ApiMetadata
+                                    .builder()
+                                    .key("email-support")
+                                    .value("${(api.primaryOwner.email)!''}")
+                                    .format(MetadataFormat.STRING)
+                                    .build()
+                            )
+                        )
+                    )
                 )
             );
 
@@ -654,9 +785,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_plan_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingPlan(
@@ -717,9 +860,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_push_plan_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingPlan(
@@ -778,9 +933,21 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_fetch_subscription_notification_data() {
             // Given
-            givenExistingApi(
-                anApi().withId("api-id"),
-                PrimaryOwnerEntity.builder().id("user-id").displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApi(
+                            anApi().withId("api-id"),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-id")
+                                .displayName("Jane Doe")
+                                .email("jane.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             givenExistingSubscription(Subscription.builder().id("subscription-id").request("my-request").reason("my-reason").build());
@@ -811,19 +978,31 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         @Test
         public void should_send_notification_to_additional_recipient() {
             // Given
-            givenExistingApplication(
-                Application
-                    .builder()
-                    .id("application-id")
-                    .name("application-name")
-                    .type(ApplicationType.SIMPLE)
-                    .status(ApplicationStatus.ACTIVE)
-                    .description("application-description")
-                    .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
-                    .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
-                    .apiKeyMode(ApiKeyMode.SHARED)
-                    .build(),
-                PrimaryOwnerEntity.builder().id("user-2").displayName("Jen Doe").email("jen.doe@gravitee.io").type("USER").build()
+            primaryOwnerDomainService.initWith(
+                Storage.from(
+                    List.of(
+                        givenExistingApplication(
+                            Application
+                                .builder()
+                                .id("application-id")
+                                .name("application-name")
+                                .type(ApplicationType.SIMPLE)
+                                .status(ApplicationStatus.ACTIVE)
+                                .description("application-description")
+                                .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                                .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                                .apiKeyMode(ApiKeyMode.SHARED)
+                                .build(),
+                            PrimaryOwnerEntity
+                                .builder()
+                                .id("user-2")
+                                .displayName("Jen Doe")
+                                .email("jen.doe@gravitee.io")
+                                .type("USER")
+                                .build()
+                        )
+                    )
+                )
             );
 
             // When
@@ -887,26 +1066,29 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
     }
 
     @SneakyThrows
-    private void givenExistingApi(Api api, PrimaryOwnerEntity primaryOwnerEntity) {
-        givenExistingApi(api, primaryOwnerEntity, List.of());
+    private Map.Entry<String, PrimaryOwnerEntity> givenExistingApi(Api api, PrimaryOwnerEntity primaryOwnerEntity) {
+        return givenExistingApi(api, primaryOwnerEntity, List.of());
     }
 
     @SneakyThrows
-    private void givenExistingApi(Api api, PrimaryOwnerEntity primaryOwnerEntity, List<ApiMetadata> metadata) {
+    private Map.Entry<String, PrimaryOwnerEntity> givenExistingApi(
+        Api api,
+        PrimaryOwnerEntity primaryOwnerEntity,
+        List<ApiMetadata> metadata
+    ) {
         lenient().when(apiRepository.findById(any())).thenReturn(Optional.empty());
         lenient().when(apiRepository.findById(api.getId())).thenReturn(Optional.of(api));
 
-        primaryOwnerDomainService.add(api.getId(), primaryOwnerEntity);
-
-        apiMetadataQueryService.initWith(List.of(Map.entry(api.getId(), metadata)));
+        apiMetadataQueryService.initWith(Storage.from(List.of(Map.entry(api.getId(), metadata))));
+        return Map.entry(api.getId(), primaryOwnerEntity);
     }
 
     @SneakyThrows
-    private void givenExistingApplication(Application application, PrimaryOwnerEntity primaryOwnerEntity) {
+    private Map.Entry<String, PrimaryOwnerEntity> givenExistingApplication(Application application, PrimaryOwnerEntity primaryOwnerEntity) {
         lenient().when(applicationRepository.findById(any())).thenReturn(Optional.empty());
         lenient().when(applicationRepository.findById(eq(application.getId()))).thenReturn(Optional.of(application));
 
-        primaryOwnerDomainService.add(application.getId(), primaryOwnerEntity);
+        return Map.entry(application.getId(), primaryOwnerEntity);
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/AccessPointQueryServiceStub.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/AccessPointQueryServiceStub.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package inmemory;
+package stub;
 
 import io.gravitee.apim.core.access_point.model.AccessPoint;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -21,7 +21,7 @@ import io.gravitee.rest.api.service.common.ReferenceContext;
 import java.util.List;
 import java.util.Optional;
 
-public class AccessPointQueryServiceInMemory implements AccessPointQueryService {
+public class AccessPointQueryServiceStub implements AccessPointQueryService {
 
     @Override
     public Optional<ReferenceContext> getReferenceContext(String host) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/ApiHostValidatorDomainServiceGoogleStub.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/ApiHostValidatorDomainServiceGoogleStub.java
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package inmemory;
+package stub;
 
-import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiHostValidatorDomainService;
+import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
+import java.util.List;
 
-public class PolicyValidationDomainServiceInMemory implements PolicyValidationDomainService {
+public class ApiHostValidatorDomainServiceGoogleStub implements ApiHostValidatorDomainService {
+
+    private final ApiHostValidatorDomainService validator = new ApiHostValidatorDomainServiceImpl();
 
     @Override
-    public String validateAndSanitizeConfiguration(String policyName, String configuration) {
-        return configuration;
+    public boolean isValidDomainOrSubDomain(String domain, List<String> domainRestrictions) {
+        return validator.isValidDomainOrSubDomain(domain, domainRestrictions);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/InstallationAccessQueryServiceStub.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/InstallationAccessQueryServiceStub.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package inmemory;
+package stub;
 
 import io.gravitee.apim.core.installation.model.RestrictedDomain;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
@@ -23,7 +23,7 @@ import java.util.List;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class InstallationAccessQueryServiceInMemory implements InstallationAccessQueryService {
+public class InstallationAccessQueryServiceStub implements InstallationAccessQueryService {
 
     @Override
     public List<String> getConsoleUrls() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/PolicyValidationDomainServiceStub.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/PolicyValidationDomainServiceStub.java
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package inmemory;
+package stub;
 
-import io.gravitee.apim.core.api.domain_service.ApiHostValidatorDomainService;
-import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
-import java.util.List;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 
-public class ApiHostValidatorDomainServiceGoogleImpl implements ApiHostValidatorDomainService {
-
-    private final ApiHostValidatorDomainService validator = new ApiHostValidatorDomainServiceImpl();
+public class PolicyValidationDomainServiceStub implements PolicyValidationDomainService {
 
     @Override
-    public boolean isValidDomainOrSubDomain(String domain, List<String> domainRestrictions) {
-        return validator.isValidDomainOrSubDomain(domain, domainRestrictions);
+    public String validateAndSanitizeConfiguration(String policyName, String configuration) {
+        return configuration;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/TriggerNotificationDomainServiceStub.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/stub/TriggerNotificationDomainServiceStub.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package inmemory;
+package stub;
 
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class TriggerNotificationDomainServiceInMemory implements TriggerNotificationDomainService {
+public class TriggerNotificationDomainServiceStub implements TriggerNotificationDomainService {
 
     public record ApplicationNotification(Recipient recipient, ApplicationHookContext context) {
         public ApplicationNotification(ApplicationHookContext context) {


### PR DESCRIPTION
# Description

- Introduce a Storage type to act as storage object for `InMemoryAlternative` objects
- Data can be manipulated through `InMemoryAlternative` objects only because of mutation method being package private
- A class using a `InMemoryAlternative` is only able to call the business code + a `data()` method returning an immutable collection
- An InMemoryAlternative can now only be initialized thanks to
  - `initWiith(Storage storage)`: to populate the storage filled with data
  - `syncStorageWith(InMemoryAlternative other)`: to use the same storage as the other object
  
 # Usage

The `syncStorageWith` method is useful when you need common data storage used by two class, let's see an example with `Page` object
`pageCrudService.syncStorageWith(pageQueryService.initWith(someData))`

If I remove some data with the `crudService`, then the `queryService` is querying on the same collection, as a real database.