### PR TITLE
test: fix OAuth2 test in Cypress api-plans test set

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -90,6 +90,7 @@ describe('API Plans Feature', () => {
   });
 
   it('Create a generic New Plan (OAuth2), verify and delete', () => {
+    cy.viewport(1920, 1200); // viewport adjustment to overcome unusual Cypress scrolling issue in this test
     // create OAuth2 plan
     cy.getByDataTestId('api_plans_add_plan_button').click();
     cy.contains('OAuth2').click();
@@ -97,11 +98,11 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_name_field').type(`${planName}-OAuth2`);
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} OAuth2`);
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.get('[role="combobox"]').eq(4).type('Test');
-    // ^ I can't find html element for this, this doesn't feel good but was best I could do as OAuth2 Resource a mandatory field
-    cy.contains('OAuth2 resource').should('exist').scrollIntoView().should('be.visible');
+    cy.contains('h2', 'OAuth2 authentication configuration').scrollIntoView().should('be.visible');
+    cy.contains('OAuth2 resource').closest('div').find('input').type('Dummy OAuth2 resource');
     cy.getByDataTestId('api_plans_nextstep').click();
-    cy.get('gio-form-label').contains('Rate Limiting').should('exist');
+
+    cy.contains('Rate Limiting').scrollIntoView().should('be.visible');
     cy.contains('Quota').should('be.visible');
     cy.contains('Resource Filtering').should('be.visible');
     cy.get('[type="submit"]').contains('Create').click();


### PR DESCRIPTION
## Description
Due to a change in the UI (additional Search field in the nav panel) the OAuth2 test failed. So, I've mainly corrected the the locator for the OAuth2 resource input field to fix it, among other tiny code adjustments in that spec file.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-efgkbvzgio.chromatic.com)
<!-- Storybook placeholder end -->
