### PR TITLE
fix: close client at every test to increase stability

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcBidirectionalStreamingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcBidirectionalStreamingV4IntegrationTest.java
@@ -87,7 +87,6 @@ public class GrpcBidirectionalStreamingV4IntegrationTest extends AbstractGrpcV4G
         );
 
         // Need a new Vertx to avoid side effects with connection pools from previous tests
-        GrpcClient client = GrpcClient.client(Vertx.vertx());
         AtomicLong timerId = new AtomicLong();
 
         // Create http server handled by gRPC
@@ -99,7 +98,7 @@ public class GrpcBidirectionalStreamingV4IntegrationTest extends AbstractGrpcV4G
         AtomicBoolean done = new AtomicBoolean();
 
         // call the remote service
-        client
+        getGrpcClient()
             .request(gatewayAddress(), StreamingGreeterGrpc.getSayHelloStreamingMethod())
             .onSuccess(request -> {
                 AtomicInteger i = new AtomicInteger();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcSecuredServerStreamingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcSecuredServerStreamingV4IntegrationTest.java
@@ -53,6 +53,6 @@ public class GrpcSecuredServerStreamingV4IntegrationTest extends GrpcServerStrea
     }
 
     public GrpcClient createGrpcClient() {
-        return GrpcClient.client(vertx, new HttpClientOptions().setUseAlpn(true).setSsl(true).setTrustAll(true));
+        return getGrpcClient(() -> GrpcClient.client(vertx, new HttpClientOptions().setUseAlpn(true).setSsl(true).setTrustAll(true)));
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcServerStreamingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcServerStreamingV4IntegrationTest.java
@@ -106,6 +106,6 @@ public class GrpcServerStreamingV4IntegrationTest extends AbstractGrpcV4GatewayT
     }
 
     protected GrpcClient createGrpcClient() {
-        return GrpcClient.client(vertx);
+        return getGrpcClient();
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcUnaryRPCV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcUnaryRPCV4IntegrationTest.java
@@ -71,8 +71,7 @@ public class GrpcUnaryRPCV4IntegrationTest extends AbstractGrpcV4GatewayTest {
         httpServer.listen();
 
         // call the service through the gateway
-        GrpcClient client = GrpcClient.client(vertx);
-        client
+        getGrpcClient()
             .request(gatewayAddress(), GreeterGrpc.getSayHelloMethod())
             .compose(request -> {
                 request.end(HelloRequest.newBuilder().setName("You").build());

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcUnknownServiceV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4/GrpcUnknownServiceV4IntegrationTest.java
@@ -53,7 +53,7 @@ public class GrpcUnknownServiceV4IntegrationTest extends AbstractGrpcV4GatewayTe
     @Test
     void should_request_and_not_get_response(VertxTestContext testContext) throws InterruptedException {
         // Get a stub to use for interacting with the remote service
-        GrpcClientChannel channel = new GrpcClientChannel(GrpcClient.client(vertx), gatewayAddress());
+        GrpcClientChannel channel = new GrpcClientChannel(getGrpcClient(), gatewayAddress());
         StreamingGreeterGrpc.StreamingGreeterStub stub = StreamingGreeterGrpc.newStub(channel);
 
         // Call the remote service, only to get a proper exception

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcBidirectionalStreamingV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcBidirectionalStreamingV4EmulationIntegrationTest.java
@@ -104,7 +104,6 @@ public class GrpcBidirectionalStreamingV4EmulationIntegrationTest extends Abstra
         );
 
         // Need a new Vertx to avoid side effects with connection pools from previous tests
-        GrpcClient client = GrpcClient.client(Vertx.vertx());
         AtomicLong timerId = new AtomicLong();
 
         // Create http server handled by gRPC
@@ -116,7 +115,7 @@ public class GrpcBidirectionalStreamingV4EmulationIntegrationTest extends Abstra
         AtomicBoolean done = new AtomicBoolean();
 
         // call the remote service
-        client
+        getGrpcClient()
             .request(gatewayAddress(), StreamingGreeterGrpc.getSayHelloStreamingMethod())
             .onSuccess(request -> {
                 AtomicInteger i = new AtomicInteger();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcNoEndpointV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcNoEndpointV4EmulationIntegrationTest.java
@@ -59,7 +59,7 @@ public class GrpcNoEndpointV4EmulationIntegrationTest extends AbstractGrpcGatewa
     @Test
     void should_have_request_in_error_when_no_endpoint(VertxTestContext testContext) throws InterruptedException {
         // Prepare gRPC Client
-        GrpcClientChannel channel = new GrpcClientChannel(GrpcClient.client(vertx), gatewayAddress());
+        GrpcClientChannel channel = new GrpcClientChannel(getGrpcClient(), gatewayAddress());
 
         // Get a stub to use for interacting with the remote service
         GreeterGrpc.GreeterStub stub = GreeterGrpc.newStub(channel);

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcSecuredServerStreamingV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcSecuredServerStreamingV4EmulationIntegrationTest.java
@@ -39,6 +39,6 @@ public class GrpcSecuredServerStreamingV4EmulationIntegrationTest extends GrpcSe
     }
 
     public GrpcClient createGrpcClient() {
-        return GrpcClient.client(vertx, new HttpClientOptions().setUseAlpn(true).setSsl(true).setTrustAll(true));
+        return getGrpcClient(() -> GrpcClient.client(vertx, new HttpClientOptions().setUseAlpn(true).setSsl(true).setTrustAll(true)));
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcServerStreamingV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcServerStreamingV4EmulationIntegrationTest.java
@@ -121,6 +121,6 @@ public class GrpcServerStreamingV4EmulationIntegrationTest extends AbstractGrpcG
     }
 
     protected GrpcClient createGrpcClient() {
-        return GrpcClient.client(vertx);
+        return getGrpcClient();
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnaryRPCV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnaryRPCV4EmulationIntegrationTest.java
@@ -84,8 +84,7 @@ public class GrpcUnaryRPCV4EmulationIntegrationTest extends AbstractGrpcGatewayT
         httpServer.listen();
 
         // call the service through the gateway
-        GrpcClient client = GrpcClient.client(vertx);
-        client
+        getGrpcClient()
             .request(gatewayAddress(), GreeterGrpc.getSayHelloMethod())
             .compose(request -> {
                 request.end(HelloRequest.newBuilder().setName("You").build());

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnknownEndpointV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnknownEndpointV4EmulationIntegrationTest.java
@@ -57,7 +57,7 @@ public class GrpcUnknownEndpointV4EmulationIntegrationTest extends AbstractGrpcG
     @Test
     void should_request_and_not_get_response(VertxTestContext testContext) throws InterruptedException {
         // Get a stub to use for interacting with the remote service
-        GrpcClientChannel channel = new GrpcClientChannel(GrpcClient.client(vertx), gatewayAddress());
+        GrpcClientChannel channel = new GrpcClientChannel(getGrpcClient(), gatewayAddress());
         GreeterGrpc.GreeterStub stub = GreeterGrpc.newStub(channel);
 
         HelloRequest request = HelloRequest.newBuilder().setName("You").build();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnknownServiceV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/grpc/v4Emulation/GrpcUnknownServiceV4EmulationIntegrationTest.java
@@ -57,7 +57,7 @@ public class GrpcUnknownServiceV4EmulationIntegrationTest extends AbstractGrpcGa
     @Test
     void should_request_and_not_get_response(VertxTestContext testContext) throws InterruptedException {
         // Get a stub to use for interacting with the remote service
-        GrpcClientChannel channel = new GrpcClientChannel(GrpcClient.client(vertx), gatewayAddress());
+        GrpcClientChannel channel = new GrpcClientChannel(getGrpcClient(), gatewayAddress());
         StreamingGreeterGrpc.StreamingGreeterStub stub = StreamingGreeterGrpc.newStub(channel);
 
         // Call the remote service, only to get a proper exception


### PR DESCRIPTION
## Description

Followup on BOM upgrade. Looks like gRPC integration are flaky. I made sure that gRPC clients are closed properly to avoid bleeding on other tests, in the hope that the issue was around that.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gbqpgtdqic.chromatic.com)
<!-- Storybook placeholder end -->
