### PR TITLE
fix: add tooltip on doc page type logo

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -32,23 +32,30 @@
           </div></ng-container
         >
         <ng-container *ngIf="page.type !== 'FOLDER'">
+          <ng-template #pageName>
+            <mat-icon svgIcon="gio:page"></mat-icon>
+            <p gioTooltipOnEllipsis>{{ page.name }}</p>
+            <img
+              [ngSrc]="getLogoForPageType(page.type)"
+              height="24"
+              width="24"
+              alt="{{ page.type }} logo"
+              [matTooltip]="getTooltipForPageType(page.type)"
+            />
+          </ng-template>
           <div
             class="documentation-pages-list__table__name"
             *gioPermission="{ anyOf: ['api-documentation-u', 'api-documentation-r'] }"
             (click)="onEditPage.emit(page.id)"
           >
-            <mat-icon svgIcon="gio:page"></mat-icon>
-            <p gioTooltipOnEllipsis>{{ page.name }}</p>
-            <img [ngSrc]="getLogoForPageType(page.type)" height="24" width="24" alt="{{ page.type }} logo" />
+            <ng-container *ngTemplateOutlet="pageName"></ng-container>
           </div>
           <div
             class="documentation-pages-list__table__name no-pointer"
             *gioPermission="{ noneOf: ['api-documentation-u', 'api-documentation-r'] }"
           >
-            <mat-icon svgIcon="gio:page"></mat-icon>
-            <p gioTooltipOnEllipsis>{{ page.name }}</p>
-          </div></ng-container
-        >
+            <ng-container *ngTemplateOutlet="pageName"></ng-container></div
+        ></ng-container>
       </td>
     </ng-container>
     <ng-container matColumnDef="status">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.ts
@@ -71,4 +71,16 @@ export class ApiDocumentationV4PagesListComponent implements OnInit, OnChanges {
   getLogoForPageType(pageType: PageType) {
     return `assets/logo_${pageType.toLowerCase()}.svg`;
   }
+  getTooltipForPageType(pageType: PageType) {
+    switch (pageType) {
+      case PageType.ASCIIDOC:
+        return 'AsciiDoc';
+      case PageType.ASYNCAPI:
+        return 'AsyncAPI';
+      case PageType.SWAGGER:
+        return 'Swagger';
+      case PageType.MARKDOWN:
+        return 'Markdown';
+    }
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3567

## Description

Add missing tooltip on page type logo

## Additional info

I took the opportunity to refactor a bit the code to avoid duplication
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wpzaoaacqk.chromatic.com)
<!-- Storybook placeholder end -->
