### PR TITLE
feat: enable markdown import in documentation page edition

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
@@ -16,7 +16,7 @@
 import { NgModule } from '@angular/core';
 import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
 import { CommonModule } from '@angular/common';
-import { GioIconsModule, GioMonacoEditorModule, GioRadioButtonModule } from '@gravitee/ui-particles-angular';
+import { GioFormFilePickerModule, GioIconsModule, GioMonacoEditorModule, GioRadioButtonModule } from '@gravitee/ui-particles-angular';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
@@ -41,6 +41,7 @@ import { ApiDocumentationV4PagesListComponent } from './documentation-pages-list
 import { ApiDocumentationV4ContentEditorComponent } from './components/api-documentation-v4-content-editor/api-documentation-v4-content-editor.component';
 import { ApiDocumentationV4PageTitleComponent } from './components/api-documentation-v4-page-title/api-documentation-v4-page-title.component';
 import { ApiDocumentationV4BreadcrumbComponent } from './components/api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.component';
+import { ApiDocumentationV4FileUploadComponent } from './components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioTooltipOnEllipsisModule } from '../../../shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.module';
@@ -58,6 +59,7 @@ import { GioTooltipOnEllipsisModule } from '../../../shared/components/gio-toolt
     ApiDocumentationV4EditPageComponent,
     ApiDocumentationV4PagesListComponent,
     ApiDocumentationV4BreadcrumbComponent,
+    ApiDocumentationV4FileUploadComponent,
   ],
   exports: [ApiDocumentationV4Component],
   imports: [
@@ -85,6 +87,7 @@ import { GioTooltipOnEllipsisModule } from '../../../shared/components/gio-toolt
     GioRadioButtonModule,
     GioPermissionModule,
     GioTooltipOnEllipsisModule,
+    GioFormFilePickerModule,
   ],
 })
 export class ApiDocumentationV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.html
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="content__header">
+  <div class="content__header__title">
+    <h4>Upload a file</h4>
+    <span class="gio-badge-neutral" *ngIf="!published">Unpublished</span>
+    <span class="gio-badge-success" *ngIf="published">Published</span>
+  </div>
+</div>
+<div class="content__file">
+  <gio-form-file-picker accept=".md,.markdown,.txt" [ngModel]="filePickerValue" (ngModelChange)="onImportFile($event)">
+    <gio-form-file-picker-add-button class="content__file__add-btn">
+      <div class="content__file__add-btn__wrapper">
+        <mat-icon svgIcon="gio:upload" class="content__file__add-btn__wrapper__icon"></mat-icon>
+        <p class="mat-body-strong">
+          Drag and drop a file to upload it.<br />
+          Alternatively, click here to choose a file.
+        </p>
+        <p>Supported file formats: {{ allowedFileExtensions }}</p>
+      </div>
+    </gio-form-file-picker-add-button>
+  </gio-form-file-picker>
+</div>
+<div *ngIf="!!importFileContent">
+  <h4>Preview of uploaded file</h4>
+  <div class="content__preview">
+    <markdown [data]="importFileContent"> </markdown>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.scss
@@ -1,0 +1,50 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.content {
+  &__header {
+    padding: 16px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &__title {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+    }
+  }
+
+  &__file {
+    display: flex;
+    justify-content: center;
+
+    gio-form-file-picker {
+      flex: 0 0 0px;
+    }
+
+    &__add-btn {
+      width: 800px;
+      height: 300px;
+
+      &__wrapper {
+        display: flex;
+        height: 300px;
+        flex-direction: column;
+        justify-content: space-evenly;
+        align-items: center;
+
+        &__icon {
+          color: mat.get-color-from-palette(gio.$mat-space-palette);
+        }
+      }
+    }
+  }
+
+  &__preview {
+    border: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker10');
+    border-radius: 8px;
+    padding: 24px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.component.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, forwardRef, Input } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NewFile } from '@gravitee/ui-particles-angular';
+
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+
+const allowedFileExtensions = ['md', 'markdown', 'txt'] as const;
+type FileExtension = (typeof allowedFileExtensions)[number];
+
+@Component({
+  selector: 'api-documentation-file-upload',
+  templateUrl: './api-documentation-v4-file-upload.component.html',
+  styleUrls: ['./api-documentation-v4-file-upload.component.scss'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ApiDocumentationV4FileUploadComponent),
+      multi: true,
+    },
+  ],
+})
+export class ApiDocumentationV4FileUploadComponent implements ControlValueAccessor {
+  @Input()
+  published = false;
+
+  public _onChange: (_selection: string) => void = () => ({});
+
+  protected _onTouched: () => void = () => ({});
+  filePickerValue = [];
+  importFile: File;
+  importFileContent: string;
+
+  constructor(private readonly snackBarService: SnackBarService) {}
+
+  async onImportFile(event: (NewFile | string)[] | undefined) {
+    if (!event || event.length !== 1) {
+      this.resetImportFile();
+      return;
+    }
+    const file = event[0];
+
+    if (!(file instanceof NewFile)) {
+      return;
+    }
+
+    const extension = file.name.split('.').pop().toLowerCase() as FileExtension;
+    if (!allowedFileExtensions.includes(extension)) {
+      this.resetImportFile('Invalid file format. Supported file formats: ' + allowedFileExtensions.join(', '));
+      return;
+    }
+    const fileContent = await getFileContent(file.file);
+    this.importFile = file.file;
+    this.importFileContent = fileContent;
+    this._onChange(fileContent);
+  }
+  private resetImportFile(message?: string) {
+    if (message) {
+      this.snackBarService.error(message);
+    }
+    this.importFile = undefined;
+    this.importFileContent = undefined;
+    this._onChange(undefined);
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnChange(fn: (value: string) => void): void {
+    this._onChange = fn;
+  }
+
+  // From ControlValueAccessor interface
+  public registerOnTouched(fn: () => void): void {
+    this._onTouched = fn;
+  }
+
+  writeValue(content: string): void {
+    this.importFileContent = content;
+  }
+
+  protected readonly allowedFileExtensions = allowedFileExtensions;
+}
+
+const getFileContent = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      resolve(reader.result as string);
+    };
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });
+};

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-file-upload/api-documentation-v4-file-upload.harness.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { GioFormFilePickerInputHarness } from '@gravitee/ui-particles-angular';
+
+export class ApiDocumentationV4FileUploadHarness extends ComponentHarness {
+  public static hostSelector = 'api-documentation-file-upload';
+
+  protected filePickerLocator = this.locatorFor(GioFormFilePickerInputHarness);
+  public getFileSelector(): Promise<GioFormFilePickerInputHarness> {
+    return this.filePickerLocator();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -62,10 +62,47 @@
             <button mat-flat-button color="primary" matStepperNext [disabled]="stepOneForm.invalid">Next</button>
           </div>
         </mat-step>
-        <mat-step>
-          <ng-template matStepLabel>{{ step2Title }}</ng-template>
+        <mat-step *ngIf="mode === 'create'">
+          <ng-template matStepLabel>Determine source</ng-template>
           <div class="stepper__content">
-            <api-documentation-content formControlName="content" [published]="page?.published"></api-documentation-content>
+            <div class="mat-body-2">Page source</div>
+
+            <mat-radio-group class="gio-radio-group stepper__content__source" formControlName="source">
+              <mat-radio-button value="FILL" class="gio-radio-button">
+                <gio-radio-button-content icon="gio:edit-pencil">
+                  <gio-radio-button-title>Fill in the content myself</gio-radio-button-title>
+                </gio-radio-button-content>
+              </mat-radio-button>
+              <mat-radio-button value="IMPORT" class="gio-radio-button">
+                <gio-radio-button-content icon="gio:down-circle">
+                  <gio-radio-button-title>Import from file</gio-radio-button-title>
+                </gio-radio-button-content>
+              </mat-radio-button>
+              <mat-radio-button value="EXTERNAL" class="gio-radio-button" disabled="true">
+                <gio-radio-button-content icon="gio:language">
+                  <gio-radio-button-title>Import from source (URL)</gio-radio-button-title>
+                  <gio-radio-button-subtitle><div class="gio-badge-primary">Coming soon</div></gio-radio-button-subtitle>
+                </gio-radio-button-content>
+              </mat-radio-button>
+            </mat-radio-group>
+          </div>
+          <div class="stepper__actions">
+            <button mat-flat-button color="primary" matStepperNext>Next</button>
+            <button mat-stroked-button matStepperPrevious>Previous</button>
+          </div>
+        </mat-step>
+        <mat-step>
+          <ng-template matStepLabel>{{ step3Title }}</ng-template>
+          <div class="stepper__content">
+            <api-documentation-content
+              formControlName="content"
+              [published]="page?.published"
+              *ngIf="form.value?.source === 'FILL'"
+            ></api-documentation-content>
+            <api-documentation-file-upload
+              formControlName="content"
+              *ngIf="form.value?.source === 'IMPORT'"
+            ></api-documentation-file-upload>
             <mat-error *ngIf="stepOneForm.controls.content?.errors?.required">Page content cannot be empty</mat-error>
           </div>
           <div class="stepper__actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -40,7 +40,8 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
   mode: 'create' | 'edit';
   pageTitle = 'Add new page';
   exitLabel = 'Exit without saving';
-  step2Title: string;
+  step3Title: string;
+  source: 'FILL' | 'IMPORT' | 'EXTERNAL' = 'FILL';
   breadcrumbs: Breadcrumb[];
 
   api: Api;
@@ -68,12 +69,14 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
     });
     this.form = this.formBuilder.group({
       stepOne: this.stepOneForm,
+      source: this.formBuilder.control(this.source, [Validators.required]),
       content: this.formBuilder.control('', [Validators.required]),
     });
 
     if (this.activatedRoute.snapshot.params.pageId) {
       this.mode = 'edit';
-      this.step2Title = 'Edit content';
+      this.step3Title = 'Edit content';
+      this.source = 'FILL';
 
       this.form.valueChanges
         .pipe(
@@ -82,6 +85,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
               this.formUnchanged =
                 this.page.name === value.stepOne?.name &&
                 this.page.visibility === value.stepOne?.visibility &&
+                this.source === value.source &&
                 this.page.content === value.content;
             }
           }),
@@ -94,7 +98,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
       }
     } else {
       this.mode = 'create';
-      this.step2Title = 'Add content';
+      this.step3Title = this.source === 'IMPORT' ? 'Upload a file' : 'Add content';
     }
 
     this.apiV2Service


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2793

## Description

Allow to select "Import from file" when creating a editing a markdown file. 

![Screenshot 2024-01-30 at 14 52 15](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/d10b2383-51d0-47d1-a13b-0e6b842a29c5)
![Screenshot 2024-01-30 at 14 52 49](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/e4420ec7-99e0-4bbe-bd1b-5a47141e6e83)
![Screenshot 2024-01-30 at 17 14 54](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/7435001c-e5c3-4755-adbb-ef6bd964fefc)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vlgnsygbto.chromatic.com)
<!-- Storybook placeholder end -->
