### PR TITLE
feat: add use case to set policy plugin deployed attribute based on license

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -104,7 +104,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
 
     function expectPolicySchemaV2GetRequest(type: string, schema: unknown) {
       httpTestingController
-        .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/${type}/schema`, method: 'GET' })
+        .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/${type}/schema`, method: 'GET' })
         .flush(schema);
     }
 

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -613,7 +613,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
   function expectGetPolicies() {
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/policies`,
+        url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies`,
         method: 'GET',
       })
       .flush([fakePolicyPlugin(), ...fakePoliciesPlugin()]);

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
@@ -43,7 +43,7 @@ describe('PolicyV2Service', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.v2BaseURL}/plugins/policies`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies`);
       expect(req.request.method).toEqual('GET');
 
       req.flush(policies);
@@ -60,7 +60,7 @@ describe('PolicyV2Service', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/policy#1/schema`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/policy#1/schema`);
       expect(req.request.method).toEqual('GET');
 
       req.flush(policySchema);
@@ -77,7 +77,7 @@ describe('PolicyV2Service', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/policy#1/documentation`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/policy#1/documentation`);
       expect(req.request.method).toEqual('GET');
 
       req.flush(policyDocumentation);

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
@@ -29,16 +29,16 @@ export class PolicyV2Service {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   list(): Observable<PolicyPlugin[]> {
-    return this.http.get<PolicyListItem[]>(`${this.constants.v2BaseURL}/plugins/policies`);
+    return this.http.get<PolicyListItem[]>(`${this.constants.org.v2BaseURL}/plugins/policies`);
   }
 
   getSchema(policyId: string): Observable<PolicySchema> {
-    return this.http.get<PolicySchema>(`${this.constants.v2BaseURL}/plugins/policies/${policyId}/schema`);
+    return this.http.get<PolicySchema>(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/schema`);
   }
 
   getDocumentation(policyId: string): Observable<PolicyDocumentation> {
     return this.http
-      .get(`${this.constants.v2BaseURL}/plugins/policies/${policyId}/documentation`, {
+      .get(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/documentation`, {
         responseType: 'text',
       })
       .pipe(map((buffer) => buffer.toString()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.management.v2.rest.model.Organization;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EntrypointsResource;
+import io.gravitee.rest.api.management.v2.rest.resource.plugin.PoliciesResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
@@ -94,5 +95,10 @@ public class OrganizationResource extends AbstractResource {
     @Path("/plugins/entrypoints")
     public EntrypointsResource getOrganizationEntrypointsResource() {
         return resourceContext.getResource(EntrypointsResource.class);
+    }
+
+    @Path("/plugins/policies")
+    public PoliciesResource getOrganizationPoliciesResource() {
+        return resourceContext.getResource(PoliciesResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -39,7 +39,7 @@ servers:
           managementAPIHost:
               description: The domain of the server hosting your Management API
               default: localhost:8083
-          ordId:
+          orgId:
               description: The unique ID of your organization
               default: DEFAULT
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -39,7 +39,7 @@ servers:
           managementAPIHost:
               description: The domain of the server hosting your Management API
               default: localhost:8083
-          ordId:
+          orgId:
               description: The unique ID of your organization
               default: DEFAULT
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -27,6 +27,21 @@ servers:
           managementAPIHost:
               description: The domain of the server hosting your Management API
               default: localhost:8083
+    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+      description: APIM Management API v2 - Base URL to target specific organizations
+      variables:
+          protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                  - https
+                  - http
+          managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+          ordId:
+              description: The unique ID of your organization
+              default: DEFAULT
 
 tags:
     - name: Plugins - Endpoints
@@ -463,7 +478,7 @@ components:
                     minLength: 1
                 deployed:
                     type: boolean
-                    description: The deployment status of the plugin.
+                    description: The deployment status of the plugin. This property is true if the plugin is deployed on the installation and the license allows to use it.
         ApiType:
             type: string
             description: API's type.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
@@ -158,6 +158,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public PolicyPluginQueryServiceInMemory policyPluginQueryServiceInMemory() {
+        return new PolicyPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ResourcesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ResourcesResourceTest.java
@@ -19,6 +19,8 @@ import static jakarta.ws.rs.core.Response.Status.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.license.License;
+import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.model.ResourceListItem;
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
 import io.gravitee.rest.api.service.ResourceService;
@@ -26,6 +28,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.GenericType;
 import java.util.Set;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Antoine Cordier (antoine.cordier at graviteesource.com)
@@ -36,6 +39,9 @@ public class ResourcesResourceTest extends AbstractResourceTest {
     @Inject
     ResourceService resourceService;
 
+    @Autowired
+    protected LicenseManager licenseManager;
+
     @Override
     protected String contextPath() {
         return "resources";
@@ -43,13 +49,59 @@ public class ResourcesResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldReturnResources() {
-        when(resourceService.findAll()).thenReturn(Set.of(PlatformPluginEntity.builder().id("resource-id").build()));
+        when(resourceService.findAll())
+            .thenReturn(
+                Set.of(
+                    PlatformPluginEntity
+                        .builder()
+                        .id("resource-id-1")
+                        .feature("resource-feature-1")
+                        .name("Resource 1")
+                        .deployed(true)
+                        .build(),
+                    PlatformPluginEntity
+                        .builder()
+                        .id("resource-id-2")
+                        .feature("resource-feature-2")
+                        .name("Resource 2")
+                        .deployed(true)
+                        .build(),
+                    PlatformPluginEntity
+                        .builder()
+                        .id("resource-id-3")
+                        .feature("resource-feature-3")
+                        .name("Resource 3")
+                        .deployed(false)
+                        .build()
+                )
+            );
+        var license = mock(License.class);
+        when(licenseManager.getOrganizationLicenseOrPlatform("DEFAULT")).thenReturn(license);
+        when(license.isFeatureEnabled("resource-feature-1")).thenReturn(false);
+        when(license.isFeatureEnabled("resource-feature-2")).thenReturn(true);
+        when(license.isFeatureEnabled("resource-feature-3")).thenReturn(true);
 
         var response = envTarget().request().get();
         assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
 
         var resources = response.readEntity(new GenericType<Set<ResourceListItem>>() {});
-        assertThat(resources).extracting("id").containsExactly("resource-id");
+        var expected1 = new ResourceListItem();
+        expected1.setId("resource-id-1");
+        expected1.setName("Resource 1");
+        expected1.setDeployed(false);
+        expected1.setFeature("resource-feature-1");
+        var expected2 = new ResourceListItem();
+        expected2.setId("resource-id-2");
+        expected2.setName("Resource 2");
+        expected2.setDeployed(true);
+        expected2.setFeature("resource-feature-2");
+        var expected3 = new ResourceListItem();
+        expected3.setId("resource-id-3");
+        expected3.setName("Resource 3");
+        expected3.setDeployed(false);
+        expected3.setFeature("resource-feature-3");
+
+        assertThat(resources).hasSize(3).containsExactly(expected1, expected3, expected2);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
@@ -142,6 +142,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public PolicyPluginQueryServiceInMemory policyPluginQueryServiceInMemory() {
+        return new PolicyPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/platform/plugin/PlatformPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/platform/plugin/PlatformPluginEntity.java
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
  */
 @Data
 @NoArgsConstructor
-@SuperBuilder
+@SuperBuilder(toBuilder = true)
 public class PlatformPluginEntity {
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
@@ -141,6 +141,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public PolicyPluginQueryServiceInMemory policyPluginQueryServiceInMemory() {
+        return new PolicyPluginQueryServiceInMemory();
+    }
+
+    @Bean
     public FlowCrudServiceInMemory flowCrudServiceInMemory() {
         return new FlowCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/domain_service/PluginFilterByLicenseDomainService.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.core.plugin.domain_service;
 
-import io.gravitee.apim.core.plugin.model.ConnectorPlugin;
+import io.gravitee.apim.core.plugin.model.PlatformPlugin;
 import io.gravitee.node.api.license.LicenseManager;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,11 +28,11 @@ public class PluginFilterByLicenseDomainService {
         this.licenseManager = licenseManager;
     }
 
-    public Set<ConnectorPlugin> setPluginDeployedStatusDependingOnLicense(Set<ConnectorPlugin> pluginSet, String organizationId) {
+    public <T extends PlatformPlugin> Set<T> setPluginDeployedStatusDependingOnLicense(Set<T> pluginSet, String organizationId) {
         var license = licenseManager.getOrganizationLicenseOrPlatform(organizationId);
         return pluginSet
             .stream()
-            .map(plugin -> plugin.toBuilder().deployed(plugin.isDeployed() && license.isFeatureEnabled(plugin.getFeature())).build())
+            .peek(plugin -> plugin.setDeployed(plugin.isDeployed() && license.isFeatureEnabled(plugin.getFeature())))
             .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PolicyPlugin.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PolicyPlugin.java
@@ -13,21 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.v4.policy;
+package io.gravitee.apim.core.plugin.model;
 
-import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data
-@ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@Schema(name = "PolicyPluginEntityV4")
-@SuperBuilder(toBuilder = true)
 @NoArgsConstructor
-public class PolicyPluginEntity extends PlatformPluginEntity {
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class PolicyPlugin extends PlatformPlugin {
+
+    public enum ExecutionPhase {
+        REQUEST,
+        RESPONSE,
+        MESSAGE_REQUEST,
+        MESSAGE_RESPONSE,
+    }
 
     private Set<ExecutionPhase> proxy;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/query_service/PolicyPluginQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/query_service/PolicyPluginQueryService.java
@@ -13,23 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.v4.policy;
+package io.gravitee.apim.core.plugin.query_service;
 
-import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import java.util.Set;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
 
-@Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@Schema(name = "PolicyPluginEntityV4")
-@SuperBuilder(toBuilder = true)
-@NoArgsConstructor
-public class PolicyPluginEntity extends PlatformPluginEntity {
-
-    private Set<ExecutionPhase> proxy;
-
-    private Set<ExecutionPhase> message;
+public interface PolicyPluginQueryService {
+    Set<PolicyPlugin> findAll();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetPolicyPluginsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/use_case/GetPolicyPluginsUseCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.apim.core.plugin.query_service.PolicyPluginQueryService;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+public class GetPolicyPluginsUseCase {
+
+    private final PolicyPluginQueryService policyPluginQueryService;
+    private final PluginFilterByLicenseDomainService licenseChecker;
+
+    public GetPolicyPluginsUseCase(PolicyPluginQueryService policyPluginQueryService, PluginFilterByLicenseDomainService licenseChecker) {
+        this.policyPluginQueryService = policyPluginQueryService;
+        this.licenseChecker = licenseChecker;
+    }
+
+    public Output getPoliciesByOrganization(Input input) {
+        return new Output(
+            this.licenseChecker.setPluginDeployedStatusDependingOnLicense(policyPluginQueryService.findAll(), input.organizationId)
+                .stream()
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(PolicyPlugin::getName))))
+        );
+    }
+
+    public record Input(String organizationId) {}
+
+    public record Output(Set<PolicyPlugin> plugins) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PolicyPluginAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PolicyPluginAdapter.java
@@ -13,23 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.management.v2.rest.mapper;
+package io.gravitee.apim.infra.adapter;
 
-import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
-import java.util.Set;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
-public interface PolicyPluginMapper {
-    PolicyPluginMapper INSTANCE = Mappers.getMapper(PolicyPluginMapper.class);
+public interface PolicyPluginAdapter {
+    PolicyPluginAdapter INSTANCE = Mappers.getMapper(PolicyPluginAdapter.class);
 
-    PolicyPlugin map(PolicyPluginEntity policyEntity);
-
-    Set<PolicyPlugin> map(Set<PolicyPluginEntity> policyEntitySet);
-
-    PolicyPlugin mapToCore(io.gravitee.apim.core.plugin.model.PolicyPlugin policyEntity);
-
-    Set<PolicyPlugin> mapToCore(Set<io.gravitee.apim.core.plugin.model.PolicyPlugin> policyEntitySet);
+    PolicyPlugin map(PolicyPluginEntity source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.plugin;
+
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.apim.core.plugin.query_service.PolicyPluginQueryService;
+import io.gravitee.apim.infra.adapter.PolicyPluginAdapter;
+import io.gravitee.rest.api.service.v4.PolicyPluginService;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PolicyPluginQueryServiceLegacyWrapper implements PolicyPluginQueryService {
+
+    private final PolicyPluginService policyPluginService;
+
+    public PolicyPluginQueryServiceLegacyWrapper(PolicyPluginService policyPluginService) {
+        this.policyPluginService = policyPluginService;
+    }
+
+    @Override
+    public Set<PolicyPlugin> findAll() {
+        return policyPluginService.findAll().stream().map(PolicyPluginAdapter.INSTANCE::map).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/UsecaseSpringConfiguration.java
@@ -71,8 +71,10 @@ import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
 import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
 import io.gravitee.apim.core.plugin.query_service.EndpointPluginQueryService;
 import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
+import io.gravitee.apim.core.plugin.query_service.PolicyPluginQueryService;
 import io.gravitee.apim.core.plugin.use_case.GetEndpointPluginsUseCase;
 import io.gravitee.apim.core.plugin.use_case.GetEntrypointPluginsUseCase;
+import io.gravitee.apim.core.plugin.use_case.GetPolicyPluginsUseCase;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
@@ -353,6 +355,14 @@ public class UsecaseSpringConfiguration {
         PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService
     ) {
         return new GetEndpointPluginsUseCase(endpointPluginQueryService, pluginFilterByLicenseDomainService);
+    }
+
+    @Bean
+    public GetPolicyPluginsUseCase getPolicyPluginsUseCase(
+        PolicyPluginQueryService policyPluginQueryService,
+        PluginFilterByLicenseDomainService pluginFilterByLicenseDomainService
+    ) {
+        return new GetPolicyPluginsUseCase(policyPluginQueryService, pluginFilterByLicenseDomainService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EndpointPluginQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/EndpointPluginQueryServiceInMemory.java
@@ -31,9 +31,6 @@ import java.util.Set;
 
 public class EndpointPluginQueryServiceInMemory implements EndpointPluginQueryService, InMemoryAlternative<ConnectorPlugin> {
 
-    public static final String HTTP_PROXY_CONNECTOR_ID = "http-proxy";
-    public static final String SSE_CONNECTOR_ID = "sse";
-    public static final String MOCK_CONNECTOR_ID = "mock";
     private static final List<ConnectorPlugin> DEFAULT_LIST = List.of(
         ConnectorPlugin
             .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PolicyPluginQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PolicyPluginQueryServiceInMemory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.apim.core.plugin.query_service.PolicyPluginQueryService;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PolicyPluginQueryServiceInMemory implements PolicyPluginQueryService, InMemoryAlternative<PolicyPlugin> {
+
+    private List<PolicyPlugin> storage = List.of();
+
+    @Override
+    public Set<PolicyPlugin> findAll() {
+        return new HashSet<>(storage);
+    }
+
+    @Override
+    public void initWith(List<PolicyPlugin> items) {
+        this.storage = items;
+    }
+
+    @Override
+    public void reset() {
+        this.storage = List.of();
+    }
+
+    @Override
+    public List<PolicyPlugin> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetPolicyPluginsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plugin/use_case/GetPolicyPluginsUseCaseTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plugin.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import inmemory.PolicyPluginQueryServiceInMemory;
+import io.gravitee.apim.core.plugin.domain_service.PluginFilterByLicenseDomainService;
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetPolicyPluginsUseCaseTest {
+
+    private final PolicyPluginQueryServiceInMemory policyPluginQueryServiceInMemory = new PolicyPluginQueryServiceInMemory();
+    private LicenseManager licenseManager;
+
+    private GetPolicyPluginsUseCase getPolicyPluginsUseCase;
+
+    @BeforeEach
+    void setup() {
+        licenseManager = mock(LicenseManager.class);
+        getPolicyPluginsUseCase =
+            new GetPolicyPluginsUseCase(policyPluginQueryServiceInMemory, new PluginFilterByLicenseDomainService(licenseManager));
+    }
+
+    @Test
+    void getPoliciesByOrganization() {
+        policyPluginQueryServiceInMemory.initWith(
+            List.of(
+                PolicyPlugin.builder().id("policy-1").name("Policy 1").feature("feature-policy-1").deployed(true).build(),
+                PolicyPlugin.builder().id("policy-2").name("Policy 2").feature("feature-policy-2").deployed(true).build(),
+                PolicyPlugin.builder().id("policy-3").name("Policy 3").feature("feature-policy-3").deployed(false).build()
+            )
+        );
+        var license = mock(io.gravitee.node.api.license.License.class);
+        when(licenseManager.getOrganizationLicenseOrPlatform("org-id")).thenReturn(license);
+
+        when(license.isFeatureEnabled("feature-policy-1")).thenReturn(false);
+        when(license.isFeatureEnabled("feature-policy-2")).thenReturn(true);
+        when(license.isFeatureEnabled("feature-policy-3")).thenReturn(true);
+
+        assertThat(getPolicyPluginsUseCase.getPoliciesByOrganization(new GetPolicyPluginsUseCase.Input("org-id")).plugins())
+            .containsExactly(
+                PolicyPlugin.builder().id("policy-1").name("Policy 1").feature("feature-policy-1").deployed(false).build(),
+                PolicyPlugin.builder().id("policy-2").name("Policy 2").feature("feature-policy-2").deployed(true).build(),
+                PolicyPlugin.builder().id("policy-3").name("Policy 3").feature("feature-policy-3").deployed(false).build()
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.plugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
+import io.gravitee.rest.api.service.v4.PolicyPluginService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PolicyPluginQueryServiceLegacyWrapperTest {
+
+    PolicyPluginService policyPluginService;
+    PolicyPluginQueryServiceLegacyWrapper service;
+
+    @BeforeEach
+    void setup() {
+        policyPluginService = mock(PolicyPluginService.class);
+        service = new PolicyPluginQueryServiceLegacyWrapper(policyPluginService);
+    }
+
+    @Test
+    void findAll() {
+        when(policyPluginService.findAll())
+            .thenReturn(
+                Set.of(
+                    PolicyPluginEntity.builder().id("policy-1").name("Policy 1").build(),
+                    PolicyPluginEntity.builder().id("policy-2").name("Policy 2").build()
+                )
+            );
+
+        assertThat(service.findAll())
+            .containsExactly(
+                PolicyPlugin.builder().id("policy-1").name("Policy 1").build(),
+                PolicyPlugin.builder().id("policy-2").name("Policy 2").build()
+            );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3566

## Description

In this PR, I have created a new service in management-v2 to set `deployed` attribute on policies
I also changed management-v1 to do the same for policies and resources

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kgvxoprvzv.chromatic.com)
<!-- Storybook placeholder end -->
