### PR TITLE
feat: load boot plugins

### DIFF
--- a/gravitee-apim-console-webui/angular.json
+++ b/gravitee-apim-console-webui/angular.json
@@ -166,7 +166,8 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
             "proxyConfig": "proxy.conf.mjs",
-            "browserTarget": "apim-console:build"
+            "browserTarget": "apim-console:build",
+            "disableHostCheck": true
           },
           "configurations": {
             "production": {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-connector/src/main/java/io/gravitee/gateway/connector/spring/ConnectorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-connector/src/main/java/io/gravitee/gateway/connector/spring/ConnectorConfiguration.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import(ConnectorPluginConfiguration.class)
 public class ConnectorConfiguration {
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
@@ -42,7 +42,6 @@ public class ApiManagementEndpoint implements Handler<RoutingContext>, Managemen
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApiManagementEndpoint.class);
 
-    @Lazy
     @Autowired
     private ApiManager apiManager;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
@@ -44,7 +44,6 @@ public class ApisManagementEndpoint implements Handler<RoutingContext>, Manageme
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApisManagementEndpoint.class);
 
-    @Lazy
     @Autowired
     private ApiManager apiManager;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -78,7 +78,6 @@ public class ApiHandlerConfiguration {
     @Autowired
     private io.gravitee.node.api.configuration.Configuration configuration;
 
-    @Lazy
     @Bean
     public ApiManager apiManager(EventManager eventManager, GatewayConfiguration gatewayConfiguration, DataEncryptor dataEncryptor) {
         return new ApiManagerImpl(eventManager, gatewayConfiguration, dataEncryptor);
@@ -124,7 +123,6 @@ public class ApiHandlerConfiguration {
         return new SpringComponentProvider(applicationContext);
     }
 
-    @Lazy
     @Bean
     public DataEncryptor apiPropertiesEncryptor(Environment environment) {
         return new DataEncryptor(environment, "api.properties.encryption.secret", "vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/GatewayContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/GatewayContainer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.standalone;
 
+import io.gravitee.gateway.standalone.node.GatewayNode;
 import io.gravitee.gateway.standalone.spring.StandaloneConfiguration;
 import io.gravitee.node.container.spring.SpringBasedContainer;
 import java.util.List;
@@ -24,6 +25,10 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public class GatewayContainer extends SpringBasedContainer {
+
+    public GatewayContainer() {
+        super(GatewayNode.class);
+    }
 
     @Override
     protected List<Class<?>> annotatedClasses() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -33,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class GatewayNode extends AbstractNode {
 
+    @Lazy
     @Autowired
     private NodeMetadataResolver nodeMetadataResolver;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
@@ -52,10 +52,6 @@ public class GatewayNodeMetadataResolver implements NodeMetadataResolver {
 
     @Lazy
     @Autowired
-    private LicenseRepository licenseRepository;
-
-    @Lazy
-    @Autowired
     private EnvironmentRepository environmentRepository;
 
     @Autowired

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.standalone.spring;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.apim.plugin.reactor.spring.ReactorPluginConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.EventManagerImpl;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -37,19 +36,9 @@ import io.gravitee.gateway.standalone.node.GatewayNode;
 import io.gravitee.gateway.standalone.node.GatewayNodeMetadataResolver;
 import io.gravitee.gateway.standalone.vertx.VertxReactorConfiguration;
 import io.gravitee.node.api.NodeMetadataResolver;
-import io.gravitee.node.certificates.spring.NodeCertificatesConfiguration;
 import io.gravitee.node.container.NodeFactory;
-import io.gravitee.node.kubernetes.spring.NodeKubernetesConfiguration;
-import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
-import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
-import io.gravitee.plugin.apiservice.spring.ApiServicePluginConfiguration;
-import io.gravitee.plugin.core.spring.PluginConfiguration;
-import io.gravitee.plugin.discovery.spring.ServiceDiscoveryPluginConfiguration;
-import io.gravitee.plugin.endpoint.spring.EndpointConnectorPluginConfiguration;
-import io.gravitee.plugin.entrypoint.spring.EntrypointConnectorPluginConfiguration;
 import io.gravitee.plugin.policy.spring.PolicyPluginConfiguration;
-import io.gravitee.plugin.resource.spring.ResourcePluginConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -61,26 +50,14 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import(
     {
-        VertxConfiguration.class,
         ReactorConfiguration.class,
-        NodeCertificatesConfiguration.class,
-        NodeKubernetesConfiguration.class,
         VertxReactorConfiguration.class,
-        PluginConfiguration.class,
-        PolicyPluginConfiguration.class,
-        ResourcePluginConfiguration.class,
         ReporterConfiguration.class,
         ApiHandlerConfiguration.class,
         DictionaryConfiguration.class,
-        AlertPluginConfiguration.class,
-        ServiceDiscoveryPluginConfiguration.class,
         PolicyConfiguration.class,
         PlatformConfiguration.class,
         ConnectorConfiguration.class,
-        EntrypointConnectorPluginConfiguration.class,
-        ApiServicePluginConfiguration.class,
-        EndpointConnectorPluginConfiguration.class,
-        ReactorPluginConfiguration.class,
         TimeoutConfiguration.class,
     }
 )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -49,7 +49,6 @@ public class VertxReactorConfiguration {
 
     protected static final String SERVERS_PREFIX = "servers";
 
-    @Lazy
     @Bean
     public ServerManager serverManager(
         VertxServerFactory<VertxServer<?, VertxServerOptions>, VertxServerOptions> serverFactory,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/junit/stmt/ApiDeployerStatement.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/junit/stmt/ApiDeployerStatement.java
@@ -82,6 +82,7 @@ public class ApiDeployerStatement extends Statement {
         System.setProperty("gravitee.conf", graviteeHome + File.separator + "config" + File.separator + "gravitee.yml");
 
         GatewayTestContainer container = new GatewayTestContainer();
+        container.initialize();
         applicationContext = container.applicationContext();
         final Environment environment = applicationContext.getBean(Environment.class);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.gateway.tests.sdk;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.gravitee.apim.gateway.tests.sdk.utils.URLUtils.exchangePort;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,6 +37,7 @@ import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.platform.organization.ReactableOrganization;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.node.container.spring.env.GraviteeYamlPropertySource;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.reactivex.rxjava3.observers.TestObserver;
@@ -64,6 +64,8 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
 import org.springframework.test.util.TestSocketUtils;
 import org.springframework.util.StringUtils;
 
@@ -140,6 +142,15 @@ public abstract class AbstractGatewayTest
      */
     protected <T> T getBean(Class<T> requiredType) {
         return applicationContext.getBean(requiredType);
+    }
+
+    /**
+     * Get the Spring {@link io.gravitee.node.container.spring.env.GraviteeYamlPropertySource} bean.
+     * @return the Spring {@link io.gravitee.node.container.spring.env.GraviteeYamlPropertySource} bean.
+     */
+    protected GraviteeYamlPropertySource getGraviteeYamlProperties() {
+        final ConfigurableEnvironment environment = (ConfigurableEnvironment) getBean(Environment.class);
+        return (GraviteeYamlPropertySource) environment.getPropertySources().get("graviteeYamlConfiguration");
     }
 
     protected AbstractGatewayTest() {}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-handler/src/main/java/io/gravitee/plugin/apiservice/internal/ApiServicePluginHandler.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-handler/src/main/java/io/gravitee/plugin/apiservice/internal/ApiServicePluginHandler.java
@@ -18,6 +18,7 @@ package io.gravitee.plugin.apiservice.internal;
 import io.gravitee.gateway.reactive.api.apiservice.ApiServiceConfiguration;
 import io.gravitee.plugin.apiservice.ApiServicePlugin;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
+import io.gravitee.plugin.apiservice.spring.ApiServicePluginConfiguration;
 import io.gravitee.plugin.core.api.AbstractSimplePluginHandler;
 import io.gravitee.plugin.core.api.Plugin;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.net.URLClassLoader;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -32,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @AllArgsConstructor
 @NoArgsConstructor
+@Import(ApiServicePluginConfiguration.class)
 public class ApiServicePluginHandler extends AbstractSimplePluginHandler<ApiServicePlugin<?, ?>> {
 
     @Autowired

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-handler/src/main/java/io/gravitee/plugin/endpoint/internal/EndpointConnectorPluginHandler.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-handler/src/main/java/io/gravitee/plugin/endpoint/internal/EndpointConnectorPluginHandler.java
@@ -17,16 +17,18 @@ package io.gravitee.plugin.endpoint.internal;
 
 import io.gravitee.gateway.reactive.api.connector.endpoint.EndpointConnectorConfiguration;
 import io.gravitee.plugin.core.api.AbstractSimplePluginHandler;
-import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.spring.EndpointConnectorPluginConfiguration;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author GraviteeSource Team
  */
+@Import(EndpointConnectorPluginConfiguration.class)
 public class EndpointConnectorPluginHandler extends AbstractSimplePluginHandler<EndpointConnectorPlugin<?, ?>> {
 
     @Autowired

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/internal/EntrypointConnectorPluginHandler.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/internal/EntrypointConnectorPluginHandler.java
@@ -20,14 +20,17 @@ import io.gravitee.plugin.core.api.AbstractSimplePluginHandler;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.spring.EntrypointConnectorPluginConfiguration;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Import(EntrypointConnectorPluginConfiguration.class)
 public class EntrypointConnectorPluginHandler extends AbstractSimplePluginHandler<EntrypointConnectorPlugin<?, ?>> {
 
     @Autowired

--- a/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManager.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManager.java
@@ -46,11 +46,12 @@ public class DefaultReactorPluginManager extends AbstractPluginManager<ReactorPl
     public DefaultReactorPluginManager(
         ApplicationContext applicationContext,
         PluginContextFactory pluginContextFactory,
+        ReactorFactoryManager factoryManager,
         ServiceManager serviceManager
     ) {
         this.applicationContext = applicationContext;
         this.pluginContextFactory = pluginContextFactory;
-        this.factoryManager = applicationContext.getBean(ReactorFactoryManager.class);
+        this.factoryManager = factoryManager;
         this.serviceManager = serviceManager;
     }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/ReactorPluginHandler.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/ReactorPluginHandler.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.plugin.reactor.internal;
 
 import io.gravitee.apim.plugin.reactor.ReactorPlugin;
 import io.gravitee.apim.plugin.reactor.ReactorPluginManager;
+import io.gravitee.apim.plugin.reactor.spring.ReactorPluginConfiguration;
 import io.gravitee.plugin.core.api.AbstractSimplePluginHandler;
 import io.gravitee.plugin.core.api.Plugin;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.net.URLClassLoader;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -31,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @AllArgsConstructor
 @NoArgsConstructor
+@Import(ReactorPluginConfiguration.class)
 public class ReactorPluginHandler extends AbstractSimplePluginHandler<ReactorPlugin<?>> {
 
     @Autowired

--- a/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/spring/ReactorPluginConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/spring/ReactorPluginConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.plugin.reactor.spring;
 
 import io.gravitee.apim.plugin.reactor.internal.DefaultReactorPluginManager;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.node.plugins.service.ServiceManager;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import org.springframework.context.ApplicationContext;
@@ -33,8 +34,9 @@ public class ReactorPluginConfiguration {
     public DefaultReactorPluginManager reactorPluginManager(
         final ApplicationContext applicationContext,
         final PluginContextFactory pluginContextFactory,
+        final ReactorFactoryManager factoryManager,
         final ServiceManager serviceManager
     ) {
-        return new DefaultReactorPluginManager(applicationContext, pluginContextFactory, serviceManager);
+        return new DefaultReactorPluginManager(applicationContext, pluginContextFactory, factoryManager, serviceManager);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/test/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManagerTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/test/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManagerTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -66,8 +65,7 @@ class DefaultReactorPluginManagerTest {
 
     @BeforeEach
     void setUp() {
-        when(applicationContext.getBean(ReactorFactoryManager.class)).thenReturn(reactorFactoryManager);
-        cut = new DefaultReactorPluginManager(applicationContext, pluginContextFactory, serviceManager);
+        cut = new DefaultReactorPluginManager(applicationContext, pluginContextFactory, reactorFactoryManager, serviceManager);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/plugin/IdentityProviderPluginHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/plugin/IdentityProviderPluginHandler.java
@@ -19,15 +19,18 @@ import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginClassLoaderFactory;
 import io.gravitee.plugin.core.api.PluginHandler;
 import io.gravitee.rest.api.idp.api.IdentityProvider;
+import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
 import org.springframework.util.Assert;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Import(IdentityProviderPluginConfiguration.class)
 public class IdentityProviderPluginHandler implements PluginHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IdentityProviderPluginHandler.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -17,8 +17,6 @@ package io.gravitee.rest.api.management.v2.rest.spring;
 
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
-import io.gravitee.plugin.core.spring.PluginConfiguration;
-import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,9 +27,7 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import(
-    { PluginConfiguration.class, ServiceConfiguration.class, IdentityProviderPluginConfiguration.class, UsecaseSpringConfiguration.class }
-)
+@Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class })
 public class RestManagementConfiguration {
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -29,9 +29,7 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import(
-    { PluginConfiguration.class, ServiceConfiguration.class, IdentityProviderPluginConfiguration.class, UsecaseSpringConfiguration.class }
-)
+@Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class })
 public class RestManagementConfiguration {
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
@@ -29,7 +29,5 @@ import org.springframework.context.annotation.Import;
  */
 @Configuration
 @ComponentScan({ "io.gravitee.rest.api.portal.rest.mapper" })
-@Import(
-    { PluginConfiguration.class, ServiceConfiguration.class, SecurityPortalConfiguration.class, IdentityProviderPluginConfiguration.class }
-)
+@Import({ ServiceConfiguration.class, SecurityPortalConfiguration.class })
 public class RestPortalConfiguration {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -30,16 +30,6 @@ import io.gravitee.json.validation.JsonSchemaValidator;
 import io.gravitee.json.validation.JsonSchemaValidatorImpl;
 import io.gravitee.node.services.initializer.spring.InitializerConfiguration;
 import io.gravitee.node.services.upgrader.spring.UpgraderConfiguration;
-import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
-import io.gravitee.plugin.apiservice.spring.ApiServicePluginConfiguration;
-import io.gravitee.plugin.connector.spring.ConnectorPluginConfiguration;
-import io.gravitee.plugin.discovery.spring.ServiceDiscoveryPluginConfiguration;
-import io.gravitee.plugin.endpoint.spring.EndpointConnectorPluginConfiguration;
-import io.gravitee.plugin.entrypoint.spring.EntrypointConnectorPluginConfiguration;
-import io.gravitee.plugin.fetcher.spring.FetcherPluginConfiguration;
-import io.gravitee.plugin.notifier.spring.NotifierPluginConfiguration;
-import io.gravitee.plugin.policy.spring.PolicyPluginConfiguration;
-import io.gravitee.plugin.resource.spring.ResourcePluginConfiguration;
 import io.gravitee.repository.management.model.flow.FlowStep;
 import io.gravitee.rest.api.fetcher.spring.FetcherConfigurationConfiguration;
 import io.gravitee.rest.api.model.api.ApiEntity;
@@ -56,11 +46,7 @@ import io.gravitee.rest.api.service.validator.RegexPasswordValidator;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.*;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -75,20 +61,10 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @Import(
     {
-        PolicyPluginConfiguration.class,
-        ResourcePluginConfiguration.class,
-        FetcherPluginConfiguration.class,
         FetcherConfigurationConfiguration.class,
         SearchEngineConfiguration.class,
-        NotifierPluginConfiguration.class,
-        AlertPluginConfiguration.class,
-        ServiceDiscoveryPluginConfiguration.class,
-        ConnectorPluginConfiguration.class,
-        EndpointConnectorPluginConfiguration.class,
-        EntrypointConnectorPluginConfiguration.class,
         UpgraderConfiguration.class,
         InitializerConfiguration.class,
-        ApiServicePluginConfiguration.class,
         InfraServiceSpringConfiguration.class,
     }
 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/GraviteeApisContainer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/GraviteeApisContainer.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.standalone;
 
 import io.gravitee.node.container.spring.SpringBasedContainer;
+import io.gravitee.rest.api.standalone.node.GraviteeApisNode;
 import io.gravitee.rest.api.standalone.spring.StandaloneConfiguration;
 import java.util.List;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -25,6 +26,10 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
  * @author GraviteeSource Team
  */
 public class GraviteeApisContainer extends SpringBasedContainer {
+
+    public GraviteeApisContainer() {
+        super(GraviteeApisNode.class);
+    }
 
     @Override
     protected List<Class<?>> annotatedClasses() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -22,12 +22,12 @@ import io.gravitee.node.services.initializer.spring.InitializerConfiguration;
 import io.gravitee.node.services.upgrader.spring.UpgraderConfiguration;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import io.gravitee.plugin.alert.AlertTriggerProviderManager;
-import io.gravitee.rest.api.service.InitializerService;
 import io.gravitee.rest.api.service.ScheduledCommandService;
 import io.gravitee.rest.api.standalone.jetty.JettyEmbeddedContainer;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class GraviteeApisNode extends AbstractNode {
 
+    @Lazy
     @Autowired
     private NodeMetadataResolver nodeMetadataResolver;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -16,9 +16,7 @@
 package io.gravitee.rest.api.standalone.spring;
 
 import io.gravitee.node.api.NodeMetadataResolver;
-import io.gravitee.node.certificates.spring.NodeCertificatesConfiguration;
 import io.gravitee.node.container.NodeFactory;
-import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
 import io.gravitee.rest.api.management.rest.spring.RestManagementConfiguration;
 import io.gravitee.rest.api.portal.rest.spring.RestPortalConfiguration;
@@ -39,11 +37,9 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import(
     {
-        VertxConfiguration.class,
         RestManagementConfiguration.class,
         io.gravitee.rest.api.management.v2.rest.spring.RestManagementConfiguration.class,
         RestPortalConfiguration.class,
-        NodeCertificatesConfiguration.class,
     }
 )
 public class StandaloneConfiguration {

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.4.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>5.1.0</gravitee-node.version>
+        <gravitee-node.version>5.3.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>2.2.0</gravitee-plugin.version>
+        <gravitee-plugin.version>3.0.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.28.0</gravitee-reporter-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-297

## Description

This PR upgrades `gravitee-node` and `gravitee-plugin` and brings the required adaptations to allow for loading plugins in 2 steps, first, the boot plugins such as the secret provider plugins, and second, the rest of the plugins. This allows for a wider support of secret resolution during startup.

## Additional context

This PR can be tested by enabling and configuring a Kubernetes secret provider. It can be achieved by specifying the following environment variables on both management and gateway:

```properties
gravitee_secrets_kubernetes_enabled=true
gravitee_secrets_kubernetes_namespace=graviteeio
```

You can create a Kubernetes secret with several entries representing some "sensitive" information such as jwt secret, keystore password, ..., ex:

```bash
kubectl create secret -n graviteeio generic apim \
     --from-literal=jwt.secret=A_Very_Sensitive_JWT_Secret \
     --from-literal=api.properties.encryption.secret=A_Very_Sensitive_Api_Encryption_Secret \
     --from-literal=services.core.http.auth.basic.password=A_Very_Sensitive_Password \
     --from-literal=jetty.ssl.keystore.password=secret \
     --from-literal=http.ssl.keystore.password=secret \
     --dry-run=client -o yaml | k apply -f -
```

⚠️ This is not an exhaustive list, further tests can be made (ex: recaptcha, MongoDB password, ...)

Then for the management rest API, a couple of secrets can be configured via environment variables:

```properties
# Protect the jwt secret using a k8s secret.
gravitee_jwt_secret=secret://kubernetes/apim:jwt.secret

# Protect Api properties encryption secret.
gravitee_api_properties_encryption_secret=secret://kubernetes/apim:api.properties.encryption.secret

# Configure SSL on jetty and protect the password in a secret.
gravitee_jetty_secured=true
gravitee_jetty_ssl_keystore_password=secret://kubernetes/apim:jetty.ssl.keystore.password
gravitee_jetty_ssl_keystore_path=localhost.p12
gravitee_jetty_ssl_keystore_type=PKCS12
```

A similar configuration can be made for the gateway:

```properties
# Protect Api properties encryption secret.
gravitee_api_properties_encryption_secret=secret://kubernetes/apim:api.properties.encryption.secret

# Configure SSL on Vertx and protect the password in a secret.
gravitee_http_secured=true
gravitee_http_ssl_keystore_password=secret://kubernetes/apim:http.ssl.keystore.password
gravitee_http_ssl_keystore_path=localhost.p12
gravitee_http_ssl_keystore_type=PKCS12
```

You can use the following command to generate a CA and  a localhost.p12 keystore:

```bash
openssl req -newkey rsa:4096 -keyform PEM -keyout ca.key -x509 -days 3650 -subj "/emailAddress=unit.tests@graviteesource.com/CN=localhost/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR" -passout pass:ca-secret -outform PEM -out ca.pem
openssl pkcs12 -export -inkey ca.key -in ca.pem -out ca.p12 -passin pass:ca-secret -passout pass:ca-secret -name local-ca
openssl genrsa -out localhost.key 4096
openssl req -new -key localhost.key -out localhost.csr -sha256 -subj "/emailAddress=unit.tests@graviteesource.com/CN=localhost/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR"
openssl x509 -req -in localhost.csr -CA ca.pem -CAkey ca.key -set_serial 100 -extensions server -days 36500 -outform PEM -out localhost.cer -sha256 -passin pass:ca-secret
openssl pkcs12 -export -inkey localhost.key -in localhost.cer -out localhost.p12 -passout pass:secret -name localhost
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgjgvwqwxk.chromatic.com)
<!-- Storybook placeholder end -->
