### PR TITLE
chore: remove unnecessary override of gravitee-connector-http version

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -30,10 +30,6 @@
     <artifactId>gravitee-apim-gateway-standalone-container</artifactId>
     <name>Gravitee.io APIM - Gateway - Standalone - Container</name>
 
-    <properties>
-        <gravitee-connector-http.version>3.0.1</gravitee-connector-http.version>
-    </properties>
-
     <dependencies>
         <!-- Gravitee.io -->
         <dependency>


### PR DESCRIPTION
## Description

Should close https://github.com/gravitee-io/gravitee-api-management/pull/6662

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

