### PR TITLE
fix: make service discovery creating HttpEndpoint instead of Endpoint

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
@@ -23,6 +23,7 @@ import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.EndpointGroup;
 import io.gravitee.definition.model.HttpClientSslOptions;
+import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.discovery.api.ServiceDiscovery;
 import io.gravitee.discovery.api.service.Service;
@@ -175,7 +176,7 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
         final String serviceName = "sd#" + service.id().replaceAll(":", "#");
         String target = scheme + "://" + service.host() + (service.port() > 0 ? ":" + service.port() : "") + basePath;
 
-        io.gravitee.definition.model.Endpoint endpoint = new Endpoint(serviceName, target);
+        HttpEndpoint endpoint = new HttpEndpoint(serviceName, target);
 
         endpoint.setConfiguration(getEndpointConfiguration(group, endpoint, scheme));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3617

## Description

When trying to unregister an endpoint, the EndpointHealthCheckResolver compare the Endpoint to remove to its list of cronHandler.
https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java#L169

The comparison method use the `equals` method of the `Endpoint` class which rely on the class of the object to compare.

But the cronHandler contains HttpEndpoint and the ServiceDiscovery creates Endpoint.

So the comparison is always `false`


This PR changes the `EndpointDiscoveryVerticle` to create `HttpEndpoint`.