### PR TITLE
fix(console): only subscriptions to api key plans can validate with c…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
@@ -57,7 +57,8 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
     }
 
     $onInit() {
-      this.canUseCustomApiKey = this.Constants.env.settings.plan.security.customApiKey.enabled;
+      this.canUseCustomApiKey =
+        this.subscription.plan.security === PlanSecurityType.API_KEY && this.Constants.env.settings.plan.security.customApiKey.enabled;
       this.listApiKeys();
       this.getApiPlans();
     }


### PR DESCRIPTION
…ustom api key

## Issue

https://gravitee.atlassian.net/browse/APIM-3779

## Description

Only subscriptions to plans that are API_KEY can add a 'customApiKey' during accepting a subscription.

![Screenshot 2024-02-06 at 11 55 30](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/9378ca0e-c3ad-4373-b18b-2f968788962b)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xoenowhomd.chromatic.com)
<!-- Storybook placeholder end -->
