### PR TITLE
fix: filter groups in environment settings

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ajs.ts
@@ -16,7 +16,7 @@
 import { IScope } from 'angular';
 
 import { Router } from '@angular/router';
-import { filter } from 'rxjs/operators';
+import { filter } from 'lodash';
 
 import GroupService from '../../../services/group.service';
 import NotificationService from '../../../services/notification.service';


### PR DESCRIPTION
## Description

The environment groups settings page is broken ( see https://apim-master-console.team-apim.gravitee.dev/#!/fr-apim-master-dev/settings/groups ) This pr contains a rollback on the filter import that has certainly be changed involuntarily 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tkwwpmjlrp.chromatic.com)
<!-- Storybook placeholder end -->
