### PR TITLE
fix(rest-api-v2): map the endpoint gRPC type as HttpEndpointV2

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.html
@@ -104,7 +104,7 @@
             <span *ngIf="element.healthcheck === 'enable'" matTooltip="Health-check is enabled locally" class="gio-badge-primary"
               ><mat-icon svgIcon="gio:heart"></mat-icon
             ></span>
-            <span *ngIf="element.inherit" matTooltip="HTTP configuration inherited" class="gio-badge-neutral"
+            <span *ngIf="element.inherit" matTooltip="Configuration inherited" class="gio-badge-neutral"
               ><mat-icon svgIcon="gio:network-alt"></mat-icon
             ></span>
           </div>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/list/api-proxy-endpoint-list.component.spec.ts
@@ -381,7 +381,7 @@ describe('ApiProxyEndpointListComponent', () => {
         }),
       );
 
-      expect(await loader.getChildLoader('[mattooltip="HTTP configuration inherited"]')).toBeTruthy();
+      expect(await loader.getChildLoader('[mattooltip="Configuration inherited"]')).toBeTruthy();
     });
   });
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -146,6 +146,10 @@ public class Endpoint implements Serializable {
         this.tenants = tenants;
     }
 
+    public void setType(String type) {
+        this.type = type;
+    }
+
     public String getType() {
         return type;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
@@ -95,8 +95,8 @@ public interface EndpointMapper {
             return null;
         }
 
-        // If endpoint is a http endpoint, we need to parse the configuration and use it as the actual instance
-        if (endpoint.getType().equals("http") && endpoint.getConfiguration() != null) {
+        // If endpoint is a http or grpc endpoint, we need to parse the configuration and use it as the actual instance
+        if ((endpoint.getType().equals("http") || endpoint.getType().equals("grpc")) && endpoint.getConfiguration() != null) {
             ObjectMapper mapper = new GraviteeMapper();
             io.gravitee.definition.model.endpoint.HttpEndpoint config;
             try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -4183,6 +4183,7 @@ components:
                 propertyName: type
                 mapping:
                     http: HttpEndpointV2
+                    grpc: HttpEndpointV2
         BaseEndpointV2:
             type: object
             properties:
@@ -4227,6 +4228,7 @@ components:
                 propertyName: type
                 mapping:
                     http: HttpEndpointV2
+                    grpc: HttpEndpointV2
             required:
                 - type
         HttpEndpointV2:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
@@ -204,6 +204,33 @@ public class EndpointMapperTest {
     }
 
     @Test
+    void should_map_from_endpoint_entity_V2_with_gRPC_type() throws JsonProcessingException {
+        // Init http endpoint configuration
+        var httpEndpointV2Configuration = EndpointModelFixtures.aModelHttpEndpointV2();
+
+        var httpHeader = new io.gravitee.common.http.HttpHeader();
+        httpHeader.setName("headerName");
+        httpHeader.setValue("headerValue");
+        httpEndpointV2Configuration.setHeaders(List.of(httpHeader));
+
+        // Set http endpoint configuration into endpoint.configuration
+        var endpointEntityV2 = EndpointModelFixtures.aModelEndpointV2();
+        endpointEntityV2.setType("grpc");
+        endpointEntityV2.setName("Should not be mapped");
+        endpointEntityV2.setConfiguration(new ObjectMapper().writeValueAsString(httpEndpointV2Configuration));
+
+        var endpointV2 = endpointMapper.map(endpointEntityV2);
+
+        // assert nested configuration only are mapped if filled
+        assertV2EndpointsAreEquals(httpEndpointV2Configuration, endpointV2);
+        // Check http configuration
+        var httpEndpointV2 = endpointV2.getHttpEndpointV2();
+        assertThat(httpEndpointV2Configuration.getHeaders()).isNotNull();
+        assertThat(httpEndpointV2Configuration.getHeaders().get(0).getName()).isEqualTo(httpEndpointV2.getHeaders().get(0).getName());
+        assertThat(httpEndpointV2Configuration.getHeaders().get(0).getValue()).isEqualTo(httpEndpointV2.getHeaders().get(0).getValue());
+    }
+
+    @Test
     void shouldMapToEndpointGroupEntityV2() throws JsonProcessingException {
         var endpointGroupV2 = EndpointFixtures.anEndpointGroupV2();
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3676
https://gravitee.atlassian.net/browse/APIM-3655

## Description

map the endpoint gRPC type as HttpEndpointV2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xfwncuaxkk.chromatic.com)
<!-- Storybook placeholder end -->
