### PR TITLE
fix(console): only filter subscriptions by non-keyless plans

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/list/api-general-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/list/api-general-subscription-list.component.spec.ts
@@ -66,6 +66,7 @@ describe('ApiGeneralSubscriptionListComponent', () => {
   const APPLICATION_ID = 'application_1';
   const anAPI = fakeApiV4({ id: API_ID });
   const aPlan = fakePlanV4({ id: PLAN_ID, apiId: API_ID });
+  const aKeylessPlan = fakePlanV4({ id: 'keyless-plan', apiId: API_ID, name: 'Keyless plan', security: { type: 'KEY_LESS' } });
   const anApplication = fakeApplication({ id: APPLICATION_ID, owner: { displayName: 'Gravitee.io' } });
 
   let fixture: ComponentFixture<TestComponent>;
@@ -157,6 +158,22 @@ describe('ApiGeneralSubscriptionListComponent', () => {
       const apiKeyInput = await harness.getApiKeyInput();
       expect(await apiKeyInput.isDisabled()).toEqual(false);
       expect(await apiKeyInput.getValue()).toEqual('apiKey_1');
+    }));
+
+    it('should not include keyless plan in plan filters', fakeAsync(async () => {
+      await initComponent([], anAPI, [aPlan, aKeylessPlan], [anApplication], {
+        plan: PLAN_ID,
+        application: APPLICATION_ID,
+        status: 'CLOSED,REJECTED',
+        apiKey: 'apiKey_1',
+      });
+      const harness = await loader.getHarness(ApiGeneralSubscriptionListHarness);
+
+      const planSelectInput = await harness.getPlanSelectInput();
+      await planSelectInput.open();
+      const planSelectOptions = await planSelectInput.getOptions();
+      expect(planSelectOptions.length).toEqual(1);
+      expect(await planSelectOptions[0].getText()).toEqual('Default plan');
     }));
 
     it('should reset filters from params', fakeAsync(async () => {

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/list/api-general-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/list/api-general-subscription-list.component.ts
@@ -145,7 +145,7 @@ export class ApiGeneralSubscriptionListComponent implements OnInit, OnDestroy {
             this.api.definitionVersion !== 'V1';
         }),
         switchMap(() => this.apiPlanService.list(this.activatedRoute.snapshot.params.apiId, null, null, null, 1, 9999)),
-        tap((plansResponse) => (this.plans = plansResponse.data)),
+        tap((plansResponse) => (this.plans = plansResponse.data.filter((plan) => plan.security?.type !== 'KEY_LESS'))),
         catchError((error) => {
           this.snackBarService.error(error.message);
           return EMPTY;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3026

## Description

When in the subscription view, the user must only be able to filter by non-keyless plans

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nsbtvonwri.chromatic.com)
<!-- Storybook placeholder end -->
