### PR TITLE
fix(helm): backward incompatibility during helm upgrade

### DIFF
--- a/helm/templates/api/api-autoscaler.yaml
+++ b/helm/templates/api/api-autoscaler.yaml
@@ -11,13 +11,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-bridge-ingress.yaml
+++ b/helm/templates/api/api-bridge-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -26,7 +26,7 @@ metadata:
     {{- if .Values.api.services.bridge.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.services.bridge.ingress.annotations "ingressClassName" .Values.api.services.bridge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -22,7 +22,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -33,7 +33,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -61,7 +61,7 @@ spec:
         {{- range $key, $value := .Values.api.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- if .Values.common.annotations }}
+        {{- if and .Values.common .Values.common.annotations }}
         {{- range $key, $value := .Values.common.annotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
@@ -80,7 +80,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- if .Values.common.labels }}
+        {{- if and .Values.common .Values.common.labels }}
         {{- range $key, $value := .Values.common.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/helm/templates/api/api-ingress-management.yaml
+++ b/helm/templates/api/api-ingress-management.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.api.ingress.management.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.management.annotations "ingressClassName" .Values.api.ingress.management.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-ingress-portal.yaml
+++ b/helm/templates/api/api-ingress-portal.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.api.ingress.portal.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.ingress.portal.annotations "ingressClassName" .Values.api.ingress.portal.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-pdb.yaml
+++ b/helm/templates/api/api-pdb.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-service.yaml
+++ b/helm/templates/api/api-service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -19,7 +19,7 @@ metadata:
     {{- range $key, $value := .Values.api.service.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-technical-ingress.yaml
+++ b/helm/templates/api/api-technical-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.api.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.api.http.services.core.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.http.services.core.ingress.annotations "ingressClassName" .Values.api.http.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -21,7 +21,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -34,7 +34,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/common/rolebinding.yaml
+++ b/helm/templates/common/rolebinding.yaml
@@ -9,13 +9,13 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: "{{ .Values.apim.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/common/serviceaccount.yaml
+++ b/helm/templates/common/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- with .Values.apim.serviceAccountAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: "{{ .Values.apim.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-autoscaler.yaml
+++ b/helm/templates/gateway/gateway-autoscaler.yaml
@@ -11,14 +11,14 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
     {{- $annotations := dict }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- $annotations = merge $annotations .Values.common.annotations }}
     {{- end }}
     {{- range $key, $value := $annotations }}

--- a/helm/templates/gateway/gateway-bridge-ingress.yaml
+++ b/helm/templates/gateway/gateway-bridge-ingress.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -26,7 +26,7 @@ metadata:
     {{- if .Values.gateway.services.bridge.ingress.annotations }}
       {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.bridge.ingress.annotations "ingressClassName" .Values.gateway.services.bridge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -13,13 +13,13 @@ metadata:
     {{- if .Values.gateway.ingressController }}
     gravitee.io/component: ingress
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -22,13 +22,13 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-ingress.yaml
+++ b/helm/templates/gateway/gateway-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.gateway.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.ingress.annotations "ingressClassName" .Values.gateway.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-pdb.yaml
+++ b/helm/templates/gateway/gateway-pdb.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-service.yaml
+++ b/helm/templates/gateway/gateway-service.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/gateway/gateway-technical-ingress.yaml
+++ b/helm/templates/gateway/gateway-technical-ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- if .Values.gateway.services.core.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/portal/portal-autoscaler.yaml
+++ b/helm/templates/portal/portal-autoscaler.yaml
@@ -11,13 +11,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.portal.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/portal/portal-configmap.yaml
+++ b/helm/templates/portal/portal-configmap.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.portal.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/portal/portal-deployment.yaml
+++ b/helm/templates/portal/portal-deployment.yaml
@@ -20,7 +20,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -31,7 +31,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -59,7 +59,7 @@ spec:
         {{- range $key, $value := .Values.portal.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- if .Values.common.annotations }}
+        {{- if and .Values.common .Values.common.annotations }}
         {{- range $key, $value := .Values.common.annotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
@@ -78,7 +78,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-        {{- if .Values.common.labels }}
+        {{- if and .Values.common .Values.common.labels }}
         {{- range $key, $value := .Values.common.labels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/helm/templates/portal/portal-ingress.yaml
+++ b/helm/templates/portal/portal-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.portal.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.portal.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.portal.ingress.annotations "ingressClassName" .Values.portal.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/portal/portal-pdb.yaml
+++ b/helm/templates/portal/portal-pdb.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.portal.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/portal/portal-service.yaml
+++ b/helm/templates/portal/portal-service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.portal.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -19,7 +19,7 @@ metadata:
     {{- range $key, $value := .Values.portal.service.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/ui/ui-autoscaler.yaml
+++ b/helm/templates/ui/ui-autoscaler.yaml
@@ -11,13 +11,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.ui.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/ui/ui-configmap.yaml
+++ b/helm/templates/ui/ui-configmap.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.ui.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -20,7 +20,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -31,7 +31,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -59,7 +59,7 @@ spec:
         {{- range $key, $value := .Values.ui.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-        {{- if .Values.common.annotations }}
+        {{- if and .Values.common .Values.common.annotations }}
         {{- range $key, $value := .Values.common.annotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}

--- a/helm/templates/ui/ui-ingress.yaml
+++ b/helm/templates/ui/ui-ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.ui.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -25,7 +25,7 @@ metadata:
     {{- if .Values.ui.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.ui.ingress.annotations "ingressClassName" .Values.ui.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/ui/ui-pdb.yaml
+++ b/helm/templates/ui/ui-pdb.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.ui.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}

--- a/helm/templates/ui/ui-service.yaml
+++ b/helm/templates/ui/ui-service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.ui.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.common.labels }}
+    {{- if and .Values.common .Values.common.labels }}
     {{- range $key, $value := .Values.common.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
@@ -19,7 +19,7 @@ metadata:
     {{- range $key, $value := .Values.ui.service.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-    {{- if .Values.common.annotations }}
+    {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3638

## Description

Since helm chart related to APIM 3.20.21 we introduce the commit `2f117b5` which implies a backward compatibility issue. In fact, a values.yml without common.labels definition cannot be used. This should be fixed by set optional this definition.

Howto reproduce the issue:

```
sed -i -e '/common:/,/ *annotations:/d' values.yaml

cd helm
helm install graviteeio-apim . --version 3.20.20 -f values.yaml --create-namespace --namespace test-playground
```

This helm install failed.

