### PR TITLE
feat(console): skip archi choice in creation wizard if oem in license

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
@@ -16,6 +16,7 @@
 
 import { HarnessLoader } from '@angular/cdk/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
+import { License } from '@gravitee/ui-particles-angular';
 
 import { Step1ApiDetailsHarness } from './steps/step-1-api-details/step-1-api-details.harness';
 import { Step2Entrypoints0ArchitectureHarness } from './steps/step-2-entrypoints/step-2-entrypoints-0-architecture.harness';
@@ -29,14 +30,23 @@ import { Step3EndpointListHarness } from './steps/step-3-endpoints/step-3-endpoi
 import { ApiType, ConnectorPlugin } from '../../../entities/management-api-v2';
 
 export class ApiCreationV4SpecStepperHelper {
+  private ossLicense: License = { tier: 'oss', features: [], packs: [] };
+
   constructor(
     private harnessLoader: HarnessLoader,
     private httpExpects: ApiCreationV4SpecHttpExpects,
     private httpTestingController: HttpTestingController,
   ) {}
 
-  async fillAndValidateStep1_ApiDetails(name = 'API name', version = '1.0', description = 'description') {
+  async fillAndValidateStep1_ApiDetails(
+    name = 'API name',
+    version = '1.0',
+    description = 'description',
+    license: License = this.ossLicense,
+  ) {
     const apiDetails = await this.harnessLoader.getHarness(Step1ApiDetailsHarness);
+    this.httpExpects.expectLicenseGetRequest(license);
+
     await apiDetails.fillAndValidate(name, version, description);
   }
 
@@ -54,7 +64,6 @@ export class ApiCreationV4SpecStepperHelper {
   ) {
     const entrypointsList = await this.harnessLoader.getHarness(Step2Entrypoints1ListHarness);
     this.httpExpects.expectEntrypointsGetRequest(entrypoints);
-    this.httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
     if (architecture === 'MESSAGE') {
       await entrypointsList.fillAsyncAndValidate(entrypoints.map((entrypoint) => entrypoint.id));

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
@@ -124,7 +124,6 @@ describe('ApiCreationV4Component - Message', () => {
       httpExpects.expectEntrypointsGetRequest([
         { id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE', supportedListenerType: 'SUBSCRIPTION' },
       ]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 
@@ -141,7 +140,6 @@ describe('ApiCreationV4Component - Message', () => {
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE' }]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 
@@ -164,7 +162,6 @@ describe('ApiCreationV4Component - Message', () => {
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE' }]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 
@@ -190,7 +187,6 @@ describe('ApiCreationV4Component - Message', () => {
         { id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE', supportedListenerType: 'HTTP' },
         { id: 'webhook', supportedApiType: 'MESSAGE', name: 'Webhook', supportedListenerType: 'SUBSCRIPTION' },
       ]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse', 'webhook']));
 
@@ -264,7 +260,6 @@ describe('ApiCreationV4Component - Message', () => {
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE' }]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 
@@ -291,7 +286,6 @@ describe('ApiCreationV4Component - Message', () => {
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE', supportedListenerType: 'HTTP' }]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 
@@ -343,7 +337,6 @@ describe('ApiCreationV4Component - Message', () => {
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'MESSAGE', name: 'SSE' }]);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       await step2Harness.getAsyncEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
@@ -205,7 +205,6 @@ describe('ApiCreationV4Component - Navigation', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('test API', '1', 'description');
 
       fixture.detectChanges();
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       component.stepper.compileStepPayload(component.currentStep);
       expect(component.currentStep.payload).toEqual({ name: 'test API', version: '1', description: 'description' });
@@ -216,7 +215,6 @@ describe('ApiCreationV4Component - Navigation', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API', '1.0', null);
 
       fixture.detectChanges();
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       component.stepper.compileStepPayload(component.currentStep);
       expect(component.currentStep.payload).toEqual({ name: 'API', version: '1.0', description: '' });
@@ -227,12 +225,15 @@ describe('ApiCreationV4Component - Navigation', () => {
       const apiDetailsHarness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
       expect(apiDetailsHarness).toBeDefined();
       await apiDetailsHarness.clickExit();
+      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       expect(routerNavigateSpy).toHaveBeenCalled();
     });
 
     it('should cancel exit in confirmation', async () => {
       const apiDetailsHarness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
+      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+
       await apiDetailsHarness.setName('Draft API');
       await apiDetailsHarness.clickExit();
 
@@ -248,6 +249,8 @@ describe('ApiCreationV4Component - Navigation', () => {
 
     it('should not save data after exiting', async () => {
       const apiDetailsHarness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
+      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+
       await apiDetailsHarness.setName('Draft API');
 
       await apiDetailsHarness.clickExit();
@@ -270,8 +273,6 @@ describe('ApiCreationV4Component - Navigation', () => {
       await architectureHarness.clickPrevious();
       expect(component.currentStep.group.label).toEqual('API details');
 
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
-
       const apiDetailsHarness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
       expect(apiDetailsHarness).toBeDefined();
       expect(await apiDetailsHarness.getName()).toEqual('API');
@@ -286,8 +287,6 @@ describe('ApiCreationV4Component - Navigation', () => {
       const step2Entrypoints1ListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
       httpExpects.expectEntrypointsGetRequest([httpProxyEntrypoint, tcpProxyEntrypoint, sseEntrypoint]);
-
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
       const entrypointsRadio = await step2Entrypoints1ListHarness.getSyncEntrypoints();
       expect(await entrypointsRadio.getValues()).toEqual(['http-proxy', 'tcp-proxy']);
@@ -316,7 +315,6 @@ describe('ApiCreationV4Component - Navigation', () => {
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('MESSAGE');
 
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
-      httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
       httpExpects.expectEntrypointsGetRequest([sseEntrypoint, webhookEntrypoint, httpProxyEntrypoint]);
 
       const list = await step2Harness.getAsyncEntrypoints();
@@ -464,7 +462,6 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('PROXY');
         let entrypointsListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
         httpExpects.expectEntrypointsGetRequest([httpProxyEntrypoint, tcpProxyEntrypoint]);
-        httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
         await entrypointsListHarness.fillSyncAndValidate('http-proxy');
         httpExpects.expectEndpointGetRequest({ id: 'http-proxy', supportedApiType: 'PROXY', name: 'HTTP Proxy' });
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(httpProxyEntrypoints);
@@ -545,7 +542,6 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('PROXY');
         let entrypointsListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
         httpExpects.expectEntrypointsGetRequest([httpProxyEntrypoint, tcpProxyEntrypoint]);
-        httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
         await entrypointsListHarness.fillSyncAndValidate('http-proxy');
         httpExpects.expectEndpointGetRequest({ id: 'http-proxy', supportedApiType: 'PROXY', name: 'HTTP Proxy' });
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(httpProxyEntrypoints);
@@ -629,7 +625,6 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('MESSAGE');
         let entrypointsListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
         httpExpects.expectEntrypointsGetRequest(messageEntrypoints);
-        httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
         await entrypointsListHarness.fillAsyncAndValidate(['http-post', 'http-get']);
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig([httpPostEntrypoint, httpGetEntrypoint]);
 
@@ -723,7 +718,6 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('MESSAGE');
         let entrypointsListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
         httpExpects.expectEntrypointsGetRequest(messageEntrypoints);
-        httpExpects.expectLicenseGetRequest({ tier: '', features: [], packs: [] });
         await entrypointsListHarness.fillAsyncAndValidate(['http-post', 'http-get']);
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig([httpPostEntrypoint, httpGetEntrypoint]);
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.oem.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.oem.component.spec.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { License, LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { set } from 'lodash';
+
+import { ApiCreationV4Component } from './api-creation-v4.component';
+import { ApiCreationV4Module } from './api-creation-v4.module';
+import { Step5SummaryHarness } from './steps/step-5-summary/step-5-summary.harness';
+import { ApiCreationV4SpecStepperHelper } from './api-creation-v4-spec-stepper-helper';
+import { ApiCreationV4SpecHttpExpects } from './api-creation-v4-spec-http-expects';
+import { Step2Entrypoints0ArchitectureHarness } from './steps/step-2-entrypoints/step-2-entrypoints-0-architecture.harness';
+import { Step2Entrypoints1ListHarness } from './steps/step-2-entrypoints/step-2-entrypoints-1-list.harness';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
+import { ConnectorPlugin } from '../../../entities/management-api-v2';
+
+describe('ApiCreationV4Component - OEM', () => {
+  const httpProxyEntrypoint: Partial<ConnectorPlugin>[] = [
+    { id: 'http-proxy', supportedApiType: 'PROXY', name: 'HTTP Proxy', supportedListenerType: 'HTTP' },
+  ];
+
+  const oemLicense: License = {
+    tier: 'galaxy',
+    features: ['oem-customization'],
+    packs: [],
+  };
+
+  let fixture: ComponentFixture<ApiCreationV4Component>;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  let enabledReviewMode = false;
+  let httpExpects: ApiCreationV4SpecHttpExpects;
+  let stepperHelper: ApiCreationV4SpecStepperHelper;
+
+  const init = async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ApiCreationV4Component],
+      providers: [
+        {
+          provide: 'Constants',
+          useFactory: () => {
+            const constants = CONSTANTS_TESTING;
+            set(constants, 'env.settings.plan.security', {
+              apikey: {
+                enabled: true,
+              },
+              jwt: {
+                enabled: true,
+              },
+              keyless: {
+                enabled: true,
+              },
+              oauth2: {
+                enabled: true,
+              },
+              customApiKey: {
+                enabled: true,
+              },
+              sharedApiKey: {
+                enabled: true,
+              },
+              push: {
+                enabled: true,
+              },
+            });
+
+            set(constants, 'env.settings.apiReview', {
+              get enabled() {
+                return enabledReviewMode;
+              },
+            });
+            return constants;
+          },
+        },
+        {
+          provide: 'LicenseConfiguration',
+          useValue: LICENSE_CONFIGURATION_TESTING,
+        },
+      ],
+      imports: [NoopAnimationsModule, ApiCreationV4Module, GioHttpTestingModule, MatIconTestingModule],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ApiCreationV4Component);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    harnessLoader = await TestbedHarnessEnvironment.loader(fixture);
+    httpExpects = new ApiCreationV4SpecHttpExpects(httpTestingController);
+    stepperHelper = new ApiCreationV4SpecStepperHelper(harnessLoader, httpExpects, httpTestingController);
+  };
+
+  beforeEach(async () => await init());
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    httpTestingController.verify();
+    enabledReviewMode = false;
+  });
+
+  describe('Present "oem-customization" feature in license', () => {
+    it('should not have architecture choice', async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API', '1.0', 'Description', oemLicense);
+
+      await harnessLoader
+        .getHarness(Step2Entrypoints0ArchitectureHarness)
+        .then((_) => fail('Should not load architecture choice'))
+        .catch((err) => expect(err).toBeTruthy());
+      httpExpects.expectEntrypointsGetRequest([
+        { id: 'http-proxy', supportedApiType: 'PROXY', name: 'HTTP Proxy', supportedListenerType: 'HTTP' },
+      ]);
+
+      const entrypointListHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
+      expect(entrypointListHarness).toBeTruthy();
+
+      const syncEntrypoints = await entrypointListHarness.getSyncEntrypoints();
+      expect(await syncEntrypoints.getValues().then((values) => values.length === 1 && values[0] === 'http-proxy'));
+    });
+
+    it('should create the API', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API', '1.0', 'Description', oemLicense);
+      await stepperHelper.fillAndValidateStep2_1_EntrypointsList('PROXY', httpProxyEntrypoint);
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(httpProxyEntrypoint);
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(httpProxyEntrypoint);
+      await stepperHelper.validateStep4_1_SecurityPlansList();
+
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      const step1Summary = await step5Harness.getStepSummaryTextContent(1);
+      expect(step1Summary).toContain('API name:' + 'API');
+      expect(step1Summary).toContain('Version:' + '1.0');
+      expect(step1Summary).toContain('Description:' + ' Description');
+
+      const step2Summary = await step5Harness.getStepSummaryTextContent(2);
+      expect(step2Summary).toContain('Path:' + '/api/my-api-3');
+      expect(step2Summary).toContain('Type:' + 'HTTP');
+      expect(step2Summary).toContain('Entrypoints:' + ' HTTP Proxy');
+
+      const step3Summary = await step5Harness.getStepSummaryTextContent(3);
+      expect(step3Summary).toContain('Endpoints' + 'Endpoints: ' + 'HTTP Proxy ');
+
+      const step4Summary = await step5Harness.getStepSummaryTextContent(4);
+      expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
+    }));
+  });
+});


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3627

## Description

If a license includes `oem-customization`, a user cannot create a message API via the V4 API creation wizard.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kjqqxxofsj.chromatic.com)
<!-- Storybook placeholder end -->
