### PR TITLE
feat: add host property to el requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.4.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.4.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>5.1.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>


### PR DESCRIPTION
this bump of gateway-api allows to get the host of a request using `{#request.host}` and enables retrieving the host on http2 requests where the host header is not available

see https://gravitee.atlassian.net/browse/APIM-3651

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jnlzubfcia.chromatic.com)
<!-- Storybook placeholder end -->
