### PR TITLE
feat(mapi-v2): allow no-auth for all `/ui/*` endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -64,9 +64,6 @@ paths:
                 User can only access the customization of their organization.
                 An empty response is returned if the OEM Customization is missing from the Gravitee License.
             operationId: getConsoleCustomizationByOrganization
-            security:
-                - BasicAuth: []
-                - CookieAuth: []
             responses:
                 "200":
                     description: The customization settings for the console.
@@ -183,12 +180,3 @@ components:
                 application/json:
                     schema:
                         $ref: "#/components/schemas/Error"
-
-    securitySchemes:
-        BasicAuth:
-            type: http
-            scheme: basic
-        CookieAuth:
-            type: apiKey
-            in: cookie
-            name: Auth-Graviteeio-APIM

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/BasicSecurityConfigurerAdapter.java
@@ -278,11 +278,11 @@ public class BasicSecurityConfigurerAdapter {
             .requestMatchers(HttpMethod.OPTIONS, "**")
             .permitAll()
             /*
-             * Management UI bootstrap resources.
+             * Management UI resources.
              */
-            .requestMatchers(HttpMethod.GET, "/ui/bootstrap")
+            .requestMatchers(HttpMethod.GET, "/ui/**")
             .permitAll()
-            .requestMatchers(HttpMethod.GET, "/ui/customization")
+            .requestMatchers(HttpMethod.GET, uriOrgPrefix + "/ui/**")
             .permitAll()
             // Any other request must be authenticated
             .anyRequest()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3735

## Description

Allow all `/ui/` resources to be accessed without auth so that console can access the resources before user login

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

