### PR TITLE
fix(service): validate endpoint group type by api type

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -120,7 +120,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             )
         );
         // Validate and clean endpoints
-        newApiEntity.setEndpointGroups(endpointGroupsValidationService.validateAndSanitize(newApiEntity.getEndpointGroups()));
+        newApiEntity.setEndpointGroups(
+            endpointGroupsValidationService.validateAndSanitize(newApiEntity.getType(), newApiEntity.getEndpointGroups())
+        );
         // Validate and clean logging
         newApiEntity.setAnalytics(
             analyticsValidationService.validateAndSanitize(executionContext, newApiEntity.getType(), newApiEntity.getAnalytics())
@@ -171,7 +173,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             )
         );
         // Validate and clean endpoints
-        updateApiEntity.setEndpointGroups(endpointGroupsValidationService.validateAndSanitize(updateApiEntity.getEndpointGroups()));
+        updateApiEntity.setEndpointGroups(
+            endpointGroupsValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getEndpointGroups())
+        );
         // Validate and clean logging
         updateApiEntity.setAnalytics(
             analyticsValidationService.validateAndSanitize(executionContext, updateApiEntity.getType(), updateApiEntity.getAnalytics())
@@ -214,7 +218,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             listenerValidationService.validateAndSanitize(executionContext, null, apiEntity.getListeners(), apiEntity.getEndpointGroups())
         );
         // Validate and clean endpoints
-        apiEntity.setEndpointGroups(endpointGroupsValidationService.validateAndSanitize(apiEntity.getEndpointGroups()));
+        apiEntity.setEndpointGroups(
+            endpointGroupsValidationService.validateAndSanitize(apiEntity.getType(), apiEntity.getEndpointGroups())
+        );
         // Validate and clean logging
         apiEntity.setAnalytics(
             analyticsValidationService.validateAndSanitize(executionContext, apiEntity.getType(), apiEntity.getAnalytics())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.v4.validation;
 
 import io.gravitee.definition.model.Endpoint;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.ConnectorService;
@@ -27,5 +28,5 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface EndpointGroupsValidationService {
-    List<EndpointGroup> validateAndSanitize(List<EndpointGroup> endpointGroups);
+    List<EndpointGroup> validateAndSanitize(ApiType apiType, List<EndpointGroup> endpointGroups);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -134,7 +134,7 @@ public class ApiValidationServiceImplTest {
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null);
         verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
         verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
-        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(null);
+        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), newApiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(resourcesValidationService, never()).validateAndSanitize(any());
@@ -156,7 +156,7 @@ public class ApiValidationServiceImplTest {
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, Set.of());
         verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
         verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
-        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(null);
+        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2631

## Description

- V4 Proxy Apis can only have a `http-proxy` endpoint group type
- V4 Message Apis cannot have a `http-proxy` endpoint group type

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

