### PR TITLE
fix(console): only subscriptions to api key plans can add custom api key

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.harness.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MatLegacyButtonHarness as MatButtonHarness } from '@angular/material/legacy-button/testing';
+import { MatLegacyDialogHarness as MatDialogHarness } from '@angular/material/legacy-dialog/testing';
+
+import { ApiKeyValidationHarness } from '../../api-key-validation/api-key-validation.harness';
+
+export class ApiPortalSubscriptionValidateDialogHarness extends MatDialogHarness {
+  static override hostSelector = 'api-portal-subscription-validate-dialog';
+  protected getCustomApiKeyInput = this.locatorForOptional(ApiKeyValidationHarness);
+  protected getCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  public getValidateButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate' }));
+
+  // Custom API Key
+  public async isCustomApiKeyInputDisplayed() {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return matInputHarness !== null;
+  }
+
+  public async setCustomApiKey(customApiKey: string) {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return await matInputHarness.setInputValue(customApiKey);
+  }
+
+  public async getCustomApiKey() {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return await matInputHarness.getInputValue();
+  }
+
+  // Action buttons
+  public async cancelSubscription() {
+    const matButtonHarness = await this.getCancelButton();
+    return await matButtonHarness.click();
+  }
+
+  public async validateSubscription() {
+    const matButtonHarness = await this.getValidateButton();
+    return await matButtonHarness.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
@@ -115,7 +115,6 @@ export class ApiSubscriptionEditComponent implements OnInit {
 
   ngOnInit(): void {
     this.apiId = this.activatedRoute.snapshot.params.apiId;
-    this.canUseCustomApiKey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
     this.displayedColumns = ['key', 'createdAt', 'endDate', 'actions'];
     this.apiKeys = [];
     this.apiKeysTotalCount = 0;
@@ -156,6 +155,9 @@ export class ApiSubscriptionEditComponent implements OnInit {
               consumerConfiguration: subscription.consumerConfiguration,
               metadata: subscription.metadata,
             };
+
+            this.canUseCustomApiKey =
+              this.subscription.plan.securityType === 'API_KEY' && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
 
             if (this.subscription.plan.securityType === 'API_KEY' && this.subscription.status !== 'REJECTED') {
               this.hasSharedApiKeyMode = subscription.application.apiKeyMode === 'SHARED';


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-3779

## Description

Only subscriptions to plans that are API_KEY can add a 'customApiKey' during validation.

![Screenshot 2024-02-01 at 17 40 49](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/965dead8-02ca-4d95-a48e-65cfc5e7d251)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cnepjwprea.chromatic.com)
<!-- Storybook placeholder end -->
