### PR TITLE
portal: scope documentation path by api

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
@@ -29,6 +29,7 @@
   <app-gv-page
     *ngIf="currentPage"
     [page]="currentPage"
+    [pages]="pages"
     withToc="true"
     [ngClass]="{ 'gv-documentation__content_swagger': isSwagger(currentPage), show: isLoaded, fullscreen: this.hasTreeClosed }"
     [fragment]="this.fragment"

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -67,6 +67,10 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
     this.isLoaded = true;
   }
 
+  get pages() {
+    return this._pages;
+  }
+
   constructor(private notificationService: NotificationService, private route: ActivatedRoute, private router: Router) {}
 
   static PAGE_PADDING_TOP_BOTTOM = 44;

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.ts
@@ -31,6 +31,7 @@ import { MarkdownService } from '../../services/markdown.service';
 export class GvPageMarkdownComponent implements OnInit, AfterViewInit {
   @Input() withToc: boolean;
   @Input() pageBaseUrl: string;
+  @Input() pages: Page[];
 
   pageContent: string;
   pageElementsPosition: any[];
@@ -55,7 +56,7 @@ export class GvPageMarkdownComponent implements OnInit, AfterViewInit {
 
     this.page = this.pageService.getCurrentPage();
     if (this.page?.content) {
-      this.pageContent = this.markdownService.render(this.page.content, this.baseURL, this.pageBaseUrl);
+      this.pageContent = this.markdownService.render(this.page.content, this.baseURL, this.pageBaseUrl, this.pages ?? []);
     }
   }
 

--- a/gravitee-apim-portal-webui/src/app/components/gv-page/gv-page.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page/gv-page.component.ts
@@ -48,6 +48,8 @@ export class GvPageComponent implements OnChanges, OnDestroy {
 
   @Input() pageBaseUrl: string;
 
+  @Input() pages: Page[];
+
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
     private portalService: PortalService,
@@ -97,6 +99,7 @@ export class GvPageComponent implements OnChanges, OnDestroy {
           viewerPage.instance.fragment = this.fragment;
           viewerPage.instance.withToc = this.withToc;
           viewerPage.instance.pageBaseUrl = this.pageBaseUrl;
+          viewerPage.instance.pages = this.pages;
           this.loaded.emit(true);
         });
       }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3048

## Description

With the new syntax, users are able to add links to markdown that will find a page based upon its name and type within the given api.

### Markdown page

In Console: 

![Screenshot 2024-02-08 at 12 18 46](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/567c4fa8-fe25-4b4d-a63f-c38e96245c0b)

In Portal:

![Screenshot 2024-02-08 at 12 17 32](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/d3593419-3cd3-4f8b-b5ed-c2b36344d6d7)


### Description

In Console:

![Screenshot 2024-02-08 at 12 19 01](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/13ced3ad-a0df-4171-8914-126067dc9b1b)

In Portal:

With good link:
![Screenshot 2024-02-08 at 12 17 55](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/53bcc78a-1475-4a84-98af-6c8b57754952)

With broken link:
![Screenshot 2024-02-08 at 12 18 30](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/0ff7f457-b757-4530-bbb5-aa23990d7a3d)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wbrefjrudg.chromatic.com)
<!-- Storybook placeholder end -->
