### PR TITLE
test: minor finetuning of Cypress api-plans test

### DIFF
--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   cypress:
-    image: cypress/included:13.6.1
+    image: cypress/included:13.6.3
     working_dir: /test
     command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts' --record"
     volumes:

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -174,7 +174,7 @@ describe('API Plans Feature', () => {
     cy.contains('tr', `${planName}-Keyless`).find('[data-testid="api_plans_close_plan_button"]').click();
     cy.get(`[placeholder="${planName}-Keyless"]`).type(`${planName}-Keyless`);
     cy.getByDataTestId('confirm-dialog').click();
-    cy.wait('@closePlan');
+    cy.wait('@closePlan', { requestTimeout: 10000 });
     cy.contains(`The plan ${planName}-Keyless has been closed with success.`).should('be.visible');
     cy.contains(`${planName}-Keyless`).should('not.exist');
   });


### PR DESCRIPTION
## Description

A rather small adjustment that includes 2 changes:
- Update to new Cypress version for the Docker Cypress env (CircleCI)
- Raised request timeout for one occurrence of cy.wait(<ALIAS>) as this was a source of problems in the past
  - If it that mitigates the flakiness we'll apply the same on other occurrences as well
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qzuclzgbhs.chromatic.com)
<!-- Storybook placeholder end -->
