### PR TITLE
fix: use correct variable to configure installation proxy in HelloCommand

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -59,7 +59,7 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
     @Value("${installation.api.url:http://localhost:8083}")
     private String apiURL;
 
-    @Value("${installation.api.management.proxyPath:${http.api.management.entrypoint:${http.api.entrypoint:/}management}}")
+    @Value("${installation.api.proxyPath.management:${http.api.management.entrypoint:${http.api.entrypoint:/}management}}")
     private String managementProxyPath;
 
     @Value("${cockpit.auth.path:/auth/cockpit?token={token}}")


### PR DESCRIPTION

Make sure the HelloCommand uses the correct variable to configure the proxyPath. It is being used already by
-  InstallationAccessQueryServiceImpl
https://github.com/gravitee-io/gravitee-api-management/blob/1cd987134b5167351b4a2f2b24f95db8ade089ed/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java#L58
-  and generated via Helm values: https://github.com/gravitee-io/gravitee-api-management/blob/9e65749b0bc5179b99e70604e88ff36cc8ac1dd1/helm/templates/api/api-configmap.yaml#L99C18-L114C26

