### PR TITLE
Apim 3735 apply orgId scope to console

### DIFF
--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -80,7 +80,7 @@ function fetchData(): Promise<{ constants: Constants; build: any }> {
 
       return Promise.all([
         fetch(`${constants.org.baseURL}/console`, requestConfig).then((r) => r.json()),
-        fetch(`${constants.v2BaseURL}/ui/customization`, requestConfig).then((r) => (r.status === 200 ? r.json() : null)),
+        fetch(`${constants.org.v2BaseURL}/ui/customization`, requestConfig).then((r) => (r.status === 200 ? r.json() : null)),
         fetch(`${constants.org.baseURL}/social-identities`, requestConfig).then((r) => r.json()),
       ]).then(([consoleResponse, uiCustomizationResponse, identityProvidersResponse]) => {
         constants.org.settings = consoleResponse;

--- a/gravitee-apim-console-webui/src/services-ngx/ui-customization.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/ui-customization.service.spec.ts
@@ -63,7 +63,7 @@ describe('UiCustomizationService', () => {
     });
 
     const req = httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.v2BaseURL}/ui/customization`,
+      url: `${CONSTANTS_TESTING.org.v2BaseURL}/ui/customization`,
       method: 'GET',
     });
 

--- a/gravitee-apim-console-webui/src/services-ngx/ui-customization.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/ui-customization.service.ts
@@ -25,6 +25,6 @@ export class UiCustomizationService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   getConsoleCustomization(): Observable<ConsoleCustomization> {
-    return this.http.get<ConsoleCustomization>(`${this.constants.v2BaseURL}/ui/customization`);
+    return this.http.get<ConsoleCustomization>(`${this.constants.org.v2BaseURL}/ui/customization`);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3735

## Description

Scope the ui customization by orgId by default

⚠️ Must merge https://github.com/gravitee-io/gravitee-api-management/pull/6482 before ⚠️ 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kqmxkcufmz.chromatic.com)
<!-- Storybook placeholder end -->
