### PR TITLE
fix: remove trimming of description when not set

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -204,8 +204,10 @@ public class ApiMapper {
 
         repoApi.setName(newApiEntity.getName().trim());
         repoApi.setVersion(newApiEntity.getApiVersion().trim());
-        repoApi.setDescription(newApiEntity.getDescription().trim());
-
+        String description = newApiEntity.getDescription();
+        if (description != null) {
+            repoApi.setDescription(description.trim());
+        }
         repoApi.setDefinitionVersion(newApiEntity.getDefinitionVersion());
         repoApi.setDefinition(toApiDefinition(generatedApiId, newApiEntity));
         repoApi.setType(newApiEntity.getType());
@@ -253,7 +255,10 @@ public class ApiMapper {
 
         repoApi.setName(updateApiEntity.getName().trim());
         repoApi.setVersion(updateApiEntity.getApiVersion().trim());
-        repoApi.setDescription(updateApiEntity.getDescription().trim());
+        String description = updateApiEntity.getDescription();
+        if (description != null) {
+            repoApi.setDescription(description.trim());
+        }
         repoApi.setPicture(updateApiEntity.getPicture());
         repoApi.setBackground(updateApiEntity.getBackground());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -235,7 +235,6 @@ public class ApiMapperTest {
         newApiEntity.setName("name");
         newApiEntity.setApiVersion("version");
         newApiEntity.setType(ApiType.MESSAGE);
-        newApiEntity.setDescription("description");
         newApiEntity.setTags(Set.of("tag"));
         newApiEntity.setGroups(Set.of("group1"));
         newApiEntity.setListeners(List.of(new HttpListener()));
@@ -244,6 +243,10 @@ public class ApiMapperTest {
         newApiEntity.setFlows(List.of(new Flow(), new Flow()));
 
         Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), newApiEntity);
+        assertThat(api.getDescription()).isNull();
+
+        newApiEntity.setDescription("description");
+        api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), newApiEntity);
 
         assertThat(api.getId()).isNotNull();
         assertThat(api.getType()).isEqualTo(ApiType.MESSAGE);
@@ -367,7 +370,6 @@ public class ApiMapperTest {
         apiEntity.setApiVersion("version");
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
         apiEntity.setType(ApiType.MESSAGE);
-        apiEntity.setDescription("description");
         apiEntity.setVisibility(io.gravitee.rest.api.model.Visibility.PUBLIC);
         apiEntity.setTags(Set.of("tag1", "tag2"));
         apiEntity.setPicture("my-picture");
@@ -397,6 +399,10 @@ public class ApiMapperTest {
             .thenReturn(List.of(existingCategoryByIdEntity, existingCategoryByKeyEntity));
 
         Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), apiEntity);
+        assertThat(api.getDescription()).isNull();
+
+        apiEntity.setDescription("description");
+        api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), apiEntity);
 
         assertThat(api.getId()).isEqualTo("id");
         assertThat(api.getEnvironmentId()).isEqualTo("DEFAULT");


### PR DESCRIPTION
## Description

NPE was raised when trimming description when creating/updating v4 APIs

## Additional context

Was trying to create a V4 API, the hard way, almost writing the JSON by hand. I noticed a few things.
```
        CreateGenericApi:
            type: object
            properties:
            [...]
            required: [name, apiVersion, definitionVersion]
```
By the look at it: description is not mandatory. But I get an NPE when not having it set.

```
java.lang.NullPointerException: Cannot invoke "String.trim()" because the return value of "io.gravitee.rest.api.model.v4.api.NewApiEntity.getDescription()" is null
	at io.gravitee.rest.api.service.v4.mapper.ApiMapper.toRepository(ApiMapper.java:207)
	at io.gravitee.rest.api.service.v4.impl.ApiServiceImpl.create(ApiServiceImpl.java:233)
```
Same goes with UpdateApiEntity L256

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

