### PR TITLE
refactor: extract create api domain service

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/ApiDefinitionFixtures.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/ApiDefinitionFixtures.java
@@ -20,12 +20,14 @@ import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 public class ApiDefinitionFixtures {
@@ -46,6 +48,48 @@ public class ApiDefinitionFixtures {
         var httpListener = HttpListener.builder().paths(List.of(new Path())).build();
 
         return BASE_V4.get().listeners(List.of(httpListener)).endpointGroups(List.of(EndpointGroup.builder().build())).build();
+    }
+
+    public static Api aHttpProxyApiV4(String apiId) {
+        return BASE_V4
+            .get()
+            .id(apiId)
+            .analytics(Analytics.builder().enabled(false).build())
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.PROXY)
+            .listeners(
+                List.of(
+                    HttpListener
+                        .builder()
+                        .paths(List.of(Path.builder().path("/http_proxy").build()))
+                        .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+                        .build()
+                )
+            )
+            .endpointGroups(
+                List.of(
+                    EndpointGroup
+                        .builder()
+                        .name("default-group")
+                        .type("http-proxy")
+                        .sharedConfiguration("{}")
+                        .endpoints(
+                            List.of(
+                                Endpoint
+                                    .builder()
+                                    .name("default-endpoint")
+                                    .type("http-proxy")
+                                    .inheritConfiguration(true)
+                                    .configuration("{\"target\":\"https://api.gravitee.io/echo\"}")
+                                    .build()
+                            )
+                        )
+                        .build()
+                )
+            )
+            .flows(List.of())
+            .flowExecution(new FlowExecution())
+            .build();
     }
 
     public static io.gravitee.definition.model.Api anApiV2() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GenericNotificationConfig.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GenericNotificationConfig.java
@@ -18,11 +18,21 @@ package io.gravitee.repository.management.model;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class GenericNotificationConfig {
 
     private String id;
@@ -35,86 +45,6 @@ public class GenericNotificationConfig {
     private String referenceId;
     private Date createdAt;
     private Date updatedAt;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getNotifier() {
-        return notifier;
-    }
-
-    public void setNotifier(String notifier) {
-        this.notifier = notifier;
-    }
-
-    public String getConfig() {
-        return config;
-    }
-
-    public void setConfig(String config) {
-        this.config = config;
-    }
-
-    public List<String> getHooks() {
-        return hooks;
-    }
-
-    public void setHooks(List<String> hooks) {
-        this.hooks = hooks;
-    }
-
-    public NotificationReferenceType getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(NotificationReferenceType referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public boolean isUseSystemProxy() {
-        return useSystemProxy;
-    }
-
-    public void setUseSystemProxy(boolean useSystemProxy) {
-        this.useSystemProxy = useSystemProxy;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Workflow.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Workflow.java
@@ -17,11 +17,17 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class Workflow {
 
     public enum AuditEvent implements Audit.ApiAuditEvent {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/InMemoryConfiguration.java
@@ -36,6 +36,7 @@ import inmemory.IndexerInMemory;
 import inmemory.InstallationAccessQueryServiceInMemory;
 import inmemory.InstanceQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.MessageLogCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
@@ -250,5 +251,10 @@ public class InMemoryConfiguration {
     @Bean
     public IndexerInMemory indexer() {
         return new IndexerInMemory();
+    }
+
+    @Bean
+    public MembershipCrudServiceInMemory membershipCrudServiceInMemory() {
+        return new MembershipCrudServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.spring;
 
 import static org.mockito.Mockito.mock;
 
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
@@ -36,9 +37,30 @@ import io.gravitee.apim.infra.sanitizer.SanitizerSpringConfiguration;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.ApiDuplicatorService;
+import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.ApiService;
-import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.MediaService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.v4.ApiDuplicateService;
+import io.gravitee.rest.api.service.v4.ApiImportExportService;
+import io.gravitee.rest.api.service.v4.ApiLicenseService;
+import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import org.springframework.context.annotation.Bean;
@@ -289,5 +311,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiEventQueryService apiEventQueryService() {
         return mock(ApiEventQueryService.class);
+    }
+
+    @Bean
+    public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService() {
+        return mock(ApiMetadataDecoderDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/InMemoryConfiguration.java
@@ -190,4 +190,9 @@ public class InMemoryConfiguration {
     public IndexerInMemory indexer() {
         return new IndexerInMemory();
     }
+
+    @Bean
+    public MembershipCrudServiceInMemory membershipCrudServiceInMemory() {
+        return new MembershipCrudServiceInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiPolicyValidatorDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
@@ -573,5 +574,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiEventQueryService apiEventQueryService() {
         return mock(ApiEventQueryService.class);
+    }
+
+    @Bean
+    public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService() {
+        return mock(ApiMetadataDecoderDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/notification/GenericNotificationConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/notification/GenericNotificationConfigEntity.java
@@ -18,11 +18,21 @@ package io.gravitee.rest.api.model.notification;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class GenericNotificationConfigEntity {
 
     @JsonProperty("config_type")
@@ -36,78 +46,6 @@ public class GenericNotificationConfigEntity {
     private String config;
     private List<String> hooks;
     private boolean useSystemProxy;
-
-    public NotificationConfigType getConfigType() {
-        return configType;
-    }
-
-    public void setConfigType(NotificationConfigType configType) {
-        this.configType = configType;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getNotifier() {
-        return notifier;
-    }
-
-    public void setNotifier(String notifier) {
-        this.notifier = notifier;
-    }
-
-    public String getConfig() {
-        return config;
-    }
-
-    public void setConfig(String config) {
-        this.config = config;
-    }
-
-    public List<String> getHooks() {
-        return hooks;
-    }
-
-    public void setHooks(List<String> hooks) {
-        this.hooks = hooks;
-    }
-
-    public String getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(String referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public boolean isUseSystemProxy() {
-        return useSystemProxy;
-    }
-
-    public void setUseSystemProxy(boolean useSystemProxy) {
-        this.useSystemProxy = useSystemProxy;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/InMemoryConfiguration.java
@@ -34,6 +34,7 @@ import inmemory.GroupQueryServiceInMemory;
 import inmemory.IndexerInMemory;
 import inmemory.InstanceQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.MessageLogCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
@@ -220,5 +221,10 @@ public class InMemoryConfiguration {
     @Bean
     public IndexerInMemory indexer() {
         return new IndexerInMemory();
+    }
+
+    @Bean
+    public MembershipCrudServiceInMemory membershipCrudServiceInMemory() {
+        return new MembershipCrudServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiPolicyValidatorDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
@@ -528,5 +529,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiEventQueryService apiEventQueryService() {
         return mock(ApiEventQueryService.class);
+    }
+
+    @Bean
+    public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService() {
+        return mock(ApiMetadataDecoderDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.ApiMetadataDecodeContext;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.PrimaryOwnerMetadataDecodeContext;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.Indexer;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import java.util.Date;
+
+public class ApiIndexerDomainService {
+
+    private final ApiMetadataDecoderDomainService apiMetadataDecoderDomainService;
+    private final Indexer indexer;
+
+    public ApiIndexerDomainService(ApiMetadataDecoderDomainService apiMetadataDecoderDomainService, Indexer indexer) {
+        this.apiMetadataDecoderDomainService = apiMetadataDecoderDomainService;
+        this.indexer = indexer;
+    }
+
+    public void index(Indexer.IndexationContext context, Api apiToIndex, PrimaryOwnerEntity primaryOwner) {
+        var metadata = apiMetadataDecoderDomainService.decodeMetadata(
+            apiToIndex.getId(),
+            ApiMetadataDecodeContext
+                .builder()
+                .name(apiToIndex.getName())
+                .description(apiToIndex.getDescription())
+                .createdAt(Date.from(apiToIndex.getCreatedAt().toInstant()))
+                .updatedAt(Date.from(apiToIndex.getUpdatedAt().toInstant()))
+                .primaryOwner(
+                    new PrimaryOwnerMetadataDecodeContext(
+                        primaryOwner.id(),
+                        primaryOwner.displayName(),
+                        primaryOwner.email(),
+                        primaryOwner.type().name()
+                    )
+                )
+                .build()
+        );
+
+        indexer.index(context, new IndexableApi(apiToIndex, primaryOwner, metadata));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDecoderDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDecoderDomainService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.template.TemplateProcessor;
+import io.gravitee.apim.core.template.TemplateProcessorException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ApiMetadataDecoderDomainService {
+
+    private final ApiMetadataQueryService metadataQueryService;
+    private final TemplateProcessor templateProcessor;
+
+    public ApiMetadataDecoderDomainService(ApiMetadataQueryService metadataQueryService, TemplateProcessor templateProcessor) {
+        this.metadataQueryService = metadataQueryService;
+        this.templateProcessor = templateProcessor;
+    }
+
+    public Map<String, String> decodeMetadata(String apiId, ApiMetadataDecodeContext context) {
+        var metadata = metadataQueryService
+            .findApiMetadata(apiId)
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().getValue() != null)
+            .map(entry -> Map.entry(entry.getKey(), entry.getValue().getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        return decode(metadata, context);
+    }
+
+    private Map<String, String> decode(Map<String, String> metadata, ApiMetadataDecodeContext context) {
+        if (metadata.isEmpty()) {
+            return metadata;
+        }
+
+        try {
+            var decodedValue = templateProcessor.processInlineTemplate(metadata.toString(), Collections.singletonMap("api", context));
+
+            return Arrays
+                .stream(decodedValue.substring(1, decodedValue.length() - 1).split(", "))
+                .map(entry -> entry.split("=", 2))
+                .collect(Collectors.toMap(entry -> entry[0], entry -> entry.length > 1 ? entry[1] : ""));
+        } catch (TemplateProcessorException e) {
+            log.warn("Error while creating template '{}' from reader:\n{}", e.getTemplate(), e.getMessage());
+            return metadata;
+        } catch (Exception ex) {
+            throw new TechnicalDomainException("An error occurs while evaluating API metadata", ex);
+        }
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Data
+    public static class ApiMetadataDecodeContext {
+
+        private String name;
+        private String description;
+        private Date createdAt;
+        private Date updatedAt;
+        private PrimaryOwnerMetadataDecodeContext primaryOwner;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Data
+    public static class PrimaryOwnerMetadataDecodeContext {
+
+        private String id;
+        private String displayName;
+        private String email;
+        private String type;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDomainService.java
@@ -16,13 +16,78 @@
 package io.gravitee.apim.core.api.domain_service;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.datetime.TimeProvider;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.common.utils.IdGenerator;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ApiMetadataDomainService {
-    void saveApiMetadata(String apiId, List<ApiMetadata> metadata, AuditInfo auditInfo);
+public class ApiMetadataDomainService {
+
+    private final MetadataCrudService metadataCrudService;
+    private final AuditDomainService auditService;
+
+    public ApiMetadataDomainService(MetadataCrudService metadataCrudService, AuditDomainService auditService) {
+        this.metadataCrudService = metadataCrudService;
+        this.auditService = auditService;
+    }
+
+    /**
+     * Create all default metadata for an API that has been created
+     *
+     * <p>
+     *     Currently, it only creates the email-support metadata.
+     * </p>
+     * @param apiId The created API id
+     * @param auditInfo The audit information
+     */
+    public void createDefaultApiMetadata(String apiId, AuditInfo auditInfo) {
+        var now = TimeProvider.now();
+        String name = "email-support";
+        var emailSupportMetadata = metadataCrudService.create(
+            Metadata
+                .builder()
+                .key(IdGenerator.generate(name))
+                .format(Metadata.MetadataFormat.MAIL)
+                .name(name)
+                .value("${(api.primaryOwner.email)!''}")
+                .referenceType(Metadata.ReferenceType.API)
+                .referenceId(apiId)
+                .createdAt(now)
+                .updatedAt(now)
+                .build()
+        );
+        createAuditLog(emailSupportMetadata, auditInfo);
+    }
+
+    public void saveApiMetadata(String apiId, List<ApiMetadata> metadata, AuditInfo auditInfo) {
+        throw new TechnicalDomainException("Not yet implemented");
+    }
+
+    private void createAuditLog(Metadata created, AuditInfo auditInfo) {
+        auditService.createApiAuditLog(
+            ApiAuditLogEntity
+                .builder()
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .apiId(created.getReferenceId())
+                .event(ApiAuditEvent.METADATA_CREATED)
+                .actor(auditInfo.actor())
+                .newValue(created)
+                .createdAt(created.getCreatedAt())
+                .properties(Map.of(AuditProperties.METADATA, created.getKey()))
+                .build()
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api.domain_service;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.crd.ApiCRD;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 
@@ -24,5 +25,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
  * @author GraviteeSource Team
  */
 public interface CreateApiDomainService {
+    ApiWithFlows create(Api api, AuditInfo auditInfo);
     Api create(ApiCRD api, AuditInfo auditInfo);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainServiceImpl.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static io.gravitee.apim.core.workflow.model.Workflow.newApiReviewWorkflow;
+
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.model.crd.ApiCRD;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.apim.core.parameters.model.ParameterContext;
+import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
+import io.gravitee.apim.core.search.Indexer;
+import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import java.util.Collections;
+
+public class CreateApiDomainServiceImpl implements CreateApiDomainService {
+
+    private final ValidateApiDomainService validateApiDomainService;
+    private final ApiCrudService apiCrudService;
+    private final AuditDomainService auditService;
+    private final ApiIndexerDomainService apiIndexerDomainService;
+    private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
+    private final ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
+    private final ApiMetadataDomainService apiMetadataDomainService;
+    private final FlowCrudService flowCrudService;
+    private final NotificationConfigCrudService notificationConfigCrudService;
+    private final ParametersQueryService parametersQueryService;
+    private final WorkflowCrudService workflowCrudService;
+
+    public CreateApiDomainServiceImpl(
+        ValidateApiDomainService validateApiDomainService,
+        ApiCrudService apiCrudService,
+        AuditDomainService auditService,
+        ApiIndexerDomainService apiIndexerDomainService,
+        ApiMetadataDomainService apiMetadataDomainService,
+        ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
+        ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService,
+        FlowCrudService flowCrudService,
+        NotificationConfigCrudService notificationConfigCrudService,
+        ParametersQueryService parametersQueryService,
+        WorkflowCrudService workflowCrudService
+    ) {
+        this.validateApiDomainService = validateApiDomainService;
+        this.apiCrudService = apiCrudService;
+        this.auditService = auditService;
+        this.apiIndexerDomainService = apiIndexerDomainService;
+        this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
+        this.apiPrimaryOwnerDomainService = apiPrimaryOwnerDomainService;
+        this.apiMetadataDomainService = apiMetadataDomainService;
+        this.flowCrudService = flowCrudService;
+        this.notificationConfigCrudService = notificationConfigCrudService;
+        this.parametersQueryService = parametersQueryService;
+        this.workflowCrudService = workflowCrudService;
+    }
+
+    @Override
+    public ApiWithFlows create(Api api, AuditInfo auditInfo) {
+        var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(
+            auditInfo.organizationId(),
+            auditInfo.environmentId(),
+            auditInfo.actor().userId()
+        );
+
+        var sanitized = validateApiDomainService.validateAndSanitizeForCreation(
+            api,
+            primaryOwner,
+            auditInfo.environmentId(),
+            auditInfo.organizationId()
+        );
+
+        var created = apiCrudService.create(sanitized);
+
+        createAuditLog(created, auditInfo);
+
+        apiPrimaryOwnerDomainService.createApiPrimaryOwnerMembership(created.getId(), primaryOwner, auditInfo);
+
+        createDefaultMailNotification(created.getId());
+
+        apiMetadataDomainService.createDefaultApiMetadata(created.getId(), auditInfo);
+
+        flowCrudService.saveApiFlows(api.getId(), api.getApiDefinitionV4().getFlows());
+
+        if (isApiReviewEnabled(auditInfo.organizationId(), auditInfo.environmentId())) {
+            workflowCrudService.create(newApiReviewWorkflow(api.getId(), auditInfo.actor().userId()));
+        }
+
+        apiIndexerDomainService.index(
+            new Indexer.IndexationContext(auditInfo.organizationId(), auditInfo.environmentId()),
+            created,
+            primaryOwner
+        );
+        return new ApiWithFlows(created, api.getApiDefinitionV4().getFlows());
+    }
+
+    @Override
+    public Api create(ApiCRD api, AuditInfo auditInfo) {
+        return null;
+    }
+
+    private void createAuditLog(Api created, AuditInfo auditInfo) {
+        auditService.createApiAuditLog(
+            ApiAuditLogEntity
+                .builder()
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .apiId(created.getId())
+                .event(ApiAuditEvent.API_CREATED)
+                .actor(auditInfo.actor())
+                .newValue(created)
+                .createdAt(created.getCreatedAt())
+                .properties(Collections.emptyMap())
+                .build()
+        );
+    }
+
+    private void createDefaultMailNotification(String apiId) {
+        notificationConfigCrudService.create(NotificationConfig.defaultMailNotificationConfigFor(apiId));
+    }
+
+    private boolean isApiReviewEnabled(String organizationId, String environmentId) {
+        return parametersQueryService.findAsBoolean(
+            Key.API_REVIEW_ENABLED,
+            new ParameterContext(environmentId, organizationId, ParameterReferenceType.ENVIRONMENT)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiDomainService.java
@@ -13,13 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.crud_service;
+package io.gravitee.apim.core.api.domain_service;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 
-public interface ApiCrudService {
-    Api get(String id);
-    boolean existsById(String id);
-    Api create(Api api);
-    Api update(Api api);
+public interface ValidateApiDomainService {
+    Api validateAndSanitizeForCreation(final Api api, final PrimaryOwnerEntity primaryOwner, String environmentId, String organizationId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -23,11 +23,16 @@ import io.gravitee.definition.model.v4.property.Property;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
-@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
 public class Api {
 
     /**
@@ -86,10 +91,12 @@ public class Api {
      * The Api last updated date
      */
     private ZonedDateTime updatedAt;
+
     /**
      * The api visibility
      */
-    private Visibility visibility;
+    @Builder.Default
+    private Visibility visibility = Visibility.PRIVATE;
 
     /**
      * The current runtime life cycle state.
@@ -110,6 +117,7 @@ public class Api {
      */
     private Set<String> categories;
     /**
+     *
      */
     private List<String> labels;
 
@@ -171,6 +179,7 @@ public class Api {
 
     /**
      * Updates the list of properties to include dynamic properties
+     *
      * @param dynamicProperties the list of dynamic properties to update the list of property
      * @return true if an update has been done, meaning the Api need to be persisted
      */
@@ -188,22 +197,22 @@ public class Api {
         return properties.needToUpdate();
     }
 
-    public static class ApiBuilder {
+    public abstract static class ApiBuilder<C extends Api, B extends ApiBuilder<C, B>> {
 
-        public ApiBuilder apiDefinition(io.gravitee.definition.model.Api apiDefinition) {
+        public B apiDefinition(io.gravitee.definition.model.Api apiDefinition) {
             this.apiDefinition = apiDefinition;
             if (apiDefinition != null) {
                 this.definitionVersion = apiDefinition.getDefinitionVersion();
             }
-            return this;
+            return self();
         }
 
-        public ApiBuilder apiDefinitionV4(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
+        public B apiDefinitionV4(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
             this.apiDefinitionV4 = apiDefinitionV4;
             if (apiDefinitionV4 != null) {
                 this.definitionVersion = apiDefinitionV4.getDefinitionVersion();
             }
-            return this;
+            return self();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiMetadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiMetadata.java
@@ -22,12 +22,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.With;
 
-@Builder
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ApiMetadata {
 
+    String apiId;
     String key;
     String name;
     MetadataFormat format;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import io.gravitee.definition.model.v4.flow.Flow;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiWithFlows extends Api {
+
+    private List<Flow> flows;
+
+    public ApiWithFlows(Api api, List<Flow> flows) {
+        super(
+            api.getId(),
+            api.getEnvironmentId(),
+            api.getCrossId(),
+            api.getName(),
+            api.getDescription(),
+            api.getVersion(),
+            api.getDefinitionContext(),
+            api.getDefinitionVersion(),
+            api.getApiDefinitionV4(),
+            api.getApiDefinition(),
+            api.getType(),
+            api.getDeployedAt(),
+            api.getCreatedAt(),
+            api.getUpdatedAt(),
+            api.getVisibility(),
+            api.getLifecycleState(),
+            api.getPicture(),
+            api.getGroups(),
+            api.getCategories(),
+            api.getLabels(),
+            api.isDisableMembershipNotifications(),
+            api.getApiLifecycleState(),
+            api.getBackground()
+        );
+        this.flows = flows;
+    }
+
+    public Api toApi() {
+        return super.toBuilder().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ApiAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ApiAuditEvent.java
@@ -20,7 +20,13 @@ package io.gravitee.apim.core.audit.model.event;
  * @author GraviteeSource Team
  */
 public enum ApiAuditEvent implements AuditEvent {
+    API_CREATED,
     API_UPDATED,
+    API_DELETED,
+    API_ROLLBACKED,
+    API_LOGGING_ENABLED,
+    API_LOGGING_DISABLED,
+    API_LOGGING_UPDATED,
     METADATA_DELETED,
     METADATA_CREATED,
     METADATA_UPDATED,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/MembershipAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/MembershipAuditEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.audit.model.event;
+
+public enum MembershipAuditEvent implements AuditEvent {
+    MEMBERSHIP_CREATED,
+    MEMBERSHIP_UPDATED,
+    MEMBERSHIP_DELETED,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
@@ -19,5 +19,6 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import java.util.List;
 
 public interface FlowCrudService {
+    List<Flow> saveApiFlows(String apiId, List<Flow> flows);
     List<Flow> savePlanFlows(String planId, List<Flow> flows);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import io.gravitee.apim.core.group.query_service.GroupQueryService;
+import io.gravitee.apim.core.membership.exception.NoPrimaryOwnerGroupForUserException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.apim.core.parameters.model.ParameterContext;
+import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.util.stream.Collectors;
+
+/**
+ * Factory to create a primary owner entity for a new API based on the primary owner mode defined at the environment level.
+ */
+public class ApiPrimaryOwnerFactory {
+
+    private final MembershipQueryService membershipQueryService;
+    private final ParametersQueryService parametersQueryService;
+    private final RoleQueryService roleQueryService;
+    private final UserCrudService userCrudService;
+    private final GroupQueryService groupQueryService;
+
+    public ApiPrimaryOwnerFactory(
+        GroupQueryService groupQueryService,
+        MembershipQueryService membershipQueryService,
+        ParametersQueryService parametersQueryService,
+        RoleQueryService roleQueryService,
+        UserCrudService userCrudService
+    ) {
+        this.membershipQueryService = membershipQueryService;
+        this.parametersQueryService = parametersQueryService;
+        this.roleQueryService = roleQueryService;
+        this.userCrudService = userCrudService;
+        this.groupQueryService = groupQueryService;
+    }
+
+    public PrimaryOwnerEntity createForNewApi(String organizationId, String environmentId, String userId) {
+        var mode = ApiPrimaryOwnerMode.valueOf(
+            parametersQueryService.findAsString(
+                Key.API_PRIMARY_OWNER_MODE,
+                new ParameterContext(environmentId, organizationId, ParameterReferenceType.ENVIRONMENT)
+            )
+        );
+        return switch (mode) {
+            case HYBRID, USER -> initUserPrimaryOwner(userId);
+            case GROUP -> initWithFirstGroupWhereUserIsPrimaryOwner(userId, organizationId);
+        };
+    }
+
+    private PrimaryOwnerEntity initUserPrimaryOwner(String userId) {
+        var user = userCrudService.getBaseUser(userId);
+        return new PrimaryOwnerEntity(user.getId(), user.getEmail(), user.displayName(), PrimaryOwnerEntity.Type.USER);
+    }
+
+    private PrimaryOwnerEntity initWithFirstGroupWhereUserIsPrimaryOwner(String userId, String organizationId) {
+        var userGroupIds = membershipQueryService
+            .findGroupsThatUserBelongsTo(userId)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+        var group = groupQueryService
+            .findByIds(userGroupIds)
+            .stream()
+            .filter(g -> g.getApiPrimaryOwner() != null && !g.getApiPrimaryOwner().isBlank())
+            .findFirst();
+
+        return group
+            .flatMap(g ->
+                membershipQueryService
+                    .findByReferenceAndRoleId(Membership.ReferenceType.GROUP, g.getId(), getApiPrimaryOwnerRole(organizationId).getId())
+                    .stream()
+                    .findFirst()
+                    .map(membership -> userCrudService.getBaseUser(membership.getMemberId()))
+                    .map(user -> new PrimaryOwnerEntity(g.getId(), user.getEmail(), g.getName(), PrimaryOwnerEntity.Type.GROUP))
+            )
+            .orElseThrow(() -> new NoPrimaryOwnerGroupForUserException(userId));
+    }
+
+    private Role getApiPrimaryOwnerRole(String organizationId) {
+        return roleQueryService.getApiRole(
+            SystemRole.PRIMARY_OWNER.name(),
+            ReferenceContext.builder().referenceType(ReferenceContext.Type.ORGANIZATION).referenceId(organizationId).build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/NoPrimaryOwnerGroupForUserException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/NoPrimaryOwnerGroupForUserException.java
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.parameters.query_service;
+package io.gravitee.apim.core.membership.exception;
 
-import io.gravitee.apim.core.parameters.model.ParameterContext;
-import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 
-public interface ParametersQueryService {
-    boolean findAsBoolean(Key key, ParameterContext context);
-    String findAsString(Key key, ParameterContext context);
+public class NoPrimaryOwnerGroupForUserException extends ValidationDomainException {
+
+    private final String userId;
+
+    public NoPrimaryOwnerGroupForUserException(String userId) {
+        super("User must belong to at least one group with a primary owner member.");
+        this.userId = userId;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/RoleNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/RoleNotFoundException.java
@@ -13,12 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.parameters.query_service;
+package io.gravitee.apim.core.membership.exception;
 
-import io.gravitee.apim.core.parameters.model.ParameterContext;
-import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.rest.api.service.common.ReferenceContext;
 
-public interface ParametersQueryService {
-    boolean findAsBoolean(Key key, ParameterContext context);
-    String findAsString(Key key, ParameterContext context);
+public class RoleNotFoundException extends ValidationDomainException {
+
+    private final String roleId;
+
+    public RoleNotFoundException(String roleId) {
+        super("Role not found: " + roleId);
+        this.roleId = roleId;
+    }
+
+    public RoleNotFoundException(String name, ReferenceContext referenceContext) {
+        super("Role '" + name + "' for " + referenceContext + " not found.");
+        this.roleId = name;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
@@ -31,7 +31,10 @@ public class Membership {
     private ReferenceType referenceType;
     private String referenceId;
     private String roleId;
-    private String source;
+
+    @Builder.Default
+    private String source = "system";
+
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/Membership.java
@@ -51,4 +51,8 @@ public class Membership {
         ORGANIZATION,
         PLATFORM,
     }
+
+    public boolean isGroupUser() {
+        return referenceType == ReferenceType.GROUP && memberType == Type.USER;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/MembershipQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/MembershipQueryService.java
@@ -22,4 +22,6 @@ import java.util.List;
 public interface MembershipQueryService {
     Collection<Membership> findByReferenceAndRoleId(Membership.ReferenceType referenceType, String referenceId, String roleId);
     Collection<Membership> findByReferencesAndRoleId(Membership.ReferenceType referenceType, List<String> referenceIds, String roleId);
+
+    Collection<Membership> findGroupsThatUserBelongsTo(String userId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.membership.query_service;
 
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import java.util.Optional;
@@ -22,4 +23,8 @@ import java.util.Optional;
 public interface RoleQueryService {
     Optional<Role> findApiRole(String name, ReferenceContext referenceContext);
     Optional<Role> findApplicationRole(String name, ReferenceContext referenceContext);
+
+    default Role getApiRole(String name, ReferenceContext referenceContext) {
+        return findApiRole(name, referenceContext).orElseThrow(() -> new RoleNotFoundException(name, referenceContext));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/crud_service/MetadataCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/crud_service/MetadataCrudService.java
@@ -13,15 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.audit.model.event;
+package io.gravitee.apim.core.metadata.crud_service;
 
-/**
- * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum ApiAuditEvent implements AuditEvent {
-    API_UPDATED,
-    METADATA_DELETED,
-    METADATA_CREATED,
-    METADATA_UPDATED,
+import io.gravitee.apim.core.metadata.model.Metadata;
+
+public interface MetadataCrudService {
+    Metadata create(Metadata metadata);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/model/Metadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/model/Metadata.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.metadata.model;
+
+import java.time.ZonedDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Metadata {
+
+    private String key;
+    private ReferenceType referenceType;
+    private String referenceId;
+    private String name;
+    private MetadataFormat format;
+    private String value;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+
+    public enum ReferenceType {
+        DEFAULT,
+        API,
+        APPLICATION,
+        USER;
+
+        public static ReferenceType parse(String value) {
+            try {
+                return ReferenceType.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                return ReferenceType.DEFAULT;
+            }
+        }
+    }
+
+    public enum MetadataFormat {
+        STRING,
+        NUMERIC,
+        BOOLEAN,
+        DATE,
+        MAIL,
+        URL,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/crud_service/NotificationConfigCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/crud_service/NotificationConfigCrudService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.crud_service;
+
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+
+public interface NotificationConfigCrudService {
+    NotificationConfig create(NotificationConfig config);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/config/NotificationConfig.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/config/NotificationConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.model.config;
+
+import io.gravitee.apim.core.datetime.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.HookScope;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class NotificationConfig {
+
+    private Type type;
+    private String id;
+    private String name;
+    private String referenceType;
+    private String referenceId;
+    private String notifier;
+    private String config;
+    private List<String> hooks;
+    private boolean useSystemProxy;
+
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+
+    public enum Type {
+        PORTAL,
+        GENERIC,
+    }
+
+    public static NotificationConfig defaultMailNotificationConfigFor(String apiId) {
+        var now = TimeProvider.now();
+        return NotificationConfig
+            .builder()
+            .type(Type.GENERIC)
+            .id(UuidString.generateRandom())
+            .name("Default Mail Notifications")
+            .referenceType(HookScope.API.name())
+            .referenceId(apiId)
+            .notifier("default-email")
+            .config("${(api.primaryOwner.email)!''}")
+            .hooks(Arrays.stream(ApiHook.values()).map(Enum::name).sorted().toList())
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.search.model;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class IndexableApi implements Indexable {
+
+    private Api api;
+
+    private PrimaryOwnerEntity primaryOwner;
+
+    /** Decoded API metadata */
+    private Map<String, String> decodedMetadata;
+
+    @Override
+    public String getId() {
+        return api.getId();
+    }
+
+    @Override
+    public void setId(String id) {
+        api.setId(id);
+    }
+
+    @Override
+    public String getReferenceType() {
+        return ReferenceContext.Type.ENVIRONMENT.name();
+    }
+
+    @Override
+    public void setReferenceType(String referenceType) {}
+
+    @Override
+    public String getReferenceId() {
+        return api.getEnvironmentId();
+    }
+
+    @Override
+    public void setReferenceId(String referenceId) {
+        api.setEnvironmentId(referenceId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra.template;
+package io.gravitee.apim.core.template;
 
 import java.util.Map;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessorException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessorException.java
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra.template;
+package io.gravitee.apim.core.template;
 
+import lombok.Getter;
+
+@Getter
 public class TemplateProcessorException extends Exception {
 
-    public TemplateProcessorException(Throwable cause) {
+    private String template;
+
+    public TemplateProcessorException(String template, Throwable cause) {
         super(cause);
+        this.template = template;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/crud_service/WorkflowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/crud_service/WorkflowCrudService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.workflow.crud_service;
+
+import io.gravitee.apim.core.workflow.model.Workflow;
+
+public interface WorkflowCrudService {
+    Workflow create(Workflow workflow);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/model/Workflow.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/model/Workflow.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.workflow.model;
+
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class Workflow {
+
+    private String id;
+    private ReferenceType referenceType;
+    private String referenceId;
+    private Type type;
+    private State state;
+    private String comment;
+    private String user;
+    private ZonedDateTime createdAt;
+
+    public enum ReferenceType {
+        API,
+        APPLICATION,
+    }
+
+    public enum Type {
+        REVIEW,
+    }
+
+    public enum State {
+        DRAFT,
+        IN_REVIEW,
+        REQUEST_FOR_CHANGES,
+        REVIEW_OK,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/model/Workflow.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/workflow/model/Workflow.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.workflow.model;
 
+import io.gravitee.apim.core.datetime.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
 import java.time.ZonedDateTime;
 import lombok.Builder;
 import lombok.Data;
@@ -46,5 +48,19 @@ public class Workflow {
         IN_REVIEW,
         REQUEST_FOR_CHANGES,
         REVIEW_OK,
+    }
+
+    public static Workflow newApiReviewWorkflow(String apiId, String userId) {
+        return Workflow
+            .builder()
+            .id(UuidString.generateRandom())
+            .referenceType(Workflow.ReferenceType.API)
+            .referenceId(apiId)
+            .type(Workflow.Type.REVIEW)
+            .state(Workflow.State.DRAFT)
+            .comment("")
+            .user(userId)
+            .createdAt(TimeProvider.now())
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.api.model.crd.ApiCRD;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import java.io.IOException;
 import java.util.stream.Stream;
@@ -50,6 +51,9 @@ public interface ApiAdapter {
     io.gravitee.repository.management.model.Api toRepository(Api source);
 
     Stream<io.gravitee.repository.management.model.Api> toRepositoryStream(Stream<Api> source);
+
+    @Mapping(target = "apiVersion", source = "version")
+    NewApiEntity toNewApiEntity(Api source);
 
     @Mapping(target = "apiVersion", source = "version")
     io.gravitee.definition.model.v4.Api toApiDefinition(ApiCRD source);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MetadataAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MetadataAdapter.java
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.audit.model.event;
+package io.gravitee.apim.infra.adapter;
 
-/**
- * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum ApiAuditEvent implements AuditEvent {
-    API_UPDATED,
-    METADATA_DELETED,
-    METADATA_CREATED,
-    METADATA_UPDATED,
+import io.gravitee.apim.core.metadata.model.Metadata;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface MetadataAdapter {
+    MetadataAdapter INSTANCE = Mappers.getMapper(MetadataAdapter.class);
+
+    Metadata toEntity(io.gravitee.repository.management.model.Metadata source);
+
+    io.gravitee.repository.management.model.Metadata toRepository(Metadata source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MetadataAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/MetadataAdapter.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.metadata.model.Metadata;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -26,4 +28,11 @@ public interface MetadataAdapter {
     Metadata toEntity(io.gravitee.repository.management.model.Metadata source);
 
     io.gravitee.repository.management.model.Metadata toRepository(Metadata source);
+
+    @Mapping(target = "apiId", source = "referenceId")
+    ApiMetadata toApiMetadata(Metadata source);
+
+    @Mapping(target = "referenceType", expression = "java(io.gravitee.apim.core.metadata.model.Metadata.ReferenceType.API)")
+    @Mapping(target = "referenceId", source = "apiId")
+    Metadata toMetadata(ApiMetadata source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/NotificationConfigAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/NotificationConfigAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.repository.management.model.GenericNotificationConfig;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface NotificationConfigAdapter {
+    NotificationConfigAdapter INSTANCE = Mappers.getMapper(NotificationConfigAdapter.class);
+
+    @Mapping(target = "type", source = "id", qualifiedByName = "computeType")
+    NotificationConfig toEntity(GenericNotificationConfig source);
+
+    GenericNotificationConfig toRepository(NotificationConfig source);
+
+    @Named("computeType")
+    default NotificationConfig.Type computeType(String id) {
+        return id == null ? NotificationConfig.Type.PORTAL : NotificationConfig.Type.GENERIC;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/WorkflowAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/WorkflowAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.workflow.model.Workflow;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface WorkflowAdapter {
+    WorkflowAdapter INSTANCE = Mappers.getMapper(WorkflowAdapter.class);
+
+    Workflow toEntity(io.gravitee.repository.management.model.Workflow source);
+
+    io.gravitee.repository.management.model.Workflow toRepository(Workflow source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
@@ -61,6 +61,15 @@ public class ApiCrudServiceImpl implements ApiCrudService {
     }
 
     @Override
+    public Api create(Api api) {
+        try {
+            return ApiAdapter.INSTANCE.toCoreModel(apiRepository.create(ApiAdapter.INSTANCE.toRepository(api)));
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to create the api: " + api.getId(), e);
+        }
+    }
+
+    @Override
     public Api update(Api api) {
         try {
             return ApiAdapter.INSTANCE.toCoreModel(apiRepository.update(ApiAdapter.INSTANCE.toRepository(api)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImpl.java
@@ -40,6 +40,11 @@ public class FlowCrudServiceImpl extends TransactionalService implements FlowCru
     }
 
     @Override
+    public List<Flow> saveApiFlows(String apiId, List<Flow> flows) {
+        return save(FlowReferenceType.API, apiId, flows);
+    }
+
+    @Override
     public List<Flow> savePlanFlows(String planId, List<Flow> flows) {
         return save(FlowReferenceType.PLAN, planId, flows);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.metadata;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.infra.adapter.MetadataAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.MetadataRepository;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MetadataCrudServiceImpl implements MetadataCrudService {
+
+    private final MetadataRepository metadataRepository;
+
+    public MetadataCrudServiceImpl(@Lazy MetadataRepository metadataRepository) {
+        this.metadataRepository = metadataRepository;
+    }
+
+    public Metadata create(Metadata metadata) {
+        try {
+            var result = metadataRepository.create(MetadataAdapter.INSTANCE.toRepository(metadata));
+            return MetadataAdapter.INSTANCE.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format(
+                    "An error occurs while trying to create the %s metadata of [%sId=%s]",
+                    metadata.getKey(),
+                    metadata.getReferenceType().name().toLowerCase(),
+                    metadata.getReferenceId()
+                ),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/notification/NotificationConfigCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/notification/NotificationConfigCrudServiceImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.notification;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.apim.infra.adapter.NotificationConfigAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationConfigCrudServiceImpl implements NotificationConfigCrudService {
+
+    private final GenericNotificationConfigRepository notificationConfigRepository;
+
+    public NotificationConfigCrudServiceImpl(@Lazy GenericNotificationConfigRepository notificationConfigRepository) {
+        this.notificationConfigRepository = notificationConfigRepository;
+    }
+
+    @Override
+    public NotificationConfig create(NotificationConfig config) {
+        try {
+            var result = notificationConfigRepository.create(NotificationConfigAdapter.INSTANCE.toRepository(config));
+            return NotificationConfigAdapter.INSTANCE.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format(
+                    "An error occurs while trying to create the %s notification config of %s",
+                    config.getReferenceType(),
+                    config.getReferenceId()
+                ),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/workflow/WorkflowCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/workflow/WorkflowCrudServiceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.workflow;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import io.gravitee.apim.infra.adapter.WorkflowAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.WorkflowRepository;
+import org.springframework.context.annotation.Lazy;
+
+public class WorkflowCrudServiceImpl implements WorkflowCrudService {
+
+    private final WorkflowRepository workflowRepository;
+
+    public WorkflowCrudServiceImpl(@Lazy WorkflowRepository metadataRepository) {
+        this.workflowRepository = metadataRepository;
+    }
+
+    public Workflow create(Workflow workflow) {
+        try {
+            var result = workflowRepository.create(WorkflowAdapter.INSTANCE.toRepository(workflow));
+            return WorkflowAdapter.INSTANCE.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format(
+                    "An error occurs while trying to create the %s workflow of [%sId=%s]",
+                    workflow.getType(),
+                    workflow.getReferenceType().name().toLowerCase(),
+                    workflow.getReferenceId()
+                ),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiMetadataDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiMetadataDomainServiceLegacyWrapper.java
@@ -17,7 +17,9 @@ package io.gravitee.apim.infra.domain_service.api;
 
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
 import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -31,11 +33,16 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @Slf4j
-public class ApiMetadataDomainServiceLegacyWrapper implements ApiMetadataDomainService {
+public class ApiMetadataDomainServiceLegacyWrapper extends ApiMetadataDomainService {
 
     private final ApiMetadataService metadataService;
 
-    public ApiMetadataDomainServiceLegacyWrapper(ApiMetadataService metadataService) {
+    public ApiMetadataDomainServiceLegacyWrapper(
+        ApiMetadataService metadataService,
+        AuditDomainService auditDomainService,
+        MetadataCrudService metadataCrudService
+    ) {
+        super(metadataCrudService, auditDomainService);
         this.metadataService = metadataService;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CreateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CreateApiDomainServiceLegacyWrapper.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.domain_service.api;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.crd.ApiCRD;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
@@ -38,6 +39,11 @@ public class CreateApiDomainServiceLegacyWrapper implements CreateApiDomainServi
     public CreateApiDomainServiceLegacyWrapper(ApiService delegate, ApiCrudService apiCrudService) {
         this.delegate = delegate;
         this.apiCrudService = apiCrudService;
+    }
+
+    @Override
+    public ApiWithFlows create(Api api, AuditInfo auditInfo) {
+        throw new RuntimeException("This method is not implemented");
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
+import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainService {
+
+    private final ApiValidationService apiValidationService;
+
+    public ValidateApiDomainServiceLegacyWrapper(ApiValidationService apiValidationService) {
+        this.apiValidationService = apiValidationService;
+    }
+
+    @Override
+    public Api validateAndSanitizeForCreation(Api api, PrimaryOwnerEntity primaryOwner, String environmentId, String organizationId) {
+        apiValidationService.validateAndSanitizeNewApi(
+            new ExecutionContext(organizationId, environmentId),
+            ApiAdapter.INSTANCE.toNewApiEntity(api),
+            PrimaryOwnerAdapter.INSTANCE.toRestEntity(primaryOwner)
+        );
+        return api;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
@@ -69,6 +69,7 @@ public class ApiMetadataQueryServiceImpl implements ApiMetadataQueryService {
                                 .orElse(
                                     ApiMetadata
                                         .builder()
+                                        .apiId(m.getReferenceId())
                                         .key(m.getKey())
                                         .value(m.getValue())
                                         .format(MetadataFormat.valueOf(m.getFormat().name()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.infra.adapter.MembershipAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
 import java.util.Collection;
 import java.util.List;
@@ -63,6 +64,22 @@ public class MembershipQueryServiceImpl implements MembershipQueryService {
                 .toList();
         } catch (TechnicalException e) {
             throw new TechnicalDomainException(String.format("An error occurs while trying to find %s membership", referenceType), e);
+        }
+    }
+
+    @Override
+    public Collection<Membership> findGroupsThatUserBelongsTo(String memberId) {
+        try {
+            return membershipRepository
+                .findByMemberIdAndMemberTypeAndReferenceType(memberId, MembershipMemberType.USER, MembershipReferenceType.GROUP)
+                .stream()
+                .map(MembershipAdapter.INSTANCE::toEntity)
+                .toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurs while trying to find Group memberships of member %s", memberId),
+                e
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/parameters/ParameterQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/parameters/ParameterQueryServiceLegacyWrapper.java
@@ -39,4 +39,9 @@ public class ParameterQueryServiceLegacyWrapper implements ParametersQueryServic
             context.referenceType()
         );
     }
+
+    @Override
+    public String findAsString(Key key, ParameterContext context) {
+        return parameterService.find(new ExecutionContext(context.environmentId(), context.organizationId()), key, context.referenceType());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
@@ -41,6 +41,7 @@ import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryS
 import io.gravitee.apim.core.license.crud_service.LicenseCrudService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
@@ -324,12 +325,21 @@ public class CoreServiceSpringConfiguration {
 
     @Bean
     public ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService(
+        AuditDomainService auditDomainService,
         GroupQueryService groupQueryService,
+        MembershipCrudService membershipCrudService,
         MembershipQueryService membershipQueryService,
         RoleQueryService roleQueryService,
         UserCrudService userCrudService
     ) {
-        return new ApiPrimaryOwnerDomainService(groupQueryService, membershipQueryService, roleQueryService, userCrudService);
+        return new ApiPrimaryOwnerDomainService(
+            auditDomainService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.infra.spring;
 
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.ApiHostValidatorDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiPolicyValidatorDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api_key.crud_service.ApiKeyCrudService;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
@@ -66,6 +68,7 @@ import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.infra.domain_service.documentation.FreemarkerTemplateResolver;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
@@ -368,5 +371,13 @@ public class CoreServiceSpringConfiguration {
             roleQueryService,
             userCrudService
         );
+    }
+
+    @Bean
+    public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService(
+        ApiMetadataQueryService metadataQueryService,
+        TemplateProcessor templateProcessor
+    ) {
+        return new ApiMetadataDecoderDomainService(metadataQueryService, templateProcessor);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/spring/CoreServiceSpringConfiguration.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
@@ -350,5 +351,22 @@ public class CoreServiceSpringConfiguration {
         UserCrudService userCrudService
     ) {
         return new ApplicationPrimaryOwnerDomainService(groupQueryService, membershipQueryService, roleQueryService, userCrudService);
+    }
+
+    @Bean
+    public ApiPrimaryOwnerFactory apiPrimaryOwnerFactory(
+        MembershipQueryService membershipQueryService,
+        ParametersQueryService parametersQueryService,
+        RoleQueryService roleQueryService,
+        UserCrudService userCrudService,
+        GroupQueryService groupQueryService
+    ) {
+        return new ApiPrimaryOwnerFactory(
+            groupQueryService,
+            membershipQueryService,
+            parametersQueryService,
+            roleQueryService,
+            userCrudService
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
@@ -18,6 +18,8 @@ package io.gravitee.apim.infra.template;
 import freemarker.core.TemplateClassResolver;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import io.gravitee.apim.core.template.TemplateProcessor;
+import io.gravitee.apim.core.template.TemplateProcessorException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
@@ -41,7 +43,7 @@ public class FreemarkerTemplateProcessor implements TemplateProcessor {
             Template freemarkerTemplate = new Template("", new StringReader(template), configuration);
             return FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, params);
         } catch (TemplateException | IOException e) {
-            throw new TemplateProcessorException(e);
+            throw new TemplateProcessorException(template, e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -72,7 +72,7 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
     public static final String FIELD_METADATA = "metadata";
     public static final String FIELD_METADATA_SPLIT = "metadata_split";
     public static final String FIELD_DEFINITION_VERSION = "definition_version";
-    private static final Pattern SPECIAL_CHARS = Pattern.compile("[|\\-+!(){}^\"~*?:&\\/]");
+    public static final Pattern SPECIAL_CHARS = Pattern.compile("[|\\-+!(){}^\"~*?:&\\/]");
     public static final String FIELD_ORIGIN = "origin";
     public static final String FIELD_HAS_HEALTH_CHECK = "has_health_check";
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CREATED_AT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HOSTS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_HOSTS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_SORTED;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ORIGIN;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_MAIL;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SORTED;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_UPDATED_AT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.SPECIAL_CHARS;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.rest.api.model.search.Indexable;
+import io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.apache.lucene.util.BytesRef;
+import org.springframework.stereotype.Component;
+
+@Component
+public class IndexableApiDocumentTransformer implements DocumentTransformer<IndexableApi> {
+
+    @Override
+    public Document transform(IndexableApi indexableApi) {
+        var api = indexableApi.getApi();
+        var primaryOwner = indexableApi.getPrimaryOwner();
+        var metadata = indexableApi.getDecodedMetadata();
+
+        if (api.getDefinitionVersion() != null && api.getDefinitionVersion() != DefinitionVersion.V4) {
+            throw new TechnicalDomainException("Unsupported definition version: " + api.getDefinitionVersion());
+        }
+
+        Document doc = new Document();
+
+        doc.add(new StringField(FIELD_ID, api.getId(), Field.Store.YES));
+        doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
+
+        // If no definition version or name, the api is being deleted. No need for more info in doc.
+        if (api.getDefinitionVersion() == null && api.getName() == null) {
+            return doc;
+        }
+
+        if (api.getDefinitionVersion() != null) {
+            doc.add(new StringField(FIELD_DEFINITION_VERSION, api.getDefinitionVersion().getLabel(), Field.Store.NO));
+        }
+
+        if (indexableApi.getReferenceId() != null) {
+            doc.add(new StringField(FIELD_REFERENCE_TYPE, indexableApi.getReferenceType(), Field.Store.NO));
+            doc.add(new StringField(FIELD_REFERENCE_ID, indexableApi.getReferenceId(), Field.Store.NO));
+        }
+
+        if (api.getName() != null) {
+            doc.add(new StringField(FIELD_NAME, api.getName(), Field.Store.NO));
+            doc.add(new SortedDocValuesField(FIELD_NAME_SORTED, toSortedValue(api.getName())));
+            doc.add(new StringField(FIELD_NAME_LOWERCASE, api.getName().toLowerCase(), Field.Store.NO));
+            doc.add(new TextField(FIELD_NAME_SPLIT, api.getName(), Field.Store.NO));
+        }
+        if (api.getDescription() != null) {
+            doc.add(new StringField(FIELD_DESCRIPTION, api.getDescription(), Field.Store.NO));
+            doc.add(new StringField(FIELD_DESCRIPTION_LOWERCASE, api.getDescription().toLowerCase(), Field.Store.NO));
+            doc.add(new TextField(FIELD_DESCRIPTION_SPLIT, api.getDescription(), Field.Store.NO));
+        }
+        if (primaryOwner != null) {
+            doc.add(new StringField(FIELD_OWNER, primaryOwner.displayName(), Field.Store.NO));
+            doc.add(new StringField(FIELD_OWNER_LOWERCASE, primaryOwner.displayName().toLowerCase(), Field.Store.NO));
+            if (primaryOwner.email() != null) {
+                doc.add(new TextField(FIELD_OWNER_MAIL, primaryOwner.email(), Field.Store.NO));
+            }
+        }
+
+        var apiDefinitionV4 = api.getApiDefinitionV4();
+        if (apiDefinitionV4.getListeners() != null) {
+            final int[] pathIndex = { 0 };
+            apiDefinitionV4
+                .getListeners()
+                .stream()
+                .filter(listener -> listener.getType() == ListenerType.HTTP)
+                .flatMap(listener -> {
+                    HttpListener httpListener = (HttpListener) listener;
+                    return httpListener.getPaths().stream();
+                })
+                .forEach(path -> appendPath(doc, pathIndex, path.getHost(), path.getPath()));
+        }
+
+        // labels
+        if (api.getLabels() != null) {
+            for (String label : api.getLabels()) {
+                doc.add(new StringField(FIELD_LABELS, label, Field.Store.YES));
+                doc.add(new StringField(FIELD_LABELS_LOWERCASE, label.toLowerCase(), Field.Store.NO));
+                doc.add(new TextField(FIELD_LABELS_SPLIT, label, Field.Store.NO));
+            }
+        }
+
+        // categories
+        if (api.getCategories() != null) {
+            for (String category : api.getCategories()) {
+                doc.add(new StringField(FIELD_CATEGORIES, category, Field.Store.NO));
+                doc.add(new TextField(FIELD_CATEGORIES_SPLIT, category, Field.Store.NO));
+            }
+        }
+
+        // tags
+        if (api.getTags() != null) {
+            for (String tag : api.getTags()) {
+                doc.add(new StringField(FIELD_TAGS, tag, Field.Store.NO));
+                doc.add(new TextField(FIELD_TAGS_SPLIT, tag, Field.Store.NO));
+            }
+        }
+
+        if (api.getCreatedAt() != null) {
+            doc.add(new LongPoint(FIELD_CREATED_AT, api.getCreatedAt().toInstant().toEpochMilli()));
+        }
+        if (api.getUpdatedAt() != null) {
+            doc.add(new LongPoint(FIELD_UPDATED_AT, api.getUpdatedAt().toInstant().toEpochMilli()));
+        }
+
+        // metadata
+        if (metadata != null) {
+            metadata
+                .values()
+                .forEach(metadataValue -> {
+                    doc.add(new StringField(FIELD_METADATA, metadataValue, Field.Store.NO));
+                    doc.add(new TextField(FIELD_METADATA_SPLIT, metadataValue, Field.Store.NO));
+                });
+        }
+
+        if (api.getDefinitionContext() != null && api.getDefinitionContext().getOrigin() != null) {
+            doc.add(new StringField(FIELD_ORIGIN, api.getDefinitionContext().getOrigin(), Field.Store.NO));
+        }
+
+        return doc;
+    }
+
+    private void appendPath(final Document doc, final int[] pathIndex, final String host, final String path) {
+        doc.add(new StringField(FIELD_PATHS, path, Field.Store.NO));
+        doc.add(new TextField(FIELD_PATHS_SPLIT, path, Field.Store.NO));
+        if (host != null && !host.isEmpty()) {
+            doc.add(new StringField(FIELD_HOSTS, host, Field.Store.NO));
+            doc.add(new TextField(FIELD_HOSTS_SPLIT, host, Field.Store.NO));
+        }
+        if (pathIndex[0]++ == 0) {
+            doc.add(new SortedDocValuesField(FIELD_PATHS_SORTED, new BytesRef(QueryParser.escape(path))));
+        }
+    }
+
+    private BytesRef toSortedValue(String value) {
+        return new BytesRef(SPECIAL_CHARS.matcher(value).replaceAll("").toLowerCase());
+    }
+
+    @Override
+    public boolean handle(Class<? extends Indexable> source) {
+        return IndexableApi.class.isAssignableFrom(source);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/EmailNotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/EmailNotifierServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.rest.api.service.notifiers.impl;
 
-import io.gravitee.apim.infra.template.TemplateProcessor;
-import io.gravitee.apim.infra.template.TemplateProcessorException;
+import io.gravitee.apim.core.template.TemplateProcessor;
+import io.gravitee.apim.core.template.TemplateProcessorException;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MetadataFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MetadataFixtures.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.metadata.model.Metadata;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.function.Supplier;
+
+public class MetadataFixtures {
+
+    private static final Supplier<Metadata.MetadataBuilder> BASE = () ->
+        Metadata
+            .builder()
+            .key("my-key")
+            .format(Metadata.MetadataFormat.MAIL)
+            .value("my-value")
+            .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()));
+
+    public static Metadata anApiMetadata() {
+        return BASE.get().referenceType(Metadata.ReferenceType.API).referenceId("api-id").build();
+    }
+
+    public static Metadata anApiMetadata(String apiId) {
+        return BASE.get().referenceType(Metadata.ReferenceType.API).referenceId(apiId).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.OptionalInt;
-import java.util.function.Predicate;
 
 public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternative<Api> {
 
@@ -37,6 +36,12 @@ public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternati
     @Override
     public boolean existsById(String id) {
         return storage.stream().anyMatch(api -> id.equals(api.getId()));
+    }
+
+    @Override
+    public Api create(Api api) {
+        storage.add(api);
+        return api;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
@@ -22,10 +22,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlternative<Flow> {
 
+    final Map<String, List<Flow>> apiFlows = new HashMap<>();
     final Map<String, List<Flow>> planFlows = new HashMap<>();
+
+    @Override
+    public List<Flow> saveApiFlows(String apiId, List<Flow> flows) {
+        apiFlows.put(apiId, flows);
+        return flows;
+    }
 
     @Override
     public List<Flow> savePlanFlows(String planId, List<Flow> flows) {
@@ -46,13 +54,12 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
     @Override
     public List<Flow> storage() {
         return Collections.unmodifiableList(
-            planFlows
-                .values()
-                .stream()
+            Stream
+                .concat(planFlows.values().stream(), apiFlows.values().stream())
                 .reduce(
                     new ArrayList<>(),
-                    (acc, flows) -> {
-                        acc.addAll(flows);
+                    (acc, flow) -> {
+                        acc.addAll(flow);
                         return acc;
                     }
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipQueryServiceInMemory.java
@@ -63,6 +63,11 @@ public class MembershipQueryServiceInMemory implements MembershipQueryService, I
     }
 
     @Override
+    public Collection<Membership> findGroupsThatUserBelongsTo(String userId) {
+        return storage.stream().filter(membership -> membership.isGroupUser() && membership.getMemberId().equals(userId)).toList();
+    }
+
+    @Override
     public void initWith(List<Membership> items) {
         storage.addAll(items);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MetadataCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MetadataCrudServiceInMemory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MetadataCrudServiceInMemory implements MetadataCrudService, InMemoryAlternative<Metadata> {
+
+    final ArrayList<Metadata> storage = new ArrayList<>();
+
+    @Override
+    public Metadata create(Metadata entity) {
+        storage.add(entity);
+        return entity;
+    }
+
+    @Override
+    public void initWith(List<Metadata> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Metadata> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/NotificationConfigCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/NotificationConfigCrudServiceInMemory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationConfigCrudServiceInMemory implements NotificationConfigCrudService, InMemoryAlternative<NotificationConfig> {
+
+    final ArrayList<NotificationConfig> storage = new ArrayList<>();
+
+    @Override
+    public NotificationConfig create(NotificationConfig entity) {
+        storage.add(entity);
+        return entity;
+    }
+
+    @Override
+    public void initWith(List<NotificationConfig> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<NotificationConfig> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersQueryServiceInMemory.java
@@ -38,6 +38,16 @@ public class ParametersQueryServiceInMemory implements ParametersQueryService, I
     }
 
     @Override
+    public String findAsString(Key key, ParameterContext context) {
+        return parameters
+            .stream()
+            .filter(parameter -> key.equals(Key.findByKey(parameter.getKey())))
+            .map(Parameter::getValue)
+            .findFirst()
+            .orElse(null);
+    }
+
+    @Override
     public void initWith(List<Parameter> items) {
         parameters.clear();
         parameters.addAll(items);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersQueryServiceInMemory.java
@@ -53,6 +53,10 @@ public class ParametersQueryServiceInMemory implements ParametersQueryService, I
         parameters.addAll(items);
     }
 
+    public void define(Parameter entity) {
+        parameters.add(entity);
+    }
+
     @Override
     public void reset() {
         parameters.clear();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/RoleQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/RoleQueryServiceInMemory.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.ReferenceContext;
+import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/WorkflowCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/WorkflowCrudServiceInMemory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WorkflowCrudServiceInMemory implements WorkflowCrudService, InMemoryAlternative<Workflow> {
+
+    final ArrayList<Workflow> storage = new ArrayList<>();
+
+    @Override
+    public Workflow create(Workflow entity) {
+        storage.add(entity);
+        return entity;
+    }
+
+    @Override
+    public void initWith(List<Workflow> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Workflow> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDecoderDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDecoderDomainServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiMetadataQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.ApiMetadataDecodeContext;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.PrimaryOwnerMetadataDecodeContext;
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.rest.api.model.MetadataFormat;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiMetadataDecoderDomainServiceTest {
+
+    private static final String API_ID = "api-id";
+
+    private static final ApiMetadataDecodeContext CONTEXT = ApiMetadataDecodeContext
+        .builder()
+        .name("My Api")
+        .description("api-description")
+        .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+        .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+        .primaryOwner(
+            PrimaryOwnerMetadataDecodeContext.builder().displayName("Jane Doe").email("jane.doe@gravitee.io").type("USER").build()
+        )
+        .build();
+
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory();
+
+    ApiMetadataDecoderDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiMetadataDecoderDomainService(apiMetadataQueryService, new FreemarkerTemplateProcessor());
+    }
+
+    @Test
+    public void should_return_simple_metadata() {
+        // Given
+        givenExistingApiMetadata(
+            List.of(
+                ApiMetadata.builder().apiId(API_ID).key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                ApiMetadata.builder().apiId(API_ID).key("key2").value("true").format(MetadataFormat.BOOLEAN).build()
+            )
+        );
+
+        // When
+        var result = service.decodeMetadata(API_ID, CONTEXT);
+
+        // Then
+        assertThat(result).isEqualTo(Map.of("key1", "value1", "key2", "true"));
+    }
+
+    @Test
+    public void should_filter_metadata_with_null_value() {
+        // Given
+        givenExistingApiMetadata(
+            List.of(
+                ApiMetadata.builder().apiId(API_ID).key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                ApiMetadata.builder().apiId(API_ID).key("null_key").value(null).format(MetadataFormat.STRING).build()
+            )
+        );
+
+        // When
+        var result = service.decodeMetadata(API_ID, CONTEXT);
+
+        // Then
+        assertThat(result).isEqualTo(Map.of("key1", "value1"));
+    }
+
+    @Test
+    public void should_decode_metadata_having_el() {
+        // Given
+        givenExistingApiMetadata(
+            List.of(
+                ApiMetadata.builder().apiId(API_ID).key("apiName").value("${(api.name)!''}").format(MetadataFormat.STRING).build(),
+                ApiMetadata
+                    .builder()
+                    .apiId(API_ID)
+                    .key("apiDescription")
+                    .value("${(api.description)!''}")
+                    .format(MetadataFormat.STRING)
+                    .build(),
+                ApiMetadata
+                    .builder()
+                    .apiId(API_ID)
+                    .key("ownerName")
+                    .value("${(api.primaryOwner.displayName)!''}")
+                    .format(MetadataFormat.STRING)
+                    .build(),
+                ApiMetadata
+                    .builder()
+                    .apiId(API_ID)
+                    .key("email-support")
+                    .value("${(api.primaryOwner.email)!''}")
+                    .format(MetadataFormat.STRING)
+                    .build()
+            )
+        );
+
+        // When
+        var result = service.decodeMetadata(API_ID, CONTEXT);
+
+        // Then
+        assertThat(result)
+            .isEqualTo(
+                Map.ofEntries(
+                    Map.entry("apiName", "My Api"),
+                    Map.entry("apiDescription", "api-description"),
+                    Map.entry("ownerName", "Jane Doe"),
+                    Map.entry("email-support", "jane.doe@gravitee.io")
+                )
+            );
+    }
+
+    @Test
+    public void should_return_raw_metadata_when_one_of_them_has_invalid_el() {
+        // Given
+        givenExistingApiMetadata(
+            List.of(
+                ApiMetadata.builder().apiId(API_ID).key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                ApiMetadata.builder().apiId(API_ID).key("apiVersion").value("${api.version}").format(MetadataFormat.STRING).build()
+            )
+        );
+
+        // When
+        var result = service.decodeMetadata(API_ID, CONTEXT);
+
+        // Then
+        assertThat(result).isEqualTo(Map.ofEntries(Map.entry("key1", "value1"), Map.entry("apiVersion", "${api.version}")));
+    }
+
+    private void givenExistingApiMetadata(List<ApiMetadata> metadata) {
+        apiMetadataQueryService.initWith(metadata);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiMetadataDomainServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.datetime.TimeProvider;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.impl.upgrade.initializer.DefaultMetadataInitializer;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiMetadataDomainServiceTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String API_ID = "my-api";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+
+    ApiMetadataDomainService service;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ApiMetadataDomainService(
+                metadataCrudService,
+                new AuditDomainService(auditCrudService, new UserCrudServiceInMemory(), new JacksonJsonDiffProcessor())
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(metadataCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class CreateDefaultApiMetadata {
+
+        @Test
+        void should_create_email_support_metadata() {
+            service.createDefaultApiMetadata(API_ID, AUDIT_INFO);
+
+            Assertions
+                .assertThat(metadataCrudService.storage())
+                .contains(
+                    Metadata
+                        .builder()
+                        .key("email-support")
+                        .format(Metadata.MetadataFormat.MAIL)
+                        .name(DefaultMetadataInitializer.METADATA_EMAIL_SUPPORT_KEY)
+                        .value("${(api.primaryOwner.email)!''}")
+                        .referenceType(Metadata.ReferenceType.API)
+                        .referenceId(API_ID)
+                        .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                        .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                        .build()
+                );
+        }
+
+        @Test
+        void should_create_an_audit() {
+            service.createDefaultApiMetadata(API_ID, AUDIT_INFO);
+
+            assertThat(auditCrudService.storage())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+                .containsExactly(
+                    AuditEntity
+                        .builder()
+                        .id("generated-id")
+                        .organizationId(ORGANIZATION_ID)
+                        .environmentId(ENVIRONMENT_ID)
+                        .referenceType(AuditEntity.AuditReferenceType.API)
+                        .referenceId(API_ID)
+                        .user(USER_ID)
+                        .properties(Map.of("METADATA", "email-support"))
+                        .event(ApiAuditEvent.METADATA_CREATED.name())
+                        .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                        .build()
+                );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainServiceTest.java
@@ -1,0 +1,526 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.definition.ApiDefinitionFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.IndexerInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.NotificationConfigCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import inmemory.WorkflowCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.core.datetime.TimeProvider;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.impl.NotifierServiceImpl;
+import io.gravitee.rest.api.service.impl.upgrade.initializer.DefaultMetadataInitializer;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class CreateApiDomainServiceTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String API_ID = "my-api";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String GROUP_ID = "group-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    ValidateApiDomainService validateApiDomainService;
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
+    ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
+    IndexerInMemory indexer = new IndexerInMemory();
+
+    CreateApiDomainServiceImpl service;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        validateApiDomainService = mock(ValidateApiDomainService.class);
+
+        var metadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
+        var membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+
+        service =
+            new CreateApiDomainServiceImpl(
+                validateApiDomainService,
+                apiCrudService,
+                auditService,
+                new ApiIndexerDomainService(
+                    new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                    indexer
+                ),
+                new ApiMetadataDomainService(metadataCrudService, auditService),
+                new ApiPrimaryOwnerFactory(
+                    groupQueryService,
+                    membershipQueryService,
+                    parametersQueryService,
+                    roleQueryService,
+                    userCrudService
+                ),
+                new ApiPrimaryOwnerDomainService(
+                    auditService,
+                    groupQueryService,
+                    membershipCrudService,
+                    membershipQueryService,
+                    roleQueryService,
+                    userCrudService
+                ),
+                flowCrudService,
+                notificationConfigCrudService,
+                parametersQueryService,
+                workflowCrudService
+            );
+
+        when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode.USER);
+        roleQueryService.resetSystemRoles(ORGANIZATION_ID);
+        givenExistingUsers(
+            List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(
+                apiCrudService,
+                auditCrudService,
+                flowCrudService,
+                groupQueryService,
+                membershipCrudService,
+                metadataCrudService,
+                notificationConfigCrudService,
+                parametersQueryService,
+                userCrudService,
+                workflowCrudService
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_throw_when_api_is_invalid() {
+        // Given
+        when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any()))
+            .thenThrow(new ValidationDomainException("Definition version is unsupported, should be V4 or higher"));
+        var api = ApiFixtures.aProxyApiV4().toBuilder().definitionVersion(DefinitionVersion.V2).build();
+
+        // When
+        var throwable = catchThrowable(() -> service.create(api, AUDIT_INFO));
+
+        // Then
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+    }
+
+    @Test
+    void should_create_api() {
+        // Given
+        var api = ApiFixtures.aProxyApiV4();
+
+        // When
+        var createdApi = service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(apiCrudService.storage()).contains(createdApi.toApi());
+    }
+
+    @Test
+    void should_create_an_audit() {
+        // Given
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+            .containsExactly(
+                // API Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(API_ID)
+                    .user(USER_ID)
+                    .properties(Collections.emptyMap())
+                    .event(ApiAuditEvent.API_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build(),
+                // Membership Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(API_ID)
+                    .user(USER_ID)
+                    .properties(Map.of("USER", USER_ID))
+                    .event(MembershipAuditEvent.MEMBERSHIP_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build(),
+                // Metadata Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(API_ID)
+                    .user(USER_ID)
+                    .properties(Map.of("METADATA", "email-support"))
+                    .event(ApiAuditEvent.METADATA_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ApiPrimaryOwnerMode.class, mode = EnumSource.Mode.INCLUDE, names = { "USER", "HYBRID" })
+    void should_create_primary_owner_membership_when_user_or_hybrid_mode_is_enabled(ApiPrimaryOwnerMode mode) {
+        // Given
+        enableApiPrimaryOwnerMode(mode);
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(membershipCrudService.storage())
+            .contains(
+                Membership
+                    .builder()
+                    .id("generated-id")
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceId(API_ID)
+                    .referenceType(Membership.ReferenceType.API)
+                    .source("system")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_primary_owner_membership_when_group_mode_is_enabled() {
+        // Given
+        enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode.GROUP);
+        givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").apiPrimaryOwner(USER_ID).build()));
+        givenExistingMemberships(
+            List.of(
+                Membership
+                    .builder()
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(GROUP_ID)
+                    .memberType(Membership.Type.USER)
+                    .memberId(USER_ID)
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .build()
+            )
+        );
+
+        var api = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault())).build();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(membershipCrudService.storage())
+            .contains(
+                Membership
+                    .builder()
+                    .id("generated-id")
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .memberId(GROUP_ID)
+                    .memberType(Membership.Type.GROUP)
+                    .referenceId(API_ID)
+                    .referenceType(Membership.ReferenceType.API)
+                    .source("system")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_default_email_notification_configuration() {
+        // Given
+        var api = ApiFixtures.aProxyApiV4();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(notificationConfigCrudService.storage())
+            .containsExactly(
+                NotificationConfig
+                    .builder()
+                    .id("generated-id")
+                    .type(NotificationConfig.Type.GENERIC)
+                    .name("Default Mail Notifications")
+                    .referenceType("API")
+                    .referenceId(API_ID)
+                    .hooks(
+                        List.of(
+                            "APIKEY_EXPIRED",
+                            "APIKEY_RENEWED",
+                            "APIKEY_REVOKED",
+                            "API_DEPLOYED",
+                            "API_DEPRECATED",
+                            "API_STARTED",
+                            "API_STOPPED",
+                            "API_UPDATED",
+                            "ASK_FOR_REVIEW",
+                            "MESSAGE",
+                            "NEW_RATING",
+                            "NEW_RATING_ANSWER",
+                            "NEW_SUPPORT_TICKET",
+                            "REQUEST_FOR_CHANGES",
+                            "REVIEW_OK",
+                            "SUBSCRIPTION_ACCEPTED",
+                            "SUBSCRIPTION_CLOSED",
+                            "SUBSCRIPTION_NEW",
+                            "SUBSCRIPTION_PAUSED",
+                            "SUBSCRIPTION_REJECTED",
+                            "SUBSCRIPTION_RESUMED",
+                            "SUBSCRIPTION_TRANSFERRED"
+                        )
+                    )
+                    .notifier(NotifierServiceImpl.DEFAULT_EMAIL_NOTIFIER_ID)
+                    .config("${(api.primaryOwner.email)!''}")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_default_api_metadata() {
+        // Given
+        var api = ApiFixtures.aProxyApiV4();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(metadataCrudService.storage())
+            .containsExactly(
+                Metadata
+                    .builder()
+                    .key("email-support")
+                    .format(Metadata.MetadataFormat.MAIL)
+                    .name(DefaultMetadataInitializer.METADATA_EMAIL_SUPPORT_KEY)
+                    .value("${(api.primaryOwner.email)!''}")
+                    .referenceType(Metadata.ReferenceType.API)
+                    .referenceId(API_ID)
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_save_all_flows() {
+        // Given
+        var flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
+        var api = ApiFixtures
+            .aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionV4(ApiDefinitionFixtures.aHttpProxyApiV4(API_ID).toBuilder().flows(flows).build())
+            .build();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(flowCrudService.storage()).containsExactlyElementsOf(flows);
+    }
+
+    @Test
+    void should_index_the_created_api() {
+        // Given
+        var api = ApiFixtures.aProxyApiV4();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(indexer.storage())
+            .containsExactly(
+                new IndexableApi(
+                    api,
+                    new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
+                    Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io"))
+                )
+            );
+    }
+
+    @Test
+    void should_return_the_api_with_it_flows() {
+        // Given
+        var flows = List.of(Flow.builder().name("a flow").selectors(List.of(new HttpSelector())).build());
+        var api = ApiFixtures
+            .aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionV4(ApiDefinitionFixtures.aHttpProxyApiV4(API_ID).toBuilder().flows(flows).build())
+            .build();
+
+        // When
+        var result = service.create(api, AUDIT_INFO);
+
+        // Then
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.toApi()).isEqualTo(api);
+            soft.assertThat(result.getFlows()).isEqualTo(flows);
+        });
+    }
+
+    @Test
+    void should_create_an_api_review_workflow_when_api_review_is_enabled() {
+        // Given
+        enableApiReview();
+        var api = ApiFixtures.aProxyApiV4();
+
+        // When
+        service.create(api, AUDIT_INFO);
+
+        // Then
+        assertThat(workflowCrudService.storage())
+            .contains(
+                Workflow
+                    .builder()
+                    .id("generated-id")
+                    .referenceType(Workflow.ReferenceType.API)
+                    .referenceId(API_ID)
+                    .type(Workflow.Type.REVIEW)
+                    .state(Workflow.State.DRAFT)
+                    .user(USER_ID)
+                    .comment("")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    private void enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode mode) {
+        parametersQueryService.initWith(
+            List.of(new Parameter(Key.API_PRIMARY_OWNER_MODE.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, mode.name()))
+        );
+    }
+
+    private void enableApiReview() {
+        parametersQueryService.define(
+            new Parameter(Key.API_REVIEW_ENABLED.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, "true")
+        );
+    }
+
+    private void givenExistingUsers(List<BaseUserEntity> users) {
+        userCrudService.initWith(users);
+    }
+
+    private void givenExistingMemberships(List<Membership> memberships) {
+        membershipCrudService.initWith(memberships);
+    }
+
+    private void givenExistingGroup(List<Group> groups) {
+        groupQueryService.initWith(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerDomainServiceTest.java
@@ -15,50 +15,97 @@
  */
 package io.gravitee.apim.core.membership.domain_service;
 
+import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.RoleFixtures;
+import inmemory.AuditCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.InMemoryAlternative;
+import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.core.audit.model.event.PlanAuditEvent;
+import io.gravitee.apim.core.datetime.TimeProvider;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ApiPrimaryOwnerDomainServiceTest {
 
-    public static final String ORGANIZATION_ID = "DEFAULT";
-    public static final String API_PRIMARY_OWNER_ROLE_ID = "api-po-id-DEFAULT";
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String MEMBER_ID = "member-id";
+    private static final String GROUP_ID = "group-id";
+    private static final String USER_ID = "user-id";
+    private static final String API_ID = "my-api";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
 
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
     GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
-    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
 
     ApiPrimaryOwnerDomainService service;
 
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
     @BeforeEach
     void setUp() {
-        service = new ApiPrimaryOwnerDomainService(groupQueryService, membershipQueryService, roleQueryService, userCrudService);
+        service =
+            new ApiPrimaryOwnerDomainService(
+                new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+                groupQueryService,
+                membershipCrudService,
+                membershipQueryService,
+                roleQueryService,
+                userCrudService
+            );
 
         roleQueryService.resetSystemRoles(ORGANIZATION_ID);
     }
 
     @AfterEach
     void tearDown() {
-        Stream.of(membershipQueryService, roleQueryService, userCrudService).forEach(InMemoryAlternative::reset);
+        Stream.of(auditCrudService, membershipCrudService, roleQueryService, userCrudService).forEach(InMemoryAlternative::reset);
     }
 
     @Nested
@@ -68,7 +115,7 @@ class ApiPrimaryOwnerDomainServiceTest {
         @SneakyThrows
         public void should_return_a_user_primary_owner_of_an_api() {
             givenExistingUsers(
-                List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+                List.of(BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
             );
             givenExistingMemberships(
                 List.of(
@@ -77,8 +124,8 @@ class ApiPrimaryOwnerDomainServiceTest {
                         .referenceType(Membership.ReferenceType.API)
                         .referenceId("api-id")
                         .memberType(Membership.Type.USER)
-                        .memberId("user-id")
-                        .roleId(API_PRIMARY_OWNER_ROLE_ID)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -90,7 +137,7 @@ class ApiPrimaryOwnerDomainServiceTest {
                 .isEqualTo(
                     PrimaryOwnerEntity
                         .builder()
-                        .id("user-id")
+                        .id(MEMBER_ID)
                         .displayName("Jane Doe")
                         .email("jane.doe@gravitee.io")
                         .type(PrimaryOwnerEntity.Type.USER)
@@ -102,9 +149,9 @@ class ApiPrimaryOwnerDomainServiceTest {
         @SneakyThrows
         public void should_return_a_group_primary_owner_of_an_api() {
             givenExistingUsers(
-                List.of(BaseUserEntity.builder().id("user-id").firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+                List.of(BaseUserEntity.builder().id(MEMBER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
             );
-            givenExistingGroup(List.of(Group.builder().id("group-id").name("Group name").build()));
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
             givenExistingMemberships(
                 List.of(
                     Membership
@@ -112,16 +159,16 @@ class ApiPrimaryOwnerDomainServiceTest {
                         .referenceType(Membership.ReferenceType.API)
                         .referenceId("api-id")
                         .memberType(Membership.Type.GROUP)
-                        .memberId("group-id")
-                        .roleId(API_PRIMARY_OWNER_ROLE_ID)
+                        .memberId(GROUP_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build(),
                     Membership
                         .builder()
                         .referenceType(Membership.ReferenceType.GROUP)
-                        .referenceId("group-id")
+                        .referenceId(GROUP_ID)
                         .memberType(Membership.Type.USER)
-                        .memberId("user-id")
-                        .roleId(API_PRIMARY_OWNER_ROLE_ID)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -133,7 +180,7 @@ class ApiPrimaryOwnerDomainServiceTest {
                 .isEqualTo(
                     PrimaryOwnerEntity
                         .builder()
-                        .id("group-id")
+                        .id(GROUP_ID)
                         .displayName("Group name")
                         .email("jane.doe@gravitee.io")
                         .type(PrimaryOwnerEntity.Type.GROUP)
@@ -144,7 +191,7 @@ class ApiPrimaryOwnerDomainServiceTest {
         @Test
         @SneakyThrows
         public void should_return_a_group_primary_owner_with_no_email_when_group_has_no_users() {
-            givenExistingGroup(List.of(Group.builder().id("group-id").name("Group name").build()));
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").build()));
             givenExistingMemberships(
                 List.of(
                     Membership
@@ -152,8 +199,8 @@ class ApiPrimaryOwnerDomainServiceTest {
                         .referenceType(Membership.ReferenceType.API)
                         .referenceId("api-id")
                         .memberType(Membership.Type.GROUP)
-                        .memberId("group-id")
-                        .roleId(API_PRIMARY_OWNER_ROLE_ID)
+                        .memberId(GROUP_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -162,9 +209,7 @@ class ApiPrimaryOwnerDomainServiceTest {
 
             Assertions
                 .assertThat(result)
-                .isEqualTo(
-                    PrimaryOwnerEntity.builder().id("group-id").displayName("Group name").type(PrimaryOwnerEntity.Type.GROUP).build()
-                );
+                .isEqualTo(PrimaryOwnerEntity.builder().id(GROUP_ID).displayName("Group name").type(PrimaryOwnerEntity.Type.GROUP).build());
         }
 
         @Test
@@ -177,8 +222,8 @@ class ApiPrimaryOwnerDomainServiceTest {
                         .referenceType(Membership.ReferenceType.API)
                         .referenceId("api-id")
                         .memberType(Membership.Type.USER)
-                        .memberId("user-id")
-                        .roleId(API_PRIMARY_OWNER_ROLE_ID)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
                         .build()
                 )
             );
@@ -186,6 +231,128 @@ class ApiPrimaryOwnerDomainServiceTest {
             Throwable throwable = catchThrowable(() -> service.getApiPrimaryOwner(ORGANIZATION_ID, "api-id"));
 
             assertThat(throwable).isInstanceOf(ApiPrimaryOwnerNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class CreateApiPrimaryOwnerMembership {
+
+        @Nested
+        class UserMode {
+
+            @Test
+            void should_create_an_user_api_primary_owner_membership() {
+                // When
+                service.createApiPrimaryOwnerMembership(
+                    API_ID,
+                    PrimaryOwnerEntity.builder().id(MEMBER_ID).type(PrimaryOwnerEntity.Type.USER).build(),
+                    AUDIT_INFO
+                );
+
+                // Then
+                assertThat(membershipCrudService.storage())
+                    .containsExactly(
+                        Membership
+                            .builder()
+                            .id("generated-id")
+                            .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                            .memberId(MEMBER_ID)
+                            .memberType(Membership.Type.USER)
+                            .referenceId(API_ID)
+                            .referenceType(Membership.ReferenceType.API)
+                            .source("system")
+                            .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+            }
+
+            @Test
+            void should_create_an_audit() {
+                // When
+                service.createApiPrimaryOwnerMembership(
+                    API_ID,
+                    PrimaryOwnerEntity.builder().id(MEMBER_ID).type(PrimaryOwnerEntity.Type.USER).build(),
+                    AUDIT_INFO
+                );
+
+                // Then
+                assertThat(auditCrudService.storage())
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+                    .containsExactly(
+                        AuditEntity
+                            .builder()
+                            .id("generated-id")
+                            .organizationId(ORGANIZATION_ID)
+                            .environmentId(ENVIRONMENT_ID)
+                            .referenceType(AuditEntity.AuditReferenceType.API)
+                            .referenceId(API_ID)
+                            .user(USER_ID)
+                            .properties(Map.of("USER", MEMBER_ID))
+                            .event(MembershipAuditEvent.MEMBERSHIP_CREATED.name())
+                            .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+            }
+        }
+
+        @Nested
+        class GroupMode {
+
+            @Test
+            void should_create_a_group_api_primary_owner_membership() {
+                // When
+                service.createApiPrimaryOwnerMembership(
+                    API_ID,
+                    PrimaryOwnerEntity.builder().id(GROUP_ID).type(PrimaryOwnerEntity.Type.GROUP).build(),
+                    AUDIT_INFO
+                );
+
+                // Then
+                assertThat(membershipCrudService.storage())
+                    .containsExactly(
+                        Membership
+                            .builder()
+                            .id("generated-id")
+                            .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                            .memberId(GROUP_ID)
+                            .memberType(Membership.Type.GROUP)
+                            .referenceId(API_ID)
+                            .referenceType(Membership.ReferenceType.API)
+                            .source("system")
+                            .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+            }
+
+            @Test
+            void should_create_an_audit() {
+                // When
+                service.createApiPrimaryOwnerMembership(
+                    API_ID,
+                    PrimaryOwnerEntity.builder().id(GROUP_ID).type(PrimaryOwnerEntity.Type.GROUP).build(),
+                    AUDIT_INFO
+                );
+
+                // Then
+                assertThat(auditCrudService.storage())
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+                    .containsExactly(
+                        AuditEntity
+                            .builder()
+                            .id("generated-id")
+                            .organizationId(ORGANIZATION_ID)
+                            .environmentId(ENVIRONMENT_ID)
+                            .referenceType(AuditEntity.AuditReferenceType.API)
+                            .referenceId(API_ID)
+                            .user(USER_ID)
+                            .properties(Map.of("GROUP", GROUP_ID))
+                            .event(MembershipAuditEvent.MEMBERSHIP_CREATED.name())
+                            .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerFactoryTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.membership.exception.NoPrimaryOwnerGroupForUserException;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiPrimaryOwnerFactoryTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String MEMBER_ID = "member-id";
+    private static final String USER_ID = "user-id";
+    private static final String GROUP_ID = "group-id";
+
+    GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+
+    ApiPrimaryOwnerFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory =
+            new ApiPrimaryOwnerFactory(
+                groupQueryService,
+                membershipQueryService,
+                parametersQueryService,
+                roleQueryService,
+                userCrudService
+            );
+    }
+
+    @Nested
+    class UserMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.USER.name()
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_build_an_user_primary_owner() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+
+            var primaryOwner = factory.createForNewApi(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            assertThat(primaryOwner)
+                .isEqualTo(new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER));
+        }
+    }
+
+    @Nested
+    class GroupMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.GROUP.name()
+                    )
+                )
+            );
+            roleQueryService.resetSystemRoles(ORGANIZATION_ID);
+            givenExistingUsers(
+                List.of(
+                    BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build(),
+                    BaseUserEntity.builder().id(MEMBER_ID).firstname("John").lastname("Doe").email("john.doe@gravitee.io").build()
+                )
+            );
+        }
+
+        @Test
+        void should_build_a_group_primary_owner_with_the_1st_group_having_primary_owner() {
+            // Given
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingMemberships(
+                List.of(
+                    // PO role for member-id
+                    Membership
+                        .builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .build(),
+                    // Regular role for user-id
+                    Membership
+                        .builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            var primaryOwner = factory.createForNewApi(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            // Then
+            assertThat(primaryOwner)
+                .isEqualTo(new PrimaryOwnerEntity(GROUP_ID, "john.doe@gravitee.io", "My Group", PrimaryOwnerEntity.Type.GROUP));
+        }
+
+        @Test
+        void should_throw_when_user_does_not_belong_to_a_group_having_primary_owner() {
+            // Given
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").build()));
+            givenExistingMemberships(
+                List.of(
+                    Membership
+                        .builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            Throwable throwable = catchThrowable(() -> factory.createForNewApi(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+            // Then
+            assertThat(throwable).isInstanceOf(NoPrimaryOwnerGroupForUserException.class);
+        }
+
+        @Test
+        void should_throw_when_primary_owner_role_does_not_exist_for_organization() {
+            // Given
+            roleQueryService.reset();
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingMemberships(
+                List.of(
+                    // PO role for member-id
+                    Membership
+                        .builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .build(),
+                    // Regular role for user-id
+                    Membership
+                        .builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            Throwable throwable = catchThrowable(() -> factory.createForNewApi(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+            // Then
+            assertThat(throwable).isInstanceOf(RoleNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class HybridMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.HYBRID.name()
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_build_an_user_primary_owner() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+
+            var primaryOwner = factory.createForNewApi(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            assertThat(primaryOwner)
+                .isEqualTo(new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER));
+        }
+    }
+
+    private void givenExistingUsers(List<BaseUserEntity> users) {
+        userCrudService.initWith(users);
+    }
+
+    private void givenExistingMemberships(List<Membership> memberships) {
+        membershipQueryService.initWith(memberships);
+    }
+
+    private void givenExistingGroup(List<Group> groups) {
+        groupQueryService.initWith(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
@@ -18,27 +18,51 @@ package io.gravitee.apim.infra.crud_service.flow;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.datetime.TimeProvider;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.FlowRepository;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class FlowCrudServiceImplTest {
 
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    public static final String API_ID = "api-id";
     public static final String PLAN_ID = "plan-id";
     FlowRepository flowRepository;
 
     FlowCrudServiceImpl service;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
 
     @BeforeEach
     void setUp() {
@@ -48,7 +72,82 @@ class FlowCrudServiceImplTest {
     }
 
     @Nested
-    class Save {
+    class SaveApiFlows {
+
+        @Test
+        @SneakyThrows
+        void should_delete_existing_flows() {
+            // Given
+
+            // When
+            service.saveApiFlows(API_ID, List.of(Flow.builder().build()));
+
+            // Then
+            verify(flowRepository).deleteByReference(FlowReferenceType.API, API_ID);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_save_flows() {
+            // Given
+            var flows = List.of(Flow.builder().name("My flow").enabled(true).build());
+
+            // When
+            service.saveApiFlows(API_ID, flows);
+
+            // Then
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.flow.Flow.class);
+            verify(flowRepository).create(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.flow.Flow
+                        .builder()
+                        .referenceType(FlowReferenceType.API)
+                        .referenceId(API_ID)
+                        .order(0)
+                        .id("generated-id")
+                        .enabled(true)
+                        .name("My flow")
+                        .createdAt(Date.from(INSTANT_NOW))
+                        .updatedAt(Date.from(INSTANT_NOW))
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_created_flows() {
+            // Given
+            when(flowRepository.create(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
+            var flows = List.of(Flow.builder().build());
+
+            // When
+            var result = service.saveApiFlows(API_ID, flows);
+
+            // Then
+            assertThat(result).isEqualTo(flows);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            // Given
+            when(flowRepository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.saveApiFlows(API_ID, List.of(Flow.builder().build())));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to save flows for API: api-id");
+        }
+    }
+
+    @Nested
+    class SavePlanFlows {
 
         @Test
         @SneakyThrows
@@ -65,6 +164,36 @@ class FlowCrudServiceImplTest {
         @Test
         @SneakyThrows
         void should_save_flows() {
+            // Given
+            var flows = List.of(Flow.builder().name("My flow").enabled(true).build());
+
+            // When
+            service.savePlanFlows(PLAN_ID, flows);
+
+            // Then
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.flow.Flow.class);
+            verify(flowRepository).create(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.flow.Flow
+                        .builder()
+                        .referenceType(FlowReferenceType.PLAN)
+                        .referenceId(PLAN_ID)
+                        .order(0)
+                        .id("generated-id")
+                        .enabled(true)
+                        .name("My flow")
+                        .createdAt(Date.from(INSTANT_NOW))
+                        .updatedAt(Date.from(INSTANT_NOW))
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_created_flows() {
             // Given
             when(flowRepository.create(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArgument(0));
             var flows = List.of(Flow.builder().build());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImplTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.MetadataFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.MetadataRepository;
+import io.gravitee.repository.management.model.MetadataFormat;
+import java.time.Instant;
+import java.util.Date;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class MetadataCrudServiceImplTest {
+
+    MetadataRepository metadataRepository;
+
+    MetadataCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        metadataRepository = mock(MetadataRepository.class);
+
+        service = new MetadataCrudServiceImpl(metadataRepository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_metadata() {
+            var metadata = MetadataFixtures.anApiMetadata("api-id");
+            service.create(metadata);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.Metadata.class);
+            verify(metadataRepository).create(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.Metadata
+                        .builder()
+                        .referenceType(io.gravitee.repository.management.model.MetadataReferenceType.API)
+                        .referenceId("api-id")
+                        .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                        .key("my-key")
+                        .format(MetadataFormat.MAIL)
+                        .value("my-value")
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_created_metadata() {
+            when(metadataRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var toCreate = MetadataFixtures.anApiMetadata();
+            var result = service.create(toCreate);
+
+            assertThat(result).isEqualTo(toCreate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(metadataRepository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.create(MetadataFixtures.anApiMetadata()));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to create the my-key metadata of [apiId=api-id]");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/notification/NotificationConfigCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/notification/NotificationConfigCrudServiceImplTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
+import io.gravitee.repository.management.model.GenericNotificationConfig;
+import io.gravitee.repository.management.model.NotificationReferenceType;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class NotificationConfigCrudServiceImplTest {
+
+    GenericNotificationConfigRepository notificationConfigRepository;
+
+    NotificationConfigCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        notificationConfigRepository = mock(GenericNotificationConfigRepository.class);
+
+        service = new NotificationConfigCrudServiceImpl(notificationConfigRepository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_config() {
+            var config = aNotificationConfig();
+            service.create(config);
+
+            var captor = ArgumentCaptor.forClass(GenericNotificationConfig.class);
+            verify(notificationConfigRepository).create(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.GenericNotificationConfig
+                        .builder()
+                        .id("config-id")
+                        .name("Default Mail Notifications")
+                        .notifier("default-email")
+                        .config("${(api.primaryOwner.email)!''}")
+                        .hooks(List.of("hook1"))
+                        .referenceType(NotificationReferenceType.API)
+                        .referenceId("api-id")
+                        .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_created_configuration() {
+            when(notificationConfigRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var toCreate = aNotificationConfig();
+            var result = service.create(toCreate);
+
+            assertThat(result).isEqualTo(toCreate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(notificationConfigRepository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.create(aNotificationConfig()));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to create the API notification config of api-id");
+        }
+    }
+
+    private static NotificationConfig aNotificationConfig() {
+        return NotificationConfig
+            .defaultMailNotificationConfigFor("api-id")
+            .toBuilder()
+            .id("config-id")
+            .hooks(List.of("hook1"))
+            .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/workflow/WorkflowCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/workflow/WorkflowCrudServiceImplTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.workflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.WorkflowRepository;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class WorkflowCrudServiceImplTest {
+
+    WorkflowRepository workflowRepository;
+
+    WorkflowCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        workflowRepository = mock(WorkflowRepository.class);
+
+        service = new WorkflowCrudServiceImpl(workflowRepository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_workflow() {
+            var config = aWorkflow();
+            service.create(config);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.Workflow.class);
+            verify(workflowRepository).create(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.Workflow
+                        .builder()
+                        .id("workflow-id")
+                        .referenceType("API")
+                        .referenceId("api-id")
+                        .type("REVIEW")
+                        .state("DRAFT")
+                        .user("user-id")
+                        .comment("my-comment")
+                        .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_created_workflow() {
+            when(workflowRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var toCreate = aWorkflow();
+            var result = service.create(toCreate);
+
+            assertThat(result).isEqualTo(toCreate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(workflowRepository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.create(aWorkflow()));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to create the REVIEW workflow of [apiId=api-id]");
+        }
+    }
+
+    private static Workflow aWorkflow() {
+        return Workflow
+            .builder()
+            .id("workflow-id")
+            .referenceType(Workflow.ReferenceType.API)
+            .referenceId("api-id")
+            .type(Workflow.Type.REVIEW)
+            .state(Workflow.State.DRAFT)
+            .user("user-id")
+            .comment("my-comment")
+            .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
@@ -222,9 +222,15 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                 anApi().withId(API_ID),
                 PrimaryOwnerEntity.builder().id(USER_ID).build(),
                 List.of(
-                    ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
+                    ApiMetadata.builder().apiId(API_ID).key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                    ApiMetadata.builder().apiId(API_ID).key("null_key").value(null).format(MetadataFormat.STRING).build(),
+                    ApiMetadata
+                        .builder()
+                        .apiId(API_ID)
+                        .key("email-support")
+                        .value("${(api.primaryOwner.email)!''}")
+                        .format(MetadataFormat.STRING)
+                        .build()
                 )
             );
 
@@ -623,9 +629,15 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                 anApi().withId(API_ID),
                 PrimaryOwnerEntity.builder().id(USER_ID).build(),
                 List.of(
-                    ApiMetadata.builder().key("key1").value("value1").format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("null_key").value(null).format(MetadataFormat.STRING).build(),
-                    ApiMetadata.builder().key("email-support").value("${(api.primaryOwner.email)!''}").format(MetadataFormat.STRING).build()
+                    ApiMetadata.builder().apiId(API_ID).key("key1").value("value1").format(MetadataFormat.STRING).build(),
+                    ApiMetadata.builder().apiId(API_ID).key("null_key").value(null).format(MetadataFormat.STRING).build(),
+                    ApiMetadata
+                        .builder()
+                        .apiId(API_ID)
+                        .key("email-support")
+                        .value("${(api.primaryOwner.email)!''}")
+                        .format(MetadataFormat.STRING)
+                        .build()
                 )
             );
 
@@ -908,7 +920,7 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
 
         membershipCrudService.initWith(List.of(anApiPrimaryOwnerUserMembership(API_ID, primaryOwnerEntity.id(), ORGANIZATION_ID)));
 
-        apiMetadataQueryService.initWith(List.of(Map.entry(api.getId(), metadata)));
+        apiMetadataQueryService.initWith(metadata);
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
@@ -32,6 +32,7 @@ import inmemory.MembershipCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
@@ -148,8 +149,7 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                         roleQueryService,
                         userCrudService
                     ),
-                    apiMetadataQueryService,
-                    new FreemarkerTemplateProcessor()
+                    new ApiMetadataDecoderDomainService(apiMetadataQueryService, new FreemarkerTemplateProcessor())
                 )
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
@@ -42,6 +42,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ApiMetadataQueryServiceImplTest {
 
+    private static final String API_ID = "api-id";
+
     @Mock
     MetadataRepository metadataRepository;
 
@@ -59,7 +61,7 @@ public class ApiMetadataQueryServiceImplTest {
         void should_return_api_metadata() {
             // given
             givenExistingApiMetadata(
-                "api-id",
+                API_ID,
                 List.of(
                     Metadata
                         .builder()
@@ -75,7 +77,7 @@ public class ApiMetadataQueryServiceImplTest {
             );
 
             // when
-            var result = service.findApiMetadata("api-id");
+            var result = service.findApiMetadata(API_ID);
 
             // then
             Assertions
@@ -83,11 +85,11 @@ public class ApiMetadataQueryServiceImplTest {
                 .hasSize(2)
                 .containsEntry(
                     "team-contact",
-                    ApiMetadata.builder().key("team-contact").value("team@gravitee.io").format(MetadataFormat.MAIL).build()
+                    ApiMetadata.builder().apiId(API_ID).key("team-contact").value("team@gravitee.io").format(MetadataFormat.MAIL).build()
                 )
                 .containsEntry(
                     "homepage",
-                    ApiMetadata.builder().key("homepage").value("https://gravitee.io").format(MetadataFormat.URL).build()
+                    ApiMetadata.builder().apiId(API_ID).key("homepage").value("https://gravitee.io").format(MetadataFormat.URL).build()
                 );
         }
 
@@ -105,7 +107,7 @@ public class ApiMetadataQueryServiceImplTest {
                 )
             );
             givenExistingApiMetadata(
-                "api-id",
+                API_ID,
                 List.of(
                     Metadata
                         .builder()
@@ -121,7 +123,7 @@ public class ApiMetadataQueryServiceImplTest {
             );
 
             // when
-            var result = service.findApiMetadata("api-id");
+            var result = service.findApiMetadata(API_ID);
 
             // then
             Assertions
@@ -139,7 +141,7 @@ public class ApiMetadataQueryServiceImplTest {
                 )
                 .containsEntry(
                     "homepage",
-                    ApiMetadata.builder().key("homepage").value("https://gravitee.io").format(MetadataFormat.URL).build()
+                    ApiMetadata.builder().apiId(API_ID).key("homepage").value("https://gravitee.io").format(MetadataFormat.URL).build()
                 )
                 .containsEntry("brand", ApiMetadata.builder().key("brand").defaultValue("Gravitee").format(MetadataFormat.STRING).build());
         }
@@ -148,7 +150,7 @@ public class ApiMetadataQueryServiceImplTest {
         public void should_throw_when_fail_to_fetch_api_metadata() {
             givenApiMetadataFailToBeFetched("technical exception");
 
-            Throwable throwable = catchThrowable(() -> service.findApiMetadata("api-id"));
+            Throwable throwable = catchThrowable(() -> service.findApiMetadata(API_ID));
 
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }
@@ -157,7 +159,7 @@ public class ApiMetadataQueryServiceImplTest {
         public void should_throw_when_fail_to_fetch_default_metadata() {
             givenDefaultMetadataFailToBeFetched("technical exception");
 
-            Throwable throwable = catchThrowable(() -> service.findApiMetadata("api-id"));
+            Throwable throwable = catchThrowable(() -> service.findApiMetadata(API_ID));
 
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImplTest.java
@@ -226,4 +226,73 @@ class MembershipQueryServiceImplTest {
                 .hasMessage("An error occurs while trying to find API membership");
         }
     }
+
+    @Nested
+    class FindGroupsThatUserBelongsTo {
+
+        @Test
+        @SneakyThrows
+        void should_return_all_group_memberships_where_user_is_a_member() {
+            when(membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(any(), any(), any()))
+                .thenAnswer(invocation ->
+                    Set.of(
+                        Membership
+                            .builder()
+                            .referenceType(invocation.getArgument(2))
+                            .referenceId("group-1")
+                            .roleId("role-id")
+                            .id("membership-1")
+                            .memberType(io.gravitee.repository.management.model.MembershipMemberType.USER)
+                            .memberId(invocation.getArgument(0))
+                            .createdAt(Date.from(Instant.parse("2020-02-01T20:22:02.00Z")))
+                            .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
+                            .source("system")
+                            .build()
+                    )
+                );
+
+            var result = service.findGroupsThatUserBelongsTo("user-id");
+
+            assertThat(result)
+                .hasSize(1)
+                .containsExactly(
+                    io.gravitee.apim.core.membership.model.Membership
+                        .builder()
+                        .id("membership-1")
+                        .referenceType(io.gravitee.apim.core.membership.model.Membership.ReferenceType.GROUP)
+                        .referenceId("group-1")
+                        .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                        .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                        .memberId("user-id")
+                        .memberType(io.gravitee.apim.core.membership.model.Membership.Type.USER)
+                        .roleId("role-id")
+                        .source("system")
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_collection_when_no_match() {
+            when(membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(any(), any(), any())).thenAnswer(invocation -> Set.of());
+
+            var result = service.findGroupsThatUserBelongsTo("user-id");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(any(), any(), any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findGroupsThatUserBelongsTo("user-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to find Group memberships of member user-id");
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
@@ -21,9 +21,11 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
-import io.gravitee.apim.infra.spring.InfraServiceSpringConfiguration;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
@@ -52,13 +54,20 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -727,6 +736,21 @@ public class SearchEngineServiceTest {
         @Bean
         public PageCrudService pageCrudService() {
             return new PageCrudServiceInMemory();
+        }
+
+        @Bean
+        public ApiCrudServiceInMemory apiCrudService() {
+            return new ApiCrudServiceInMemory();
+        }
+
+        @Bean
+        public ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService() {
+            return mock(ApiPrimaryOwnerDomainService.class);
+        }
+
+        @Bean
+        public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService() {
+            return mock(ApiMetadataDecoderDomainService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer.FIELD_REFERENCE_ID;
+import static io.gravitee.rest.api.service.impl.search.lucene.DocumentTransformer.FIELD_REFERENCE_TYPE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_CATEGORIES_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DESCRIPTION_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ID;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_LABELS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_METADATA_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_NAME_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_ORIGIN;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_LOWERCASE;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_OWNER_MAIL;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_PATHS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TAGS_SPLIT;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.definition.model.DefinitionVersion;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.index.IndexableField;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+public class IndexableApiDocumentTransformerTest {
+
+    private static final String API_ID = "api-id";
+
+    private static final PrimaryOwnerEntity PRIMARY_OWNER = new PrimaryOwnerEntity(
+        "user-id",
+        "john.doe@gravitee.io",
+        "John Doe",
+        PrimaryOwnerEntity.Type.USER
+    );
+
+    IndexableApiDocumentTransformer cut = new IndexableApiDocumentTransformer();
+
+    @Test
+    void should_transform_id_and_type_only_when_definition_version_and_name_are_null() {
+        // Given
+        var indexable = new IndexableApi(Api.builder().id(API_ID).build(), PRIMARY_OWNER, Map.of());
+
+        // When
+        var result = cut.transform(indexable);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getFields()).hasSize(2);
+            softly.assertThat(result.getField(FIELD_ID).stringValue()).isEqualTo(API_ID);
+            softly.assertThat(result.getField(FIELD_TYPE).stringValue()).isEqualTo("api");
+        });
+    }
+
+    @Test
+    void should_transform_api_info() {
+        // Given
+        var indexable = new IndexableApi(
+            ApiFixtures.aProxyApiV4().toBuilder().labels(List.of("Label1, Label2")).categories(Set.of("Category1", "Category2")).build(),
+            PRIMARY_OWNER,
+            Map.of()
+        );
+
+        // When
+        var result = cut.transform(indexable);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            //            softly.assertThat(result.getFields()).hasSize(2);
+            softly.assertThat(result.getField(FIELD_DEFINITION_VERSION).stringValue()).isEqualTo(DefinitionVersion.V4.getLabel());
+            softly.assertThat(result.getField(FIELD_REFERENCE_TYPE).stringValue()).isEqualTo("ENVIRONMENT");
+            softly.assertThat(result.getField(FIELD_REFERENCE_ID).stringValue()).isEqualTo("environment-id");
+
+            // name
+            softly.assertThat(result.getField(FIELD_NAME).stringValue()).isEqualTo("My Api");
+            // FIELD_NAME_SORTED
+            softly.assertThat(result.getField(FIELD_NAME_LOWERCASE).stringValue()).isEqualTo("my api");
+            // FIELD_NAME_SPLIT
+
+            // description
+            softly.assertThat(result.getField(FIELD_DESCRIPTION).stringValue()).isEqualTo("api-description");
+            // FIELD_DESCRIPTION_SORTED
+            softly.assertThat(result.getField(FIELD_DESCRIPTION_LOWERCASE).stringValue()).isEqualTo("api-description");
+            // FIELD_DESCRIPTION_SPLIT
+
+            // paths
+            softly.assertThat(result.getField(FIELD_PATHS).stringValue()).isEqualTo("/http_proxy");
+            softly.assertThat(result.getField(FIELD_PATHS_SPLIT).stringValue()).isEqualTo("/http_proxy");
+            // FIELD_HOSTS
+            // FIELD_HOSTS_SPLIT
+            // FIELD_PATHS_SORTED
+
+            // labels
+            softly.assertThat(result.getField(FIELD_LABELS).stringValue()).isEqualTo("Label1, Label2");
+            softly.assertThat(result.getField(FIELD_LABELS_LOWERCASE).stringValue()).isEqualTo("label1, label2");
+            softly.assertThat(result.getField(FIELD_LABELS_SPLIT).stringValue()).isEqualTo("Label1, Label2");
+
+            // categories
+            softly
+                .assertThat(result.getFields(FIELD_CATEGORIES))
+                .extracting(IndexableField::stringValue)
+                .contains("Category1", "Category2");
+            softly
+                .assertThat(result.getFields(FIELD_CATEGORIES_SPLIT))
+                .extracting(IndexableField::stringValue)
+                .contains("Category1", "Category2");
+
+            // tags
+            softly.assertThat(result.getFields(FIELD_TAGS)).extracting(IndexableField::stringValue).contains("tag1");
+            softly.assertThat(result.getFields(FIELD_TAGS_SPLIT)).extracting(IndexableField::stringValue).contains("tag1");
+
+            // origin
+            softly.assertThat(result.getField(FIELD_ORIGIN).stringValue()).isEqualTo("management");
+        });
+    }
+
+    @Test
+    void should_transform_primary_owner_info() {
+        // Given
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of());
+
+        // When
+        var result = cut.transform(indexable);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            // owner
+            softly.assertThat(result.getField(FIELD_OWNER).stringValue()).isEqualTo("John Doe");
+            softly.assertThat(result.getField(FIELD_OWNER_LOWERCASE).stringValue()).isEqualTo("john doe");
+            softly.assertThat(result.getField(FIELD_OWNER_MAIL).stringValue()).isEqualTo("john.doe@gravitee.io");
+        });
+    }
+
+    @Test
+    void should_transform_api_metadata() {
+        // Given
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of("metadata1", "value1", "metadata2", "value2"));
+
+        // When
+        var result = cut.transform(indexable);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result.getFields(FIELD_METADATA)).extracting(IndexableField::stringValue).contains("value1", "value2");
+            softly.assertThat(result.getFields(FIELD_METADATA_SPLIT)).extracting(IndexableField::stringValue).contains("value1", "value2");
+        });
+    }
+
+    @Test
+    void should_throw_when_not_V4_api() {
+        // Given
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV2(), PRIMARY_OWNER, Map.of());
+
+        // When
+        var throwable = catchThrowable(() -> cut.transform(indexable));
+
+        // Then
+        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessage("Unsupported definition version: V2");
+    }
+}


### PR DESCRIPTION
## Issues
https://gravitee.atlassian.net/browse/APIM-3959

## Description

Extract API creation logic located in `v4.ApiServiceImpl#create`.

Currently it is not used by production code. I suggest to merge it once it is reviewed while I'm working on calling this new code when creating an API using POST request in another PR. 

⚠️ Change behavior: 
- no email is sent when we create the PrimaryOwner membership (https://graviteeio.slack.com/archives/GFJ3R39U7/p1708027779357569)
- the audit log related to the creation of the PrimaryOwner membership when the Group mode is enabled is "fixed". We now store a GROUP AuditProperties with the Group Id as a value instead of creating a property `USER` with the Group Id

## Additional context


To deal with the membership creation, two components have been introduced:
- `ApiPrimaryOwnerFactory`: This component allows us to create PrimaryOwnerEntity depending on the environment's settings (API Primary Owner mode). We have to split the creation of the entity and the database storage because we need an entity in the validation step (when the Group mode is enabled, we add the Group Primary Owner to the API's groups).
- `ApiPrimaryOwnerDomainService#createApiPrimaryOwnerMembership`: this method saves the PrimaryOwner membership in the Database and creates an AuditLog. The logic inside this method has been extracted from `MembershipServiceImpl`. It was a complicated task because the "add" method in the legacy service is handles a lot of use cases 🤯

To deal with the API Metadata creation, I have added a method `createDefaultApiMetadata` in `ApiMetadataDomainService`. It was previously an interface, and I have refactored it to a class because the new method does not rely on legacy code. Therefore, we can avoid mocking in any domain service's test using it.

To deal with API indexation, I have created an `ApiIndexerDomainService` that fetches and decodes all API metadata because they are required during the indexation. I have extracted the API metadata decoding in a dedicated domain service to share this with the Notification templates processing.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-keomurcxos.chromatic.com)
<!-- Storybook placeholder end -->
