### PR TITLE
fix(portal): security type may be empty for push plans

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
@@ -122,7 +122,7 @@ export class ApplicationSubscriptionsComponent implements OnInit {
             type: () => 'div',
             attributes: {
               innerHTML: item => {
-                const securityType = this.metadata[item.plan]?.securityType.toLocaleLowerCase().replace('_', ' ');
+                const securityType = this.metadata[item.plan]?.securityType?.toLocaleLowerCase().replace('_', ' ');
                 if (this.isAPIKeySubscription(item.plan) && this.applicationHasSharedKey()) {
                   return `${securityType} <gv-state> ${this.application.api_key_mode} </gv-state>`;
                 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3876

## Description

Security type can be null for push plans