### PR TITLE
test: update cypress to v13.6.1

### DIFF
--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   cypress:
-    image: cypress/included:13.3.3
+    image: cypress/included:13.6.1
     working_dir: /test
     command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts' --record"
     volumes:

--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -39,7 +39,7 @@
         "@types/node": "16.10.9",
         "@types/node-fetch": "2.6.1",
         "ansi-regex": "6.0.1",
-        "cypress": "13.5.1",
+        "cypress": "13.6.1",
         "dotenv": "16.0.0",
         "har-validator": "5.1.5",
         "jest": "27.5.1",

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -48,7 +48,7 @@ declare global {
 }
 export {};
 
-Cypress.Commands.add('callGateway', (contextPath, checkConditionFn?, maxRetries = 15, retryDelay = 1500) => {
+Cypress.Commands.add('callGateway', (contextPath, checkConditionFn?, maxRetries = 20, retryDelay = 1500) => {
   const defaultCheckFunction = (response: Cypress.Response<any>) => response.status === 200;
   const isResponseValid = checkConditionFn || defaultCheckFunction;
   const url = `${Cypress.env('gatewayServer')}${contextPath}`;


### PR DESCRIPTION
## Description
Update Cypress to latest version (13.6.1) for both (dev and CI env) and increase the retries when calling gateway.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wlrxqdzvvf.chromatic.com)
<!-- Storybook placeholder end -->
