### PR TITLE
feat(mapi-v2): add endpoint to return license by org id

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1073,6 +1073,33 @@ paths:
                                 $ref: "#/components/schemas/Organization"
                 default:
                     $ref: "#/components/responses/Error"
+    /organizations/{orgId}/license:
+        servers:
+            - url: /management/v2
+              description: Gravitee.io APIM - Management API -v2
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+        get:
+            tags:
+                - Installation
+            summary: Get the license used by an organization.
+            description: |-
+                Returns the organization license information.
+                If no license is scoped to the organization, then the platform license is returned.
+
+                User must be authenticated.
+            operationId: getOrganizationLicense
+            responses:
+                "200":
+                    description: |-
+                        The license and its features. If there is no license, then the features will be empty.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/GraviteeLicense"
+                default:
+                    $ref: "#/components/responses/Error"
+
 
     # API Subscriptions
     /environments/{envId}/apis/{apiId}/subscribers:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3560

## Description

Add an endpoint to return the license of a given organization.
If there is no license scoped to a specific organization, then the platform license is returned.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yxfcfwtgen.chromatic.com)
<!-- Storybook placeholder end -->
