### PR TITLE
fix: use right alias for left join

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -249,7 +249,7 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
                 .append(" fshm on f.id = fshm.flow_id  and fse.type = 'HTTP'");
             selectQueryBuilder.append(" left join ").append(FLOW_TAGS).append(" ft on f.id = ft.flow_id");
             selectQueryBuilder.append(" left join ").append(FLOW_METHODS).append(" fm on f.id = fm.flow_id");
-            selectQueryBuilder.append(" left join ").append(FLOW_CONSUMERS).append(" fc on f.id = fm.flow_id");
+            selectQueryBuilder.append(" left join ").append(FLOW_CONSUMERS).append(" fc on f.id = fc.flow_id");
             selectQueryBuilder.append(" where f.reference_id = ? and f.reference_type = ?");
             selectQueryBuilder
                 .append(" order by f.id, fs.phase, fs.")

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
@@ -59,7 +59,7 @@ public class FlowRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("my-condition", flows.get(0).getCondition());
         assertEquals(new Date(1470157767000L), flows.get(0).getCreatedAt());
         assertEquals("flow-tag1", flows.get(0).getId());
-        assertEquals(2, flows.get(0).getMethods().size(), 2);
+        assertEquals(0, flows.get(0).getMethods().size());
         assertEquals("tag-1", flows.get(0).getName());
         assertEquals(1, flows.get(0).getOrder());
         assertEquals(new Date(1470157767000L), flows.get(0).getUpdatedAt());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/flow-tests/flows.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/flow-tests/flows.json
@@ -6,10 +6,7 @@
     "referenceId": "orga-1",
     "condition": "my-condition",
     "enabled": true,
-    "methods": [
-      "GET",
-      "POST"
-    ],
+    "methods": [],
     "path": "/",
     "operator": "STARTS_WITH",
     "consumers": [


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3613

## Description

Use the right alias to join flow_consumers table
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dqmooinrwi.chromatic.com)
<!-- Storybook placeholder end -->
