### PR TITLE
Apim 3735 depreciate non org specific endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -247,6 +247,15 @@
 						</configuration>
 					</execution>
 					<execution>
+						<id>model-installation</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>${project.basedir}/src/main/resources/openapi/openapi-installation.yaml</inputSpec>
+						</configuration>
+					</execution>
+					<execution>
 						<id>model-ui</id>
 						<goals>
 							<goal>generate</goal>
@@ -262,6 +271,15 @@
 						</goals>
 						<configuration>
 							<inputSpec>${project.basedir}/src/main/resources/openapi/openapi-plugins-deprecated.yaml</inputSpec>
+						</configuration>
+					</execution>
+					<execution>
+						<id>model-installation-deprecated</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>${project.basedir}/src/main/resources/openapi/openapi-installation-deprecated.yaml</inputSpec>
 						</configuration>
 					</execution>
 				</executions>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -255,6 +255,15 @@
 							<inputSpec>${project.basedir}/src/main/resources/openapi/openapi-ui.yaml</inputSpec>
 						</configuration>
 					</execution>
+					<execution>
+						<id>model-plugins-deprecated</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>${project.basedir}/src/main/resources/openapi/openapi-plugins-deprecated.yaml</inputSpec>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
         </plugins>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -60,7 +60,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
     public GraviteeManagementV2Application() {
         //Main resource
         register(ManagementUIResource.class);
-        register(GraviteeLicenseResource.class);
+        register(GraviteeLicenseResource.class); // Deprecated
         register(OrganizationResource.class);
         register(EnvironmentsResource.class);
         register(ApisResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -32,13 +32,13 @@ import io.gravitee.rest.api.management.v2.rest.provider.CommaSeparatedQueryParam
 import io.gravitee.rest.api.management.v2.rest.provider.ObjectMapperResolver;
 import io.gravitee.rest.api.management.v2.rest.resource.OpenAPIResource;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApisResource;
-import io.gravitee.rest.api.management.v2.rest.resource.bootstrap.ManagementUIResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.EnvironmentsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.GraviteeLicenseResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.OrganizationResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EntrypointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.PoliciesResource;
+import io.gravitee.rest.api.management.v2.rest.resource.ui.ManagementUIResource;
 import io.gravitee.rest.api.rest.filter.GraviteeContextResponseFilter;
 import io.gravitee.rest.api.rest.filter.PermissionsFilter;
 import io.gravitee.rest.api.rest.filter.SecurityContextFilter;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -64,6 +64,8 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(OrganizationResource.class);
         register(EnvironmentsResource.class);
         register(ApisResource.class);
+
+        // Resources deprecated at root level
         register(EndpointsResource.class);
         register(EntrypointsResource.class);
         register(PoliciesResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
@@ -40,6 +40,7 @@ public class GraviteeLicenseResource extends AbstractResource {
     private LicenseManager licenseManager;
 
     @GET
+    @Deprecated
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     public GraviteeLicense get() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -26,11 +26,8 @@ import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EndpointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.EntrypointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.plugin.PoliciesResource;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.management.v2.rest.resource.ui.ManagementUIResource;
 import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
-import io.gravitee.rest.api.rest.annotation.Permission;
-import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.OrganizationService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -99,5 +96,10 @@ public class OrganizationResource extends AbstractResource {
     @Path("/plugins/policies")
     public PoliciesResource getOrganizationPoliciesResource() {
         return resourceContext.getResource(PoliciesResource.class);
+    }
+
+    @Path("ui")
+    public ManagementUIResource getManagementUIResource() {
+        return resourceContext.getResource(ManagementUIResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ManagementUIResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ManagementUIResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.management.v2.rest.resource.bootstrap;
+package io.gravitee.rest.api.management.v2.rest.resource.ui;
 
 import io.gravitee.apim.core.console.use_case.GetConsoleCustomizationUseCase;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-installation-deprecated.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-installation-deprecated.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Management API v2 - Installation - Deprecated</title>
+  <!-- Embed elements Elements via Web Component -->
+  <script src="https://unpkg.com/@stoplight/elements@7.7.17/web-components.min.js" integrity="sha512-er7CDLsLJUSwP4m6VU9pNH4bdjIrs3J/2DHLsbA3zCrWfGgvfSvftqmBQcqp4nHMafykJdMd4GbETNEIi34S+g==" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@7.7.17/styles.min.css" integrity="sha512-R0lX4nTGMLQSM9/IWxQD5cY/8e2VIcpcZNPaRuXdHjpCkxYxvmXF4uveEJk5NKqAGOximNajPCZIA5JwmE731w==" crossorigin="anonymous">
+</head>
+<body>
+
+<elements-api
+  apiDescriptionUrl="openapi-installation-deprecated.yaml"
+  router="hash"
+  layout="sidebar"
+/>
+
+</body>
+</html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-installation.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-installation.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Management API v2 - Installation</title>
+  <!-- Embed elements Elements via Web Component -->
+  <script src="https://unpkg.com/@stoplight/elements@7.7.17/web-components.min.js" integrity="sha512-er7CDLsLJUSwP4m6VU9pNH4bdjIrs3J/2DHLsbA3zCrWfGgvfSvftqmBQcqp4nHMafykJdMd4GbETNEIi34S+g==" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@7.7.17/styles.min.css" integrity="sha512-R0lX4nTGMLQSM9/IWxQD5cY/8e2VIcpcZNPaRuXdHjpCkxYxvmXF4uveEJk5NKqAGOximNajPCZIA5JwmE731w==" crossorigin="anonymous">
+</head>
+<body>
+
+<elements-api
+  apiDescriptionUrl="openapi-installation.yaml"
+  router="hash"
+  layout="sidebar"
+/>
+
+</body>
+</html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-plugins-deprecated.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-plugins-deprecated.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Management API v2 - Plugins - Deprecated</title>
+  <!-- Embed elements Elements via Web Component -->
+  <script src="https://unpkg.com/@stoplight/elements@7.7.17/web-components.min.js" integrity="sha512-er7CDLsLJUSwP4m6VU9pNH4bdjIrs3J/2DHLsbA3zCrWfGgvfSvftqmBQcqp4nHMafykJdMd4GbETNEIi34S+g==" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@7.7.17/styles.min.css" integrity="sha512-R0lX4nTGMLQSM9/IWxQD5cY/8e2VIcpcZNPaRuXdHjpCkxYxvmXF4uveEJk5NKqAGOximNajPCZIA5JwmE731w==" crossorigin="anonymous">
+</head>
+<body>
+
+<elements-api
+  apiDescriptionUrl="openapi-plugins-deprecated.yaml"
+  router="hash"
+  layout="sidebar"
+/>
+
+</body>
+</html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
@@ -12,5 +12,11 @@
     <li><a href="index-plugins.html">Gravitee.io APIM - Plugins</a>
     <li><a href="index-ui.html">Gravitee.io APIM - UI</a>
   </ul>
+
+  <h2>Deprecated OpenAPI Specifications:</h2>
+
+  <ul>
+    <li><a href="index-plugins-deprecated.html">Gravitee.io APIM - Plugins - Deprecated</a>
+  </ul>
 </body>
 </html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
@@ -11,12 +11,14 @@
     <li><a href="index-apis.html">Gravitee.io APIM - APIs</a>
     <li><a href="index-plugins.html">Gravitee.io APIM - Plugins</a>
     <li><a href="index-ui.html">Gravitee.io APIM - UI</a>
+    <li><a href="index-installation.html">Gravitee.io APIM - Installation</a>
   </ul>
 
   <h2>Deprecated OpenAPI Specifications:</h2>
 
   <ul>
     <li><a href="index-plugins-deprecated.html">Gravitee.io APIM - Plugins - Deprecated</a>
+    <li><a href="index-installation-deprecated.html">Gravitee.io APIM - Installation - Deprecated</a>
   </ul>
 </body>
 </html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -56,8 +56,6 @@ tags:
       description: Everything about API subscriptions
     - name: Groups
       description: Everything about groups
-    - name: Installation
-      description: Base resources about the installation
 
 paths:
     # APIs
@@ -1008,121 +1006,6 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
-    # Installation
-    /environments:
-        get:
-            parameters:
-                - $ref: "#/components/parameters/pageParam"
-                - $ref: "#/components/parameters/perPageParam"
-            tags:
-                - Installation
-            summary: List all environments.
-            description: |-
-                List all environments accessible by the current user.
-
-                User must be authenticated.
-            operationId: getEnvironments
-            responses:
-                "200":
-                    $ref: "#/components/responses/EnvironmentsResponse"
-                default:
-                    $ref: "#/components/responses/Error"
-    /environments/{envId}:
-        parameters:
-            - $ref: "#/components/parameters/envIdParam"
-        get:
-            tags:
-                - Installation
-            summary: Get a specific environment
-            description: |-
-                Get a specific environment.
-
-                User must be authenticated.
-            operationId: getEnvironmentById
-            responses:
-                "200":
-                    description: An environment
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/Environment"
-                default:
-                    $ref: "#/components/responses/Error"
-    /license:
-        servers:
-            - url: /management/v2
-              description: Gravitee.io APIM - Management API -v2
-        get:
-            tags:
-                - Installation
-            summary: Get the license gravitee is running on.
-            description: |-
-                Returns the license information of the gravitee instance.
-
-                User must be authenticated.
-            operationId: getGraviteeLicense
-            responses:
-                "200":
-                    description: |-
-                        The license and its features. If there is no license, then the features will be empty.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/GraviteeLicense"
-                default:
-                    $ref: "#/components/responses/Error"
-    /organizations/{orgId}:
-        servers:
-            - url: /management/v2
-              description: Gravitee.io APIM - Management API - v2
-        parameters:
-            - $ref: "#/components/parameters/orgIdParam"
-        get:
-            tags:
-                - Installation
-            summary: Get a specific organization
-            description: |-
-                Get a specific organization
-
-                User must be authenticated.
-            operationId: getOrganizationById
-            responses:
-                "200":
-                    description: An organization
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/Organization"
-                default:
-                    $ref: "#/components/responses/Error"
-    /organizations/{orgId}/license:
-        servers:
-            - url: /management/v2
-              description: Gravitee.io APIM - Management API -v2
-        parameters:
-            - $ref: "#/components/parameters/orgIdParam"
-        get:
-            tags:
-                - Installation
-            summary: Get the license used by an organization.
-            description: |-
-                Returns the organization license information.
-                If no license is scoped to the organization, then the platform license is returned.
-
-                User must be authenticated.
-            operationId: getOrganizationLicense
-            responses:
-                "200":
-                    description: |-
-                        The license and its features. If there is no license, then the features will be empty.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/GraviteeLicense"
-                default:
-                    $ref: "#/components/responses/Error"
-
-
     # API Subscriptions
     /environments/{envId}/apis/{apiId}/subscribers:
         parameters:
@@ -1905,34 +1788,6 @@ paths:
                     $ref: "#/components/responses/Error"
 components:
     schemas:
-        GraviteeLicense:
-            type: object
-            properties:
-                tier:
-                    type: string
-                    description: The tier gravitee is running on.
-                    example: "tier-planet"
-                packs:
-                    type: array
-                    items:
-                        type: string
-                    description: The packs included in the tier gravitee is running on.
-                    example:
-                        - "pack-observability"
-                        - "pack-event-native"
-                features:
-                    type: array
-                    items:
-                        type: string
-                    description: The features included in the tier gravitee is running on.
-                    example:
-                        - feature-debug-mode
-                        - feature-datadog-reporter
-                expiresAt:
-                    type: string
-                    format: date-time
-                    description: The date (as timestamp) when the license will expire.
-                    example: 1581256457163
         Analytics:
             type: object
             properties:
@@ -2836,23 +2691,6 @@ components:
                     $ref: "#/components/schemas/Dlq"
                 configuration:
                     type: object
-        Environment:
-            type: object
-            properties:
-                id:
-                    type: string
-                    description: Environment's uuid.
-                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
-                name:
-                    type: string
-                    description: Environment's name. Duplicate names can exists.
-                    example: My Environment
-                    minLength: 1
-                description:
-                    type: string
-                    description: Environment's description. A short description of your Environment.
-                    example: I can use many characters to describe this Environment.
-                    minLength: 1
         Error:
             type: object
             properties:
@@ -3146,23 +2984,6 @@ components:
             enum:
                 - EQUALS
                 - STARTS_WITH
-        Organization:
-            type: object
-            properties:
-                id:
-                    type: string
-                    description: Organization's uuid.
-                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
-                name:
-                    type: string
-                    description: Organization's name. Duplicate names can exists.
-                    example: My Organization
-                    minLength: 1
-                description:
-                    type: string
-                    description: Organization's description. A short description of your Organization.
-                    example: I can use many characters to describe this Organization.
-                    minLength: 1
         Pagination:
             description: Generic object to handle pagination data.
             type: object
@@ -5848,21 +5669,6 @@ components:
                 items:
                     type: integer
     responses:
-        EnvironmentsResponse:
-            description: Page of environments
-            content:
-                application/json:
-                    schema:
-                        properties:
-                            data:
-                                description: List of Environments.
-                                type: array
-                                items:
-                                    $ref: "#/components/schemas/Environment"
-                            metadata:
-                                $ref: "#/components/schemas/MetadataResponse"
-                            links:
-                                $ref: "#/components/schemas/Links"
         ApisResponse:
             description: Page of apis
             content:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
@@ -1,0 +1,137 @@
+openapi: 3.0.3
+info:
+    title: Gravitee.io APIM - Management API - Installation - Deprecated
+    description: |-
+        This is the OpenAPI specification for our new version of APIM Management API.
+    contact:
+        email: team-apim@graviteesource.com
+    license:
+        name: Apache 2.0
+        url: http://www.apache.org/licenses/LICENSE-2.0.html
+    version: 2.0.0
+
+security:
+    - CookieAuth: []
+
+servers:
+    - url: "{protocol}://{managementAPIHost}/management/v2"
+      description: APIM Management API v2 - Default base URL
+      variables:
+          protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                  - https
+                  - http
+          managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+
+tags:
+    - name: Installation
+      description: Base resources about the installation
+
+paths:
+    /license:
+        get:
+            tags:
+                - Installation
+            summary: Get the license gravitee is running on.
+            description: |-
+                Returns the license information of the gravitee instance.
+
+                User must be authenticated.
+            operationId: getGraviteeLicense
+            deprecated: true
+            responses:
+                "200":
+                    description: |-
+                        The license and its features. If there is no license, then the features will be empty.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/GraviteeLicense"
+                default:
+                    $ref: "#/components/responses/Error"
+
+components:
+    schemas:
+        Error:
+            type: object
+            properties:
+                httpStatus:
+                    type: integer
+                    format: int32
+                    description: The error code
+                    example: 400
+                message:
+                    type: string
+                    description: The error message
+                    example: Bad request
+                technicalCode:
+                    type: string
+                    description: A technical code to identify the error
+                    example: invalid.import.definition
+                parameters:
+                    type: object
+                    description: A map of parameters to be used in the error message
+                    additionalProperties:
+                        type: string
+                details:
+                    type: array
+                    description: A list of details about the error
+                    items:
+                        type: object
+                        properties:
+                            message:
+                                type: string
+                                description: The error message
+                                example: Bad request
+                            location:
+                                type: string
+                                description: The json path of the field in error.
+                                example: updateApi.properties[0].key
+                            invalidValue:
+                                type: object
+                                description: The invalid value.
+        GraviteeLicense:
+            type: object
+            properties:
+                tier:
+                    type: string
+                    description: The tier gravitee is running on.
+                    example: "tier-planet"
+                packs:
+                    type: array
+                    items:
+                        type: string
+                    description: The packs included in the tier gravitee is running on.
+                    example:
+                        - "pack-observability"
+                        - "pack-event-native"
+                features:
+                    type: array
+                    items:
+                        type: string
+                    description: The features included in the tier gravitee is running on.
+                    example:
+                        - feature-debug-mode
+                        - feature-datadog-reporter
+                expiresAt:
+                    type: string
+                    format: date-time
+                    description: The date (as timestamp) when the license will expire.
+                    example: 1581256457163
+    responses:
+        Error:
+            description: Generic error response
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/Error"
+
+    securitySchemes:
+        CookieAuth:
+            type: apiKey
+            in: cookie
+            name: Auth-Graviteeio-APIM

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
@@ -1,0 +1,327 @@
+openapi: 3.0.3
+info:
+    title: Gravitee.io APIM - Management API - Installation
+    description: |-
+        This is the OpenAPI specification for our new version of APIM Management API.
+    contact:
+        email: team-apim@graviteesource.com
+    license:
+        name: Apache 2.0
+        url: http://www.apache.org/licenses/LICENSE-2.0.html
+    version: 2.0.0
+
+security:
+    - BasicAuth: []
+    - CookieAuth: []
+
+servers:
+    - url: "{protocol}://{managementAPIHost}/management/v2"
+      description: APIM Management API v2 - Default base URL
+      variables:
+          protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                  - https
+                  - http
+          managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+      description: APIM Management API v2 - Base URL to target specific organizations
+      variables:
+          protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                  - https
+                  - http
+          managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+          orgId:
+              description: The unique ID of your organization
+              default: DEFAULT
+
+tags:
+    - name: Installation
+      description: Base resources about the installation
+
+paths:
+    /environments:
+        get:
+            parameters:
+                - $ref: "#/components/parameters/pageParam"
+                - $ref: "#/components/parameters/perPageParam"
+            tags:
+                - Installation
+            summary: List all environments.
+            description: |-
+                List all environments accessible by the current user.
+
+                User must be authenticated.
+            operationId: getEnvironments
+            responses:
+                "200":
+                    $ref: "#/components/responses/EnvironmentsResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            tags:
+                - Installation
+            summary: Get a specific environment
+            description: |-
+                Get a specific environment.
+
+                User must be authenticated.
+            operationId: getEnvironmentById
+            responses:
+                "200":
+                    description: An environment
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Environment"
+                default:
+                    $ref: "#/components/responses/Error"
+    /organizations/{orgId}:
+        servers:
+            - url: /management/v2
+              description: Gravitee.io APIM - Management API - v2
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+        get:
+            tags:
+                - Installation
+            summary: Get a specific organization
+            description: |-
+                Get a specific organization
+
+                User must be authenticated.
+            operationId: getOrganizationById
+            responses:
+                "200":
+                    description: An organization
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Organization"
+                default:
+                    $ref: "#/components/responses/Error"
+    /organizations/{orgId}/license:
+        servers:
+            - url: /management/v2
+              description: Gravitee.io APIM - Management API -v2
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+        get:
+            tags:
+                - Installation
+            summary: Get the license used by an organization.
+            description: |-
+                Returns the organization license information.
+                If no license is scoped to the organization, then the platform license is returned.
+
+                User must be authenticated.
+            operationId: getOrganizationLicense
+            responses:
+                "200":
+                    description: |-
+                        The license and its features. If there is no license, then the features will be empty.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/GraviteeLicense"
+                default:
+                    $ref: "#/components/responses/Error"
+components:
+    schemas:
+        Environment:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Environment's uuid.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                name:
+                    type: string
+                    description: Environment's name. Duplicate names can exists.
+                    example: My Environment
+                    minLength: 1
+                description:
+                    type: string
+                    description: Environment's description. A short description of your Environment.
+                    example: I can use many characters to describe this Environment.
+                    minLength: 1
+        Error:
+            type: object
+            properties:
+                httpStatus:
+                    type: integer
+                    format: int32
+                    description: The error code
+                    example: 400
+                message:
+                    type: string
+                    description: The error message
+                    example: Bad request
+                technicalCode:
+                    type: string
+                    description: A technical code to identify the error
+                    example: invalid.import.definition
+                parameters:
+                    type: object
+                    description: A map of parameters to be used in the error message
+                    additionalProperties:
+                        type: string
+                details:
+                    type: array
+                    description: A list of details about the error
+                    items:
+                        type: object
+                        properties:
+                            message:
+                                type: string
+                                description: The error message
+                                example: Bad request
+                            location:
+                                type: string
+                                description: The json path of the field in error.
+                                example: updateApi.properties[0].key
+                            invalidValue:
+                                type: object
+                                description: The invalid value.
+        GraviteeLicense:
+            type: object
+            properties:
+                tier:
+                    type: string
+                    description: The tier gravitee is running on.
+                    example: "tier-planet"
+                packs:
+                    type: array
+                    items:
+                        type: string
+                    description: The packs included in the tier gravitee is running on.
+                    example:
+                        - "pack-observability"
+                        - "pack-event-native"
+                features:
+                    type: array
+                    items:
+                        type: string
+                    description: The features included in the tier gravitee is running on.
+                    example:
+                        - feature-debug-mode
+                        - feature-datadog-reporter
+                expiresAt:
+                    type: string
+                    format: date-time
+                    description: The date (as timestamp) when the license will expire.
+                    example: 1581256457163
+        Links:
+            description: List of links for pagination
+            properties:
+                self:
+                    type: string
+                    description: Link to current resource
+                first:
+                    type: string
+                    description: In a paginated response, link to the first page
+                last:
+                    type: string
+                    description: In a paginated response, link to the last page
+                previous:
+                    type: string
+                    description: In a paginated response, link to the previous page. Maybe null if current is the first page
+                next:
+                    type: string
+                    description: In a paginated response, link to the next page. Maybe null if current is the last page
+        MetadataResponse:
+            description: Generic object to handle additional information about an entity. Can also be used for pagination data.
+            type: object
+        Organization:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: Organization's uuid.
+                    example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+                name:
+                    type: string
+                    description: Organization's name. Duplicate names can exists.
+                    example: My Organization
+                    minLength: 1
+                description:
+                    type: string
+                    description: Organization's description. A short description of your Organization.
+                    example: I can use many characters to describe this Organization.
+                    minLength: 1
+    responses:
+        EnvironmentsResponse:
+            description: Page of environments
+            content:
+                application/json:
+                    schema:
+                        properties:
+                            data:
+                                description: List of Environments.
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/Environment"
+                            metadata:
+                                $ref: "#/components/schemas/MetadataResponse"
+                            links:
+                                $ref: "#/components/schemas/Links"
+        Error:
+            description: Generic error response
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/Error"
+    parameters:
+        pageParam:
+            name: page
+            in: query
+            required: false
+            description: The page number for pagination.
+            schema:
+                type: integer
+                default: 1
+        perPageParam:
+            name: perPage
+            in: query
+            required: false
+            description: |
+                The number of items per page for pagination.
+            schema:
+                type: integer
+                default: 10
+        envIdParam:
+            name: envId
+            in: path
+            required: true
+            description: Id or Hrid (Human readable Id) of an environment.
+            schema:
+                type: string
+                default: DEFAULT
+        orgIdParam:
+            name: orgId
+            in: path
+            required: true
+            description: Id of an organization.
+            schema:
+                type: string
+                default: DEFAULT
+
+    securitySchemes:
+        BasicAuth:
+            type: http
+            scheme: basic
+        CookieAuth:
+            type: apiKey
+            in: cookie
+            name: Auth-Graviteeio-APIM

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-    title: Gravitee.io APIM - Management API - Plugins
+    title: Gravitee.io APIM - Management API - Plugins - Deprecated
     description: |-
         This is the OpenAPI specification for our new version of APIM Management API.
     contact:
@@ -11,12 +11,11 @@ info:
     version: 2.0.0
 
 security:
-    - BasicAuth: []
     - CookieAuth: []
 
 servers:
-    - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
-      description: APIM Management API v2 - Base URL to target specific organizations
+    - url: "{protocol}://{managementAPIHost}/management/v2"
+      description: APIM Management API v2 - Default base URL
       variables:
           protocol:
               description: The protocol you want to use to communicate with the mAPI
@@ -27,9 +26,6 @@ servers:
           managementAPIHost:
               description: The domain of the server hosting your Management API
               default: localhost:8083
-          orgId:
-              description: The unique ID of your organization
-              default: DEFAULT
 
 tags:
     - name: Plugins - Endpoints
@@ -45,12 +41,13 @@ paths:
         get:
             tags:
                 - Plugins - Endpoints
-            summary: Get available endpoints by organization
+            summary: Get available endpoints on the platform
             description: |
-                Get available endpoint types by organization.
+                Get available endpoint types on the platform.
 
                 User must be authenticated.
-            operationId: getEndpoints
+            operationId: getEndpointsDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: List of Endpoints.
@@ -73,7 +70,8 @@ paths:
                 Get an endpoint type.
 
                 User must be authenticated.
-            operationId: getEndpoint
+            operationId: getEndpointDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Endpoint
@@ -94,7 +92,8 @@ paths:
                 Get the documentation of an endpoint.
 
                 User must be authenticated.
-            operationId: getEndpointDocumentation
+            operationId: getEndpointDocumentationDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Documentation of the endpoint
@@ -115,7 +114,8 @@ paths:
                 More information about the endpoint.
 
                 User must be authenticated.
-            operationId: getEndpointMoreInformation
+            operationId: getEndpointMoreInformationDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: More information of the endpoint
@@ -136,7 +136,8 @@ paths:
                 Get the JSON schema that describes the configuration of an endpoint.
 
                 User must be authenticated.
-            operationId: getEndpointSchema
+            operationId: getEndpointSchemaDeprecated
+            deprecated: true
             responses:
                 "200":
                     $ref: "#/components/responses/SchemaFormResponse"
@@ -153,7 +154,8 @@ paths:
                 Get an endpoint shared configuration schema.
 
                 User must be authenticated.
-            operationId: getEndpointSharedConfigurationSchema
+            operationId: getEndpointSharedConfigurationSchemaDeprecated
+            deprecated: true
             responses:
                 "200":
                     $ref: "#/components/responses/SchemaFormResponse"
@@ -165,12 +167,13 @@ paths:
         get:
             tags:
                 - Plugins - Entrypoints
-            summary: Get available entrypoints by organization
+            summary: Get available entrypoints on the platform
             description: |
-                Get available entrypoint types by organization.
+                Get available entrypoint types on the platform.
 
                 User must be authenticated.
-            operationId: getEntrypoints
+            operationId: getEntrypointsDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: List of Entrypoints.
@@ -193,7 +196,8 @@ paths:
                 Get an entrypoint type.
 
                 User must be authenticated.
-            operationId: getEntrypoint
+            operationId: getEntrypointDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Entrypoint
@@ -214,7 +218,8 @@ paths:
                 Get the documentation of an entrypoint.
 
                 User must be authenticated.
-            operationId: getEntrypointDocumentation
+            operationId: getEntrypointDocumentationDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Documentation of the entrypoint
@@ -235,7 +240,8 @@ paths:
                 More information about the entrypoint.
 
                 User must be authenticated.
-            operationId: getEntrypointMoreInformation
+            operationId: getEntrypointMoreInformationDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: More information of the entrypoint
@@ -256,7 +262,8 @@ paths:
                 Get the JSON schema that describes the configuration of an entrypoint.
 
                 User must be authenticated.
-            operationId: getEntrypointSchema
+            operationId: getEntrypointSchemaDeprecated
+            deprecated: true
             responses:
                 "200":
                     $ref: "#/components/responses/SchemaFormResponse"
@@ -284,7 +291,8 @@ paths:
                 Get the JSON schema that describes the subscription to a given entrypoint.
 
                 User must be authenticated.
-            operationId: getEntrypointSubscriptionSchema
+            operationId: getEntrypointSubscriptionSchemaDeprecated
+            deprecated: true
             responses:
                 "200":
                     $ref: "#/components/responses/SchemaFormResponse"
@@ -296,12 +304,13 @@ paths:
         get:
             tags:
                 - Plugins - Policies
-            summary: Get available policies by organization
+            summary: Get available policies on the platform
             description: |
-                Get available policies by organization.
+                Get available policies on the platform.
 
                 User must be authenticated.
-            operationId: getPolicies
+            operationId: getPoliciesDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: List of Policies.
@@ -324,7 +333,8 @@ paths:
                 Get a policy.
 
                 User must be authenticated.
-            operationId: getPolicy
+            operationId: getPolicyDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Policy
@@ -345,7 +355,8 @@ paths:
                 Get the documentation of a policy.
 
                 User must be authenticated.
-            operationId: getPolicyDocumentation
+            operationId: getPolicyDocumentationDeprecated
+            deprecated: true
             responses:
                 "200":
                     description: Documentation of the entrypoint
@@ -377,7 +388,8 @@ paths:
                 Get the JSON schema that describes the configuration of a policy.
 
                 User must be authenticated.
-            operationId: getPolicySchema
+            operationId: getPolicySchemaDeprecated
+            deprecated: true
             responses:
                 "200":
                     $ref: "#/components/responses/SchemaFormResponse"
@@ -573,6 +585,13 @@ components:
                                 type: object
                                 description: The invalid value.
     parameters:
+        organizationIdParam:
+            name: orgId
+            in: path
+            required: true
+            description: Id of an organization.
+            schema:
+                type: string
         endpointIdParam:
             name: endpointId
             in: path
@@ -609,9 +628,6 @@ components:
                         $ref: "#/components/schemas/Error"
 
     securitySchemes:
-        BasicAuth:
-            type: http
-            scheme: basic
         CookieAuth:
             type: apiKey
             in: cookie

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -33,12 +33,12 @@ paths:
         get:
             tags:
                 - Management UI
-            summary: Get customization of Console
+            summary: Get customization of Console by default organization
             description: |
-                Get the customization settings of Console.
+                Get the customization settings of Console by default organization.
 
-                User can only access the customization of their organization.
-                An error is returned if the OEM Customization is missing from the Gravitee License.
+                No authentication necessary.
+                An empty response is returned if the OEM Customization is missing from the Gravitee License.
             operationId: getConsoleCustomization
             responses:
                 "200":
@@ -47,6 +47,35 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ConsoleCustomization"
+                "204":
+                    description: The license does not contain OEM Customization
+                default:
+                    $ref: "#/components/responses/Error"
+    /organizations/{orgId}/ui/customization:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+        get:
+            tags:
+                - Management UI
+            summary: Get customization of Console by organization
+            description: |
+                Get the customization settings of Console by organization.
+
+                User can only access the customization of their organization.
+                An empty response is returned if the OEM Customization is missing from the Gravitee License.
+            operationId: getConsoleCustomizationByOrganization
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            responses:
+                "200":
+                    description: The customization settings for the console.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ConsoleCustomization"
+                "204":
+                    description: The license does not contain OEM Customization
                 default:
                     $ref: "#/components/responses/Error"
 components:
@@ -137,6 +166,15 @@ components:
                             invalidValue:
                                 type: object
                                 description: The invalid value.
+    parameters:
+        orgIdParam:
+            name: orgId
+            in: path
+            required: true
+            description: Id of an organization.
+            schema:
+                type: string
+                default: DEFAULT
 
     responses:
         Error:
@@ -145,3 +183,12 @@ components:
                 application/json:
                     schema:
                         $ref: "#/components/schemas/Error"
+
+    securitySchemes:
+        BasicAuth:
+            type: http
+            scheme: basic
+        CookieAuth:
+            type: apiKey
+            in: cookie
+            name: Auth-Graviteeio-APIM

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ManagementUIResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ManagementUIResourceTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.management.v2.rest.resource.boostrap;
+package io.gravitee.rest.api.management.v2.rest.resource.ui;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -58,7 +58,7 @@ class ManagementUIResourceTest extends AbstractResourceTest {
 
     @Override
     protected String contextPath() {
-        return "/ui/customization";
+        return "/organizations/" + ORGANIZATION + "/ui/customization";
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3735

## Description

- separate deprecated endpoints from non-deprecated endpoints
- specify security needed for deprecated endpoints
- add `ManagementUIResource` to organizations path


![Screenshot 2024-01-29 at 10 27 00](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/28d08a96-a17a-4dec-ab06-5c54d6ca9c41)


TODO: Change urls in Console to no longer used deprecated endpoints --> #6495 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

