### PR TITLE
test: adapt test to not input a slash

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-creation-workflow.spec.ts
@@ -18,7 +18,7 @@ import faker from '@faker-js/faker';
 
 describe('API creation workflow', () => {
   const apiVersion = `${faker.datatype.number({ min: 1, max: 9 })}.${faker.datatype.number({ min: 1, max: 9 })}`;
-  const apiPath = `/${faker.commerce.productName().replace(/ /g, '_')}`;
+  const apiPath = faker.commerce.productName().replace(/ /g, '_');
   const apiName = faker.commerce.productName();
   let apiId: string;
 
@@ -92,7 +92,7 @@ describe('API creation workflow', () => {
     });
 
     it('should successfully connect to created API', function () {
-      cy.callGateway(`${apiPath}`).then((response) => {
+      cy.callGateway(`/${apiPath}`).then((response) => {
         expect(response.body.message).to.eq('Hello, World!'); // from wiremock
       });
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3684

## Description

Do not use a `/` when setting the context path of the API
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wtkhlthfmj.chromatic.com)
<!-- Storybook placeholder end -->
