### PR TITLE
fix: pass host to backend on api duplication

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/duplicateApiOptions.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/duplicateApiOptions.ts
@@ -16,7 +16,9 @@
 
 export interface DuplicateApiOptions {
   /** The context path of the duplicated API */
-  contextPath: string;
+  contextPath?: string;
+  /** The context path of the duplicated TCP API */
+  host?: string;
   /** The version of the duplicated API. If it is not defined, the value of the source API is used. */
   version?: string;
   /** The list of API fields that can be excluded to create the new API. */

--- a/gravitee-apim-console-webui/src/management/api/general/details/api-general-info-duplicate-dialog/api-general-info-duplicate-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/details/api-general-info-duplicate-dialog/api-general-info-duplicate-dialog.component.ts
@@ -116,6 +116,7 @@ export class ApiGeneralInfoDuplicateDialogComponent implements OnDestroy {
     this.apiV2Service
       .duplicate(this.apiId, {
         contextPath: configsFormValue.contextPath,
+        host: configsFormValue.host,
         version: configsFormValue.version,
         filteredFields: this.optionsCheckbox.filter((option) => !configsFormValue.options[option.id]).map((option) => option.id),
       })

--- a/gravitee-apim-console-webui/src/management/api/general/details/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/details/api-general-info.component.spec.ts
@@ -15,7 +15,7 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpTestingController } from '@angular/common/http/testing';
+import { HttpTestingController, TestRequest } from '@angular/common/http/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import {
@@ -695,7 +695,10 @@ describe('ApiGeneralInfoComponent', () => {
       const confirmButton = await confirmDialog.getHarness(MatButtonHarness.with({ text: 'Duplicate' }));
       await confirmButton.click();
 
-      await expectDuplicatePostRequest(API_ID);
+      const req = await expectDuplicatePostRequest(API_ID);
+
+      expect(req.request.body.contextPath).toEqual('/duplicate');
+      expect(req.request.body.host).toBeUndefined();
 
       expect(routerNavigateSpy).toHaveBeenCalledWith(['../', 'newApiId'], expect.anything());
     });
@@ -728,7 +731,10 @@ describe('ApiGeneralInfoComponent', () => {
       const confirmButton = await confirmDialog.getHarness(MatButtonHarness.with({ text: 'Duplicate' }));
       await confirmButton.click();
 
-      await expectDuplicatePostRequest(API_ID);
+      const req = await expectDuplicatePostRequest(API_ID);
+
+      expect(req.request.body.contextPath).toBeUndefined();
+      expect(req.request.body.host).toEqual('duplicate');
 
       expect(routerNavigateSpy).toHaveBeenCalledWith(['../', 'newApiId'], expect.anything());
     });
@@ -749,11 +755,13 @@ describe('ApiGeneralInfoComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectDuplicatePostRequest(apiId: string) {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_duplicate`, method: 'POST' }).flush({
+  function expectDuplicatePostRequest(apiId: string): TestRequest {
+    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_duplicate`, method: 'POST' });
+    req.flush({
       id: 'newApiId',
     });
     fixture.detectChanges();
+    return req;
   }
 
   function expectVerifyContextPathGetRequest(definitionVersion: DefinitionVersion = 'V2') {


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-3608

## Description

The host was not properly passed to the backend, making impossible du duplicate a TCP api

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nuyuyfqlml.chromatic.com)
<!-- Storybook placeholder end -->
