### PR TITLE
Properly display wide headers in Application logs

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/application-navigation/application-navigation.component.scss
@@ -63,5 +63,6 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     flex-direction: column;
     flex: 1 1 auto;
     height: 100%;
+    overflow: auto;
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-log.html
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-log.html
@@ -29,15 +29,15 @@
     <md-table-container class="gv-log-request-header">
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Date</span></td>
             <td md-cell>{{$ctrl.log.timestamp | date:'MMM d, y h:mm:ss.sss a'}}</td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Request ID</span></td>
             <td md-cell>{{$ctrl.log.id}}</td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Transaction ID</span></td>
             <td md-cell>{{$ctrl.log.transactionId}}</td>
           </tr>
@@ -51,19 +51,19 @@
     <md-table-container ng-class="{'gv-log-response-header-{{$ctrl.log.status / 100 | number:0}}': true}">
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row style="height: 30px" ng-if="$ctrl.log.apiKey">
+          <tr md-row ng-if="$ctrl.log.apiKey">
             <td md-cell><span style="font-weight: bold">API Key</span></td>
             <td md-cell>{{$ctrl.log.apiKey}}</td>
           </tr>
-          <tr md-row style="height: 30px" ng-if="$ctrl.log.api">
+          <tr md-row ng-if="$ctrl.log.api">
             <td md-cell><span style="font-weight: bold">API</span></td>
             <td md-cell>{{$ctrl.log.metadata[$ctrl.log.api].name}}</td>
           </tr>
-          <tr md-row style="height: 30px" ng-if="$ctrl.log.plan">
+          <tr md-row ng-if="$ctrl.log.plan">
             <td md-cell><span style="font-weight: bold">Plan</span></td>
             <td md-cell>{{$ctrl.log.metadata[$ctrl.log.plan].name}}</td>
           </tr>
-          <tr md-row style="height: 30px" ng-if="$ctrl.log.user && $ctrl.Constants.org.settings.logging.user.displayed">
+          <tr md-row ng-if="$ctrl.log.user && $ctrl.Constants.org.settings.logging.user.displayed">
             <td md-cell><span style="font-weight: bold">User</span></td>
             <td md-cell>{{$ctrl.log.user}}</td>
           </tr>
@@ -84,21 +84,19 @@
     <md-table-container>
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Method</span></td>
             <td md-cell>
-              <span
-                class="badge gravitee-policy-method-badge-info ng-binding ng-scope gravitee-policy-method-badge-{{$ctrl.log.method | uppercase}}-selected"
-              >
+              <span class="badge gravitee-policy-method-badge-info gravitee-policy-method-badge-{{$ctrl.log.method | uppercase}}-selected">
                 {{$ctrl.log.method | uppercase}}
               </span>
             </td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">URI</span></td>
             <td md-cell>{{$ctrl.log.uri}}</td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Content-length</span></td>
             <td md-cell>{{$ctrl.log.requestContentLength | number}}</td>
           </tr>
@@ -109,7 +107,7 @@
     <md-table-container>
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row ng-repeat="(key, value) in $ctrl.log.request.headers" style="height: 30px">
+          <tr md-row ng-repeat="(key, value) in $ctrl.log.request.headers" style="word-break: break-all">
             <td md-cell><span style="font-weight: bold">{{key}}</span></td>
             <td md-cell>{{value[0]}}</td>
           </tr>
@@ -138,15 +136,9 @@
     </div>
   </div>
 
-  <div flex="5" layout="column" layout-align="center center"></div>
+  <div style="width: 16px"></div>
 
-  <div
-    layout="column"
-    layout-padding
-    ng-class="{'gv-log-response-panel-{{$ctrl.log.status / 100 | number:0}}': true}"
-    style="margin-top: 3px"
-    flex="50"
-  >
+  <div layout="column" layout-padding ng-class="{'gv-log-response-panel-{{$ctrl.log.status / 100 | number:0}}': true}" flex="50">
     <div flex="5" layout="row" layout-align="center center">
       <span class="log-header" style="text-align: center">RESPONSE</span>
     </div>
@@ -154,15 +146,15 @@
     <md-table-container>
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Status</span></td>
             <td md-cell><span class="gv-statuscode-{{$ctrl.log.status / 100 | number:0}}xx">{{$ctrl.log.status | number}}</span></td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Content-length</span></td>
             <td md-cell>{{$ctrl.log.responseContentLength | number}}</td>
           </tr>
-          <tr md-row style="height: 30px">
+          <tr md-row>
             <td md-cell><span style="font-weight: bold">Response time</span></td>
             <td md-cell>{{$ctrl.log.responseTime | number}} ms</td>
           </tr>
@@ -173,7 +165,7 @@
     <md-table-container>
       <table md-table class="gv-table-dense">
         <tbody md-body>
-          <tr md-row ng-repeat="(key, value) in $ctrl.log.response.headers" style="height: 30px">
+          <tr md-row ng-repeat="(key, value) in $ctrl.log.response.headers" style="word-break: break-all">
             <td md-cell><span style="font-weight: bold">{{key}}</span></td>
             <td md-cell>{{value[0]}}</td>
           </tr>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3593
https://github.com/gravitee-io/issues/issues/9429

## Description

Properly display wide headers in Application logs

<img src="https://media2.giphy.com/media/13FrpeVH09Zrb2/giphy.gif"/>

## Screenshots

Before
![Capture d’écran 2023-12-18 à 17 29 15](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/12a5d211-5667-474e-87cb-ee05d6dfbcea)

After
![Capture d’écran 2023-12-18 à 17 28 34](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/9e909f49-b8a8-4edb-b7cd-b3337d83d8f0)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xqzgdvdspz.chromatic.com)
<!-- Storybook placeholder end -->
