### PR TITLE
fix: change API details page URL to be correctly redirected from Cockpit

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -45,8 +45,6 @@ import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -159,7 +157,7 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
                 "%s/#!/%s/%s",
                 installationAccessQueryService.getConsoleUrl(organizationId),
                 environmentId,
-                apiId == null ? "" : URLEncoder.encode(String.format("apis/%s/portal", apiId), StandardCharsets.UTF_8)
+                apiId == null ? "" : String.format("apis/%s", apiId)
             );
 
             // Redirect the user.


### PR DESCRIPTION
## Issue

The routing has been changed and it's not possible to land to the API detail page from Cockpit.

## Description

Change the redirection route to be routed to the API detail page.

