### PR TITLE
fix(e2e): remove duplicate `HttpEndpointV2FromJSONTyped` import

### DIFF
--- a/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
+++ b/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
@@ -16,7 +16,7 @@
 mkdir -p .tmp
 sed s/'uniqueItems: true'/'uniqueItems: false'/g ../gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml > .tmp/management-openapi-v2.yaml
 
-npx @openapitools/openapi-generator-cli@2.6.0 generate \
+npx @openapitools/openapi-generator-cli@2.7.0 generate \
   -i .tmp/management-openapi-v2.yaml \
   -g typescript-fetch \
   -o lib/management-v2-webclient-sdk/src/lib/ \
@@ -31,6 +31,9 @@ npx @openapitools/openapi-generator-cli@2.6.0 generate \
 
   sed -i.bak "s|NAME: '-name'|_NAME: '-name'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
   sed -i.bak "s|PATHS: '-paths'|_PATHS: '-paths'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
+  # Remove duplicate `HttpEndpointV2FromJSONTyped` import
+  sed -i.bak "s|     HttpEndpointV2FromJSONTyped,||" lib/management-v2-webclient-sdk/src/lib/models/BaseEndpointV2.ts
+
 find lib/management-v2-webclient-sdk/src -name "*.ts" -exec sed -i.bak "/* The version of the OpenAPI document/d" {} \;
 # must delete .bak files
 find lib/management-v2-webclient-sdk/src -name "*.ts.bak" -exec rm -f {} \;


### PR DESCRIPTION
## Issue
n/a

## Description

Fix this e2e erreur : 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/779f913f-f0e7-481a-b68f-2cce4fb42703)


After discussion, we'd prefer to keep the open api as it is and add a sed here to fix this TS bug. 
I tested it locally. After the merge of this PR if this CI is ok. I continu with mergify

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pqcmywkcgt.chromatic.com)
<!-- Storybook placeholder end -->
