### PR TITLE
fix: change API details page URL to be correctly redirected from a Cockpit call

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -159,7 +159,7 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
                 "%s/#!/environments/%s/%s",
                 installationAccessQueryService.getConsoleUrl(organizationId),
                 environmentId,
-                apiId == null ? "home" : URLEncoder.encode(String.format("apis/%s/portal", apiId), StandardCharsets.UTF_8)
+                apiId == null ? "home" : URLEncoder.encode(String.format("apis/%s/general", apiId), StandardCharsets.UTF_8)
             );
 
             // Redirect the user.


### PR DESCRIPTION
## Issue

The routing has been changed and it's not possible to land to the API detail page from Cockpit.

## Description

Change the redirection route to be route to the API detail page.
