### PR TITLE
chore: bump chart version

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apim
 # Also update CHANGELOG.md
-version: 4.2.0
-appVersion: 4.2.0
+version: 4.3.0
+appVersion: 4.3.0
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io
 sources:

--- a/helm/tests/gateway/configmap_ingress_controller_test.yaml
+++ b/helm/tests/gateway/configmap_ingress_controller_test.yaml
@@ -10,6 +10,7 @@ tests:
   - it: Set the Gateway Ingress Controller enabled
     chart:
       appVersion: 4.2.0
+      version: 4.2.0
     set:
       gateway:
         enabled: true


### PR DESCRIPTION
The helm chart release staging script fails because it looks for a 4.3.0 version
