### PR TITLE
fix: page link dialog

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
@@ -38,9 +38,9 @@ class ComponentCtrl implements ng.IComponentController {
   constructor(
     private readonly $http: ng.IHttpService,
     private readonly Constants,
-    private readonly activatedRoute: ActivatedRoute,
     private readonly $mdDialog: angular.material.IDialogService,
     private readonly NotificationService: NotificationService,
+    private readonly activatedRoute: ActivatedRoute,
   ) {}
 
   $onInit() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3816

## Description

Fix issue with doc page markdown edition to add link to other page

Before fix:
![Screenshot 2024-02-05 at 13 58 23](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/959a7f46-f913-43b6-9e68-ac3b68344c84)

After
![Screenshot 2024-02-05 at 13 59 01](https://github.com/gravitee-io/gravitee-api-management/assets/1655950/ddd970ce-51e1-47d8-97e7-6471bb3db274)


## Additional info
The bad order of the parameters caused the injected `$mdDialog` to have actual value of `$mdToast`. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wirrfzbctu.chromatic.com)
<!-- Storybook placeholder end -->
