### PR TITLE
fix: handle events deletion when API has no event

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
@@ -307,6 +307,10 @@ public class JdbcEventRepository extends JdbcAbstractPageableRepository<Event> i
                 apiId
             );
 
+            if (eventToDelete.isEmpty()) {
+                return 0;
+            }
+
             String propertiesDeleteQuery =
                 "delete from " + EVENT_PROPERTIES + " where event_id in (" + getOrm().buildInClause(eventToDelete) + ")";
             jdbcTemplate.update(

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
@@ -507,6 +507,24 @@ public class EventRepositoryTest extends AbstractManagementRepositoryTest {
         );
     }
 
+    @Test
+    public void shouldNotDeleteByApiWhenNoEvent() throws Exception {
+        assertTrue(
+            eventRepository
+                .search(new EventCriteria.Builder().property(Event.EventProperties.API_ID.getValue(), "api-with-no-event").build())
+                .isEmpty()
+        );
+
+        long deleteApiEvents = eventRepository.deleteApiEvents("api-with-no-event");
+        assertEquals(0, deleteApiEvents);
+
+        assertTrue(
+            eventRepository
+                .search(new EventCriteria.Builder().property(Event.EventProperties.API_ID.getValue(), "api-with-no-event").build())
+                .isEmpty()
+        );
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownEvent() throws Exception {
         Event unknownEvent = new Event();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3625

## Description

handle events deletion when API has no event