### PR TITLE
feat: Enable health-check config for the Endpoint group V4 API

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointGroupV4.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointGroupV4.fixture.ts
@@ -47,3 +47,72 @@ export function fakeEndpointGroupV4(
     ...modifier,
   };
 }
+
+export function fakeHTTPProxyEndpointGroupV4(
+  modifier?: Partial<EndpointGroupV4> | ((baseApi: EndpointGroupV4) => EndpointGroupV4),
+): EndpointGroupV4 {
+  const base: EndpointGroupV4 = {
+    name: 'Default Endpoint HTTP proxy group',
+    type: 'http-proxy',
+    loadBalancer: {
+      type: 'ROUND_ROBIN',
+    },
+    sharedConfiguration: {
+      proxy: {
+        useSystemProxy: false,
+        enabled: false,
+      },
+      http: {
+        keepAlive: true,
+        followRedirects: false,
+        readTimeout: 10000,
+        idleTimeout: 60000,
+        connectTimeout: 3000,
+        useCompression: true,
+        maxConcurrentConnections: 20,
+        version: 'HTTP_1_1',
+        pipelining: false,
+      },
+      ssl: {
+        hostnameVerifier: true,
+        trustAll: false,
+        truststore: {
+          type: '',
+        },
+        keystore: {
+          type: '',
+        },
+      },
+    },
+    endpoints: [
+      {
+        name: 'Default Endpoint HTTP proxy',
+        type: 'http-proxy',
+        weight: 1,
+        inheritConfiguration: true,
+        configuration: {
+          target: 'https://api.gravitee.io/echo',
+        },
+        services: {},
+        secondary: false,
+      },
+    ],
+    services: {
+      healthCheck: {
+        configuration: {},
+        enabled: false,
+        overrideConfiguration: false,
+        type: 'http-health-check',
+      },
+    },
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -167,13 +167,6 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
-    if (this.permissionService.hasAnyMatching(['api-health-r'])) {
-      tabs.push({
-        displayName: 'Health-check',
-        routerLink: 'DISABLED',
-      });
-    }
-
     return {
       displayName: 'Endpoints',
       icon: 'endpoints',

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.html
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="health-check">
+  <div class="health-check__header">
+    <h2>Health-check</h2>
+    Monitor the availability and health of your endpoints and/or your API Gateways
+  </div>
+
+  <form *ngIf="healthCheckForm" [formGroup]="healthCheckForm" autocomplete="off">
+    <gio-form-slide-toggle class="health-check__enable-field">
+      <gio-form-label>Enabled</gio-form-label>
+      This service is requiring an API deployment. Do not forget to deploy API to start health-check service.
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="enabled"
+        aria-label="Enable health check service"
+        name="enabled"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
+    <gio-form-json-schema [jsonSchema]="healthCheckSchema" formControlName="configuration"></gio-form-json-schema>
+  </form>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.scss
@@ -1,0 +1,6 @@
+.health-check {
+  &__enable-field {
+    width: 100%;
+    padding-bottom: 24px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { FormControl, UntypedFormGroup } from '@angular/forms';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ApiHealthCheckV4FormHarness } from './api-health-check-v4-form.harness';
+import { ApiHealthCheckV4FormModule } from './api-health-check-v4-form.module';
+
+import { GioHttpTestingModule } from '../../../../shared/testing';
+
+@Component({
+  template: ` <api-health-check-v4-form [healthCheckForm]="healthCheckForm"></api-health-check-v4-form> `,
+})
+class TestComponent {
+  healthCheckForm = new UntypedFormGroup({
+    enabled: new FormControl({
+      value: false,
+      disabled: false,
+    }),
+    configuration: new FormControl(
+      {
+        value: {},
+        disabled: false,
+      } ?? {},
+    ),
+  });
+}
+
+describe('ApiHealthCheckV4FormComponent', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+  let healthCheckConfigurationHarness: ApiHealthCheckV4FormHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiHealthCheckV4FormModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    healthCheckConfigurationHarness = await loader.getHarness(ApiHealthCheckV4FormHarness);
+    fixture.detectChanges();
+
+    expect(component).toBeTruthy();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should initialize the component with default configuration', async () => {
+    expect(await healthCheckConfigurationHarness.getEnableToggleValue()).toBeFalsy();
+
+    await healthCheckConfigurationHarness.toggleEnableInput();
+    expect(await healthCheckConfigurationHarness.getEnableToggleValue()).toBeTruthy();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.ts
@@ -13,9 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ServiceV4 } from './serviceV4';
 
-export interface EndpointGroupServices {
-  discovery?: ServiceV4;
-  healthCheck?: ServiceV4;
+import { Component, Input } from '@angular/core';
+
+import { EndpointGroupHealthCheckFormType } from '../../endpoints-v4/endpoint-group/api-endpoint-group.component';
+
+@Component({
+  selector: 'api-health-check-v4-form',
+  templateUrl: './api-health-check-v4-form.component.html',
+  styleUrls: ['./api-health-check-v4-form.component.scss'],
+})
+export class ApiHealthCheckV4FormComponent {
+  @Input() healthCheckForm: EndpointGroupHealthCheckFormType;
+  @Input() healthCheckSchema: unknown;
+
+  public static readonly HTTP_HEALTH_CHECK = 'http-health-check';
 }

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.harness.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatLegacySlideToggleHarness as MatSlideToggleHarness } from '@angular/material/legacy-slide-toggle/testing';
+import { MatLegacyInputHarness as MatInputHarness } from '@angular/material/legacy-input/testing';
+
+export class ApiHealthCheckV4FormHarness extends ComponentHarness {
+  static hostSelector = 'api-health-check-v4-form';
+
+  private getEnableToggle = this.locatorForOptional(MatSlideToggleHarness.with({ selector: '[formControlName=enabled]' }));
+  private getConfigurationInput = (id: string) => this.locatorForOptional(MatInputHarness.with({ selector: `[id*="${id}"]` }))();
+
+  public async getEnableToggleValue(): Promise<boolean> {
+    return this.getEnableToggle().then((toggle) => toggle.isChecked());
+  }
+
+  public async toggleEnableInput(): Promise<void> {
+    return this.getEnableToggle().then((toggle) => toggle.toggle());
+  }
+
+  async getConfigurationInputValue(inputId: string): Promise<string> {
+    return this.getConfigurationInput(inputId).then((input) => input.getValue());
+  }
+
+  async setConfigurationInputValue(inputId: string, text: string): Promise<void> {
+    await this.getConfigurationInput(inputId).then((input) => input.setValue(text));
+    await this.waitForTasksOutsideAngular();
+  }
+
+  async isConfigurationInputDisabled(inputId: string): Promise<boolean> {
+    return this.getConfigurationInput(inputId).then((input) => input.isDisabled());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.module.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field';
+import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';
+import { GioFormSlideToggleModule, GioFormJsonSchemaModule } from '@gravitee/ui-particles-angular';
+
+import { ApiHealthCheckV4FormComponent } from './api-health-check-v4-form.component';
+
+@NgModule({
+  declarations: [ApiHealthCheckV4FormComponent],
+  exports: [ApiHealthCheckV4FormComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+
+    MatCardModule,
+    MatFormFieldModule,
+    MatSlideToggleModule,
+
+    GioFormSlideToggleModule,
+    GioFormJsonSchemaModule,
+  ],
+})
+export class ApiHealthCheckV4FormModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.html
@@ -38,6 +38,16 @@
             ></api-endpoint-group-configuration>
           </div>
         </mat-tab>
+        <mat-tab label="Health-check" *ngIf="healthCheckForm && isHttpProxyApi">
+          <!-- Health check tab content -->
+          <div class="tab-body-wrapper">
+            <api-health-check-v4-form
+              *ngIf="healthCheckSchema"
+              [healthCheckForm]="healthCheckForm"
+              [healthCheckSchema]="healthCheckSchema"
+            ></api-health-check-v4-form>
+          </div>
+        </mat-tab>
       </mat-tab-group>
     </mat-card-content>
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
@@ -20,13 +20,17 @@ import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { ApiEndpointGroupGeneralHarness } from './general/api-endpoint-group-general.harness';
 
+import { ApiHealthCheckV4FormHarness } from '../../component/health-check-v4-form/api-health-check-v4-form.harness';
+
 export class ApiEndpointGroupHarness extends ComponentHarness {
   static hostSelector = 'api-endpoint-group';
 
   private getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mattooltip="Go back"]' }));
   private getGeneralTab = this.locatorFor(MatTabHarness.with({ label: 'General' }));
   private getConfigurationTab = this.locatorFor(MatTabHarness.with({ label: 'Configuration' }));
+  private getHealthCheckTab = this.locatorFor(MatTabHarness.with({ label: 'Health-check' }));
   private getEndpointGroupGeneralHarness = this.locatorFor(ApiEndpointGroupGeneralHarness);
+  private getHealthCheckGeneralHarness = this.locatorFor(ApiHealthCheckV4FormHarness);
   private getEndpointGroupSubmissionBar = this.locatorFor(GioSaveBarHarness);
 
   public async clickBackButton() {
@@ -65,8 +69,34 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
     return this.getEndpointGroupSubmissionBar().then((saveBar) => saveBar.clickReset());
   }
 
+  public async clickHealthCheckTab() {
+    return this.getHealthCheckTab().then((tab) => tab.select());
+  }
+
+  public async toggleEnableHealthCheckInput() {
+    return this.getHealthCheckGeneralHarness().then((harness) => harness.toggleEnableInput());
+  }
+
+  public async isHealthCheckConfigurationInputDisabled(inputId: string): Promise<boolean> {
+    return this.getHealthCheckGeneralHarness().then((harness) => harness.isConfigurationInputDisabled(inputId));
+  }
+
+  public async readHealthCheckConfigurationValueInput(inputId: string) {
+    return this.getHealthCheckGeneralHarness().then((harness) => harness.getConfigurationInputValue(inputId));
+  }
+
+  public writeToHealthCheckConfigurationValueInput(inputId: string, inputValue) {
+    return this.getHealthCheckGeneralHarness().then((harness) => harness.setConfigurationInputValue(inputId, inputValue));
+  }
+
   public configurationTabIsVisible(): Promise<boolean> {
     return this.getConfigurationTab()
+      .then((_) => true)
+      .catch((_) => false);
+  }
+
+  public healthCheckTabIsVisible(): Promise<boolean> {
+    return this.getHealthCheckTab()
       .then((_) => true)
       .catch((_) => false);
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.module.ts
@@ -50,6 +50,7 @@ import { ApiEndpointGroupCreateComponent } from './create/api-endpoint-group-cre
 import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 import { GioConnectorListModule } from '../../../../shared/components/gio-connector-list-option/gio-connector-list.module';
+import { ApiHealthCheckV4FormModule } from '../../component/health-check-v4-form/api-health-check-v4-form.module';
 
 @NgModule({
   declarations: [
@@ -65,6 +66,7 @@ import { GioConnectorListModule } from '../../../../shared/components/gio-connec
     ReactiveFormsModule,
     RouterModule,
 
+    ApiHealthCheckV4FormModule,
     MatButtonModule,
     MatCardModule,
     MatDialogModule,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1418

## Description

Enable health-check config for the V4 API

Moved Health-check tab to the Endpoint group edit page. Added health-check-v4 form to avoid code duplication. Enable schema config on the Endpoint group edit

## Additional context

<img width="1211" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/158490653/91c114c5-b522-44cf-9837-13cd87a36b01">


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6572/console](https://pr.team-apim.gravitee.dev/6572/console)
      Portal: [https://pr.team-apim.gravitee.dev/6572/portal](https://pr.team-apim.gravitee.dev/6572/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6572/api/management](https://pr.team-apim.gravitee.dev/6572/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6572](https://pr.team-apim.gravitee.dev/6572)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6572](https://pr.gateway-v3.team-apim.gravitee.dev/6572)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ydmsbtpaoc.chromatic.com)
<!-- Storybook placeholder end -->
