### PR TITLE
fix: virtual host double check should be done on subDomainHost

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
@@ -103,13 +103,19 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
       if (!isEmpty(this.domainRestrictions) && !this.domainRestrictions.some((domainRestriction) => fullHost.endsWith(domainRestriction))) {
         return { host: 'Host is not valid (must end with one of restriction domain).' };
       }
+      return null;
     };
   }
 
   public listenersValidator(): ValidatorFn {
     return (formArray: UntypedFormArray): ValidationErrors | null => {
       const listenerFormArrayControls = formArray.controls;
-      const listenerValues = listenerFormArrayControls.map((listener) => ({ path: listener.value?.path, host: listener.value?.host }));
+      const listenerValues = listenerFormArrayControls.map((listener) => ({
+        path: listener.value?.path && listener.value?.path?.endsWith('/') ? listener.value?.path : listener.value?.path + '/',
+        _hostSubDomain: listener.value?._hostSubDomain,
+        _hostDomain: listener.value?._hostDomain,
+        host: listener.value?.host,
+      }));
       if (new Set(listenerValues.map((value) => JSON.stringify(value))).size !== listenerValues.length) {
         return { contextPath: 'Duplicated virtual host not allowed' };
       }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.module.spec.ts
@@ -201,18 +201,42 @@ describe('GioFormListenersVirtualHostModule', () => {
     // Add path on last path row
     const firstVirtualHostRow = await formVirtualHosts.getLastListenerRow();
     await firstVirtualHostRow.hostSubDomainInput.setValue('aa.com');
-    await firstVirtualHostRow.pathInput.setValue('test');
+    await firstVirtualHostRow.pathInput.setValue('/test');
 
     await formVirtualHosts.addListenerRow();
 
     const secondVirtualHostRow = await formVirtualHosts.getLastListenerRow();
     await secondVirtualHostRow.hostSubDomainInput.setValue('aa.com');
-    await secondVirtualHostRow.pathInput.setValue('test');
-
+    await secondVirtualHostRow.pathInput.setValue('/test');
     fixture.detectChanges();
 
-    expect(testComponent.formControl.valid).toBeFalsy();
-    expect(testComponent.formControl.errors).not.toBeNull();
+    expect(testComponent.formControl.invalid).toBeTruthy();
+
+    await secondVirtualHostRow.pathInput.setValue('/test/');
+    fixture.detectChanges();
+
+    expect(testComponent.formControl.invalid).toBeTruthy();
+  });
+
+  it('should accept 2 virtual hosts with different hosts but same paths', async () => {
+    const formVirtualHosts = await loader.getHarness(GioFormListenersVirtualHostHarness);
+    expect((await formVirtualHosts.getListenerRows()).length).toEqual(1);
+
+    // Add path on last path row
+    const firstVirtualHostRow = await formVirtualHosts.getLastListenerRow();
+    await firstVirtualHostRow.hostSubDomainInput.setValue('aa.com');
+    await firstVirtualHostRow.pathInput.setValue('/test');
+
+    fixture.detectChanges();
+    expect(testComponent.formControl.errors).toBeNull();
+
+    await formVirtualHosts.addListenerRow();
+    const secondVirtualHostRow = await formVirtualHosts.getLastListenerRow();
+    await secondVirtualHostRow.hostSubDomainInput.setValue('bb.com');
+    await secondVirtualHostRow.pathInput.setValue('/test');
+
+    fixture.detectChanges();
+    expect(testComponent.formControl.errors).toBeNull();
   });
 
   it('should edit virtual host', async () => {


### PR DESCRIPTION
## Description

Currently we have an issue when a user try to add multiple virtual host with the same path but different host. Here is a fix to allow users to do it

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6387/console](https://pr.team-apim.gravitee.dev/6387/console)
      Portal: [https://pr.team-apim.gravitee.dev/6387/portal](https://pr.team-apim.gravitee.dev/6387/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6387/api/management](https://pr.team-apim.gravitee.dev/6387/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6387](https://pr.team-apim.gravitee.dev/6387)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6387](https://pr.gateway-v3.team-apim.gravitee.dev/6387)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-okjmhnyjkj.chromatic.com)
<!-- Storybook placeholder end -->
