### PR TITLE
fix: prevent v2 apis from sending unexpected headers to gRPC backend

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>3.0.1</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.0.2</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>4.0.1</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.1</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.1</gravitee-policy-assign-content.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3675

## Description

V2 gRPC APIs were sending unexpected headers to gRPC backend:
- a duplicated `Content-Type` header
- the `Host` header

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bekhkzypel.chromatic.com)
<!-- Storybook placeholder end -->
