### PR TITLE
fix: use correct method to fetch user's application

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.InlinePictureEntity;
@@ -108,4 +109,6 @@ public interface ApplicationService {
     );
 
     Set<String> searchIds(final ExecutionContext executionContext, ApplicationQuery applicationQuery, Sortable sortable);
+
+    Set<String> findUserApplicationsIds(ExecutionContext executionContext, String username, ApplicationStatus status);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -1232,7 +1232,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         return criteriaBuilder.build();
     }
 
-    private Set<String> findUserApplicationsIds(ExecutionContext executionContext, String username, ApplicationStatus status) {
+    public Set<String> findUserApplicationsIds(ExecutionContext executionContext, String username, ApplicationStatus status) {
         //find applications where the user is a member
         Set<String> appIds = membershipService.getReferenceIdsByMemberAndReference(
             MembershipMemberType.USER,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -257,7 +257,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
             }
         }
 
-        Set<String> applicationIds = getUserApplicationIds(executionContext, userId);
+        Set<String> applicationIds = applicationService.findUserApplicationsIds(executionContext, userId, ApplicationStatus.ACTIVE);
 
         if (applicationIds.isEmpty()) {
             return false;
@@ -318,7 +318,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
 
             // get user subscribed apis, useful when an API becomes private and an app owner is not anymore in members.
             if (!manageOnly) {
-                Set<String> applicationIds = getUserApplicationIds(executionContext, userId);
+                Set<String> applicationIds = applicationService.findUserApplicationsIds(executionContext, userId, ApplicationStatus.ACTIVE);
 
                 if (!applicationIds.isEmpty()) {
                     final SubscriptionQuery query = new SubscriptionQuery();
@@ -344,31 +344,6 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
             }
         }
         return apiCriteriaList;
-    }
-
-    private Set<String> getUserApplicationIds(ExecutionContext executionContext, String userId) {
-        Set<String> userApplicationIds = membershipService.getReferenceIdsByMemberAndReference(
-            MembershipMemberType.USER,
-            userId,
-            MembershipReferenceType.APPLICATION
-        );
-
-        Set<String> applicationIds = new HashSet<>(userApplicationIds);
-
-        Set<String> userGroupIds = membershipService.getReferenceIdsByMemberAndReference(
-            MembershipMemberType.USER,
-            userId,
-            MembershipReferenceType.GROUP
-        );
-
-        ApplicationQuery appQuery = new ApplicationQuery();
-        appQuery.setGroups(userGroupIds);
-        appQuery.setStatus(ApplicationStatus.ACTIVE.name());
-
-        Set<String> groupApplicationIds = applicationService.searchIds(executionContext, appQuery, null);
-        applicationIds.addAll(groupApplicationIds);
-
-        return applicationIds;
     }
 
     private Set<String> findApiIdsByUserGroups(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -32,6 +32,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.management.model.Visibility;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiQuery;
@@ -482,7 +483,8 @@ public class ApiAuthorizationServiceImplTest {
 
         when(roleService.findByScope(RoleScope.API, GraviteeContext.getCurrentOrganization())).thenReturn(List.of(poRole, userRole));
 
-        when(applicationService.searchIds(any(), any(), isNull())).thenReturn(Set.of(applicationId));
+        when(applicationService.findUserApplicationsIds(GraviteeContext.getExecutionContext(), USER_NAME, ApplicationStatus.ACTIVE))
+            .thenReturn(Set.of(applicationId));
 
         SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
         subscriptionEntity.setId("subscriptionId");
@@ -538,9 +540,7 @@ public class ApiAuthorizationServiceImplTest {
         when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
         when(api.getVisibility()).thenReturn(io.gravitee.rest.api.model.Visibility.PRIVATE);
 
-        when(
-            membershipService.getReferenceIdsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.APPLICATION)
-        )
+        when(applicationService.findUserApplicationsIds(GraviteeContext.getExecutionContext(), USER_NAME, ApplicationStatus.ACTIVE))
             .thenReturn(Collections.singleton("application-id"));
 
         final SubscriptionQuery query = new SubscriptionQuery();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3881

## Description

Use an existing and functional method to get application of a user (direct and with a group).

With the current method, if a user has no group associated, we still look for applications...And we found all applications of the environment !