### PR TITLE
[CI][Bridge] Adapt bridge compatibility tests - 4.2.x

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -314,6 +314,7 @@ workflows:
                 - 4.2.x-latest
                 - 4.1.x-latest
                 - 4.0.x-latest
+                - 3.20.x-latest
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -61,7 +61,7 @@ export class BridgeCompatibilityTestsWorkflow {
         matrix: {
           execution_mode: ['v3', 'v4-emulation-engine'],
           database: ['bridge'],
-          apim_client_tag: ['4.2.x-latest', '4.1.x-latest', '4.0.x-latest'],
+          apim_client_tag: ['4.2.x-latest', '4.1.x-latest', '4.0.x-latest', '3.20.x-latest'],
         },
       }),
     ];


### PR DESCRIPTION
## Issue

N/A

## Description

Bridge server 4.2 should be compatible with all previous supported versions of bridge client 3.20 & 4.0 & 4.1 & 4.2.