### PR TITLE
fix: retrieve organization information with the correct id

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/V4ApiCommandHandler.java
@@ -22,12 +22,10 @@ import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.CommandHandler;
 import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.v4api.V4ApiCommand;
-import io.gravitee.cockpit.api.command.v4api.V4ApiPayload;
 import io.gravitee.cockpit.api.command.v4api.V4ApiReply;
-import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.cockpit.services.V4ApiServiceCockpit;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.rxjava3.core.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,10 +42,12 @@ public class V4ApiCommandHandler implements CommandHandler<V4ApiCommand, V4ApiRe
 
     private final V4ApiServiceCockpit v4ApiServiceCockpit;
     private final UserService userService;
+    private final OrganizationService organizationService;
 
-    public V4ApiCommandHandler(V4ApiServiceCockpit v4ApiServiceCockpit, UserService userService) {
+    public V4ApiCommandHandler(V4ApiServiceCockpit v4ApiServiceCockpit, UserService userService, OrganizationService organizationService) {
         this.v4ApiServiceCockpit = v4ApiServiceCockpit;
         this.userService = userService;
+        this.organizationService = organizationService;
     }
 
     @Override
@@ -57,8 +57,9 @@ public class V4ApiCommandHandler implements CommandHandler<V4ApiCommand, V4ApiRe
 
     @Override
     public Single<V4ApiReply> handle(V4ApiCommand command) {
-        final V4ApiPayload payload = command.getPayload();
-        final UserEntity user = userService.findBySource(payload.getOrganizationId(), "cockpit", payload.getUserId(), true);
+        var payload = command.getPayload();
+        var org = organizationService.findByCockpitId(payload.getOrganizationId());
+        var user = userService.findBySource(org.getId(), "cockpit", payload.getUserId(), true);
 
         authenticateAs(user);
 


### PR DESCRIPTION
## Issue

After introducing multi-tenancy, the publication of trial's API v4 is fetching the user with the organization id known by Cockpit.

## Description

The organization's information needs to be retrieved from the orgService before fetching the user information
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6348/console](https://pr.team-apim.gravitee.dev/6348/console)
      Portal: [https://pr.team-apim.gravitee.dev/6348/portal](https://pr.team-apim.gravitee.dev/6348/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6348/api/management](https://pr.team-apim.gravitee.dev/6348/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6348](https://pr.team-apim.gravitee.dev/6348)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6348](https://pr.gateway-v3.team-apim.gravitee.dev/6348)

<!-- Environment placeholder end -->
