### PR TITLE
Endpoints Proxy V4 -  add "Propagate client Accept-Encoding header" option

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -58,6 +58,17 @@
                 }
             }
         },
+        "propagateClientAcceptEncoding":{
+            "title":"Propagate client Accept-Encoding header",
+            "description": "Accept-Encoding can only be propagated if \"Enable compression\" is disabled.",
+            "type": "boolean",
+            "gioConfig": {
+                "banner": {
+                    "title": "Propagate client Accept-Encoding header (no decompression if any)",
+                    "text": "If the client request header includes a value for Accept-Encoding, the gateway will propagate it to the backend. The gateway will NEVER attempt to decompress the body content if the backend response is compressed (gzip, deflate). Therefore, transformation policies cannot be applied if the content body is compressed. If logging is enabled for the API, the compressed content body will be logged as is without any transformation applied. DO NOT activate this option if you plan to interact with body responses."
+                }
+            }
+        },
         "idleTimeout":{
             "type":"integer",
             "title":"Idle timeout (ms)",
@@ -111,6 +122,9 @@
                         "useCompression":{
                             "$ref":"#/definitions/useCompression"
                         },
+                        "propagateClientAcceptEncoding":{
+                            "$ref":"#/definitions/propagateClientAcceptEncoding"
+                        },
                         "idleTimeout":{
                             "$ref":"#/definitions/idleTimeout"
                         },
@@ -152,6 +166,9 @@
                         },
                         "useCompression":{
                             "$ref":"#/definitions/useCompression"
+                        },
+                        "propagateClientAcceptEncoding":{
+                            "$ref":"#/definitions/propagateClientAcceptEncoding"
                         },
                         "idleTimeout":{
                             "$ref":"#/definitions/idleTimeout"


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-3704

## Description

This is no longer displayed dynamically, but it clearly indicates that user need to deactivate "Enable compression" before. 



## Additional context
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/1189b204-15e8-40f7-8686-6bd90d576715)



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

