### PR TITLE
fix: enforce 3 char path in context path mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
@@ -209,7 +209,7 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
 
   public validateListenerControl(listenerControl: AbstractControl, httpListeners: PathV4[], currentIndex: number): ValidationErrors | null {
     const listenerPathControl = listenerControl.get('path');
-    let error = this.validateGenericPathListenerControl(listenerControl);
+    let error = this.validateContextPath(listenerControl);
     if (!error) {
       const contextPathAlreadyExist = httpListeners
         .filter((l, index) => index !== currentIndex)
@@ -223,10 +223,21 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
     return error;
   }
 
-  public validateGenericPathListenerControl(listenerControl: AbstractControl): ValidationErrors | null {
+  private validateContextPath(listenerControl: AbstractControl): ValidationErrors | null {
     const listenerPathControl = listenerControl.get('path');
     const contextPath: string = listenerPathControl.value;
 
+    let errors = this.validateGenericPathListenerControl(contextPath);
+
+    if (contextPath.length <= 3) {
+      errors = { contextPath: 'Context path has to be more than 3 characters long.' };
+    }
+
+    setTimeout(() => listenerPathControl.setErrors(errors), 0);
+    return errors;
+  }
+
+  protected validateGenericPathListenerControl(contextPath: string): ValidationErrors | null {
     let errors = null;
     if (isEmpty(contextPath)) {
       errors = {
@@ -237,7 +248,6 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
     } else if (!PATH_PATTERN_REGEX.test(contextPath)) {
       errors = { contextPath: 'Context path is not valid.' };
     }
-    setTimeout(() => listenerPathControl.setErrors(errors), 0);
     return errors;
   }
 

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
@@ -145,9 +145,9 @@ describe('GioFormListenersContextPathModule', () => {
     await emptyLastContextPathRow.pathInput.setValue('/abc yeh');
     expect(await pathInputHost.hasClass('ng-invalid')).toEqual(true);
 
-    // Valid
+    // Invalid: too short
     await emptyLastContextPathRow.pathInput.setValue('/ba');
-    expect(await pathInputHost.hasClass('ng-invalid')).toEqual(false);
+    expect(await pathInputHost.hasClass('ng-invalid')).toEqual(true);
 
     // Valid
     await emptyLastContextPathRow.pathInput.setValue('/good-path');

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
@@ -71,7 +71,7 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
   }
 
   validateListenerControl(listenerControl: AbstractControl, httpListeners: PathV4[], currentIndex: number): ValidationErrors | null {
-    const inheritErrors = super.validateGenericPathListenerControl(listenerControl);
+    const inheritErrors = this.validateVirtualHostPath(listenerControl);
     const subDomainControl = listenerControl.get('_hostSubDomain');
     const domainControl = listenerControl.get('_hostDomain');
     const contextPathControl = listenerControl.get('path');
@@ -104,6 +104,16 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
 
     setTimeout(() => subDomainControl.setErrors(null), 0);
     return inheritErrors;
+  }
+
+  private validateVirtualHostPath(listenerControl: AbstractControl): ValidationErrors | null {
+    const listenerPathControl = listenerControl.get('path');
+    const contextPath: string = listenerPathControl.value;
+
+    const errors = this.validateGenericPathListenerControl(contextPath);
+
+    setTimeout(() => listenerPathControl.setErrors(errors), 0);
+    return errors;
   }
 
   protected getValue(): PathV4[] {


### PR DESCRIPTION
## Description

In contextPath mode, we should enforce a path to have minimum 3 char to prevent from creating am API using `/` that could "catch" all the traffic of the Gateway. This rule has been incorrectly removed to allow `/` in VirtualHost mode.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aomzuxcmem.chromatic.com)
<!-- Storybook placeholder end -->
