### PR TITLE
fix(console): do not use application cached if the wanted applicationId is different

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -145,7 +145,7 @@ export class ApiV2Service {
   }
 
   getLastApiFetch(apiId: string): Observable<Api> {
-    const start = this.lastApiFetch$.value ? of(this.lastApiFetch$.value) : this.get(apiId);
+    const start = this.lastApiFetch$.value && this.lastApiFetch$.value.id === apiId ? of(this.lastApiFetch$.value) : this.get(apiId);
     return start.pipe(
       switchMap(() => this.lastApiFetch$.asObservable()),
       filter((api) => !!api),

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -134,7 +134,10 @@ export class ApplicationService {
   }
 
   getLastApplicationFetch(applicationId: string): Observable<Application> {
-    const start = this.lastApplicationFetch$.value ? of(this.lastApplicationFetch$.value) : this.getById(applicationId);
+    const start =
+      this.lastApplicationFetch$.value && this.lastApplicationFetch$.value.id === applicationId
+        ? of(this.lastApplicationFetch$.value)
+        : this.getById(applicationId);
     return start.pipe(
       switchMap(() => this.lastApplicationFetch$.asObservable()),
       filter((application) => !!application),


### PR DESCRIPTION
## Issue

maybe or not yet :p 

## Description

To reproduce : 
- Go to an application
- Go tou application list
- Go to another application 
- Bug : You always see the first application

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ubwiqkueqx.chromatic.com)
<!-- Storybook placeholder end -->
