### PR TITLE
feat: enable api notifications for V4 API

### DIFF
--- a/gravitee-apim-console-webui/src/entities/notification/notificationSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/notification/notificationSettings.fixture.ts
@@ -31,3 +31,17 @@ export function fakeNotificationSettings(attributes?: Partial<NotificationSettin
     ...attributes,
   };
 }
+
+export function fakePortalNotificationSettings(attributes?: Partial<NotificationSettings>): NotificationSettings {
+  const defaultValue: NotificationSettings = {
+    name: 'Portal Notification',
+    referenceType: 'API',
+    referenceId: 'f1ddf4b5-c23a-33a7-87bf-28ec0a1d9db9',
+    hooks: [],
+    config_type: 'PORTAL',
+  };
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
@@ -328,7 +328,7 @@ export class ApiNavigationComponent implements OnInit, OnDestroy {
   }
 
   private findActiveMenuItem(items: MenuItem[]) {
-    return items.filter((item) => item.tabs).find((item) => this.isTabActive(item.tabs));
+    return items.filter((item) => item?.tabs).find((item) => this.isTabActive(item?.tabs));
   }
 
   private findActiveMenuItemHeader() {
@@ -373,6 +373,7 @@ export class ApiNavigationComponent implements OnInit, OnDestroy {
     const environmentId = this.activatedRoute.snapshot.params.envId;
     const apiId = this.currentApi.id;
     const parentRouterLink = getPathFromRoot(this.activatedRoute);
+
     return this.mapToMenuSearchItem(environmentId, apiId, parentRouterLink, this.subMenuItems).concat(
       this.mapToMenuSearchItem(
         environmentId,

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -86,7 +86,7 @@ export class ApiV4MenuService implements ApiMenuService {
     if (this.permissionService.hasAnyMatching(['api-notification-r'])) {
       tabs.push({
         displayName: 'Notifications',
-        routerLink: 'DISABLED',
+        routerLink: 'v4/notifications',
         routerLinkActiveOptions: { exact: true },
       });
     }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -49,7 +49,7 @@ export class ApiV4MenuService implements ApiMenuService {
       this.addPoliciesMenuEntry(hasTcpListeners),
       this.addApiTrafficMenuEntry(hasTcpListeners),
       this.addApiRuntimeAlertsMenuEntry(),
-    ].filter((entry) => !entry?.tabs?.every((tab) => tab.routerLink === 'DISABLED'));
+    ].filter((entry) => entry != null && !entry.tabs?.every((tab) => tab.routerLink === 'DISABLED'));
 
     const groupItems: MenuGroupItem[] = [this.getGeneralGroup()].filter((group) => !!group);
 

--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.html
@@ -1,0 +1,51 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card>
+  <mat-card-content>
+    <div class="notifications">
+      <div class="notifications__header">
+        <div class="notifications__title">
+          <h3 class="notifications__title__main">Notifications</h3>
+          <div class="notifications__title__subtitle">
+            Configure your own Developer Portal notifications using Portal, Email or Webhook notifier
+          </div>
+        </div>
+
+        <button
+          *ngIf="canAdd"
+          mat-raised-button
+          [attr.aria-label]="'Add notification'"
+          (click)="addNotification()"
+          data-testid="add-notification"
+          color="primary"
+        >
+          <mat-icon svgIcon="gio:plus"></mat-icon>Add notification
+        </button>
+      </div>
+
+      <notification-list
+        [canUpdate]="canUpdate"
+        [canDelete]="canDelete"
+        [loading]="loading"
+        [notifications]="notificationsSummary$ | async"
+        (delete)="deleteNotification($event)"
+        (edit)="editNotification($event)"
+      ></notification-list>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.scss
@@ -1,0 +1,31 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+$foreground: map.get(gio.$mat-theme, foreground);
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.notifications {
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    border-bottom: 1px solid mat.get-color-from-palette($foreground, divider);
+
+    margin-bottom: 12px;
+  }
+
+  &__title {
+    margin-bottom: 12px;
+
+    &__main {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.spec.ts
@@ -1,0 +1,529 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ActivatedRoute } from '@angular/router';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+
+import { ApiNotificationComponent } from './api-notification.component';
+import { ApiNotificationModule } from './api-notification.module';
+import { NotificationListHarness } from './components/notification-list/notification-list.harness';
+import { NotificationAddDialogHarness, NotificationEditDialogHarness } from './components';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
+import { fakeNotifier } from '../../../entities/notification/notifier.fixture';
+import { fakeNotificationSettings, fakePortalNotificationSettings } from '../../../entities/notification/notificationSettings.fixture';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { fakeHooks } from '../../../entities/notification/hooks.fixture';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+
+describe('ApiNotificationComponent', () => {
+  const API_ID = 'an-api-id';
+  const EMAIL_NOTIFICATION_ID = 'email-notification-id';
+  const WEBHOOK_NOTIFICATION_ID = 'webhook-notification-id';
+  const NOTIFIER_EMAIL_ID = 'default-email';
+  const NOTIFIER_EMAIL_NAME = 'Default Mail Notifier';
+  const NOTIFIER_WEBHOOK_ID = 'default-webhook';
+  const NOTIFIER_WEBHOOK_NAME = 'Default Webhook Notifier';
+
+  const PORTAL_NOTIFICATION = fakePortalNotificationSettings();
+  const EMAIL_NOTIFICATION = fakeNotificationSettings({
+    id: EMAIL_NOTIFICATION_ID,
+    notifier: NOTIFIER_EMAIL_ID,
+    referenceId: API_ID,
+    name: 'Default Mail Notifications',
+    hooks: ['APIKEY_EXPIRED', 'API_UPDATED'],
+  });
+  const WEBHOOK_NOTIFICATION = fakeNotificationSettings({
+    id: WEBHOOK_NOTIFICATION_ID,
+    notifier: NOTIFIER_WEBHOOK_ID,
+    referenceId: API_ID,
+    name: 'Default Webhook Notifications',
+    hooks: ['APIKEY_EXPIRED', 'API_UPDATED'],
+  });
+
+  const fakeSnackBarService = {
+    success: jest.fn(),
+  };
+
+  let fixture: ComponentFixture<ApiNotificationComponent>;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
+
+  let httpTestingController: HttpTestingController;
+  let permissionsService: GioPermissionService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatIconTestingModule, GioHttpTestingModule, ApiNotificationModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+      ],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This checks focus trap, set it to true to avoid the warning
+          isTabbable: () => true,
+        },
+      })
+      .compileComponents();
+
+    permissionsService = TestBed.inject(GioPermissionService);
+
+    initComponent();
+  });
+
+  function initComponent(permissions = ['api-notification-c', 'api-notification-d', 'api-notification-u']) {
+    permissionsService._setPermissions(permissions);
+    fixture = TestBed.createComponent(ApiNotificationComponent);
+    fixture.detectChanges();
+
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    expectNotificationSettingsRequest();
+    expectNotifiersRequest();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should display notifications', async () => {
+    const table = await loader.getHarness(NotificationListHarness);
+    expect(await table.rows()).toEqual([
+      {
+        name: PORTAL_NOTIFICATION.name,
+        notifier: '',
+        subscribedEvents: '0 events',
+        actions: '',
+      },
+      {
+        name: EMAIL_NOTIFICATION.name,
+        notifier: NOTIFIER_EMAIL_NAME,
+        subscribedEvents: '2 events',
+        actions: '',
+      },
+      {
+        name: WEBHOOK_NOTIFICATION.name,
+        notifier: NOTIFIER_WEBHOOK_NAME,
+        subscribedEvents: '2 events',
+        actions: '',
+      },
+    ]);
+  });
+
+  describe('Add new notification', () => {
+    it('should add new notification', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid=add-notification]' }));
+      await addButton.click();
+
+      const dialog = await rootLoader.getHarness(NotificationAddDialogHarness);
+      await dialog.fillForm('New Notification', NOTIFIER_WEBHOOK_NAME).then(() => dialog.confirm());
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings`,
+      });
+      expect(req.request.body).toEqual({
+        name: 'New Notification',
+        notifier: NOTIFIER_WEBHOOK_ID,
+        referenceType: 'API',
+        referenceId: API_ID,
+        config_type: 'GENERIC',
+        hooks: [],
+      });
+    });
+
+    it('should display a success notification and refresh the list', async () => {
+      const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid=add-notification]' }));
+      await addButton.click();
+
+      const dialog = await rootLoader.getHarness(NotificationAddDialogHarness);
+      await dialog.fillForm('New Notification', NOTIFIER_WEBHOOK_NAME).then(() => dialog.confirm());
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings`,
+      });
+      req.flush([]);
+      expectNotificationSettingsRequest([PORTAL_NOTIFICATION, EMAIL_NOTIFICATION, WEBHOOK_NOTIFICATION, req.request.body]);
+
+      // Check that the snackbar has been displayed
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Notification created successfully');
+
+      // Check that the table has been refreshed
+      const table = await loader.getHarness(NotificationListHarness);
+      expect(await table.rows()).toEqual([
+        {
+          name: PORTAL_NOTIFICATION.name,
+          notifier: '',
+          subscribedEvents: '0 events',
+          actions: '',
+        },
+        {
+          name: EMAIL_NOTIFICATION.name,
+          notifier: NOTIFIER_EMAIL_NAME,
+          subscribedEvents: '2 events',
+          actions: '',
+        },
+        {
+          name: WEBHOOK_NOTIFICATION.name,
+          notifier: NOTIFIER_WEBHOOK_NAME,
+          subscribedEvents: '2 events',
+          actions: '',
+        },
+        {
+          name: 'New Notification',
+          notifier: NOTIFIER_WEBHOOK_NAME,
+          subscribedEvents: '0 events',
+          actions: '',
+        },
+      ]);
+    });
+
+    it('should not show Add button if the user is not allowed', async () => {
+      initComponent([]);
+
+      const addButton = await loader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid=add-notification]' }));
+      expect(addButton).toBeNull();
+    });
+  });
+
+  describe('Delete a notification', () => {
+    it('should delete notification', async () => {
+      const table = await loader.getHarness(NotificationListHarness);
+      await table.deleteRow(1);
+
+      const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+      await confirmDialog.confirm();
+
+      httpTestingController.expectOne({
+        method: 'DELETE',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${EMAIL_NOTIFICATION_ID}`,
+      });
+    });
+
+    it('should display a success notification and refresh the list', async () => {
+      const table = await loader.getHarness(NotificationListHarness);
+      await table.deleteRow(1);
+
+      const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+      await confirmDialog.confirm();
+
+      httpTestingController
+        .expectOne({
+          method: 'DELETE',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${EMAIL_NOTIFICATION_ID}`,
+        })
+        .flush([]);
+      expectNotificationSettingsRequest([PORTAL_NOTIFICATION]);
+
+      // Check that the snackbar has been displayed
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('"Default Mail Notifications" has been deleted');
+
+      // Check that the table has been refreshed
+      expect(await table.rows()).toEqual([
+        {
+          name: 'Portal Notification',
+          notifier: '',
+          subscribedEvents: '0 events',
+          actions: '',
+        },
+      ]);
+    });
+
+    it('should not show Delete button on Portal Notification row', async () => {
+      const table = await loader.getHarness(NotificationListHarness);
+      const addButton = await table.getDeleteButton(0);
+      expect(addButton).toBeNull();
+    });
+
+    it('should not show Delete button if the user is not allowed', async () => {
+      initComponent([]);
+
+      const table = await loader.getHarness(NotificationListHarness);
+      const addButton = await table.getDeleteButton(1);
+      expect(addButton).toBeNull();
+    });
+  });
+
+  describe('Edit a notification', () => {
+    describe('using Portal', () => {
+      it('should open edit modal', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(0);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([PORTAL_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+
+        // Notifier config is not available
+        const notifierConfigInput = await dialog.getNotifierConfigInput();
+        expect(notifierConfigInput).toBeNull();
+
+        // UseSystemProxy is not available
+        const useSystemProxyToggle = await dialog.getUseSystemProxyToggle();
+        expect(useSystemProxyToggle).toBeNull();
+
+        // Selected Hooks are checked
+        const hooks = await dialog.getAllHooks();
+        expect(hooks).toEqual(
+          expect.arrayContaining([
+            { name: 'APIKEY_EXPIRED', checked: false },
+            { name: 'API_UPDATED', checked: false },
+            { name: 'APIKEY_REVOKED', checked: false },
+            { name: 'API_STARTED', checked: false },
+            { name: 'API_STOPPED', checked: false },
+          ]),
+        );
+      });
+
+      it('should edit the notification', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(0);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([PORTAL_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+        await dialog.getHookCheckbox('APIKEY_EXPIRED').then((checkbox) => checkbox.uncheck());
+        await dialog.getHookCheckbox('API_UPDATED').then((checkbox) => checkbox.uncheck());
+        await dialog.getHookCheckbox('API_STARTED').then((checkbox) => checkbox.check());
+        await dialog.save();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/`,
+        });
+        expect(req.request.body).toEqual({
+          ...PORTAL_NOTIFICATION,
+          hooks: ['API_STARTED'],
+        });
+      });
+
+      it('should not show Edit button if the user is not allowed', async () => {
+        initComponent([]);
+
+        const table = await loader.getHarness(NotificationListHarness);
+
+        // Portal Notification
+        expect(await table.getEditButton(0)).toBeNull();
+
+        // Other Notification
+        expect(await table.getEditButton(1)).toBeNull();
+      });
+    });
+
+    describe('using Email Notifier', () => {
+      it('should open edit modal', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(1);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([EMAIL_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+
+        // Notifier config is available
+        const notifierConfigInput = await dialog.getNotifierConfigInput();
+        expect(notifierConfigInput).not.toBeNull();
+
+        // UseSystemProxy is not available
+        const useSystemProxyToggle = await dialog.getUseSystemProxyToggle();
+        expect(useSystemProxyToggle).toBeNull();
+
+        // Selected Hooks are checked
+        const hooks = await dialog.getAllHooks();
+        expect(hooks).toEqual(
+          expect.arrayContaining([
+            { name: 'APIKEY_EXPIRED', checked: true },
+            { name: 'API_UPDATED', checked: true },
+            { name: 'APIKEY_REVOKED', checked: false },
+            { name: 'API_STARTED', checked: false },
+            { name: 'API_STOPPED', checked: false },
+          ]),
+        );
+      });
+
+      it('should edit the notification', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(1);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([EMAIL_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+        await dialog.fillConfig('new-config');
+        await dialog.getHookCheckbox('APIKEY_EXPIRED').then((checkbox) => checkbox.toggle());
+        await dialog.getHookCheckbox('API_STOPPED').then((checkbox) => checkbox.check());
+        await dialog.save();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${EMAIL_NOTIFICATION_ID}`,
+        });
+        expect(req.request.body).toEqual({
+          ...EMAIL_NOTIFICATION,
+          config: 'new-config',
+          useSystemProxy: false,
+          hooks: ['API_UPDATED', 'API_STOPPED'],
+        });
+      });
+    });
+
+    describe('using Webhook Notifier', () => {
+      it('should open edit modal', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(2);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([WEBHOOK_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+
+        // Notifier config is available
+        const notifierConfigInput = await dialog.getNotifierConfigInput();
+        expect(notifierConfigInput).not.toBeNull();
+
+        // UseSystemProxy is available
+        const useSystemProxyToggle = await dialog.getUseSystemProxyToggle();
+        expect(useSystemProxyToggle).not.toBeNull();
+
+        // Selected Hooks are checked
+        const hooks = await dialog.getAllHooks();
+        expect(hooks).toEqual(
+          expect.arrayContaining([
+            { name: 'APIKEY_EXPIRED', checked: true },
+            { name: 'API_UPDATED', checked: true },
+            { name: 'APIKEY_REVOKED', checked: false },
+            { name: 'API_STARTED', checked: false },
+            { name: 'API_STOPPED', checked: false },
+          ]),
+        );
+      });
+
+      it('should edit the notification', async () => {
+        const table = await loader.getHarness(NotificationListHarness);
+        await table.editRow(2);
+
+        expectHooksRequest();
+        expectNotificationSettingsRequest([WEBHOOK_NOTIFICATION]);
+
+        const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+        await dialog.fillConfig('new-config');
+        await dialog.toggleUseSystemProxy();
+        await dialog.getHookCheckbox('API_UPDATED').then((checkbox) => checkbox.uncheck());
+        await dialog.getHookCheckbox('APIKEY_REVOKED').then((checkbox) => checkbox.check());
+        await dialog.save();
+
+        const req = httpTestingController.expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${WEBHOOK_NOTIFICATION_ID}`,
+        });
+        expect(req.request.body).toEqual({
+          ...WEBHOOK_NOTIFICATION,
+          config: 'new-config',
+          useSystemProxy: true,
+          hooks: ['APIKEY_EXPIRED', 'APIKEY_REVOKED'],
+        });
+      });
+    });
+
+    it.each([
+      {
+        index: 0,
+        id: '',
+      },
+      {
+        index: 1,
+        id: EMAIL_NOTIFICATION_ID,
+      },
+      {
+        index: 2,
+        id: WEBHOOK_NOTIFICATION_ID,
+      },
+    ])('should display a success notification and refresh the list', async ({ index, id }) => {
+      const table = await loader.getHarness(NotificationListHarness);
+      await table.editRow(index);
+
+      expectHooksRequest();
+      expectNotificationSettingsRequest([PORTAL_NOTIFICATION, EMAIL_NOTIFICATION, WEBHOOK_NOTIFICATION]);
+
+      const dialog = await rootLoader.getHarness(NotificationEditDialogHarness);
+      await dialog.getHookCheckbox('APIKEY_EXPIRED').then((checkbox) => checkbox.uncheck());
+      await dialog.save();
+
+      httpTestingController
+        .expectOne({
+          method: 'PUT',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings/${id}`,
+        })
+        .flush([]);
+
+      // Refresh the list
+      expectNotificationSettingsRequest([PORTAL_NOTIFICATION]);
+
+      // Check that the snackbar has been displayed
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Notification saved successfully');
+
+      // Check that the table has been refreshed
+      expect(await table.rows()).toEqual([
+        {
+          name: 'Portal Notification',
+          notifier: '',
+          subscribedEvents: '0 events',
+          actions: '',
+        },
+      ]);
+    });
+  });
+
+  function expectHooksRequest(
+    response = [
+      fakeHooks({ id: 'APIKEY_EXPIRED', label: 'API-Key expired', category: 'API KEY' }),
+      fakeHooks({ id: 'APIKEY_REVOKED', label: 'API-Key revoked', category: 'API KEY' }),
+      fakeHooks({ id: 'API_STARTED', label: 'API Started', category: 'LIFECYCLE' }),
+      fakeHooks({ id: 'API_UPDATED', label: 'API Updated', category: 'LIFECYCLE' }),
+      fakeHooks({ id: 'API_STOPPED', label: 'API Stopped', category: 'LIFECYCLE' }),
+    ],
+  ) {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/hooks`);
+    if (!req.cancelled) req.flush(response);
+  }
+
+  function expectNotificationSettingsRequest(response = [PORTAL_NOTIFICATION, EMAIL_NOTIFICATION, WEBHOOK_NOTIFICATION]) {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notificationsettings`);
+    if (!req.cancelled) req.flush(response);
+  }
+
+  function expectNotifiersRequest() {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/notifiers`);
+    req.flush([
+      fakeNotifier({ id: NOTIFIER_EMAIL_ID, type: 'EMAIL', name: NOTIFIER_EMAIL_NAME }),
+      fakeNotifier({ id: NOTIFIER_WEBHOOK_ID, type: 'WEBHOOK', name: NOTIFIER_WEBHOOK_NAME }),
+    ]);
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, EMPTY, Observable, Subject } from 'rxjs';
+import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+
+import { NotificationSummary } from './components/notification-list/notification-list.component';
+import {
+  NotificationAddDialogComponent,
+  NotificationAddDialogData,
+  NotificationAddDialogResult,
+  NotificationEditDialogComponent,
+  NotificationEditDialogData,
+  NotificationEditDialogResult,
+} from './components';
+
+import { ApiNotificationSettingsService } from '../../../services-ngx/api-notification-settings.service';
+import { Notifier } from '../../../entities/notification/notifier';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { NotificationSettings } from '../../../entities/notification/notificationSettings';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+
+@Component({
+  selector: 'api-notification',
+  templateUrl: './api-notification.component.html',
+  styleUrls: ['./api-notification.component.scss'],
+})
+export class ApiNotificationComponent implements OnInit, OnDestroy {
+  private apiId = this.activatedRoute.snapshot.params.apiId;
+  private notifications$: BehaviorSubject<NotificationSettings[]> = new BehaviorSubject(null);
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  private hooks$ = this.notificationService.getHooks();
+
+  protected loading = true;
+  protected canAdd = this.permissionService.hasAnyMatching(['api-notification-c']);
+  protected canDelete = this.permissionService.hasAnyMatching(['api-notification-d']);
+  protected canUpdate = this.permissionService.hasAnyMatching(['api-notification-u']);
+  protected notifiers: Notifier[];
+  protected notificationsSummary$: Observable<NotificationSummary[]> = this.notifications$.asObservable().pipe(
+    map((notifications) => {
+      return notifications?.map((notification) => {
+        return {
+          id: notification.id ?? notification.config_type,
+          name: notification.name,
+          subscribedEvents: notification.hooks.length ?? 0,
+          notifier: this.notifiers.find((n) => n.id === notification.notifier),
+          isPortalNotification: notification.config_type === 'PORTAL',
+        };
+      });
+    }),
+    map((notifications) => {
+      if (notifications != null) {
+        this.loading = false;
+        return notifications;
+      }
+      return [];
+    }),
+  );
+
+  constructor(
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly notificationService: ApiNotificationSettingsService,
+    private readonly matDialog: MatDialog,
+    private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
+  ) {}
+
+  public ngOnInit(): void {
+    combineLatest([this.notificationService.getNotifiers(this.apiId), this.notificationService.getAll(this.apiId)])
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(([notifiers, notifications]) => {
+        this.notifiers = notifiers;
+        this.notifications$.next(notifications);
+      });
+  }
+
+  public ngOnDestroy(): void {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+    this.notifications$.unsubscribe();
+  }
+
+  protected addNotification() {
+    this.matDialog
+      .open<NotificationAddDialogComponent, NotificationAddDialogData, NotificationAddDialogResult>(NotificationAddDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          notifiers: this.notifiers,
+        },
+        role: 'dialog',
+        id: 'addNotificationDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((result) => !!result),
+        switchMap((newNotification) =>
+          this.notificationService.create(this.apiId, {
+            name: newNotification.name,
+            notifier: newNotification.notifierId,
+            referenceType: 'API',
+            referenceId: this.apiId,
+            config_type: 'GENERIC',
+            hooks: [],
+          }),
+        ),
+        tap(() => {
+          this.snackBarService.success('Notification created successfully');
+          this.refreshList();
+        }),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  protected deleteNotification(notification: NotificationSummary) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: GIO_DIALOG_WIDTH.SMALL,
+        data: {
+          title: 'Delete notification',
+          content: `Are you sure you want to delete the notification <strong>${notification.name}</strong>?`,
+          confirmButton: 'Delete',
+        },
+        role: 'alertdialog',
+        id: 'deleteNotificationConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm) => confirm === true),
+        switchMap(() => this.notificationService.delete(this.apiId, notification.id)),
+        tap(() => {
+          this.snackBarService.success(`"${notification.name}" has been deleted`);
+          this.refreshList();
+        }),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  protected editNotification(id: string) {
+    combineLatest([this.hooks$, this.notificationService.getSingleNotificationSetting(this.apiId, id)])
+      .pipe(
+        switchMap(([hooks, notification]) => {
+          return this.matDialog
+            .open<NotificationEditDialogComponent, NotificationEditDialogData, NotificationEditDialogResult>(
+              NotificationEditDialogComponent,
+              {
+                width: GIO_DIALOG_WIDTH.LARGE,
+                data: {
+                  hooks,
+                  notifier: this.notifiers.find((n) => n.id === notification.notifier),
+                  notification,
+                },
+                role: 'dialog',
+                id: 'editNotificationDialog',
+              },
+            )
+            .afterClosed();
+        }),
+        filter((result) => !!result),
+        switchMap((updated) => this.notificationService.update(this.apiId, id, updated)),
+        tap(() => {
+          this.snackBarService.success('Notification saved successfully');
+          this.refreshList();
+        }),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+
+      .subscribe();
+  }
+
+  private refreshList() {
+    this.loading = true;
+    this.notificationService
+      .getAll(this.apiId)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((notifications) => {
+        this.notifications$.next(notifications);
+      });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.module.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatLegacySnackBarModule } from '@angular/material/legacy-snack-bar';
+
+import { ApiNotificationComponent } from './api-notification.component';
+import { NotificationAddDialogModule, NotificationEditDialogModule, NotificationListModule } from './components';
+
+@NgModule({
+  declarations: [ApiNotificationComponent],
+  exports: [],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogModule,
+    NotificationListModule,
+    NotificationAddDialogModule,
+    NotificationEditDialogModule,
+    MatLegacySnackBarModule,
+  ],
+})
+export class ApiNotificationModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/index.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/index.ts
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier?: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
-}
+
+export * from './notification-add-dialog';
+export * from './notification-edit-dialog';
+export * from './notification-list';

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/index.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/index.ts
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier?: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
-}
+
+export * from './notification-add-dialog.component';
+export * from './notification-add-dialog.harness';
+export * from './notification-add-dialog.module';

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.html
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<h2 mat-dialog-title class="title">New notification</h2>
+
+<form autocomplete="off" [formGroup]="notificationForm" (ngSubmit)="onSubmit()">
+  <mat-dialog-content>
+    <div class="form">
+      <mat-form-field>
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" required />
+        <mat-error *ngIf="notificationForm.get('name').hasError('required')">Name is required.</mat-error>
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Notifier</mat-label>
+        <mat-select formControlName="notifierId">
+          <mat-option *ngFor="let notifier of notifiersList" [value]="notifier.id">{{ notifier.name }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="" data-testid="cancel-button">Cancel</button>
+    <button mat-raised-button [disabled]="notificationForm.invalid" color="primary" type="submit" data-testid="create-button">
+      Create
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.scss
@@ -1,0 +1,12 @@
+.form {
+  display: flex;
+  flex-direction: column;
+
+  mat-form-field {
+    flex: 1 1 auto;
+  }
+}
+
+.actions {
+  justify-content: end;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.component.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { Notifier } from '../../../../../entities/notification/notifier';
+
+export interface NotificationAddDialogData {
+  notifiers: Notifier[];
+}
+
+export type NotificationAddDialogResult = {
+  name: string;
+  notifierId: string;
+};
+
+@Component({
+  selector: 'notification-add-dialog',
+  templateUrl: './notification-add-dialog.component.html',
+  styleUrls: ['./notification-add-dialog.component.scss'],
+})
+export class NotificationAddDialogComponent {
+  protected readonly notifiersList: Notifier[] = this.dialogData.notifiers;
+  protected notificationForm = new FormGroup({
+    name: new FormControl<string>('', [Validators.required]),
+    notifierId: new FormControl<string>(this.notifiersList[0].id, [Validators.required]),
+  });
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private readonly dialogData: NotificationAddDialogData,
+    public dialogRef: MatDialogRef<NotificationAddDialogData, NotificationAddDialogResult>,
+  ) {}
+
+  onSubmit() {
+    const { name, notifierId } = this.notificationForm.getRawValue();
+
+    this.dialogRef.close({
+      name,
+      notifierId,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.harness.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class NotificationAddDialogHarness extends ComponentHarness {
+  static hostSelector = 'notification-add-dialog';
+
+  private getConfirmBtn = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=create-button]' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=cancel-button]' }));
+
+  private getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName=name]' }));
+  private getNotifierSelect = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName=notifierId]' }));
+
+  public async fillForm(name: string, notifierName: string) {
+    const nameInput = await this.getNameInput();
+    await nameInput.setValue(name);
+
+    const notifierSelect = await this.getNotifierSelect();
+    await notifierSelect.clickOptions({ text: notifierName });
+  }
+
+  public async confirm(): Promise<void> {
+    const button = await this.getConfirmBtn();
+    await button.click();
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-add-dialog/notification-add-dialog.module.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+
+import { NotificationAddDialogComponent } from './notification-add-dialog.component';
+
+@NgModule({
+  declarations: [NotificationAddDialogComponent],
+  exports: [NotificationAddDialogComponent],
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MatInputModule, MatFormFieldModule, MatSelectModule, MatButtonModule],
+})
+export class NotificationAddDialogModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/index.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/index.ts
@@ -13,14 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier?: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
-}
+
+export * from './notification-edit-dialog.component';
+export * from './notification-edit-dialog.harness';
+export * from './notification-edit-dialog.module';

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.html
@@ -1,0 +1,64 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<h2 mat-dialog-title>Edit {{ notification.name }}</h2>
+
+<form [formGroup]="staticForm" (ngSubmit)="submit()">
+  <mat-dialog-content>
+    <ng-container *ngIf="notifier" formGroupName="notifier">
+      <mat-form-field>
+        <mat-label *ngIf="notifier.type === 'EMAIL'">Email list</mat-label>
+        <mat-label *ngIf="notifier.type === 'WEBHOOK'">Webhook</mat-label>
+        <input matInput formControlName="config" />
+        <mat-hint *ngIf="notifier.type === 'EMAIL'">Use space, ',' or ';' to separate emails. EL supported.</mat-hint>
+        <mat-hint *ngIf="notifier.type === 'WEBHOOK'">URL (Gravitee will POST datas to this url)</mat-hint>
+      </mat-form-field>
+      <div *ngIf="notifier.type === 'WEBHOOK'">
+        <gio-form-slide-toggle>
+          Use system proxy
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="useSystemProxy"
+            aria-label="Use system proxy"
+            name="useSystemProxy"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </div>
+    </ng-container>
+
+    <div formGroupName="hooks">
+      <h3>Event subscribed</h3>
+
+      <div *ngFor="let category of categories" class="category">
+        <h6>{{ category.name }}</h6>
+
+        <div [formGroupName]="category.name" class="events">
+          <mat-checkbox *ngFor="let hook of category.hooks" [formControlName]="hook.id" [name]="hook.id" class="event">
+            <span class="event__label">{{ hook.label }}</span>
+            <p class="event__description">{{ hook.description }}</p>
+          </mat-checkbox>
+        </div>
+      </div>
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="" data-testid="cancel-button">Cancel</button>
+    <button mat-raised-button [disabled]="staticForm.invalid" color="primary" type="submit" data-testid="save-button">Save</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.scss
@@ -1,0 +1,39 @@
+@use 'sass:map';
+
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.category {
+  margin-bottom: 20px;
+
+  h6 {
+    margin: 0;
+  }
+}
+
+.events {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.event {
+  flex-basis: calc(50% - 8px);
+  margin: 4px;
+
+  &__label {
+    @include mat.typography-level($typography, 'subtitle-2');
+  }
+
+  &__description {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.actions {
+  justify-content: end;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.component.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup } from '@angular/forms';
+import { groupBy, map } from 'lodash';
+
+import { Hooks } from '../../../../../entities/notification/hooks';
+import { Notifier } from '../../../../../entities/notification/notifier';
+import { NotificationSettings } from '../../../../../entities/notification/notificationSettings';
+
+export interface NotificationEditDialogData {
+  hooks: Hooks[];
+  notifier: Notifier;
+  notification: NotificationSettings;
+}
+
+export type NotificationEditDialogResult = NotificationSettings;
+
+@Component({
+  selector: 'notification-edit-dialog',
+  templateUrl: './notification-edit-dialog.component.html',
+  styleUrls: ['./notification-edit-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NotificationEditDialogComponent {
+  protected readonly hooks: Hooks[] = this.dialogData.hooks;
+  protected readonly categories: Category[] = groupHooks(this.dialogData.hooks);
+  protected readonly notifier: Notifier = this.dialogData.notifier;
+  protected readonly notification: NotificationSettings = this.dialogData.notification;
+
+  protected staticForm = this.buildForm();
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) private readonly dialogData: NotificationEditDialogData,
+    public dialogRef: MatDialogRef<NotificationEditDialogData, NotificationEditDialogResult>,
+  ) {}
+
+  public submit() {
+    if (this.staticForm.invalid) {
+      return;
+    }
+    const raw = this.staticForm.getRawValue();
+
+    this.dialogRef.close({
+      ...this.notification,
+      config: raw?.notifier?.config,
+      useSystemProxy: raw?.notifier?.useSystemProxy,
+      hooks: Object.values(raw.hooks)
+        .map((category) => {
+          return Object.entries(category)
+            .filter(([_, value]) => value)
+            .map(([key, _]) => key);
+        })
+        .flat(),
+    });
+  }
+
+  private buildForm() {
+    return new FormGroup({
+      ...(this.notifier != null
+        ? {
+            notifier: new FormGroup({
+              config: new FormControl(this.notification.config),
+              useSystemProxy: new FormControl(this.notification.useSystemProxy),
+            }),
+          }
+        : {}),
+      hooks: toFormGroup(this.categories, this.notification),
+    });
+  }
+}
+
+type Category = {
+  name: string;
+  hooks: Hooks[];
+};
+
+function groupHooks(hooks: Hooks[]): Category[] {
+  const group = groupBy(hooks, 'category');
+  return map(group, (h, k) => ({ name: k, hooks: h }));
+}
+
+const toFormGroup = (categories: Category[], notification: NotificationSettings) =>
+  categories.reduce(categoryToGroup(notification), new FormGroup({}));
+
+const categoryToGroup = (notification: NotificationSettings) => (group: FormGroup, category: Category) => {
+  group.addControl(category.name, category.hooks.reduce(addHookToGroup(notification), new FormGroup({})));
+  return group;
+};
+
+const addHookToGroup = (notification: NotificationSettings) => (group: FormGroup, hook: Hooks) => {
+  group.addControl(hook.id, new FormControl(notification.hooks.includes(hook.id)));
+  return group;
+};

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.harness.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+
+export class NotificationEditDialogHarness extends ComponentHarness {
+  static hostSelector = 'notification-edit-dialog';
+
+  private getSaveBtn = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=save-button]' }));
+  private getCancelBtn = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=cancel-button]' }));
+  private getAllHookCheckboxes = this.locatorForAll(MatCheckboxHarness);
+
+  public getNotifierConfigInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName=config]' }));
+  public getUseSystemProxyToggle = this.locatorForOptional(MatSlideToggleHarness.with({ selector: '[formControlName=useSystemProxy]' }));
+
+  public async getHookCheckbox(name: string) {
+    return this.locatorForOptional(MatCheckboxHarness.with({ name }))();
+  }
+  public async getAllHooks() {
+    const all = await this.getAllHookCheckboxes();
+    return Promise.all(
+      all.map((checkbox) =>
+        checkbox.getName().then((name) =>
+          checkbox.isChecked().then((isChecked) => ({
+            name,
+            checked: isChecked,
+          })),
+        ),
+      ),
+    );
+  }
+
+  public async fillConfig(value: string): Promise<void> {
+    const input = await this.getNotifierConfigInput();
+    await input.setValue(value);
+  }
+
+  public async toggleUseSystemProxy(): Promise<void> {
+    const toggle = await this.getUseSystemProxyToggle();
+    await toggle.toggle();
+  }
+
+  public async save(): Promise<void> {
+    const button = await this.getSaveBtn();
+    await button.click();
+  }
+
+  public async cancel(): Promise<void> {
+    const button = await this.getCancelBtn();
+    await button.click();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-edit-dialog/notification-edit-dialog.module.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+
+import { NotificationEditDialogComponent } from './notification-edit-dialog.component';
+
+@NgModule({
+  declarations: [NotificationEditDialogComponent],
+  exports: [NotificationEditDialogComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatButtonModule,
+    GioFormSlideToggleModule,
+    MatFormFieldModule,
+    MatSlideToggleModule,
+    MatCheckboxModule,
+  ],
+})
+export class NotificationEditDialogModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/index.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/index.ts
@@ -13,14 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export interface NotificationSettings {
-  id?: string;
-  name: string;
-  referenceType: string;
-  referenceId: string;
-  notifier?: string;
-  hooks?: string[];
-  useSystemProxy?: boolean;
-  config_type: string;
-  config?: string;
-}
+
+export * from './notification-list.module';

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.html
@@ -1,0 +1,81 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<table mat-table [dataSource]="notifications" class="notifications" id="notifications" aria-label="Notifications list">
+  <ng-container matColumnDef="name">
+    <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+    <td mat-cell *matCellDef="let element">
+      {{ element.name }}
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="subscribedEvents">
+    <th mat-header-cell *matHeaderCellDef id="subscribedEvents">Events subscribed</th>
+    <td mat-cell *matCellDef="let element">
+      <span class="gio-badge-neutral">{{ element.subscribedEvents }} events</span>
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="notifier">
+    <th mat-header-cell *matHeaderCellDef id="notifier">Notifier</th>
+    <td mat-cell *matCellDef="let element">
+      <span class="gio-badge-neutral" *ngIf="element.notifier">{{ element.notifier.name }}</span>
+    </td>
+  </ng-container>
+
+  <ng-container matColumnDef="actions">
+    <th mat-header-cell *matHeaderCellDef id="actions">Action</th>
+    <td mat-cell *matCellDef="let element">
+      <div class="notifications__actions">
+        <button
+          *ngIf="canUpdate"
+          mat-icon-button
+          aria-label="Edit notification"
+          matTooltip="Edit notification"
+          (click)="edit.emit(element.id)"
+          data-testid="edit-button"
+        >
+          <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+        </button>
+
+        <button
+          *ngIf="canDelete && !element.isPortalNotification"
+          mat-icon-button
+          aria-label="Delete notification"
+          matTooltip="Delete notification"
+          data-testid="delete-button"
+          (click)="delete.emit(element)"
+        >
+          <mat-icon svgIcon="gio:trash"></mat-icon>
+        </button>
+      </div>
+    </td>
+  </ng-container>
+
+  <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+  <!-- Row shown when there is no data -->
+  <tr class="mat-row" *matNoDataRow>
+    <td *ngIf="!loading" class="mat-cell" [attr.colspan]="displayedColumns.length">
+      {{ 'No notifications to display.' }}
+    </td>
+    <td *ngIf="loading" class="mat-cell" [attr.colspan]="displayedColumns.length">
+      <gio-loader></gio-loader>
+    </td>
+  </tr>
+</table>

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.scss
@@ -1,0 +1,24 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+@use '../../../../../scss/gio-layout' as gio-layout;
+$foreground: map.get(gio.$mat-legacy-theme, foreground);
+
+:host {
+  display: block;
+  border-top: 1px solid mat.get-color-from-palette($foreground, divider);
+
+  @include mat.elevation(3); // default elevation
+}
+
+.notifications {
+  &__actions {
+    display: flex;
+    flex-direction: row;
+  }
+}
+
+.mat-column-actions {
+  width: 100px;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.component.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { Notifier } from '../../../../../entities/notification/notifier';
+
+export interface NotificationSummary {
+  id: string;
+  name: string;
+  subscribedEvents: number;
+  notifier: Notifier;
+  isPortalNotification: boolean;
+}
+
+@Component({
+  selector: 'notification-list',
+  templateUrl: './notification-list.component.html',
+  styleUrls: ['./notification-list.component.scss'],
+})
+export class NotificationListComponent {
+  public displayedColumns = ['name', 'subscribedEvents', 'notifier', 'actions'];
+
+  @Input()
+  public canUpdate = false;
+  @Input()
+  public canDelete = false;
+  @Input()
+  public loading = true;
+  @Input()
+  public notifications: NotificationSummary[];
+
+  @Output()
+  public delete = new EventEmitter<NotificationSummary>();
+  @Output()
+  public edit = new EventEmitter<string>();
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.harness.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class NotificationListHarness extends ComponentHarness {
+  static hostSelector = 'notification-list';
+
+  public async rows() {
+    const table = await this.getTable();
+    const rows = await table.getRows();
+
+    return await parallel(() => rows.map((row) => row.getCellTextByColumnName()));
+  }
+
+  public async getDeleteButton(index: number) {
+    const table = await this.getTable();
+    const rows = await table.getRows();
+
+    return await rows[index]
+      .getCells({ columnName: 'actions' })
+      .then((cells) => cells[0].getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid=delete-button]' })));
+  }
+
+  public async deleteRow(index: number) {
+    const deleteButton = await this.getDeleteButton(index);
+    await deleteButton.click();
+  }
+
+  public async getEditButton(index: number) {
+    const table = await this.getTable();
+    const rows = await table.getRows();
+
+    return await rows[index]
+      .getCells({ columnName: 'actions' })
+      .then((cells) => cells[0].getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid=edit-button]' })));
+  }
+
+  public async editRow(index: number) {
+    const editButton = await this.getEditButton(index);
+    await editButton.click();
+  }
+
+  private getTable = this.locatorFor(MatTableHarness.with({ selector: '#notifications' }));
+}

--- a/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/components/notification-list/notification-list.module.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { GioLoaderModule } from '@gravitee/ui-particles-angular';
+
+import { NotificationListComponent } from './notification-list.component';
+
+@NgModule({
+  declarations: [NotificationListComponent],
+  exports: [NotificationListComponent],
+  imports: [CommonModule, MatIconModule, MatButtonModule, MatTableModule, MatTooltipModule, GioLoaderModule],
+})
+export class NotificationListModule {}

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -78,6 +78,7 @@ import { ApiAuditListComponent } from './api-audit-list/api-audit-list.component
 import { ApiAuditLogsComponent } from './api-audit-logs/api-audit-logs.component';
 import { ApiDynamicPropertiesV4Component } from './properties-v4/dynamic-properties/api-dynamic-properties-v4.component';
 import { ApiDeploymentConfigurationComponent } from './deployment-configuration-v4/api-deployment-configuration.component';
+import { ApiNotificationComponent } from './api-notification/api-notification.component';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -962,6 +963,15 @@ const apisRoutes: Routes = [
           },
           apiPermissions: {
             only: ['api-audit-r'],
+          },
+        },
+      },
+      {
+        path: 'v4/notifications',
+        component: ApiNotificationComponent,
+        data: {
+          apiPermissions: {
+            only: ['api-notification-r'],
           },
         },
       },

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -49,6 +49,7 @@ import { ApiAuditListModule } from './api-audit-list/api-audit-list.module';
 import { ApiDynamicPropertiesV4Module } from './properties-v4/dynamic-properties/api-dynamic-properties-v4.module';
 import { ApiDeploymentConfigurationModule } from './deployment-configuration-v4/api-deployment-configuration.module';
 import { ApiAuditLogsModule } from './api-audit-logs/api-audit-logs.module';
+import { ApiNotificationModule } from './api-notification/api-notification.module';
 
 import { SpecificJsonSchemaTypeModule } from '../../shared/components/specific-json-schema-type/specific-json-schema-type.module';
 import { DocumentationModule } from '../../components/documentation/documentation.module';
@@ -88,6 +89,7 @@ import { AlertsModule } from '../../components/alerts/alerts.module';
     ApiResponseTemplatesModule,
     ApiRuntimeLogsV4Module,
     ApiAuditLogsModule,
+    ApiNotificationModule,
     ApiSubscriptionsModule,
     ApiV4PolicyStudioModule,
     ApiUserGroupModule,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1426

## Description

Enable API notification for V4 API. 
I've used the REST Management v1 🙈 

I'd like your opinion on this before updating other Notifications (Applications & Environments). 
Changes brought:
- only one "page", addition and edition are done with a modal
- the edition form is "generated" using the FormGroup as input

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6565/console](https://pr.team-apim.gravitee.dev/6565/console)
      Portal: [https://pr.team-apim.gravitee.dev/6565/portal](https://pr.team-apim.gravitee.dev/6565/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6565/api/management](https://pr.team-apim.gravitee.dev/6565/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6565](https://pr.team-apim.gravitee.dev/6565)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6565](https://pr.gateway-v3.team-apim.gravitee.dev/6565)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cvcsyukwcm.chromatic.com)
<!-- Storybook placeholder end -->
