### PR TITLE
fix(model): map health-check to correct plugin for license check

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/services/Services.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/services/Services.java
@@ -109,7 +109,10 @@ public final class Services implements Serializable {
                     .ofNullable(this.getDiscoveryService())
                     .filter(Service::isEnabled)
                     .map(s -> new Plugin("service_discovery", s.getProvider())),
-                Optional.ofNullable(this.getHealthCheckService()).filter(Service::isEnabled).map(s -> new Plugin("service", "healthcheck")),
+                Optional
+                    .ofNullable(this.getHealthCheckService())
+                    .filter(Service::isEnabled)
+                    .map(s -> new Plugin("api-service", "http-health-check")),
                 Optional
                     .ofNullable(this.getDynamicPropertyService())
                     .filter(Service::isEnabled)

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/ApiTest.java
@@ -94,7 +94,7 @@ class ApiTest {
         Services services = new Services();
         services.set(List.of(new HealthCheckService()));
         apiWithServices.setServices(services);
-        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("service", "healthcheck"));
+        assertThat(apiWithServices.getPlugins()).containsOnly(new Plugin("api-service", "http-health-check"));
     }
 
     @Test
@@ -135,7 +135,7 @@ class ApiTest {
             .containsOnly(
                 new Plugin("connector", "connector-http"),
                 new Plugin("service_discovery", "provider"),
-                new Plugin("service", "healthcheck"),
+                new Plugin("api-service", "http-health-check"),
                 new Plugin("service", "mgmt-service-dynamicproperties")
             );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3879

## Description

Map the health check to its correct value in the plugin manager so that APIs that use this feature can be deployed.

![Screenshot 2024-02-13 at 10 59 48](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/c0f99a5c-39ea-4561-a64b-18c09d3ba76d)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hvgpzjpcqs.chromatic.com)
<!-- Storybook placeholder end -->
