### PR TITLE
fix table of contents links

### DIFF
--- a/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.html
+++ b/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.html
@@ -160,6 +160,6 @@
   <gio-table-of-contents
     class="gio-instance-details-environment__toc"
     [sectionNames]="{ '': 'Environment' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.spec.ts
@@ -21,6 +21,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatTableHarness } from '@angular/material/table/testing';
 import { formatDate } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { InstanceDetailsEnvironmentModule } from './instance-details-environment.module';
 import { InstanceDetailsEnvironmentComponent } from './instance-details-environment.component';
@@ -35,11 +36,11 @@ describe('InstanceDetailsEnvironmentComponent', () => {
   let httpTestingController: HttpTestingController;
   const instanceId = '5bc17c57-b350-460d-817c-57b350060db3';
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioHttpTestingModule, InstanceDetailsEnvironmentModule],
-      providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { instanceId } } } }],
-    });
+      providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { instanceId } }, fragment: of('') } }],
+    }).compileComponents();
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture = TestBed.createComponent(InstanceDetailsEnvironmentComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);

--- a/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/api-logging/api-logging.component.html
@@ -307,6 +307,6 @@
   <gio-table-of-contents
     class="api-logging__toc"
     [sectionNames]="{ '': 'Settings' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -444,6 +444,6 @@
   <gio-table-of-contents
     class="settings-general__toc"
     [sectionNames]="{ '': 'Settings' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -51,9 +51,7 @@ describe('ConsoleSettingsComponent', () => {
         },
       })
       .compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(OrgSettingsGeneralComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.html
@@ -258,6 +258,6 @@
 
   <gio-table-of-contents
     [sectionNames]="{ '': 'Identity provider' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/identity-provider/org-settings-identity-provider.component.spec.ts
@@ -29,6 +29,7 @@ import { MatTableHarness } from '@angular/material/table/testing';
 import { GioFormTagsInputHarness, GioSaveBarHarness, GioLicenseTestingModule } from '@gravitee/ui-particles-angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { OrgSettingsIdentityProviderComponent } from './org-settings-identity-provider.component';
 
@@ -474,6 +475,7 @@ describe('OrgSettingsIdentityProviderComponent', () => {
                   id: 'providerId',
                 },
               },
+              fragment: of(''),
             },
           },
         ],

--- a/gravitee-apim-console-webui/src/organization/configuration/navigation/org-navigation.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/navigation/org-navigation.component.html
@@ -40,7 +40,7 @@
       </ng-container>
     </gio-submenu>
   </div>
-  <div class="org-navigation__content gio-toc-scrolling-container">
+  <div id="gio-toc-scrolling-container" class="org-navigation__content">
     <router-outlet></router-outlet>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.html
@@ -86,6 +86,6 @@
   <gio-table-of-contents
     class="org-settings-notification-template__toc"
     [sectionNames]="{ '': 'Templates' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.spec.ts
@@ -23,6 +23,7 @@ import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { OrgSettingsNotificationTemplateComponent } from './org-settings-notification-template.component';
 
@@ -54,6 +55,7 @@ describe('OrgSettingsNotificationTemplateComponent', () => {
                 scope: 'scope',
               },
             },
+            fragment: of(''),
           },
         },
       ],

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.html
@@ -41,6 +41,6 @@
   <gio-table-of-contents
     class="org-settings-notification-templates__toc"
     [sectionNames]="{ '': 'Templates' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.html
@@ -77,6 +77,6 @@
   <gio-table-of-contents
     class="org-settings-roles__toc"
     [sectionNames]="{ '': 'Roles' }"
-    scrollingContainer=".gio-toc-scrolling-container"
+    scrollingContainer="#gio-toc-scrolling-container"
   ></gio-table-of-contents>
 </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -453,5 +453,5 @@
 <gio-table-of-contents
   class="toc"
   [sectionNames]="{ '': 'User details' }"
-  scrollingContainer=".gio-toc-scrolling-container"
+  scrollingContainer="#gio-toc-scrolling-container"
 ></gio-table-of-contents>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -28,6 +28,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { OrgSettingsUserDetailComponent } from './org-settings-user-detail.component';
 
@@ -60,7 +61,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioHttpTestingModule, OrganizationSettingsModule, MatIconTestingModule],
       providers: [
-        { provide: ActivatedRoute, useValue: { snapshot: { params: { userId: 'userId' } } } },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { userId: 'userId' } }, fragment: of('') } },
         {
           provide: GioTestingPermissionProvider,
           useValue: ['organization-user-u', 'organization-user-d', 'organization-user-c'],

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.html
@@ -20,9 +20,9 @@
   <nav [attr.aria-label]="section?.name + ' Table of Contents'">
     <a
       *ngFor="let link of sortByTopOffset(section?.links); let i = index"
-      [href]="rootUrl + '#' + link.id"
       [class.active]="link.active"
-      (click)="onClick($event, link.id)"
+      [routerLink]="['.']"
+      [fragment]="link.id"
       class="toc__link--level-{{ link.type }} toc__link"
       >{{ link.name }}</a
     >

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.component.spec.ts
@@ -13,32 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { LocationStrategy } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { camelCase } from 'lodash';
-import { MockLocationStrategy } from '@angular/common/testing';
 
 import { TocSectionLink } from './TocSection';
 import { GioTableOfContentsComponent } from './gio-table-of-contents.component';
 import { GioTableOfContentsModule } from './gio-table-of-contents.module';
 import { GioTableOfContentsService } from './gio-table-of-contents.service';
 
-describe('GioConfirmDialogComponent', () => {
+import { GioHttpTestingModule } from '../../testing';
+
+describe('GioTableOfContentsComponent', () => {
   let component: GioTableOfContentsComponent;
   let fixture: ComponentFixture<GioTableOfContentsComponent>;
   let gioTableOfContentsService: GioTableOfContentsService;
-  let locationStrategy: MockLocationStrategy;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [GioTableOfContentsModule],
-      providers: [{ provide: LocationStrategy, useClass: MockLocationStrategy }],
+      imports: [GioTableOfContentsModule, GioHttpTestingModule],
     });
     fixture = TestBed.createComponent(GioTableOfContentsComponent);
     component = fixture.componentInstance;
 
     gioTableOfContentsService = TestBed.inject(GioTableOfContentsService);
-    locationStrategy = TestBed.inject(LocationStrategy) as MockLocationStrategy;
     fixture.nativeElement.getBoundingClientRect = jest.fn();
   });
 
@@ -158,48 +155,6 @@ describe('GioConfirmDialogComponent', () => {
 
     fixture.detectChanges();
     expect(getSectionsName()).toEqual(['Fox section']);
-  });
-
-  it('should update location by clicking on link', async () => {
-    fixture.detectChanges();
-    locationStrategy.simulatePopState('');
-
-    gioTableOfContentsService.addLink('', fakeLink({ name: '1️⃣' }));
-    gioTableOfContentsService.addLink('', fakeLink({ name: '2️⃣' }));
-    fixture.detectChanges();
-
-    component.onClick({ stopPropagation: jest.fn() } as unknown as PointerEvent, '1');
-
-    expect(locationStrategy.path()).toBe('#1');
-  });
-
-  it('should update scroll position', async () => {
-    component.scrollingContainer = document.body;
-
-    // Init Dom with elements
-    const element_1 = document.createElement('h2');
-    element_1.id = 'toc-1';
-    element_1.scrollIntoView = jest.fn();
-    const element_1_2 = document.createElement('h2');
-    element_1_2.id = 'toc-1-2';
-    element_1_2.scrollIntoView = jest.fn();
-    document.body.appendChild(element_1);
-    document.body.appendChild(element_1_2);
-    fixture.detectChanges();
-
-    // Init links
-    gioTableOfContentsService.addLink('', fakeLink({ name: '1️⃣' }));
-    gioTableOfContentsService.addLink('', fakeLink({ name: '2️⃣' }));
-    fixture.detectChanges();
-
-    // Simulate location change to link 2️⃣
-    locationStrategy.simulatePopState('#2');
-    locationStrategy.simulatePopState('#1-2');
-    expect(element_1_2.scrollIntoView).toHaveBeenCalledTimes(1);
-
-    locationStrategy.simulatePopState('#1');
-
-    expect(element_1.scrollIntoView).toHaveBeenCalledTimes(1);
   });
 
   const getLinksText = () => [...fixture.nativeElement.querySelectorAll('.toc__link')].map((el) => el.innerHTML);

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-of-contents/gio-table-of-contents.module.ts
@@ -15,12 +15,13 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { GioTableOfContentsComponent } from './gio-table-of-contents.component';
 import { GioTableOfContentsDirective } from './gio-table-of-contents.directive';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   declarations: [GioTableOfContentsComponent, GioTableOfContentsDirective],
   exports: [GioTableOfContentsComponent, GioTableOfContentsDirective],
 })


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- integrate new router for the links
- fix having an active link in table of contents when scrolling
- move scrolling container identifier from class to id to avoid ng re-rendering

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6221/console](https://pr.team-apim.gravitee.dev/6221/console)
      Portal: [https://pr.team-apim.gravitee.dev/6221/portal](https://pr.team-apim.gravitee.dev/6221/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6221/api/management](https://pr.team-apim.gravitee.dev/6221/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6221](https://pr.team-apim.gravitee.dev/6221)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6221](https://pr.gateway-v3.team-apim.gravitee.dev/6221)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pmwpxoqepe.chromatic.com)
<!-- Storybook placeholder end -->
