### PR TITLE
feat: hide api designer option for OEM in api creation startup screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.html
@@ -49,7 +49,7 @@
       </div>
     </div>
 
-    <div *ngIf="!isLoading" class="api-creation-get-started__row__card api-designer-card">
+    <div *ngIf="!isLoading && !isOEM" class="api-creation-get-started__row__card api-designer-card">
       <div mat-card-image class="api-designer-card__img">
         <img [src]="'assets/api-create-design-link.png'" alt="Api Designer logo" />
       </div>

--- a/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.scss
@@ -62,14 +62,13 @@ $typography: map.get(gio.$mat-legacy-theme, typography);
     }
 
     .api-v4-creation-card {
-      margin-right: 24px;
-
       &__img {
         background-color: mat.get-color-from-palette(gio.$mat-cyan-palette, 'lighter60');
       }
     }
 
     .api-designer-card {
+      margin-left: 24px;
       &__img {
         background-color: mat.get-color-from-palette(gio.$mat-blue-palette, 'lighter60');
       }

--- a/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.ts
@@ -41,6 +41,7 @@ export class ApiCreationGetStartedComponent implements OnInit, OnDestroy {
   cockpitLink: string;
 
   isLoading = true;
+  isOEM = false;
 
   policies = [];
 
@@ -60,6 +61,7 @@ export class ApiCreationGetStartedComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const hasInstallationPermission = this.permissionService.hasAnyMatching(['organization-installation-r']);
+    this.isOEM = this.constants.isOEM;
 
     (hasInstallationPermission ? this.installationService.get() : of(undefined))
       .pipe(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3755

## Description

Hide API Designer option in api creation startup page when OEM

![Screenshot 2024-01-31 at 09 40 49](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/31d19dea-8a9b-41ba-8058-19893c06e4b0)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-droxslddra.chromatic.com)
<!-- Storybook placeholder end -->
