### PR TITLE
feat: add apiId in HealthCheck log

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -52,6 +52,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.scheduling.support.SimpleTriggerContext;
@@ -117,12 +118,17 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
 
     @Override
     public void handle(Long timer) {
-        T endpoint = rule.endpoint();
-        logger.debug("Running health-check for endpoint: {} [{}]", endpoint.getName(), endpoint.getTarget());
+        try {
+            MDC.put("api", rule.api().getId());
+            T endpoint = rule.endpoint();
+            logger.debug("Running health-check for endpoint: {} [{}]", endpoint.getName(), endpoint.getTarget());
 
-        // Run request for each step
-        for (HealthCheckStep step : rule.steps()) {
-            runStep(endpoint, step);
+            // Run request for each step
+            for (HealthCheckStep step : rule.steps()) {
+                runStep(endpoint, step);
+            }
+        } finally {
+            MDC.remove("api");
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3576

## Description

Add apiId in MDC so the log pattern add the API :
`<pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>`

Before:

```
12:57:15.012 [vert.x-eventloop-thread-13] [] WARN  i.g.g.s.h.rule.EndpointRuleHandler
```

After:

```
12:57:15.012 [vert.x-eventloop-thread-13] [6479f69e-6673-316a-b493-b409da9a24b4] WARN i.g.g.s.h.rule.EndpointRuleHandler
```