### PR TITLE
feat(mapi-v2): add scope to `/license` response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
@@ -53,6 +53,7 @@ public class GraviteeLicenseResource extends AbstractResource {
                 .packs(license.getPacks())
                 .features(license.getFeatures())
                 .expiresAt(license.getExpirationDate())
+                .scope(license.getReferenceType())
                 .build()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -34,6 +34,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
+import java.util.Objects;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -75,6 +76,7 @@ public class OrganizationResource extends AbstractResource {
                 .packs(license.getPacks())
                 .features(license.getFeatures())
                 .expiresAt(license.getExpirationDate())
+                .scope(license.getReferenceType())
                 .build()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
@@ -122,6 +122,10 @@ components:
                     format: date-time
                     description: The date (as timestamp) when the license will expire.
                     example: 1581256457163
+                scope:
+                    type: string
+                    description: The scope of the license.
+                    example: "PLATFORM"
     responses:
         Error:
             description: Generic error response

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
@@ -222,6 +222,10 @@ components:
                     format: date-time
                     description: The date (as timestamp) when the license will expire.
                     example: 1581256457163
+                scope:
+                    type: string
+                    description: The scope of the license.
+                    example: "PLATFORM"
         Links:
             description: List of links for pagination
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
@@ -51,6 +51,7 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         when(license.getTier()).thenReturn("universe");
         when(license.getPacks()).thenReturn(Set.of("observability"));
         when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
+        when(license.getReferenceType()).thenReturn("PLATFORM");
 
         var now = Instant.now();
         var nowDate = Date.from(now);
@@ -65,5 +66,6 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         assertThat(graviteeLicense.getPacks()).containsExactly("observability");
         assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
         assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
+        assertThat(graviteeLicense.getScope()).isEqualTo("PLATFORM");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
@@ -99,6 +99,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             when(license.getPacks()).thenReturn(Set.of("observability"));
             when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
             when(license.getExpirationDate()).thenReturn(nowDate);
+            when(license.getReferenceType()).thenReturn("PLATFORM");
 
             var response = rootTarget(ORGANIZATION).path("license").request().get();
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
@@ -109,6 +110,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             assertThat(graviteeLicense.getPacks()).containsExactly("observability");
             assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
             assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
+            assertThat(graviteeLicense.getScope()).isEqualTo("PLATFORM");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
@@ -41,4 +41,6 @@ public class GraviteeLicenseEntity {
     private Set<String> features = Set.of();
 
     private Date expiresAt;
+
+    private String scope;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3855

## Description

Add scope to the /license response. Uses the `referenceType` of the license object from the `LicenseManager`

TODO: The front-end will be integrated in a later PR

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

