### PR TITLE
feat: add method to retrieve plugins list for an API

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.plugins.resources.Resource;
@@ -239,22 +240,26 @@ public class Api implements Serializable {
         this.definitionContext = definitionContext;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return Stream
             .of(
                 Optional
                     .ofNullable(this.getResources())
-                    .map(r -> r.stream().map(Resource::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .map(r ->
+                        r.stream().filter(Resource::isEnabled).map(Resource::getPlugins).flatMap(List::stream).collect(Collectors.toList())
+                    )
                     .orElse(List.of()),
                 Optional
                     .ofNullable(this.getFlows())
-                    .map(f -> f.stream().map(Flow::getPlugins).flatMap(List::stream).toList())
+                    .map(f -> f.stream().filter(Flow::isEnabled).map(Flow::getPlugins).flatMap(List::stream).toList())
                     .orElse(List.of()),
                 Optional
                     .ofNullable(this.getPlans())
                     .map(p -> p.stream().map(Plan::getPlugins).flatMap(List::stream).toList())
                     .orElse(List.of()),
-                Optional.ofNullable(this.getServices()).map(Services::getPlugins).orElse(List.of())
+                Optional.ofNullable(this.getServices()).map(Services::getPlugins).orElse(List.of()),
+                Optional.ofNullable(this.proxy).map(Proxy::getPlugins).orElse(List.of())
             )
             .flatMap(List::stream)
             .collect(Collectors.toList());

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -206,6 +206,11 @@ public class Endpoint implements Serializable {
         return name.hashCode();
     }
 
+    @JsonIgnore
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("connector", String.format("connector-%s", type)));
+    }
+
     public enum Status {
         UP(3),
         DOWN(0),

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/EndpointGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/EndpointGroup.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.definition.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.definition.model.services.Services;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -138,5 +142,19 @@ public class EndpointGroup implements Serializable {
     @Override
     public int hashCode() {
         return name.hashCode();
+    }
+
+    @JsonIgnore
+    public List<Plugin> getPlugins() {
+        return Stream
+            .of(
+                Optional
+                    .ofNullable(this.endpoints)
+                    .map(e -> e.stream().map(Endpoint::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .orElse(List.of()),
+                Optional.ofNullable(this.services).map(Services::getPlugins).orElse(List.of())
+            )
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.flow.Flow;
 import java.io.Serializable;
@@ -159,6 +160,7 @@ public class Plan implements Serializable {
         this.status = status;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return this.getFlows().stream().map(Flow::getPlugins).flatMap(List::stream).toList();
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
@@ -158,4 +158,8 @@ public class Plan implements Serializable {
     public void setStatus(String status) {
         this.status = status;
     }
+
+    public List<Plugin> getPlugins() {
+        return this.getFlows().stream().map(Flow::getPlugins).flatMap(List::stream).toList();
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plugin.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plugin.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+public record Plugin(String type, String id) {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Proxy.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Proxy.java
@@ -18,6 +18,7 @@ package io.gravitee.definition.model;
 import com.fasterxml.jackson.annotation.*;
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -123,5 +124,13 @@ public class Proxy implements Serializable {
 
     public void setServers(List<String> servers) {
         this.servers = servers;
+    }
+
+    @JsonIgnore
+    public List<Plugin> getPlugins() {
+        return Optional
+            .ofNullable(this.groups)
+            .map(g -> g.stream().map(EndpointGroup::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+            .orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Service.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Service.java
@@ -62,6 +62,7 @@ public abstract class Service implements Serializable {
         return Objects.hash(name);
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("service", name));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Service.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Service.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 import lombok.experimental.SuperBuilder;
 
@@ -59,5 +60,9 @@ public abstract class Service implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(name);
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("service", name));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Flow.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Flow.java
@@ -19,8 +19,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.ConditionSupplier;
+import io.gravitee.definition.model.Plugin;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -164,5 +170,15 @@ public class Flow implements Serializable, ConditionSupplier {
 
     public void setConsumers(List<Consumer> consumers) {
         this.consumers = consumers;
+    }
+
+    public List<Plugin> getPlugins() {
+        return Stream
+            .of(
+                this.post.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()),
+                this.pre.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList())
+            )
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Flow.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Flow.java
@@ -21,10 +21,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.definition.model.Plugin;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
@@ -172,13 +169,16 @@ public class Flow implements Serializable, ConditionSupplier {
         this.consumers = consumers;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
-        return Stream
-            .of(
-                this.post.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()),
-                this.pre.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList())
-            )
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
+        return Stream.of(computePlugins(this.post), computePlugins(this.pre)).flatMap(List::stream).collect(Collectors.toList());
+    }
+
+    @JsonIgnore
+    private List<Plugin> computePlugins(List<Step> steps) {
+        return Optional
+            .ofNullable(steps)
+            .map(s -> s.stream().filter(Step::isEnabled).map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+            .orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Step.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Step.java
@@ -16,8 +16,10 @@
 package io.gravitee.definition.model.flow;
 
 import com.fasterxml.jackson.annotation.*;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -101,5 +103,9 @@ public class Step implements Serializable {
 
     public void setCondition(String condition) {
         this.condition = condition;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("policy", policy));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Step.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/flow/Step.java
@@ -105,6 +105,7 @@ public class Step implements Serializable {
         this.condition = condition;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("policy", policy));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/plugins/resources/Resource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/plugins/resources/Resource.java
@@ -107,6 +107,7 @@ public class Resource implements Serializable {
         return Objects.hash(name);
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("resource", type));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/plugins/resources/Resource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/plugins/resources/Resource.java
@@ -17,8 +17,10 @@ package io.gravitee.definition.model.plugins.resources;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -103,5 +105,9 @@ public class Resource implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(name);
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("resource", type));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/services/Services.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/services/Services.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.model.services;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.Service;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
@@ -24,8 +25,10 @@ import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -98,5 +101,9 @@ public final class Services implements Serializable {
         if (dynamicPropertyService != null) {
             put(DynamicPropertyService.class, dynamicPropertyService);
         }
+    }
+
+    public List<Plugin> getPlugins() {
+        return this.services.values().stream().map(Service::getPlugins).flatMap(List::stream).collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.model.v4;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -31,13 +32,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -125,6 +123,35 @@ public class Api implements Serializable {
         } else {
             this.plans = new HashMap<>();
         }
+    }
+
+    public List<Plugin> getPlugins() {
+        return Stream
+            .of(
+                Optional
+                    .ofNullable(this.getResources())
+                    .map(r -> r.stream().map(Resource::getPlugins).flatMap(List::stream).toList())
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.getFlows())
+                    .map(f -> f.stream().map(Flow::getPlugins).flatMap(List::stream).toList())
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.getPlans())
+                    .map(p -> p.stream().map(Plan::getPlugins).flatMap(List::stream).toList())
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.getListeners())
+                    .map(l -> l.stream().map(Listener::getPlugins).flatMap(List::stream).toList())
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.getEndpointGroups())
+                    .map(r -> r.stream().map(EndpointGroup::getPlugins).flatMap(List::stream).toList())
+                    .orElse(List.of()),
+                Optional.ofNullable(this.getServices()).map(ApiServices::getPlugins).orElse(List.of())
+            )
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 
     public static class ApiBuilder {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
@@ -125,16 +126,17 @@ public class Api implements Serializable {
         }
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return Stream
             .of(
                 Optional
                     .ofNullable(this.getResources())
-                    .map(r -> r.stream().map(Resource::getPlugins).flatMap(List::stream).toList())
+                    .map(r -> r.stream().filter(Resource::isEnabled).map(Resource::getPlugins).flatMap(List::stream).toList())
                     .orElse(List.of()),
                 Optional
                     .ofNullable(this.getFlows())
-                    .map(f -> f.stream().map(Flow::getPlugins).flatMap(List::stream).toList())
+                    .map(f -> f.stream().filter(Flow::isEnabled).map(Flow::getPlugins).flatMap(List::stream).toList())
                     .orElse(List.of()),
                 Optional
                     .ofNullable(this.getPlans())

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/Endpoint.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -95,5 +96,9 @@ public class Endpoint implements Serializable {
 
     public void setSharedConfigurationOverride(final String overriddenSharedConfiguration) {
         this.sharedConfigurationOverride = overriddenSharedConfiguration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("endpoint-connector", type));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/Endpoint.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.endpointgroup;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -98,6 +99,7 @@ public class Endpoint implements Serializable {
         this.sharedConfigurationOverride = overriddenSharedConfiguration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("endpoint-connector", type));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.endpointgroup;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -75,6 +76,7 @@ public class EndpointGroup implements Serializable {
         this.sharedConfiguration = sharedConfiguration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return Optional
             .ofNullable(this.endpoints)

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.endpointgroup.loadbalancer.LoadBalancer;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,6 +27,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.*;
 
 /**
@@ -70,5 +73,12 @@ public class EndpointGroup implements Serializable {
 
     public void setSharedConfiguration(final String sharedConfiguration) {
         this.sharedConfiguration = sharedConfiguration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return Optional
+            .ofNullable(this.endpoints)
+            .map(e -> e.stream().map(Endpoint::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+            .orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
@@ -77,27 +77,19 @@ public class Flow implements Serializable {
         return Optional.empty();
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return Stream
-            .of(
-                Optional
-                    .ofNullable(this.request)
-                    .map(r -> r.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
-                    .orElse(List.of()),
-                Optional
-                    .ofNullable(this.response)
-                    .map(r -> r.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
-                    .orElse(List.of()),
-                Optional
-                    .ofNullable(this.publish)
-                    .map(p -> p.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
-                    .orElse(List.of()),
-                Optional
-                    .ofNullable(this.subscribe)
-                    .map(s -> s.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
-                    .orElse(List.of())
-            )
+            .of(computePlugins(this.request), computePlugins(this.response), computePlugins(this.publish), computePlugins(this.subscribe))
             .flatMap(List::stream)
             .collect(Collectors.toList());
+    }
+
+    @JsonIgnore
+    private List<Plugin> computePlugins(List<Step> step) {
+        return Optional
+            .ofNullable(step)
+            .map(r -> r.stream().filter(Step::isEnabled).map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+            .orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
@@ -16,6 +16,7 @@
 package io.gravitee.definition.model.v4.flow;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.flow.selector.SelectorType;
 import io.gravitee.definition.model.v4.flow.step.Step;
@@ -26,6 +27,8 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.*;
 
 /**
@@ -72,5 +75,29 @@ public class Flow implements Serializable {
         }
 
         return Optional.empty();
+    }
+
+    public List<Plugin> getPlugins() {
+        return Stream
+            .of(
+                Optional
+                    .ofNullable(this.request)
+                    .map(r -> r.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.response)
+                    .map(r -> r.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.publish)
+                    .map(p -> p.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .orElse(List.of()),
+                Optional
+                    .ofNullable(this.subscribe)
+                    .map(s -> s.stream().map(Step::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+                    .orElse(List.of())
+            )
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.flow.step;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -74,6 +75,7 @@ public class Step implements Serializable {
         return (String) this.configuration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("policy", policy));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
+import java.util.List;
 import lombok.*;
 
 /**
@@ -70,5 +72,9 @@ public class Step implements Serializable {
 
     public String getConfiguration() {
         return (String) this.configuration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("policy", policy));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
@@ -22,6 +22,7 @@ import static io.gravitee.definition.model.v4.listener.Listener.TCP_LABEL;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
@@ -32,6 +33,8 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -96,5 +99,12 @@ public abstract class Listener implements Serializable {
         this.type = b.type;
         this.entrypoints = b.entrypoints;
         this.servers = b.servers;
+    }
+
+    public List<Plugin> getPlugins() {
+        return Optional
+            .ofNullable(this.entrypoints)
+            .map(e -> e.stream().map(Entrypoint::getPlugins).flatMap(List::stream).collect(Collectors.toList()))
+            .orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
@@ -19,6 +19,7 @@ import static io.gravitee.definition.model.v4.listener.Listener.HTTP_LABEL;
 import static io.gravitee.definition.model.v4.listener.Listener.SUBSCRIPTION_LABEL;
 import static io.gravitee.definition.model.v4.listener.Listener.TCP_LABEL;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -101,6 +102,7 @@ public abstract class Listener implements Serializable {
         this.servers = b.servers;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return Optional
             .ofNullable(this.entrypoints)

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/entrypoint/Entrypoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/entrypoint/Entrypoint.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.listener.entrypoint;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -64,6 +65,7 @@ public class Entrypoint implements Serializable {
         this.configuration = configuration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("entrypoint-connector", type));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/entrypoint/Entrypoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/entrypoint/Entrypoint.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import java.io.Serializable;
+import java.util.List;
 import lombok.*;
 
 /**
@@ -60,5 +62,9 @@ public class Entrypoint implements Serializable {
 
     public void setConfiguration(final String configuration) {
         this.configuration = configuration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("entrypoint-connector", type));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
@@ -16,6 +16,7 @@
 package io.gravitee.definition.model.v4.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -23,6 +24,7 @@ import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.*;
 
 /**
@@ -89,5 +91,9 @@ public class Plan implements Serializable {
             this.getSecurity() != null &&
             ("API_KEY".equalsIgnoreCase(this.getSecurity().getType()) || "api-key".equalsIgnoreCase(this.getSecurity().getType()))
         );
+    }
+
+    public List<Plugin> getPlugins() {
+        return this.flows.stream().map(Flow::getPlugins).flatMap(List::stream).collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.plan;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.flow.Flow;
@@ -93,7 +94,8 @@ public class Plan implements Serializable {
         );
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
-        return this.flows.stream().map(Flow::getPlugins).flatMap(List::stream).collect(Collectors.toList());
+        return this.flows.stream().filter(Flow::isEnabled).map(Flow::getPlugins).flatMap(List::stream).collect(Collectors.toList());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/resource/Resource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/resource/Resource.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -68,5 +70,9 @@ public class Resource implements Serializable {
 
     public void setConfiguration(final String configuration) {
         this.configuration = configuration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("resource", type));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/resource/Resource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/resource/Resource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.resource;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -72,6 +73,7 @@ public class Resource implements Serializable {
         this.configuration = configuration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("resource", type));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/ApiServices.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/ApiServices.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.definition.model.v4.service;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import lombok.*;
 
 /**
@@ -40,7 +42,8 @@ public class ApiServices implements Serializable {
     @JsonProperty("dynamicProperty")
     private Service dynamicProperty;
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
-        return dynamicProperty.getPlugins();
+        return Optional.ofNullable(dynamicProperty).filter(Service::isEnabled).map(Service::getPlugins).orElse(List.of());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/ApiServices.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/ApiServices.java
@@ -16,6 +16,7 @@
 package io.gravitee.definition.model.v4.service;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
 import java.util.List;
@@ -38,4 +39,8 @@ public class ApiServices implements Serializable {
 
     @JsonProperty("dynamicProperty")
     private Service dynamicProperty;
+
+    public List<Plugin> getPlugins() {
+        return dynamicProperty.getPlugins();
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/Service.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/Service.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.service;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -67,6 +68,7 @@ public class Service implements Serializable {
         this.configuration = configuration;
     }
 
+    @JsonIgnore
     public List<Plugin> getPlugins() {
         return List.of(new Plugin("service", type));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/Service.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/service/Service.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.Plugin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
+import java.util.List;
 import lombok.*;
 
 /**
@@ -63,5 +65,9 @@ public class Service implements Serializable {
 
     public void setConfiguration(final String configuration) {
         this.configuration = configuration;
+    }
+
+    public List<Plugin> getPlugins() {
+        return List.of(new Plugin("service", type));
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/ApiDefinitionFixtures.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/ApiDefinitionFixtures.java
@@ -23,7 +23,9 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 public class ApiDefinitionFixtures {
@@ -47,7 +49,7 @@ public class ApiDefinitionFixtures {
     }
 
     public static io.gravitee.definition.model.Api anApiV2() {
-        return BASE_V2.get().definitionVersion(DefinitionVersion.V2).build();
+        return BASE_V2.get().definitionVersion(DefinitionVersion.V2).plans(new HashMap<>()).build();
     }
 
     public static io.gravitee.definition.model.Api anApiV1() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.definition.ApiDefinitionFixtures;
+import fixtures.definition.FlowFixtures;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Step;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
+import io.gravitee.definition.model.v4.service.ApiServices;
+import io.gravitee.definition.model.v4.service.Service;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApiTest {
+
+    @Test
+    void getPluginsForApiV2() {
+        Api api = ApiDefinitionFixtures.anApiV2();
+        assertThat(api.getPlugins()).isEmpty();
+
+        Api apiWithResource = ApiDefinitionFixtures.anApiV2();
+        apiWithResource.setResources(List.of(Resource.builder().type("cache").build()));
+        assertThat(apiWithResource.getPlugins()).containsExactly(new Plugin("resource", "cache"));
+
+        Api apiWithFlows = ApiDefinitionFixtures.anApiV2();
+        Flow flow = FlowFixtures.aFlowV2();
+        flow.setPre(List.of(Step.builder().policy("policy-request-validation").build()));
+        flow.setPost(List.of(Step.builder().policy("json-validation").build()));
+        apiWithFlows.setFlows(List.of(flow));
+        assertThat(apiWithFlows.getPlugins())
+            .containsOnly(new Plugin("policy", "policy-request-validation"), new Plugin("policy", "json-validation"));
+
+        Api apiWithPlans = ApiDefinitionFixtures.anApiV2();
+        Plan plan = Plan.builder().flows(List.of(Flow.builder().pre(List.of(Step.builder().policy("json-xml").build())).build())).build();
+        apiWithPlans.setPlans(List.of(plan));
+        assertThat(apiWithPlans.getPlugins()).containsOnly(new Plugin("policy", "json-xml"));
+
+        Api apiWithServices = ApiDefinitionFixtures.anApiV2();
+        Services services = new Services();
+        services.set(List.of(new HealthCheckService()));
+        apiWithServices.setServices(services);
+        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "health-check"));
+    }
+
+    @Test
+    void getPluginsForApiV4() {
+        io.gravitee.definition.model.v4.Api api = ApiDefinitionFixtures.anApiV4();
+        assertThat(api.getPlugins()).isEmpty();
+
+        io.gravitee.definition.model.v4.Api apiWithResource = ApiDefinitionFixtures.anApiV4();
+        apiWithResource.setResources(List.of(io.gravitee.definition.model.v4.resource.Resource.builder().type("cache").build()));
+        assertThat(apiWithResource.getPlugins()).containsExactly(new Plugin("resource", "cache"));
+
+        io.gravitee.definition.model.v4.Api apiWithMessageFlows = ApiDefinitionFixtures.anApiV4();
+        io.gravitee.definition.model.v4.flow.Flow flow = FlowFixtures.aMessageFlowV4();
+        flow.setRequest(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-request-validation").build()));
+        flow.setResponse(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("json-validation").build()));
+        flow.setPublish(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-override-request-method").build()));
+        flow.setSubscribe(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("transform-queryparams").build()));
+        apiWithMessageFlows.setFlows(List.of(flow));
+        assertThat(apiWithMessageFlows.getPlugins())
+            .containsOnly(
+                new Plugin("policy", "policy-request-validation"),
+                new Plugin("policy", "json-validation"),
+                new Plugin("policy", "policy-override-request-method"),
+                new Plugin("policy", "transform-queryparams")
+            );
+
+        io.gravitee.definition.model.v4.Api apiWithProxyFlows = ApiDefinitionFixtures.anApiV4();
+        io.gravitee.definition.model.v4.flow.Flow proxyFlow = FlowFixtures.aProxyFlowV4();
+        proxyFlow.setRequest(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-request-validation").build()));
+        proxyFlow.setResponse(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("json-validation").build()));
+        proxyFlow.setPublish(
+            List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-override-request-method").build())
+        );
+        proxyFlow.setSubscribe(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("transform-queryparams").build()));
+        apiWithProxyFlows.setFlows(List.of(proxyFlow));
+        assertThat(apiWithProxyFlows.getPlugins())
+            .containsOnly(
+                new Plugin("policy", "policy-request-validation"),
+                new Plugin("policy", "json-validation"),
+                new Plugin("policy", "policy-override-request-method"),
+                new Plugin("policy", "transform-queryparams")
+            );
+
+        io.gravitee.definition.model.v4.Api apiWithPlans = ApiDefinitionFixtures.anApiV4();
+        io.gravitee.definition.model.v4.plan.Plan plan = io.gravitee.definition.model.v4.plan.Plan
+            .builder()
+            .flows(
+                List.of(
+                    io.gravitee.definition.model.v4.flow.Flow
+                        .builder()
+                        .request(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("json-xml").build()))
+                        .build()
+                )
+            )
+            .build();
+        apiWithPlans.setPlans(List.of(plan));
+        assertThat(apiWithPlans.getPlugins()).containsOnly(new Plugin("policy", "json-xml"));
+
+        io.gravitee.definition.model.v4.Api apiWithServices = ApiDefinitionFixtures.anApiV4();
+        ApiServices services = new ApiServices();
+        Service dynamicPropertyService = new Service();
+        dynamicPropertyService.setType("health-check");
+        services.setDynamicProperty(dynamicPropertyService);
+        apiWithServices.setServices(services);
+        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "health-check"));
+
+        io.gravitee.definition.model.v4.Api apiWithListeners = ApiDefinitionFixtures.anApiV4();
+        apiWithListeners.setListeners(
+            List.of(SubscriptionListener.builder().entrypoints(List.of(Entrypoint.builder().type("websocket").build())).build())
+        );
+        assertThat(apiWithListeners.getPlugins()).containsOnly(new Plugin("entrypoint-connector", "websocket"));
+
+        io.gravitee.definition.model.v4.Api apiWithEndpoints = ApiDefinitionFixtures.anApiV4();
+        apiWithEndpoints.setEndpointGroups(
+            List.of(EndpointGroup.builder().endpoints(List.of(Endpoint.builder().type("mqtt5").build())).build())
+        );
+        assertThat(apiWithEndpoints.getPlugins()).containsOnly(new Plugin("endpoint-connector", "mqtt5"));
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
@@ -16,15 +16,14 @@
 package io.gravitee.definition.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.definition.ApiDefinitionFixtures;
 import fixtures.definition.FlowFixtures;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -33,21 +32,34 @@ import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ApiTest {
 
     @Test
-    void getPluginsForApiV2() {
+    void getPluginsForEmptyApiV2() {
         Api api = ApiDefinitionFixtures.anApiV2();
         assertThat(api.getPlugins()).isEmpty();
+    }
 
+    @Test
+    void getPluginsForApiV2WithResource() {
         Api apiWithResource = ApiDefinitionFixtures.anApiV2();
-        apiWithResource.setResources(List.of(Resource.builder().type("cache").build()));
+        apiWithResource.setResources(List.of(Resource.builder().type("cache").enabled(true).build()));
         assertThat(apiWithResource.getPlugins()).containsExactly(new Plugin("resource", "cache"));
+    }
 
+    @Test
+    void getPluginsForApiV2WithDisabledResource() {
+        Api apiWithDisabledResource = ApiDefinitionFixtures.anApiV2();
+        apiWithDisabledResource.setResources(List.of(Resource.builder().type("cache").enabled(false).build()));
+        assertThat(apiWithDisabledResource.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV2WithFlows() {
         Api apiWithFlows = ApiDefinitionFixtures.anApiV2();
         Flow flow = FlowFixtures.aFlowV2();
         flow.setPre(List.of(Step.builder().policy("policy-request-validation").build()));
@@ -55,28 +67,129 @@ class ApiTest {
         apiWithFlows.setFlows(List.of(flow));
         assertThat(apiWithFlows.getPlugins())
             .containsOnly(new Plugin("policy", "policy-request-validation"), new Plugin("policy", "json-validation"));
+    }
 
+    @Test
+    void getPluginsForApiV2WithDisabledFlows() {
+        Api apiWithDisabledFlows = ApiDefinitionFixtures.anApiV2();
+        Flow disabledFlow = FlowFixtures.aFlowV2();
+        disabledFlow.setEnabled(false);
+        disabledFlow.setPre(List.of(Step.builder().policy("policy-request-validation").build()));
+        disabledFlow.setPost(List.of(Step.builder().policy("json-validation").build()));
+        apiWithDisabledFlows.setFlows(List.of(disabledFlow));
+        assertThat(apiWithDisabledFlows.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV2WithPlans() {
         Api apiWithPlans = ApiDefinitionFixtures.anApiV2();
         Plan plan = Plan.builder().flows(List.of(Flow.builder().pre(List.of(Step.builder().policy("json-xml").build())).build())).build();
         apiWithPlans.setPlans(List.of(plan));
         assertThat(apiWithPlans.getPlugins()).containsOnly(new Plugin("policy", "json-xml"));
+    }
 
+    @Test
+    void getPluginsForApiV2WithServices() {
         Api apiWithServices = ApiDefinitionFixtures.anApiV2();
         Services services = new Services();
         services.set(List.of(new HealthCheckService()));
         apiWithServices.setServices(services);
-        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "health-check"));
+        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "healthcheck"));
     }
 
     @Test
-    void getPluginsForApiV4() {
+    void getPluginsForApiV2WithDisabledServices() {
+        Api apiWithDisabledServices = ApiDefinitionFixtures.anApiV2();
+        Services services = new Services();
+        io.gravitee.definition.model.Service service = new HealthCheckService();
+        service.setEnabled(false);
+        services.set(List.of(service));
+        apiWithDisabledServices.setServices(services);
+        assertThat(apiWithDisabledServices.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV2WithProxy() {
+        Api apiWithProxy = ApiDefinitionFixtures.anApiV2();
+        Services services = new Services();
+        EndpointDiscoveryService endpointDiscoveryService = new EndpointDiscoveryService();
+        endpointDiscoveryService.setProvider("provider");
+        io.gravitee.definition.model.Service healthCheckService = new HealthCheckService();
+        io.gravitee.definition.model.Service dynamicPropertyService = new DynamicPropertyService();
+        services.set(List.of(endpointDiscoveryService, healthCheckService, dynamicPropertyService));
+        apiWithProxy.setProxy(
+            Proxy
+                .builder()
+                .groups(
+                    Set.of(
+                        io.gravitee.definition.model.EndpointGroup
+                            .builder()
+                            .endpoints(Set.of(io.gravitee.definition.model.Endpoint.builder().type("http").build()))
+                            .services(services)
+                            .build()
+                    )
+                )
+                .build()
+        );
+        assertThat(apiWithProxy.getPlugins())
+            .containsOnly(
+                new Plugin("connector", "connector-http"),
+                new Plugin("service_discovery", "provider"),
+                new Plugin("service", "healthcheck"),
+                new Plugin("service", "mgmt-service-dynamicproperties")
+            );
+    }
+
+    @Test
+    void getPluginsForApiV2WithProxyWithDisabledService() {
+        Api apiWithProxy = ApiDefinitionFixtures.anApiV2();
+        Services services = new Services();
+        io.gravitee.definition.model.Service service = new HealthCheckService();
+        service.setEnabled(false);
+        services.set(List.of(service));
+        apiWithProxy.setProxy(
+            Proxy
+                .builder()
+                .groups(
+                    Set.of(
+                        io.gravitee.definition.model.EndpointGroup
+                            .builder()
+                            .endpoints(Set.of(io.gravitee.definition.model.Endpoint.builder().type("http").build()))
+                            .services(services)
+                            .build()
+                    )
+                )
+                .build()
+        );
+        assertThat(apiWithProxy.getPlugins()).containsOnly(new Plugin("connector", "connector-http"));
+    }
+
+    @Test
+    void getPluginsForEmptyApiV4() {
         io.gravitee.definition.model.v4.Api api = ApiDefinitionFixtures.anApiV4();
         assertThat(api.getPlugins()).isEmpty();
+    }
 
+    @Test
+    void getPluginsForApiV4WithResources() {
         io.gravitee.definition.model.v4.Api apiWithResource = ApiDefinitionFixtures.anApiV4();
-        apiWithResource.setResources(List.of(io.gravitee.definition.model.v4.resource.Resource.builder().type("cache").build()));
+        apiWithResource.setResources(
+            List.of(io.gravitee.definition.model.v4.resource.Resource.builder().type("cache").enabled(true).build())
+        );
         assertThat(apiWithResource.getPlugins()).containsExactly(new Plugin("resource", "cache"));
+    }
 
+    @Test
+    void getPluginsForApiV4WithDisabledResources() {
+        io.gravitee.definition.model.v4.Api apiWithDisabledResource = ApiDefinitionFixtures.anApiV4();
+        apiWithDisabledResource.setResources(
+            List.of(io.gravitee.definition.model.v4.resource.Resource.builder().type("cache").enabled(false).build())
+        );
+        assertThat(apiWithDisabledResource.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV4WithFlows() {
         io.gravitee.definition.model.v4.Api apiWithMessageFlows = ApiDefinitionFixtures.anApiV4();
         io.gravitee.definition.model.v4.flow.Flow flow = FlowFixtures.aMessageFlowV4();
         flow.setRequest(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-request-validation").build()));
@@ -91,7 +204,29 @@ class ApiTest {
                 new Plugin("policy", "policy-override-request-method"),
                 new Plugin("policy", "transform-queryparams")
             );
+    }
 
+    @Test
+    void getPluginsForApiV4WithDisabledFlows() {
+        io.gravitee.definition.model.v4.Api apiWithMessageFlowsDisabled = ApiDefinitionFixtures.anApiV4();
+        io.gravitee.definition.model.v4.flow.Flow flowDisabled = FlowFixtures.aMessageFlowV4();
+        flowDisabled.setEnabled(false);
+        flowDisabled.setRequest(
+            List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-request-validation").build())
+        );
+        flowDisabled.setResponse(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("json-validation").build()));
+        flowDisabled.setPublish(
+            List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-override-request-method").build())
+        );
+        flowDisabled.setSubscribe(
+            List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("transform-queryparams").build())
+        );
+        apiWithMessageFlowsDisabled.setFlows(List.of(flowDisabled));
+        assertThat(apiWithMessageFlowsDisabled.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV4WithProxyFlows() {
         io.gravitee.definition.model.v4.Api apiWithProxyFlows = ApiDefinitionFixtures.anApiV4();
         io.gravitee.definition.model.v4.flow.Flow proxyFlow = FlowFixtures.aProxyFlowV4();
         proxyFlow.setRequest(List.of(io.gravitee.definition.model.v4.flow.step.Step.builder().policy("policy-request-validation").build()));
@@ -108,7 +243,10 @@ class ApiTest {
                 new Plugin("policy", "policy-override-request-method"),
                 new Plugin("policy", "transform-queryparams")
             );
+    }
 
+    @Test
+    void getPluginsForApiV4WithPlans() {
         io.gravitee.definition.model.v4.Api apiWithPlans = ApiDefinitionFixtures.anApiV4();
         io.gravitee.definition.model.v4.plan.Plan plan = io.gravitee.definition.model.v4.plan.Plan
             .builder()
@@ -123,7 +261,10 @@ class ApiTest {
             .build();
         apiWithPlans.setPlans(List.of(plan));
         assertThat(apiWithPlans.getPlugins()).containsOnly(new Plugin("policy", "json-xml"));
+    }
 
+    @Test
+    void getPluginsForApiV4WithServices() {
         io.gravitee.definition.model.v4.Api apiWithServices = ApiDefinitionFixtures.anApiV4();
         ApiServices services = new ApiServices();
         Service dynamicPropertyService = new Service();
@@ -131,13 +272,31 @@ class ApiTest {
         services.setDynamicProperty(dynamicPropertyService);
         apiWithServices.setServices(services);
         assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "health-check"));
+    }
 
+    @Test
+    void getPluginsForApiV4WithDisabledServices() {
+        io.gravitee.definition.model.v4.Api apiWithDisabledServices = ApiDefinitionFixtures.anApiV4();
+        ApiServices services = new ApiServices();
+        Service dynamicPropertyService = new Service();
+        dynamicPropertyService.setType("health-check");
+        dynamicPropertyService.setEnabled(false);
+        services.setDynamicProperty(dynamicPropertyService);
+        apiWithDisabledServices.setServices(services);
+        assertThat(apiWithDisabledServices.getPlugins()).isEmpty();
+    }
+
+    @Test
+    void getPluginsForApiV4WithListeners() {
         io.gravitee.definition.model.v4.Api apiWithListeners = ApiDefinitionFixtures.anApiV4();
         apiWithListeners.setListeners(
             List.of(SubscriptionListener.builder().entrypoints(List.of(Entrypoint.builder().type("websocket").build())).build())
         );
         assertThat(apiWithListeners.getPlugins()).containsOnly(new Plugin("entrypoint-connector", "websocket"));
+    }
 
+    @Test
+    void getPluginsForApiV4WithEndpoints() {
         io.gravitee.definition.model.v4.Api apiWithEndpoints = ApiDefinitionFixtures.anApiV4();
         apiWithEndpoints.setEndpointGroups(
             List.of(EndpointGroup.builder().endpoints(List.of(Endpoint.builder().type("mqtt5").build())).build())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3605

## Description

Use API definition to compute the list of plugins used by an API. 
This plugins list will be provided to the licenseManager to check if API can be deployed on the Gateway.
