### PR TITLE
Apim 3563 show warning if api not deployable

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/index.ts
@@ -36,3 +36,4 @@ export * from './primaryOwner';
 export * from './property';
 export * from './resource';
 export * from './responseTemplate';
+export * from './verifyApiDeploy';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/verifyApiDeploy.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/verifyApiDeploy.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class VerifyApiDeployResponse {
+  ok?: boolean;
+  reason?: string;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
@@ -91,6 +91,13 @@ describe('ApiNavigationComponent', () => {
               deploymentState: 'NEED_REDEPLOY',
             }),
           );
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/deployments/_verify`,
+            method: 'GET',
+          })
+          .flush({ ok: true });
       });
       it('should display "API version out-of-date" banner', (done) => {
         apiNgNavigationComponent.banners$.subscribe((banners) => {
@@ -112,6 +119,44 @@ describe('ApiNavigationComponent', () => {
               id: API_ID,
             }),
           );
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/deployments/_verify`,
+            method: 'GET',
+          })
+          .flush({ ok: true });
+      });
+      it('should display "API cannot be deployed" banner', (done) => {
+        apiNgNavigationComponent.banners$.subscribe((banners) => {
+          expect(banners).toEqual([
+            {
+              title: 'This API cannot be deployed.',
+              body: 'The current configuration uses features not in your license.',
+              type: 'error',
+            },
+          ]);
+          done();
+        });
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`,
+            method: 'GET',
+          })
+          .flush(
+            fakeApiV4({
+              id: API_ID,
+              deploymentState: 'NEED_REDEPLOY',
+            }),
+          );
+
+        httpTestingController
+          .expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/deployments/_verify`,
+            method: 'GET',
+          })
+          .flush({ ok: false });
       });
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -33,6 +33,7 @@ import {
 import { ApiTransferOwnership } from '../entities/management-api-v2/api/apiTransferOwnership';
 import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 import { VerifyApiHostsResponse } from '../entities/management-api-v2/api/verifyApiHosts';
+import { VerifyApiDeployResponse } from '../entities/management-api-v2/api/verifyApiDeploy';
 
 @Injectable({
   providedIn: 'root',
@@ -78,6 +79,10 @@ export class ApiV2Service {
     return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/deployments`, {
       deploymentLabel,
     });
+  }
+
+  verifyDeploy(apiId: string): Observable<VerifyApiDeployResponse> {
+    return this.http.get(`${this.constants.env.v2BaseURL}/apis/${apiId}/deployments/_verify`);
   }
 
   duplicate(apiId: string, options: DuplicateApiOptions): Observable<Api> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3563

## Description

Add a banner to the api navigation when an API uses features not in the current license.

<img width="1042" alt="Screenshot 2024-01-08 at 17 13 37" src="https://github.com/gravitee-io/gravitee-api-management/assets/42294616/6d7ee785-0bae-47f5-934e-f302e555dc20">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-odjgsynvgm.chromatic.com)
<!-- Storybook placeholder end -->
