### PR TITLE
update api V4 menu - notifications & metadata

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -70,6 +70,14 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
+    if (this.permissionService.hasAnyMatching(['api-notification-r'])) {
+      tabs.push({
+        displayName: 'Notifications',
+        routerLink: 'DISABLED',
+        routerLinkActiveOptions: { exact: true },
+      });
+    }
+
     return {
       displayName: 'Configuration',
       icon: 'settings',
@@ -302,13 +310,6 @@ export class ApiV4MenuService implements ApiMenuService {
       title: 'Notifications',
       items: [],
     };
-
-    if (this.permissionService.hasAnyMatching(['api-notification-r'])) {
-      notificationsGroup.items.push({
-        displayName: 'Notification settings',
-        routerLink: 'DISABLED',
-      });
-    }
 
     if (!this.constants.isOEM && this.constants.org.settings.alert?.enabled && this.permissionService.hasAnyMatching(['api-alert-r'])) {
       notificationsGroup.items.push({

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -70,6 +70,14 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
+    if (this.permissionService.hasAnyMatching(['api-metadata-r'])) {
+      tabs.push({
+        displayName: 'Metadata',
+        routerLink: 'DISABLED',
+        routerLinkActiveOptions: { exact: true },
+      });
+    }
+
     if (this.permissionService.hasAnyMatching(['api-notification-r'])) {
       tabs.push({
         displayName: 'Notifications',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3442

## Description

 move notifications menu entry in configuration and add metadata tab

<img width="1790" alt="Capture d’écran 2024-01-22 à 15 14 02" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/abfb6a17-904b-488b-ad13-287820e41658">

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tzaylzomux.chromatic.com)
<!-- Storybook placeholder end -->
