### PR TITLE
Apim 3706 add license management permission

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
@@ -45,7 +45,10 @@
     </gio-menu-list>
 
     <gio-menu-license-expiration-notification *ngIf="licenseExpirationNotificationEnabled">
-      <gio-license-expiration-notification [expirationDate]="licenseExpirationDate$ | async"></gio-license-expiration-notification>
+      <gio-license-expiration-notification
+        *gioPermission="{ anyOf: ['organization-license_management-r'] }"
+        [expirationDate]="licenseExpirationDate$ | async"
+      ></gio-license-expiration-notification>
     </gio-menu-license-expiration-notification>
     <gio-menu-footer *ngIf="footerMenuItems.length > 0">
       <ng-container *ngFor="let item of footerMenuItems">

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
@@ -18,8 +18,11 @@ import { NgModule } from '@angular/core';
 import { GioLicenseExpirationNotificationModule, GioLicenseModule, GioMenuModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
 import { MatSelectModule } from '@angular/material/select';
 import { RouterModule } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
 
 import { GioSideNavComponent } from './gio-side-nav.component';
+
+import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
   imports: [
@@ -30,6 +33,8 @@ import { GioSideNavComponent } from './gio-side-nav.component';
     GioLicenseModule,
     RouterModule,
     GioLicenseExpirationNotificationModule,
+    GioPermissionModule,
+    MatButtonModule,
   ],
   declarations: [GioSideNavComponent],
   exports: [GioSideNavComponent],

--- a/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
@@ -24,6 +24,7 @@ export function fakePermissionsByScopes(attributes?: Partial<PermissionsByScopes
       'IDENTITY_PROVIDER',
       'IDENTITY_PROVIDER_ACTIVATION',
       'INSTALLATION',
+      'LICENSE_MANAGEMENT',
       'NOTIFICATION_TEMPLATES',
       'POLICIES',
       'ROLE',

--- a/gravitee-apim-console-webui/src/entities/user/user.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/user/user.fixture.ts
@@ -68,6 +68,7 @@ export const fakeAdminUser = (): User => {
           TAG: ['C', 'R', 'U', 'D'],
           IDENTITY_PROVIDER: ['C', 'R', 'U', 'D'],
           IDENTITY_PROVIDER_ACTIVATION: ['C', 'R', 'U', 'D'],
+          LICENSE_MANAGEMENT: ['C', 'R', 'U', 'D'],
         },
       },
     ],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -64,7 +64,6 @@ public class OrganizationResource extends AbstractResource {
     @Path("/license")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_INSTALLATION, acls = { RolePermissionAction.READ }) })
     public GraviteeLicense getOrganizationLicense(@PathParam("orgId") String orgId) {
         // Throw error if organization does not exist
         organizationService.findById(orgId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
@@ -36,7 +36,8 @@ public enum OrganizationPermission implements Permission {
     TENANT("TENANT", 2000),
     ENTRYPOINT("ENTRYPOINT", 2100),
     POLICIES("POLICIES", 2200),
-    AUDIT("AUDIT", 2300);
+    AUDIT("AUDIT", 2300),
+    LICENSE_MANAGEMENT("LICENSE_MANAGEMENT", 2400);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -94,7 +94,8 @@ public enum RolePermission {
     ORGANIZATION_TENANT(RoleScope.ORGANIZATION, OrganizationPermission.TENANT),
     ORGANIZATION_ENTRYPOINT(RoleScope.ORGANIZATION, OrganizationPermission.ENTRYPOINT),
     ORGANIZATION_POLICIES(RoleScope.ORGANIZATION, OrganizationPermission.POLICIES),
-    ORGANIZATION_AUDIT(RoleScope.ORGANIZATION, OrganizationPermission.AUDIT);
+    ORGANIZATION_AUDIT(RoleScope.ORGANIZATION, OrganizationPermission.AUDIT),
+    ORGANIZATION_LICENSE_MANAGEMENT(RoleScope.ORGANIZATION, OrganizationPermission.LICENSE_MANAGEMENT);
 
     RoleScope scope;
     Permission permission;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3706

## Description

Add a new permission: `LICENSE_MANAGEMENT`
This will be used for when managing the license.
Only users with a role that has `organization-license_management-r` will be able to see the expiration notification.

It is scoped by organization:

Default role:

![Screenshot 2024-01-23 at 16 01 11](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/4a7da09b-abdf-4066-8efb-16284554865d)

Non-Default role:

![Screenshot 2024-01-23 at 16 01 39](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/7a95b01e-1eef-4de1-a301-d8a3288273fc)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ryxrsifxvm.chromatic.com)
<!-- Storybook placeholder end -->
