### PR TITLE
fix(sanitizer): allow start attributes on ol elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-<p align="center" >
+<p style="text-align: center;">
   <img src="./assets/gravitee-logo-dark.svg#gh-light-mode-only" width="400" alt="Gravitee Dark Logo">
   <img src="./assets/gravitee-logo-white.svg#gh-dark-mode-only" width="400" alt="Gravitee Light Logo">
 </p>
 
-<h1 align="center">API Management</h1>
-<p align="center">Flexible and blazing-fast Open Source API Gateway.</p>
+<h1 style="text-align: center;">API Management</h1>
+<p style="text-align: center;">Flexible and blazing-fast Open Source API Gateway.</p>
 
 <br/>
 
-<p align="center">
+<p style="text-align: center;">
   <a href="https://circleci.com/gh/gravitee-io/gravitee-api-management">
     <img src="https://circleci.com/gh/gravitee-io/gravitee-api-management.svg?style=svg" alt="Build Status on CircleCI" />
   </a>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
@@ -91,6 +91,7 @@ public final class HtmlSanitizer {
         .and(HTML_CSS_SANITIZER)
         .and(Sanitizers.TABLES)
         .and(new HtmlPolicyBuilder().allowElements("pre", "hr").toFactory())
+        .and(new HtmlPolicyBuilder().allowElements("ol").allowAttributes("start").onElements("ol").toFactory())
         .and(HTML_IMAGES_SANITIZER)
         .and(new HtmlPolicyBuilder().allowElements("code").allowAttributes("class").globally().toFactory())
         .and(GITHUB_FLAVOURED_MARKDOWN);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -63,6 +63,12 @@ public class HtmlSanitizerTest {
     }
 
     @Test
+    public void sanitizeOlStart() {
+        var ol = "<ol start=\"48\"><li>First</li><li>Second</li></ol>";
+        assertEquals(ol, HtmlSanitizer.sanitize(ol));
+    }
+
+    @Test
     public void sanitizeExcludeSensitive() {
         String html = getNotSafe();
         assertEquals("", HtmlSanitizer.sanitize(html));


### PR DESCRIPTION
## Issue

N.A.

## Description

By default, the sanitizer considers attribute `start` on `ol` elements unsecure. This causes the following markdown to be invalid 
```
57. foo
58. bar
```
But this is demonstrated in many markdown sample pages and should not be considered invalid. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cqnhhhvwyl.chromatic.com)
<!-- Storybook placeholder end -->
