### PR TITLE
fix: pathmapping must ends with /

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -212,7 +212,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
                 .elements()
                 .forEachRemaining(jsonNode -> {
                     String pathMapping = jsonNode.asText();
-                    String pathMappingRegex = pathMapping.replaceAll(":[^/]*", "[^/]*");
+                    String pathMappingRegex = pathMapping.replaceAll(":[^/]*", "[^/]*") + "/*";
                     Pattern pattern = Pattern.compile(pathMappingRegex);
                     api.getPathMappings().put(pathMapping, pattern);
                 });

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -160,12 +160,27 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals(1, api.getPathMappings().size());
         Pattern pattern = api.getPathMappings().get("/echo/:*test/.*");
         assertNotNull(pattern);
-        assertEquals("/echo/[^/]*/.*", pattern.pattern());
+        assertEquals("/echo/[^/]*/.*/*", pattern.pattern());
         assertFalse(pattern.matcher("/echo").matches());
         assertFalse(pattern.matcher("/echo/").matches());
         assertFalse(pattern.matcher("/echo/anything").matches());
         assertTrue(pattern.matcher("/echo/anything/").matches());
         assertTrue(pattern.matcher("/echo/anything/anything-else").matches());
+    }
+
+    @Test
+    public void definition_withoutWildcardInPathMapping() throws IOException {
+        Api api = load("/io/gravitee/definition/jackson/api-without-wildcard-in-path-mapping.json", Api.class);
+        assertNotNull(api.getPathMappings());
+        assertEquals(1, api.getPathMappings().size());
+        Pattern pattern = api.getPathMappings().get("/echo/:test");
+        assertNotNull(pattern);
+        assertEquals("/echo/[^/]*/*", pattern.pattern());
+        assertFalse(pattern.matcher("/echo").matches());
+        assertTrue(pattern.matcher("/echo/").matches());
+        assertTrue(pattern.matcher("/echo/anything").matches());
+        assertTrue(pattern.matcher("/echo/anything/").matches());
+        assertFalse(pattern.matcher("/echo/anything/anything-else").matches());
     }
 
     @Test

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-without-wildcard-in-path-mapping.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-without-wildcard-in-path-mapping.json
@@ -1,0 +1,18 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:1234"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": true
+  },
+  "path_mappings": [
+    "/echo/:test"
+  ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3645

## Description

Fixing a bug introduced with https://gravitee.atlassian.net/browse/APIM-2611.
The pattern must ends with a `/`