### PR TITLE
chore: bump gravitee-node to 5.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>5.5.0</gravitee-node.version>
+        <gravitee-node.version>5.5.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3879

## Description

Bump gravitee-node to 5.5.2 in order to include fix for ignoring plugins that are not in the plugin registry during license validation.

Done in PR: https://github.com/gravitee-io/gravitee-node/pull/287

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fbdnhjtbeg.chromatic.com)
<!-- Storybook placeholder end -->
