### PR TITLE
Add abstract super class to fix issue with javadoc generation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowSelector.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowSelector.java
@@ -49,4 +49,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class FlowSelector {
 
     private FlowSelectorType type;
+
+    // Keep me for Javadoc generation purpose
+    public abstract static class FlowSelectorBuilder<C extends FlowSelector, B extends FlowSelectorBuilder<C, B>> {}
 }


### PR DESCRIPTION
## Issue

NA

## Description

Add abstract super class to fix issue with javadoc generation.

Error is available here: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/29794/workflows/d7d75329-40c1-4ab4-a071-5129b5abfe14/jobs/541334


