### PR TITLE
Add support for Secret Manager's configuration in Helm Chart

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -8,6 +8,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 - Update regex for portal and console base_href
 - 'fix: license deleted after helm upgrade [issues/9411](https://github.com/gravitee-io/issues/issues/9411)'
 - 'fix AE system mail notification without keystore'
+- Add support for Secret Manager's configuration 
 
 ### 4.1.4
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -502,11 +502,16 @@ By setting the value to `null` for `runAsUser` and `runAsGroup` it forces OpenSh
 Install `unittest` helm plugin
 
 ```shell
-helm plugin install https://github.com/quintush/helm-unittest
+helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+```
+
+Update dependencies
+```shell
+helm dependency update
 ```
 
 Inside `helm/` directory, run:
 
 ```shell
-helm unittest -f 'tests/**/*_test.yaml' .
+helm unittest -3 -f 'tests/**/*_test.yaml' .
 ```

--- a/helm/requirements.lock
+++ b/helm/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 19.10.3
+  version: 19.10.9
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.15.4
-digest: sha256:763a107d1d83956beb86428ab2e5a30a28126c8a82c69994114cb886650714a7
-generated: "2023-07-05T17:05:14.462996+02:00"
+  version: 13.16.4
+digest: sha256:39f3801d546db4a4e02c8fb923ca96cd8aea8d0bf250c176caa503bc3836d656
+generated: "2023-12-11T10:31:57.385795+01:00"

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -448,6 +448,12 @@ data:
       delay: {{ .Values.gateway.gracefulShutdown.delay }}
       unit: {{ .Values.gateway.gracefulShutdown.unit }}
 
+    # Secret Manager configuration
+    {{- if .Values.gateway.secrets }}
+    secrets:
+      {{- toYaml .Values.gateway.secrets | nindent 6 }}
+    {{- end }}
+
     # Old class loader behavior, false by default
     classloader:
       legacy:

--- a/helm/tests/gateway/configmap_secret_manager_test.yaml
+++ b/helm/tests/gateway/configmap_secret_manager_test.yaml
@@ -1,0 +1,71 @@
+suite: Test Gateway ConfigMap with Secret Manager
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: should create a ConfigMap with the `secrets` attribute
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        secrets:
+          loadFirst: kubernetes
+          kubernetes:
+            enabled: true
+            namespace: default
+            kubeConfigFile: /opt/gravitee/config/kube-config.json
+            timeoutMs: 3000
+          vault:
+            enabled: false
+            host: 127.0.0.1
+            port: 8200
+            namespace:
+              kvEngine: V2
+              readTimeoutSec: 2
+              connectTimeoutSec: 3
+            ssl:
+              enabled: false
+            auth:
+              method: token
+              config:
+                token: aToken
+            retry:
+              attempts: 2
+              intervalMs: 1000
+            watch:
+              enabled: true
+              pollIntervalSec: 30
+
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            secrets:
+              kubernetes:
+                enabled: true
+                kubeConfigFile: /opt/gravitee/config/kube-config.json
+                namespace: default
+                timeoutMs: 3000
+              loadFirst: kubernetes
+              vault:
+                auth:
+                  config:
+                    token: aToken
+                  method: token
+                enabled: false
+                host: 127.0.0.1
+                namespace:
+                  connectTimeoutSec: 3
+                  kvEngine: V2
+                  readTimeoutSec: 2
+                port: 8200
+                retry:
+                  attempts: 2
+                  intervalMs: 1000
+                ssl:
+                  enabled: false
+                watch:
+                  enabled: true
+                  pollIntervalSec: 30


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2947


## Description

 - Add support for Secret Manager's configuration in Helm Chart
 - Update the Readme to run unit tests without any issues on a fresh install
 - Update `requirement.lock` to match the versions defined in `requirement.yml`