### PR TITLE
feat(mapi-v2): add 'expiresAt' to license response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Mapper
+@Mapper(uses = { DateMapper.class })
 public interface GraviteeLicenseMapper {
     GraviteeLicenseMapper INSTANCE = Mappers.getMapper(GraviteeLicenseMapper.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
@@ -46,7 +46,13 @@ public class GraviteeLicenseResource extends AbstractResource {
         final License license = licenseManager.getPlatformLicense();
 
         return GraviteeLicenseMapper.INSTANCE.map(
-            GraviteeLicenseEntity.builder().tier(license.getTier()).packs(license.getPacks()).features(license.getFeatures()).build()
+            GraviteeLicenseEntity
+                .builder()
+                .tier(license.getTier())
+                .packs(license.getPacks())
+                .features(license.getFeatures())
+                .expiresAt(license.getExpirationDate())
+                .build()
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -71,7 +71,13 @@ public class OrganizationResource extends AbstractResource {
         final License license = licenseManager.getOrganizationLicenseOrPlatform(orgId);
 
         return GraviteeLicenseMapper.INSTANCE.map(
-            GraviteeLicenseEntity.builder().tier(license.getTier()).packs(license.getPacks()).features(license.getFeatures()).build()
+            GraviteeLicenseEntity
+                .builder()
+                .tier(license.getTier())
+                .packs(license.getPacks())
+                .features(license.getFeatures())
+                .expiresAt(license.getExpirationDate())
+                .build()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1928,6 +1928,11 @@ components:
                     example:
                         - feature-debug-mode
                         - feature-datadog-reporter
+                expiresAt:
+                    type: string
+                    format: date-time
+                    description: The date (as timestamp) when the license will expire.
+                    example: 1581256457163
         Analytics:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
@@ -24,6 +24,8 @@ import io.gravitee.node.api.license.License;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Set;
 import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,10 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         when(license.getPacks()).thenReturn(Set.of("observability"));
         when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
 
+        var now = Instant.now();
+        var nowDate = Date.from(now);
+        when(license.getExpirationDate()).thenReturn(nowDate);
+
         var response = rootTarget().request().get();
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
 
@@ -58,5 +64,6 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         assertThat(graviteeLicense.getTier()).isEqualTo("universe");
         assertThat(graviteeLicense.getPacks()).containsExactly("observability");
         assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
+        assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
@@ -35,6 +35,8 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.OrganizationNotFoundException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
@@ -88,11 +90,15 @@ public class OrganizationResourceTest extends AbstractResourceTest {
         public void shouldReturnOrganizationLicenseWithFeatures() {
             mockExistingOrganization(ORGANIZATION);
 
+            var now = Instant.now();
+            var nowDate = Date.from(now);
+
             final License license = mock(License.class);
             when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION)).thenReturn(license);
             when(license.getTier()).thenReturn("universe");
             when(license.getPacks()).thenReturn(Set.of("observability"));
             when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
+            when(license.getExpirationDate()).thenReturn(nowDate);
 
             var response = rootTarget(ORGANIZATION).path("license").request().get();
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
@@ -102,6 +108,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             assertThat(graviteeLicense.getTier()).isEqualTo("universe");
             assertThat(graviteeLicense.getPacks()).containsExactly("observability");
             assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
+            assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model.v4.license;
 
+import java.util.Date;
 import java.util.Set;
 import lombok.*;
 
@@ -38,4 +39,6 @@ public class GraviteeLicenseEntity {
 
     @Builder.Default
     private Set<String> features = Set.of();
+
+    private Date expiresAt;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3670

## Description

Return expiration date with the license for endpoints `/license` and `/organizations/:orgId/license`.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

