### PR TITLE
Apim 3564 plugin deployed attribute compute with license

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
@@ -500,6 +500,6 @@ describe('ApiCorsComponent', () => {
 
   function expectEntrypointsGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorPlugin(partial));
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
@@ -65,7 +65,7 @@ export class ApiCreationV4SpecHttpExpects {
   expectSchemaGetRequest(connectors: Partial<ConnectorPlugin>[], connectorType: 'entrypoints' | 'endpoints' = 'entrypoints') {
     connectors.forEach((connector) => {
       this.httpTestingController
-        .match({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/${connectorType}/${connector.id}/schema`, method: 'GET' })
+        .match({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/${connectorType}/${connector.id}/schema`, method: 'GET' })
         .map((req) => {
           if (!req.cancelled) req.flush(getEntrypointConnectorSchema(connector.id));
         });
@@ -74,7 +74,7 @@ export class ApiCreationV4SpecHttpExpects {
 
   expectEntrypointsGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorPlugin(partial));
-    this.httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
+    this.httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
   }
 
   expectLicenseGetRequest(license: License) {
@@ -85,19 +85,21 @@ export class ApiCreationV4SpecHttpExpects {
     const fullConnector = fakeConnectorPlugin(connector);
 
     this.httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${fullConnector.id}`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${fullConnector.id}`, method: 'GET' })
       .flush(fullConnector);
   }
 
   expectEndpointsGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorPlugin(partial));
-    this.httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' }).flush(fullConnectors);
+    this.httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`, method: 'GET' })
+      .flush(fullConnectors);
   }
 
   expectEndpointsSharedConfigurationSchemaGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     connectors.forEach((connector) => {
       this.httpTestingController
-        .match({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${connector.id}/shared-configuration-schema`, method: 'GET' })
+        .match({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${connector.id}/shared-configuration-schema`, method: 'GET' })
         .map((req) => {
           if (!req.cancelled) req.flush(getEntrypointConnectorSchema(connector.id));
         });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
@@ -76,7 +76,10 @@ function expectApiGetRequest(api: ApiV4, fixture: ComponentFixture<any>, httpTes
  * @param httpTestingController http testing controller
  */
 function expectApiSchemaGetRequests(api: ApiV4, fixture: ComponentFixture<any>, httpTestingController) {
-  httpTestingController.match({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/kafka/shared-configuration-schema`, method: 'GET' });
+  httpTestingController.match({
+    url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/kafka/shared-configuration-schema`,
+    method: 'GET',
+  });
   fixture.detectChanges();
 }
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
@@ -360,7 +360,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
 
   function expectSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSchema): void {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${endpointId}/shared-configuration-schema`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${endpointId}/shared-configuration-schema`, method: 'GET' })
       .flush(schema);
   }
 
@@ -371,7 +371,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
   }
 
   function expectEndpointListGet(): void {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' }).flush(ENDPOINT_LIST);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`, method: 'GET' }).flush(ENDPOINT_LIST);
   }
 
   /**

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
@@ -234,7 +234,7 @@ describe('ApiEndpointGroupsComponent', () => {
 
   function expectEndpointsGetRequest() {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`, method: 'GET' })
       .flush([fakeConnectorPlugin({ id: 'kafka', name: 'kafka' }), fakeConnectorPlugin({ id: 'mock', name: 'mock' })]);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -323,7 +323,7 @@ describe('ApiEndpointComponent', () => {
 
   function expectEndpointsSharedConfigurationSchemaGetRequest(id: string) {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`, method: 'GET' })
       .flush({
         $schema: 'http://json-schema.org/draft-07/schema#',
         type: 'object',
@@ -332,7 +332,7 @@ describe('ApiEndpointComponent', () => {
   }
 
   function expectEndpointSchemaGetRequest(id: string) {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/schema`, method: 'GET' }).flush({
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${id}/schema`, method: 'GET' }).flush({
       $schema: 'http://json-schema.org/draft-07/schema#',
       type: 'object',
       properties: {
@@ -355,7 +355,7 @@ describe('ApiEndpointComponent', () => {
 
   function expectEndpointPluginGetRequest(pluginId: string) {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${pluginId}`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${pluginId}`, method: 'GET' })
       .flush([fakeConnectorPlugin({ id: pluginId, name: pluginId })]);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -790,6 +790,6 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       { id: 'webhook', supportedApiType: 'MESSAGE', supportedListenerType: 'SUBSCRIPTION', name: 'Webhook' },
     ];
 
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`, method: 'GET' }).flush(entrypoints);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`, method: 'GET' }).flush(entrypoints);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.spec.ts
@@ -486,20 +486,20 @@ describe('ApiEntrypointsV4EditComponent', () => {
       },
     ];
 
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`, method: 'GET' }).flush(entrypoints);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`, method: 'GET' }).flush(entrypoints);
   };
 
   const expectGetEntrypointSchema = (entrypointType: string) => {
     const entrypointSchema = getEntrypointConnectorSchema(entrypointType);
 
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/${entrypointType}/schema`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints/${entrypointType}/schema`, method: 'GET' })
       .flush(entrypointSchema);
   };
 
   const expectEndpointsGetRequest = () => {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`, method: 'GET' })
       .flush([
         fakeConnectorPlugin({ id: 'kafka', name: 'kafka' }),
         fakeConnectorPlugin({ id: 'mock', name: 'mock', supportedApiType: 'MESSAGE', supportedModes: ['PUBLISH'] }),

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -730,7 +730,7 @@ describe('Subscription creation dialog', () => {
   function expectListEntrypoints(entrypoints: ConnectorPlugin[]) {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`,
+        url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`,
         method: 'GET',
       })
       .flush(entrypoints);
@@ -762,7 +762,7 @@ describe('Subscription creation dialog', () => {
 
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`,
+        url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`,
         method: 'GET',
       })
       .flush(response);

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -576,14 +576,14 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
 
   function expectEntrypointsGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorPlugin(partial));
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints` }).flush(fullConnectors);
   }
 
   function expectEndpointsGetRequest(connectors: Partial<ConnectorPlugin>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorPlugin(partial));
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`,
+        url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`,
         method: 'GET',
       })
       .flush(fullConnectors);

--- a/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-logs-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
@@ -211,13 +211,13 @@ describe('ApiRuntimeLogsMessagesComponent', () => {
 
   function expectEndpointPlugin(messageLog: AggregatedMessageLog) {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${messageLog.endpoint.connectorId}`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${messageLog.endpoint.connectorId}`, method: 'GET' })
       .flush([fakeConnectorPlugin({ id: messageLog.endpoint.connectorId, name: messageLog.endpoint.connectorId })]);
   }
 
   function expectEntrypointPlugin(messageLog: AggregatedMessageLog) {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/${messageLog.entrypoint.connectorId}`, method: 'GET' })
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints/${messageLog.entrypoint.connectorId}`, method: 'GET' })
       .flush([fakeConnectorPlugin({ id: messageLog.entrypoint.connectorId, name: messageLog.entrypoint.connectorId })]);
   }
 });

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
@@ -20,7 +20,7 @@ import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { ConnectorPluginsV2Service } from './connector-plugins-v2.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
-import { fakeConnectorPlugin } from '../entities/management-api-v2/plugin/connectorPlugin.fixture';
+import { fakeConnectorPlugin } from '../entities/management-api-v2';
 
 describe('Installation Plugins Service', () => {
   let httpTestingController: HttpTestingController;

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.spec.ts
@@ -47,7 +47,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`,
             method: 'GET',
           })
           .flush(fakeConnectors);
@@ -70,7 +70,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints`,
             method: 'GET',
           })
           .flush(response);
@@ -88,7 +88,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/endpointId`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/endpointId`,
             method: 'GET',
           })
           .flush(fakeConnectors);
@@ -108,7 +108,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`,
             method: 'GET',
           })
           .flush(fakeConnectors);
@@ -126,7 +126,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints`,
             method: 'GET',
           })
           .flush(fakeConnectors);
@@ -152,7 +152,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/entrypoint-id/subscription-schema`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints/entrypoint-id/subscription-schema`,
             method: 'GET',
           })
           .flush(expectedSchema);
@@ -169,7 +169,7 @@ describe('Installation Plugins Service', () => {
 
         httpTestingController
           .expectOne({
-            url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/entrypoints/entrypoint-id`,
+            url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/entrypoints/entrypoint-id`,
             method: 'GET',
           })
           .flush(entrypoint);

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
@@ -29,7 +29,7 @@ export class ConnectorPluginsV2Service {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   listEndpointPlugins(): Observable<ConnectorPlugin[]> {
-    return this.http.get<ConnectorPlugin[]>(`${this.constants.v2BaseURL}/plugins/endpoints`);
+    return this.http.get<ConnectorPlugin[]>(`${this.constants.org.v2BaseURL}/plugins/endpoints`);
   }
 
   listEndpointPluginsByApiType(apiType: ApiType): Observable<ConnectorPlugin[]> {
@@ -47,7 +47,7 @@ export class ConnectorPluginsV2Service {
   }
 
   listEntrypointPlugins(): Observable<ConnectorPlugin[]> {
-    return this.http.get<ConnectorPlugin[]>(`${this.constants.v2BaseURL}/plugins/entrypoints`);
+    return this.http.get<ConnectorPlugin[]>(`${this.constants.org.v2BaseURL}/plugins/entrypoints`);
   }
 
   listSyncEntrypointPlugins(): Observable<ConnectorPlugin[]> {
@@ -63,34 +63,34 @@ export class ConnectorPluginsV2Service {
   }
 
   getEndpointPlugin(id: string): Observable<ConnectorPlugin> {
-    return this.http.get<ConnectorPlugin>(`${this.constants.v2BaseURL}/plugins/endpoints/${id}`);
+    return this.http.get<ConnectorPlugin>(`${this.constants.org.v2BaseURL}/plugins/endpoints/${id}`);
   }
 
   getEndpointPluginSchema(id: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/endpoints/${id}/schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.org.v2BaseURL}/plugins/endpoints/${id}/schema`);
   }
 
   getEndpointPluginMoreInformation(endpointId: string): Observable<MoreInformation> {
-    return this.http.get<MoreInformation>(`${this.constants.v2BaseURL}/plugins/endpoints/${endpointId}/more-information`);
+    return this.http.get<MoreInformation>(`${this.constants.org.v2BaseURL}/plugins/endpoints/${endpointId}/more-information`);
   }
 
   getEndpointPluginSharedConfigurationSchema(id: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.org.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`);
   }
 
   getEntrypointPlugin(entrypointId: string): Observable<ConnectorPlugin> {
-    return this.http.get<ConnectorPlugin>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}`);
+    return this.http.get<ConnectorPlugin>(`${this.constants.org.v2BaseURL}/plugins/entrypoints/${entrypointId}`);
   }
 
   getEntrypointPluginSchema(entrypointId: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.org.v2BaseURL}/plugins/entrypoints/${entrypointId}/schema`);
   }
 
   getEntrypointPluginSubscriptionSchema(entrypointId: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.org.v2BaseURL}/plugins/entrypoints/${entrypointId}/subscription-schema`);
   }
 
   getEntrypointPluginMoreInformation(entrypointId: string): Observable<MoreInformation> {
-    return this.http.get<MoreInformation>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/more-information`);
+    return this.http.get<MoreInformation>(`${this.constants.org.v2BaseURL}/plugins/entrypoints/${entrypointId}/more-information`);
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConnectorPluginMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConnectorPluginMapper.java
@@ -28,4 +28,6 @@ public interface ConnectorPluginMapper {
     ConnectorPlugin map(ConnectorPluginEntity connectorPluginEntity);
 
     Set<ConnectorPlugin> map(Set<ConnectorPluginEntity> connectorPluginEntitySet);
+
+    Set<ConnectorPlugin> mapCorePlugin(Set<io.gravitee.apim.core.plugin.model.ConnectorPlugin> connectorPluginEntitySet);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -23,6 +23,8 @@ import io.gravitee.rest.api.management.v2.rest.mapper.OrganizationMapper;
 import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
 import io.gravitee.rest.api.management.v2.rest.model.Organization;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource;
+import io.gravitee.rest.api.management.v2.rest.resource.plugin.EntrypointsResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
@@ -76,5 +78,15 @@ public class OrganizationResource extends AbstractResource {
     @Path("/environments")
     public EnvironmentsResource getEnvironmentsResource() {
         return resourceContext.getResource(EnvironmentsResource.class);
+    }
+
+    @Path("/plugins/endpoints")
+    public EndpointsResource getEndpointsResource() {
+        return resourceContext.getResource(EndpointsResource.class);
+    }
+
+    @Path("/plugins/entrypoints")
+    public EntrypointsResource getOrganizationEntrypointsResource() {
+        return resourceContext.getResource(EntrypointsResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EndpointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EndpointsResource.java
@@ -15,17 +15,17 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.plugin;
 
+import io.gravitee.apim.core.plugin.use_case.GetEndpointPluginsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ConnectorPluginMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.MoreInformationMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ConnectorPlugin;
 import io.gravitee.rest.api.management.v2.rest.model.MoreInformation;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
-import jakarta.ws.rs.container.ResourceContext;
-import jakarta.ws.rs.core.Context;
 import java.util.Set;
 
 /**
@@ -37,16 +37,21 @@ import java.util.Set;
 @Path("/plugins/endpoints")
 public class EndpointsResource extends AbstractResource {
 
-    @Context
-    private ResourceContext resourceContext;
-
     @Inject
     private EndpointConnectorPluginService endpointService;
+
+    @Inject
+    private GetEndpointPluginsUseCase getEndpointPluginsUseCase;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Set<ConnectorPlugin> getEndpoints() {
-        return ConnectorPluginMapper.INSTANCE.map(endpointService.findAll());
+        String organizationId = GraviteeContext.getCurrentOrganization() != null
+            ? GraviteeContext.getCurrentOrganization()
+            : GraviteeContext.getDefaultOrganization();
+        return ConnectorPluginMapper.INSTANCE.mapCorePlugin(
+            getEndpointPluginsUseCase.getEndpointPluginsByOrganization(new GetEndpointPluginsUseCase.Input(organizationId)).plugins()
+        );
     }
 
     @Path("/{endpointId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.plugin;
 
+import io.gravitee.apim.core.plugin.use_case.GetEntrypointPluginsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ConnectorPluginMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.MoreInformationMapper;
@@ -22,11 +23,10 @@ import io.gravitee.rest.api.management.v2.rest.model.ConnectorPlugin;
 import io.gravitee.rest.api.management.v2.rest.model.MoreInformation;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
-import jakarta.ws.rs.container.ResourceContext;
-import jakarta.ws.rs.core.Context;
 import java.util.Set;
 
 /**
@@ -38,16 +38,21 @@ import java.util.Set;
 @Path("/plugins/entrypoints")
 public class EntrypointsResource extends AbstractResource {
 
-    @Context
-    private ResourceContext resourceContext;
-
     @Inject
     private EntrypointConnectorPluginService entrypointService;
+
+    @Inject
+    private GetEntrypointPluginsUseCase getEntrypointPluginsUseCase;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Set<ConnectorPlugin> getEntrypoints() {
-        return ConnectorPluginMapper.INSTANCE.map(entrypointService.findAll());
+        String organizationId = GraviteeContext.getCurrentOrganization() != null
+            ? GraviteeContext.getCurrentOrganization()
+            : GraviteeContext.getDefaultOrganization();
+        return ConnectorPluginMapper.INSTANCE.mapCorePlugin(
+            getEntrypointPluginsUseCase.getEntrypointPluginsByOrganization(new GetEntrypointPluginsUseCase.Input(organizationId)).plugins()
+        );
     }
 
     @Path("/{entrypointId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
@@ -153,6 +153,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public EndpointPluginQueryServiceInMemory endpointPluginQueryServiceInMemory() {
+        return new EndpointPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
@@ -137,6 +137,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public EndpointPluginQueryServiceInMemory endpointPluginQueryServiceInMemory() {
+        return new EndpointPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
@@ -136,6 +136,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public EndpointPluginQueryServiceInMemory endpointPluginQueryServiceInMemory() {
+        return new EndpointPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -453,8 +453,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public GraviteeLicenseDomainService graviteeLicenseDomainService() {
-        return new GraviteeLicenseDomainService(mock(LicenseManager.class));
+    public LicenseManager licenseManager() {
+        return mock(LicenseManager.class);
+    }
+
+    @Bean
+    public GraviteeLicenseDomainService graviteeLicenseDomainService(LicenseManager licenseManager) {
+        return new GraviteeLicenseDomainService(licenseManager);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.domain_service;
+
+import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PluginFilterByLicenseDomainService {
+
+    private final LicenseManager licenseManager;
+
+    public PluginFilterByLicenseDomainService(LicenseManager licenseManager) {
+        this.licenseManager = licenseManager;
+    }
+
+    public Set<ConnectorPlugin> setPluginDeployedStatusDependingOnLicense(Set<ConnectorPlugin> pluginSet, String organizationId) {
+        var license = licenseManager.getOrganizationLicenseOrPlatform(organizationId);
+        return pluginSet
+            .stream()
+            .map(plugin -> plugin.toBuilder().deployed(plugin.isDeployed() && license.isFeatureEnabled(plugin.getFeature())).build())
+            .collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/ConnectorPlugin.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/ConnectorPlugin.java
@@ -21,15 +21,11 @@ import io.gravitee.definition.model.v4.ConnectorMode;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 @Data
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString(callSuper = true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PlatformPlugin.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PlatformPlugin.java
@@ -23,7 +23,7 @@ import lombok.experimental.SuperBuilder;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class PlatformPlugin {
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/query_service/EndpointPluginQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/query_service/EndpointPluginQueryService.java
@@ -16,11 +16,8 @@
 package io.gravitee.apim.core.plugin.query_service;
 
 import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
-import io.gravitee.definition.model.v4.ApiType;
 import java.util.Set;
 
-public interface EntrypointPluginQueryService {
-    Set<ConnectorPlugin> findBySupportedApi(final ApiType apiType);
-
+public interface EndpointPluginQueryService {
     Set<ConnectorPlugin> findAll();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetEndpointPluginsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetEndpointPluginsUseCase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.apim.core.plugin.query_service.EndpointPluginQueryService;
+import java.util.Set;
+
+public class GetEndpointPluginsUseCase {
+
+    private final EndpointPluginQueryService endpointPluginQueryService;
+    private final PluginFilterByLicenseDomainService licenseChecker;
+
+    public GetEndpointPluginsUseCase(
+        EndpointPluginQueryService endpointPluginQueryService,
+        PluginFilterByLicenseDomainService licenseChecker
+    ) {
+        this.endpointPluginQueryService = endpointPluginQueryService;
+        this.licenseChecker = licenseChecker;
+    }
+
+    public Output getEndpointPluginsByOrganization(Input input) {
+        return new Output(
+            this.licenseChecker.setPluginDeployedStatusDependingOnLicense(this.endpointPluginQueryService.findAll(), input.organizationId)
+        );
+    }
+
+    public record Input(String organizationId) {}
+
+    public record Output(Set<ConnectorPlugin> plugins) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetEntrypointPluginsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetEntrypointPluginsUseCase.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
+import java.util.Set;
+
+public class GetEntrypointPluginsUseCase {
+
+    private final EntrypointPluginQueryService entrypointPluginQueryService;
+    private final PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService;
+
+    public GetEntrypointPluginsUseCase(
+        EntrypointPluginQueryService entrypointPluginQueryService,
+        PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService
+    ) {
+        this.entrypointPluginQueryService = entrypointPluginQueryService;
+        this.pluginFilterByLicenseDomainService = pluginFilterByLicenseDomainService;
+    }
+
+    public Output getEntrypointPluginsByOrganization(Input input) {
+        return new Output(
+            this.pluginFilterByLicenseDomainService.setPluginDeployedStatusDependingOnLicense(
+                    this.entrypointPluginQueryService.findAll(),
+                    input.organizationId
+                )
+        );
+    }
+
+    public record Input(String organizationId) {}
+
+    public record Output(Set<ConnectorPlugin> plugins) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/EndpointPluginQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/EndpointPluginQueryServiceLegacyWrapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.plugin;
+
+import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.apim.core.plugin.query_service.EndpointPluginQueryService;
+import io.gravitee.apim.infra.adapter.ConnectorPluginAdapter;
+import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EndpointPluginQueryServiceLegacyWrapper implements EndpointPluginQueryService {
+
+    private final EndpointConnectorPluginService endpointPluginQueryService;
+
+    public EndpointPluginQueryServiceLegacyWrapper(EndpointConnectorPluginService endpointPluginQueryService) {
+        this.endpointPluginQueryService = endpointPluginQueryService;
+    }
+
+    @Override
+    public Set<ConnectorPlugin> findAll() {
+        return endpointPluginQueryService.findAll().stream().map(ConnectorPluginAdapter.INSTANCE::map).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/EntrypointPluginQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/EntrypointPluginQueryServiceLegacyWrapper.java
@@ -41,4 +41,9 @@ public class EntrypointPluginQueryServiceLegacyWrapper implements EntrypointPlug
             .map(ConnectorPluginAdapter.INSTANCE::map)
             .collect(Collectors.toSet());
     }
+
+    @Override
+    public Set<ConnectorPlugin> findAll() {
+        return entrypointConnectorPluginService.findAll().stream().map(ConnectorPluginAdapter.INSTANCE::map).collect(Collectors.toSet());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
@@ -35,8 +35,6 @@ import io.gravitee.apim.core.documentation.domain_service.DocumentationValidatio
 import io.gravitee.apim.core.documentation.domain_service.HomepageDomainService;
 import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentationDomainService;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
-import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
@@ -53,6 +51,7 @@ import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.domain_service.ReorderPlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
 import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.sanitizer.HtmlSanitizer;
@@ -282,5 +281,10 @@ public class CoreServiceSpringConfiguration {
     @Bean
     public LicenseDomainService licenseDomainService(LicenseCrudService licenseCrudService) {
         return new LicenseDomainService(licenseCrudService);
+    }
+
+    @Bean
+    public PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService(LicenseManager licenseManager) {
+        return new PluginFilterByLicenseDomainService(licenseManager);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
@@ -67,6 +67,11 @@ import io.gravitee.apim.core.plan.domain_service.DeletePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.ReorderPlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.query_service.EndpointPluginQueryService;
+import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
+import io.gravitee.apim.core.plugin.use_case.GetEndpointPluginsUseCase;
+import io.gravitee.apim.core.plugin.use_case.GetEntrypointPluginsUseCase;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
@@ -331,5 +336,21 @@ public class UsecaseSpringConfiguration {
     @Bean
     public VerifyApiHostsUseCase verifyApiHostsUseCase(VerifyApiHostsDomainService verifyApiHostsDomainService) {
         return new VerifyApiHostsUseCase(verifyApiHostsDomainService);
+    }
+
+    @Bean
+    public GetEntrypointPluginsUseCase getEntrypointPluginUseCase(
+        EntrypointPluginQueryService entrypointPluginQueryService,
+        PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService
+    ) {
+        return new GetEntrypointPluginsUseCase(entrypointPluginQueryService, pluginFilterByLicenseDomainService);
+    }
+
+    @Bean
+    public GetEndpointPluginsUseCase getEndpointPluginUseCase(
+        EndpointPluginQueryService endpointPluginQueryService,
+        PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService
+    ) {
+        return new GetEndpointPluginsUseCase(endpointPluginQueryService, pluginFilterByLicenseDomainService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/UseCaseRulesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/UseCaseRulesTest.java
@@ -58,7 +58,11 @@ public class UseCaseRulesTest extends AbstractApimArchitectureTest {
             .areNotAnnotatedWith(Configuration.class)
             .should()
             .dependOnClassesThat()
-            .resideInAnyPackage(anyPackageThatContains(CRUD_SERVICE_PACKAGE), anyPackageThatContains(DOMAIN_SERVICE_PACKAGE))
+            .resideInAnyPackage(
+                anyPackageThatContains(CRUD_SERVICE_PACKAGE),
+                anyPackageThatContains(QUERY_SERVICE_PACKAGE),
+                anyPackageThatContains(DOMAIN_SERVICE_PACKAGE)
+            )
             .check(apimClassesWithoutTests());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EndpointPluginQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EndpointPluginQueryServiceInMemory.java
@@ -18,6 +18,7 @@ package inmemory;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.apim.core.plugin.query_service.EndpointPluginQueryService;
 import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.ConnectorMode;
@@ -28,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class EntrypointPluginQueryServiceInMemory implements EntrypointPluginQueryService, InMemoryAlternative<ConnectorPlugin> {
+public class EndpointPluginQueryServiceInMemory implements EndpointPluginQueryService, InMemoryAlternative<ConnectorPlugin> {
 
     public static final String HTTP_PROXY_CONNECTOR_ID = "http-proxy";
     public static final String SSE_CONNECTOR_ID = "sse";
@@ -36,47 +37,42 @@ public class EntrypointPluginQueryServiceInMemory implements EntrypointPluginQue
     private static final List<ConnectorPlugin> DEFAULT_LIST = List.of(
         ConnectorPlugin
             .builder()
-            .id(HTTP_PROXY_CONNECTOR_ID)
+            .id("http-proxy")
             .name("HTTP Proxy")
             .version("1.0.0")
             .supportedApiType(ApiType.PROXY)
             .supportedListenerType(ListenerType.HTTP)
             .supportedModes(Set.of(ConnectorMode.REQUEST_RESPONSE))
-            .feature("apim-proxy")
+            .feature("http-proxy")
             .deployed(true)
             .build(),
         ConnectorPlugin
             .builder()
-            .id(SSE_CONNECTOR_ID)
-            .name("SSE Entrypoint")
+            .id("kafka")
+            .name("Kafka Endpoint")
             .version("1.0.0")
             .supportedApiType(ApiType.MESSAGE)
             .supportedListenerType(ListenerType.HTTP)
             .supportedModes(Set.of(ConnectorMode.SUBSCRIBE))
             .supportedQos(Set.of(Qos.AUTO))
-            .feature("apim-en-connector-sse")
+            .feature("apim-en-endpoint-kafka")
             .deployed(true)
             .build(),
         ConnectorPlugin
             .builder()
-            .id(MOCK_CONNECTOR_ID)
+            .id("mock")
             .name("Mock Endpoint")
             .version("1.0.0")
             .supportedApiType(ApiType.MESSAGE)
             .supportedListenerType(ListenerType.HTTP)
             .supportedModes(Set.of(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE))
             .supportedQos(Set.of(Qos.AUTO))
-            .feature("apim-en-connector-mock")
+            .feature("apim-en-endpoint-mock")
             .deployed(false)
             .build()
     );
 
     private List<ConnectorPlugin> storage = DEFAULT_LIST;
-
-    @Override
-    public Set<ConnectorPlugin> findBySupportedApi(ApiType apiType) {
-        return storage.stream().filter(connectorPlugin -> connectorPlugin.getSupportedApiType().equals(apiType)).collect(toSet());
-    }
 
     @Override
     public Set<ConnectorPlugin> findAll() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainServiceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PluginFilterByLicenseDomainServiceTest {
+
+    LicenseManager licenseManager;
+    PluginFilterByLicenseDomainService service;
+
+    @BeforeEach
+    void setup() {
+        licenseManager = mock(LicenseManager.class);
+        service = new PluginFilterByLicenseDomainService(licenseManager);
+    }
+
+    @Test
+    void setPluginDeployedStatusDependingOnLicense() {
+        var input = Set.of(
+            ConnectorPlugin.builder().id("plugin-1").feature("feature-1").deployed(true).build(),
+            ConnectorPlugin.builder().id("plugin-1").feature("feature-2").deployed(true).build(),
+            ConnectorPlugin.builder().id("plugin-1").feature("feature-3").deployed(false).build()
+        );
+
+        var license = mock(io.gravitee.node.api.license.License.class);
+        when(licenseManager.getOrganizationLicenseOrPlatform("org-id")).thenReturn(license);
+        when(license.isFeatureEnabled("feature-1")).thenReturn(false);
+        when(license.isFeatureEnabled("feature-2")).thenReturn(true);
+        when(license.isFeatureEnabled("feature-3")).thenReturn(true);
+
+        var res = service.setPluginDeployedStatusDependingOnLicense(input, "org-id");
+
+        assertThat(res)
+            .containsExactly(
+                ConnectorPlugin.builder().id("plugin-1").feature("feature-1").deployed(false).build(),
+                ConnectorPlugin.builder().id("plugin-1").feature("feature-2").deployed(true).build(),
+                ConnectorPlugin.builder().id("plugin-1").feature("feature-3").deployed(false).build()
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetEndpointPluginsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetEndpointPluginsUseCaseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import inmemory.EndpointPluginQueryServiceInMemory;
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.PlatformPlugin;
+import io.gravitee.node.api.license.LicenseManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetEndpointPluginsUseCaseTest {
+
+    private final EndpointPluginQueryServiceInMemory endpointPluginQueryServiceInMemory = new EndpointPluginQueryServiceInMemory();
+    private LicenseManager licenseManager;
+    private GetEndpointPluginsUseCase getEndpointPluginsUseCase;
+
+    @BeforeEach
+    void setup() {
+        licenseManager = mock(LicenseManager.class);
+        getEndpointPluginsUseCase =
+            new GetEndpointPluginsUseCase(endpointPluginQueryServiceInMemory, new PluginFilterByLicenseDomainService(licenseManager));
+        endpointPluginQueryServiceInMemory.reset();
+    }
+
+    @Test
+    void should_set_deployed_status_depending_on_license() {
+        var license = mock(io.gravitee.node.api.license.License.class);
+        when(licenseManager.getOrganizationLicenseOrPlatform("org-id")).thenReturn(license);
+
+        when(license.isFeatureEnabled("http-proxy")).thenReturn(true);
+        when(license.isFeatureEnabled("apim-en-endpoint-kafka")).thenReturn(false);
+        when(license.isFeatureEnabled("apim-en-endpoint-mock")).thenReturn(true);
+
+        var res = getEndpointPluginsUseCase.getEndpointPluginsByOrganization(new GetEndpointPluginsUseCase.Input("org-id"));
+        assertThat(res.plugins()).hasSize(3);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("mock")).findFirst().map(PlatformPlugin::isDeployed))
+            .contains(false);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("kafka")).findFirst().map(PlatformPlugin::isDeployed))
+            .contains(false);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("http-proxy")).findFirst().map(PlatformPlugin::isDeployed))
+            .contains(true);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetEntrypointPluginsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetEntrypointPluginsUseCaseTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import inmemory.EntrypointPluginQueryServiceInMemory;
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.PlatformPlugin;
+import io.gravitee.node.api.license.LicenseManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetEntrypointPluginsUseCaseTest {
+
+    private final EntrypointPluginQueryServiceInMemory entrypointPluginQueryServiceInMemory = new EntrypointPluginQueryServiceInMemory();
+    private LicenseManager licenseManager;
+    private GetEntrypointPluginsUseCase getEntrypointPluginsUseCase;
+
+    @BeforeEach
+    void setup() {
+        licenseManager = mock(LicenseManager.class);
+        getEntrypointPluginsUseCase =
+            new GetEntrypointPluginsUseCase(entrypointPluginQueryServiceInMemory, new PluginFilterByLicenseDomainService(licenseManager));
+
+        entrypointPluginQueryServiceInMemory.reset();
+    }
+
+    @Test
+    void should_set_deployed_status_depending_on_license() {
+        var license = mock(io.gravitee.node.api.license.License.class);
+        when(licenseManager.getOrganizationLicenseOrPlatform("org-id")).thenReturn(license);
+
+        when(license.isFeatureEnabled("apim-proxy")).thenReturn(true);
+        when(license.isFeatureEnabled("apim-en-connector-mock")).thenReturn(true);
+        when(license.isFeatureEnabled("apim-en-connector-sse")).thenReturn(false);
+
+        var res = getEntrypointPluginsUseCase.getEntrypointPluginsByOrganization(new GetEntrypointPluginsUseCase.Input("org-id"));
+        assertThat(res.plugins()).hasSize(3);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("sse")).findFirst().map(PlatformPlugin::isDeployed)).contains(false);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("mock")).findFirst().map(PlatformPlugin::isDeployed))
+            .contains(false);
+        assertThat(res.plugins().stream().filter(p -> p.getId().equals("http-proxy")).findFirst().map(PlatformPlugin::isDeployed))
+            .contains(true);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/EndpointPluginQueryServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/EndpointPluginQueryServiceLegacyWrapperTest.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.infra.query_service.plugin;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,64 +25,23 @@ import io.gravitee.definition.model.v4.ConnectorFeature;
 import io.gravitee.definition.model.v4.ConnectorMode;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
-import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class EntrypointPluginQueryServiceLegacyWrapperTest {
+class EndpointPluginQueryServiceLegacyWrapperTest {
 
-    EntrypointConnectorPluginService entrypointConnectorPluginService;
-    EntrypointPluginQueryServiceLegacyWrapper service;
+    EndpointConnectorPluginService endpointConnectorPluginService;
+    EndpointPluginQueryServiceLegacyWrapper service;
 
     @BeforeEach
     void setUp() {
-        entrypointConnectorPluginService = mock(EntrypointConnectorPluginService.class);
-        service = new EntrypointPluginQueryServiceLegacyWrapper(entrypointConnectorPluginService);
-    }
-
-    @Nested
-    class FindBySupportedApi {
-
-        @Test
-        void should_return_plugins_list_supported_by_the_given_api_type() {
-            when(entrypointConnectorPluginService.findBySupportedApi(any()))
-                .thenAnswer(invocation -> {
-                    var entity = new ConnectorPluginEntity();
-                    entity.setId("id1");
-                    entity.setName("Plugin 1");
-                    entity.setVersion("1.0.0");
-                    entity.setDescription("description1");
-                    entity.setSupportedApiType(invocation.getArgument(0));
-                    entity.setSupportedListenerType(ListenerType.HTTP);
-                    entity.setSupportedModes(Set.of(ConnectorMode.REQUEST_RESPONSE));
-                    entity.setSupportedQos(Set.of(Qos.AUTO));
-                    entity.setAvailableFeatures(Set.of(ConnectorFeature.LIMIT));
-                    return Set.of(entity);
-                });
-
-            var result = service.findBySupportedApi(ApiType.PROXY);
-
-            assertThat(result)
-                .hasSize(1)
-                .containsExactly(
-                    ConnectorPlugin
-                        .builder()
-                        .id("id1")
-                        .name("Plugin 1")
-                        .version("1.0.0")
-                        .description("description1")
-                        .supportedApiType(ApiType.PROXY)
-                        .supportedListenerType(ListenerType.HTTP)
-                        .supportedModes(Set.of(ConnectorMode.REQUEST_RESPONSE))
-                        .supportedQos(Set.of(Qos.AUTO))
-                        .availableFeatures(Set.of(ConnectorFeature.LIMIT))
-                        .build()
-                );
-        }
+        endpointConnectorPluginService = mock(EndpointConnectorPluginService.class);
+        service = new EndpointPluginQueryServiceLegacyWrapper(endpointConnectorPluginService);
     }
 
     @Nested
@@ -91,7 +49,7 @@ class EntrypointPluginQueryServiceLegacyWrapperTest {
 
         @Test
         void should_return_plugins_list_with_deployed_status_depending_on_license() {
-            when(entrypointConnectorPluginService.findAll())
+            when(endpointConnectorPluginService.findAll())
                 .thenAnswer(invocation -> {
                     var plugin1 = new ConnectorPluginEntity();
                     plugin1.setId("id1");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3654

## Description

Calculate `deployed` atrribute on entrypoints and endpoints plugins with the combination of the actual deployed status of the plugin and also the license feature enabled status.

Note: this requires moving the endpoints and entrypoints resources under the organization root, as the license check requires the current organization (to check license org)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jyovtbkcjg.chromatic.com)
<!-- Storybook placeholder end -->
