### PR TITLE
feat(console): integrate use-cases into gio-license-banner

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.component.html
@@ -16,12 +16,9 @@
 
 -->
 <gio-banner type="error" icon="gio:universe" class="gio-license-banner">
-  This configuration requires an enterprise license
-  <span gioBannerBody
-    >Request a license to unlock enterprise functionality, such as support for event brokers, asynchronous APIS, and Webhook
-    subscriptions.</span
-  >
-  <div gioBannerAction>
+  {{ header }}
+  <span gioBannerBody>{{ body }}</span>
+  <div gioBannerAction *ngIf="showCta">
     <button mat-raised-button (click)="requestUpgrade($event)" type="button">Request upgrade</button>
   </div>
 </gio-banner>

--- a/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.component.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { License } from '@gravitee/ui-particles-angular';
 
 @Component({
   selector: 'gio-license-banner',
@@ -21,8 +22,39 @@ import { Component, EventEmitter, Output } from '@angular/core';
   styleUrls: ['./gio-license-banner.component.scss'],
   host: {},
 })
-export class GioLicenseBannerComponent {
+export class GioLicenseBannerComponent implements OnInit {
+  @Input()
+  license: License;
+
+  @Input()
+  isOEM = false;
+
   @Output() onRequestUpgrade = new EventEmitter<MouseEvent>();
+
+  // Default values for OSS or when license is null
+  header = 'This configuration requires an enterprise license';
+  body =
+    'Request a license to unlock enterprise functionality, such as support for connecting to event brokers, connecting to APIs via Websocket and Server-Sent Events, and publishing Webhooks.';
+  showCta = true;
+
+  ngOnInit(): void {
+    if (!this.license) {
+      return;
+    }
+
+    if (this.isOEM) {
+      // OEM
+      this.header = 'This configuration requires a license upgrade';
+      this.body = 'Your platform license does not support this feature. Please contact your platform administrator to find out more.';
+      this.showCta = false;
+    } else if (this.license.scope === 'ORGANIZATION' || this.license.tier !== 'oss') {
+      // Cloud + EE
+      this.header = 'This configuration requires a license upgrade';
+      this.body =
+        'Your organization’s license does not support some features used in this API. Request an upgrade to enable the selected features.';
+      this.showCta = this.license.scope !== 'ORGANIZATION'; // Hide for Cloud
+    }
+  }
 
   requestUpgrade($event: MouseEvent) {
     this.onRequestUpgrade.emit($event);

--- a/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.harness.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.harness.ts
@@ -14,7 +14,33 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 
 export class GioLicenseBannerHarness extends ComponentHarness {
   static hostSelector = 'gio-license-banner';
+
+  protected getButton = this.locatorForOptional(MatButtonHarness);
+  protected getBannerTitle = this.locatorForOptional(DivHarness.with({ selector: '.banner__wrapper__title' }));
+  protected getBannerBody = this.locatorForOptional(DivHarness.with({ selector: '.banner__wrapper__body' }));
+
+  public async buttonIsVisible(): Promise<boolean> {
+    const btn = await this.getButton();
+    return !!btn;
+  }
+
+  public async clickButton(): Promise<void> {
+    const btn = await this.getButton();
+    return await btn.click();
+  }
+
+  public async getTitle(): Promise<string> {
+    const div = await this.getBannerTitle();
+    return await div.getText();
+  }
+
+  public async getBody(): Promise<string> {
+    const div = await this.getBannerBody();
+    return await div.getText();
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.module.ts
@@ -16,13 +16,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
-import { MatIconModule } from '@angular/material/icon';
-import { GioBannerModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { GioLicenseBannerComponent } from './gio-license-banner.component';
 
 @NgModule({
-  imports: [CommonModule, MatButtonModule, MatIconModule, GioBannerModule],
+  imports: [CommonModule, MatButtonModule, GioIconsModule, GioBannerModule],
   declarations: [GioLicenseBannerComponent],
   exports: [GioLicenseBannerComponent],
 })

--- a/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-license-banner/gio-license-banner.stories.ts
@@ -13,29 +13,123 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MatButtonModule } from '@angular/material/button';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { License } from '@gravitee/ui-particles-angular';
+import { action } from '@storybook/addon-actions';
 
-import { GioLicenseBannerModule } from './gio-license-banner.module';
 import { GioLicenseBannerComponent } from './gio-license-banner.component';
+import { GioLicenseBannerModule } from './gio-license-banner.module';
+
+const OSS_LICENSE: License = {
+  tier: 'oss',
+  packs: [],
+  features: [],
+  scope: 'PLATFORM',
+};
+const EE_LICENSE: License = {
+  tier: 'universe',
+  packs: [],
+  features: [],
+  scope: 'PLATFORM',
+};
+const CLOUD_LICENSE: License = {
+  tier: 'universe',
+  packs: [],
+  features: [],
+  scope: 'ORGANIZATION',
+};
+const OEM_LICENSE: License = {
+  tier: 'universe',
+  packs: [],
+  features: ['oem-customization'],
+  scope: 'ORGANIZATION',
+};
 
 export default {
   title: 'Shared / Gio License banner',
   component: GioLicenseBannerComponent,
   decorators: [
     moduleMetadata({
-      imports: [BrowserAnimationsModule, MatButtonModule, GioLicenseBannerModule],
+      imports: [GioLicenseBannerModule],
     }),
   ],
   argTypes: {
-    onRequestUpgrade: { action: 'onRequestUpgrade' },
+    onRequestUpgrade: { action: 'on-request-upgrade' },
   },
-
-  render: ({ onRequestUpgrade }) => ({
-    props: { onRequestUpgrade },
-    template: `<gio-license-banner (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
-  }),
 } as Meta;
 
-export const Default: StoryObj = {};
+export const NoLicense: StoryObj = {
+  args: {
+    onRequestUpgrade: action('on-request-upgrade'),
+  },
+  render: ({ onRequestUpgrade }) => {
+    return {
+      props: {
+        license: null,
+        isOEM: false,
+        onRequestUpgrade,
+      },
+      template: `<gio-license-banner [license]="license" [isOEM]="isOEM" (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
+    };
+  },
+};
+export const OSSLicense: StoryObj = {
+  args: {
+    onRequestUpgrade: action('on-request-upgrade'),
+  },
+  render: ({ onRequestUpgrade }) => {
+    return {
+      props: {
+        license: OSS_LICENSE,
+        isOEM: false,
+        onRequestUpgrade,
+      },
+      template: `<gio-license-banner [license]="license" [isOEM]="isOEM" (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
+    };
+  },
+};
+export const OEMLicense: StoryObj = {
+  args: {
+    onRequestUpgrade: action('on-request-upgrade'),
+  },
+  render: ({ onRequestUpgrade }) => {
+    return {
+      props: {
+        license: OEM_LICENSE,
+        isOEM: true,
+        onRequestUpgrade,
+      },
+      template: `<gio-license-banner [license]="license" [isOEM]="isOEM" (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
+    };
+  },
+};
+export const EELicense: StoryObj = {
+  args: {
+    onRequestUpgrade: action('on-request-upgrade'),
+  },
+  render: ({ onRequestUpgrade }) => {
+    return {
+      props: {
+        license: EE_LICENSE,
+        isOEM: false,
+        onRequestUpgrade,
+      },
+      template: `<gio-license-banner [license]="license" [isOEM]="isOEM" (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
+    };
+  },
+};
+export const CloudLicense: StoryObj = {
+  args: {
+    onRequestUpgrade: action('on-request-upgrade'),
+  },
+  render: ({ onRequestUpgrade }) => {
+    return {
+      props: {
+        license: CLOUD_LICENSE,
+        isOEM: false,
+        onRequestUpgrade,
+      },
+      template: `<gio-license-banner [license]="license" [isOEM]="isOEM" (onRequestUpgrade)="onRequestUpgrade()"></gio-license-banner>`,
+    };
+  },
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3856

## Description

Integrate use-cases into gio-license-banner

No License

![Screenshot 2024-02-09 at 17 49 13](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/de848f35-59e1-432e-9d13-13d20703e4a6)

OSS

![Screenshot 2024-02-09 at 18 24 28](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/efea48fc-9bf5-4b99-b66c-f79419a1a5cf)

EE

![Screenshot 2024-02-09 at 18 24 37](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/09e03737-3745-45f1-8e64-f1ba7bd1f231)

Cloud

![Screenshot 2024-02-09 at 18 24 46](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/bd3ab69a-8678-4dc2-b779-9e6ae8789446)

OEM

![Screenshot 2024-02-09 at 17 49 30](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/3db8591f-ed69-443e-a124-cc692fa63cfc)



Next step: add license + isOEM to all gio-license-banner components

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ipmfqesvyk.chromatic.com)
<!-- Storybook placeholder end -->
