### PR TITLE
fix(console): only subscriptions to api key plans can validate with c…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.harness.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+import { ApiKeyValidationHarness } from '../../api-key-validation/api-key-validation.harness';
+
+export class ApiPortalSubscriptionValidateDialogHarness extends MatDialogHarness {
+  static override hostSelector = 'api-portal-subscription-validate-dialog';
+  protected getCustomApiKeyInput = this.locatorForOptional(ApiKeyValidationHarness);
+  protected getCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  public getValidateButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate' }));
+
+  // Custom API Key
+  public async isCustomApiKeyInputDisplayed() {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return matInputHarness !== null;
+  }
+
+  public async setCustomApiKey(customApiKey: string) {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return await matInputHarness.setInputValue(customApiKey);
+  }
+
+  public async getCustomApiKey() {
+    const matInputHarness = await this.getCustomApiKeyInput();
+    return await matInputHarness.getInputValue();
+  }
+
+  // Action buttons
+  public async cancelSubscription() {
+    const matButtonHarness = await this.getCancelButton();
+    return await matButtonHarness.click();
+  }
+
+  public async validateSubscription() {
+    const matButtonHarness = await this.getValidateButton();
+    return await matButtonHarness.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.spec.ts
@@ -49,6 +49,7 @@ import {
 } from '../../../../../entities/management-api-v2';
 import { ApiKeyValidationHarness } from '../components/api-key-validation/api-key-validation.harness';
 import { ApiKey, fakeApiKey } from '../../../../../entities/management-api-v2/api-key';
+import { ApiPortalSubscriptionValidateDialogHarness } from '../components/dialogs/validate/api-portal-subscription-validate-dialog.harness';
 
 const SUBSCRIPTION_ID = 'my-nice-subscription';
 const API_ID = 'api_1';
@@ -591,7 +592,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       await harness.openValidateDialog();
 
       const validateDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
-        MatDialogHarness.with({ selector: '#validateSubscriptionDialog' }),
+        ApiPortalSubscriptionValidateDialogHarness,
       );
 
       const datePicker = await validateDialog.getHarness(MatInputHarness.with({ selector: '[formControlName="dateTimeRange"]' }));
@@ -603,9 +604,8 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       expect(await message.getValue()).toEqual('');
       await message.setValue('A great new message');
 
-      const customApiKey = await validateDialog.getHarness(ApiKeyValidationHarness);
-      expect(await customApiKey.getInputValue()).toEqual('');
-      await customApiKey.setInputValue('12345678');
+      expect(await validateDialog.getCustomApiKey()).toEqual('');
+      await validateDialog.setCustomApiKey('12345678');
       expectApiSubscriptionVerify(true, '12345678');
 
       const validateBtn = await validateDialog.getHarness(MatButtonHarness.with({ text: 'Validate' }));
@@ -669,22 +669,30 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       const cancelBtn = await validateDialog.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
       await cancelBtn.click();
     });
+    it('should not show custom key field if not API_KEY', async () => {
+      const jwtSubscription: Subscription = { ...pendingSubscription };
+      jwtSubscription.plan.security.type = 'JWT';
+      await initComponent(jwtSubscription);
+      await validateInformation(false);
+    });
+    it('should show custom key field if API_KEY', async () => {
+      await initComponent(pendingSubscription);
+      expectApiKeyListGet();
+      await validateInformation(true);
+    });
 
     const validateInformation = async (apiKeyInputIsPresent: boolean) => {
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openValidateDialog();
 
       const validateDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
-        MatDialogHarness.with({ selector: '#validateSubscriptionDialog' }),
+        ApiPortalSubscriptionValidateDialogHarness,
       );
 
-      await validateDialog
-        .getHarness(ApiKeyValidationHarness)
-        .then((isPresent) => (apiKeyInputIsPresent ? expect(isPresent).toBeTruthy() : fail('ApiKeyValidationComponent should be present')))
-        .catch((err) => (apiKeyInputIsPresent ? fail('ApiKeyValidationComponent should not be present') : expect(err).toBeTruthy()));
+      expect(validateDialog).toBeTruthy();
+      expect(await validateDialog.isCustomApiKeyInputDisplayed()).toEqual(apiKeyInputIsPresent);
 
-      const validateBtn = await validateDialog.getHarness(MatButtonHarness.with({ text: 'Validate' }));
-      await validateBtn.click();
+      await validateDialog.validateSubscription();
 
       expectApiSubscriptionValidate(SUBSCRIPTION_ID, {}, BASIC_SUBSCRIPTION());
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -122,7 +122,6 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
   ngOnInit(): void {
     this.routeBase = this.ajsGlobals.current?.data?.baseRouteState ?? 'management.apis.detail.portal';
     this.apiId = this.ajsStateParams.apiId;
-    this.canUseCustomApiKey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
     this.displayedColumns = ['key', 'createdAt', 'endDate', 'actions'];
     this.apiKeys = [];
     this.apiKeysTotalCount = 0;
@@ -163,6 +162,9 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
               consumerConfiguration: subscription.consumerConfiguration,
               metadata: subscription.metadata,
             };
+
+            this.canUseCustomApiKey =
+              this.subscription.plan.securityType === 'API_KEY' && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
 
             if (this.subscription.plan.securityType === 'API_KEY' && this.subscription.status !== 'REJECTED') {
               this.hasSharedApiKeyMode = subscription.application.apiKeyMode === 'SHARED';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3779

## Description

Related to PR: #6532 -- added to make merging easier for versions pre-Angular 15 migration.

Only subscriptions to plans that are API_KEY can add a 'customApiKey' during validation.

![Screenshot 2024-02-01 at 17 40 49](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/965dead8-02ca-4d95-a48e-65cfc5e7d251)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ikdptoatlc.chromatic.com)
<!-- Storybook placeholder end -->
