### PR TITLE
fix: defer node bean instantiation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/GatewayContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/GatewayContainer.java
@@ -26,10 +26,6 @@ import java.util.List;
  */
 public class GatewayContainer extends SpringBasedContainer {
 
-    public GatewayContainer() {
-        super(GatewayNode.class);
-    }
-
     @Override
     protected List<Class<?>> annotatedClasses() {
         List<Class<?>> classes = super.annotatedClasses();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
@@ -34,7 +34,6 @@ import org.springframework.context.annotation.Lazy;
  */
 public class GatewayNode extends AbstractNode {
 
-    @Lazy
     @Autowired
     private NodeMetadataResolver nodeMetadataResolver;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
@@ -35,10 +35,9 @@ import io.gravitee.gateway.repository.plugins.GatewayRepositoryScopeProvider;
 import io.gravitee.gateway.standalone.node.GatewayNode;
 import io.gravitee.gateway.standalone.node.GatewayNodeMetadataResolver;
 import io.gravitee.gateway.standalone.vertx.VertxReactorConfiguration;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
-import io.gravitee.node.container.NodeFactory;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
-import io.gravitee.plugin.policy.spring.PolicyPluginConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -62,6 +61,11 @@ import org.springframework.context.annotation.Import;
     }
 )
 public class StandaloneConfiguration {
+
+    @Bean
+    public Node node() {
+        return new GatewayNode();
+    }
 
     @Bean
     public static GatewayConfiguration gatewayConfiguration() {
@@ -91,11 +95,6 @@ public class StandaloneConfiguration {
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {
         return new ExpressionLanguageInitializer();
-    }
-
-    @Bean
-    public NodeFactory node() {
-        return new NodeFactory(GatewayNode.class);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import io.gravitee.gateway.standalone.GatewayContainer;
 import io.gravitee.gateway.standalone.reporter.FakeReporter;
 import io.gravitee.gateway.standalone.tracer.NoOpTracer;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.container.NodeFactory;
@@ -54,8 +55,8 @@ public class GatewayTestContainer extends GatewayContainer {
     public static class GatewayTestConfiguration {
 
         @Bean
-        public NodeFactory node() {
-            return new NodeFactory(GatewayTestNode.class);
+        public Node node() {
+            return new GatewayTestNode();
         }
 
         @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.gateway.tests.sdk.tracer.NoOpTracer;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.standalone.GatewayContainer;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.node.api.license.LicenseManager;
@@ -79,8 +80,8 @@ public class GatewayTestContainer extends GatewayContainer {
     public static class GatewayTestConfiguration {
 
         @Bean
-        public NodeFactory node() {
-            return new NodeFactory(GatewayTestNode.class);
+        public Node node() {
+            return new GatewayTestNode();
         }
 
         @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/GraviteeApisContainer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/GraviteeApisContainer.java
@@ -27,10 +27,6 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
  */
 public class GraviteeApisContainer extends SpringBasedContainer {
 
-    public GraviteeApisContainer() {
-        super(GraviteeApisNode.class);
-    }
-
     @Override
     protected List<Class<?>> annotatedClasses() {
         List<Class<?>> classes = super.annotatedClasses();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Lazy;
  */
 public class GraviteeApisNode extends AbstractNode {
 
-    @Lazy
     @Autowired
     private NodeMetadataResolver nodeMetadataResolver;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.container.NodeFactory;
 import io.gravitee.platform.repository.api.RepositoryScopeProvider;
@@ -45,8 +46,8 @@ import org.springframework.context.annotation.Import;
 public class StandaloneConfiguration {
 
     @Bean
-    public NodeFactory node() {
-        return new NodeFactory(GraviteeApisNode.class);
+    public Node node() {
+        return new GraviteeApisNode();
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>5.3.0</gravitee-node.version>
+        <gravitee-node.version>5.3.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.0.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

Linked to https://gravitee.atlassian.net/browse/ARCHI-297

## Description

Move to gravitee-node 5.3.1 to embed the last fix to avoid the `Node` bean being instantiated twice. See https://github.com/gravitee-io/gravitee-node/pull/282 for details
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wjrhdatqeq.chromatic.com)
<!-- Storybook placeholder end -->
