### PR TITLE
fix(mapiv2): ignore case on endpoint type

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapper.java
@@ -96,7 +96,10 @@ public interface EndpointMapper {
         }
 
         // If endpoint is a http or grpc endpoint, we need to parse the configuration and use it as the actual instance
-        if ((endpoint.getType().equals("http") || endpoint.getType().equals("grpc")) && endpoint.getConfiguration() != null) {
+        if (
+            (endpoint.getType().equalsIgnoreCase("http") || endpoint.getType().equalsIgnoreCase("grpc")) &&
+            endpoint.getConfiguration() != null
+        ) {
             ObjectMapper mapper = new GraviteeMapper();
             io.gravitee.definition.model.endpoint.HttpEndpoint config;
             try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/EndpointMapperTest.java
@@ -180,6 +180,7 @@ public class EndpointMapperTest {
         // Set http endpoint configuration into endpoint.configuration
         var endpointEntityV2 = EndpointModelFixtures.aModelEndpointV2();
         endpointEntityV2.setName("Should not be mapped");
+        endpointEntityV2.setType("HtTp");
         endpointEntityV2.setConfiguration(new ObjectMapper().writeValueAsString(httpEndpointV2Configuration));
 
         var endpointV2 = endpointMapper.map(endpointEntityV2);
@@ -215,7 +216,7 @@ public class EndpointMapperTest {
 
         // Set http endpoint configuration into endpoint.configuration
         var endpointEntityV2 = EndpointModelFixtures.aModelEndpointV2();
-        endpointEntityV2.setType("grpc");
+        endpointEntityV2.setType("gRpC");
         endpointEntityV2.setName("Should not be mapped");
         endpointEntityV2.setConfiguration(new ObjectMapper().writeValueAsString(httpEndpointV2Configuration));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3895

## Description

Ignore case on endpoint type
Useful for backward compatibility with old existing apis with different font case in their definition 
