### PR TITLE
Apim 3918 clean application pages

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.html
@@ -15,22 +15,26 @@
     limitations under the License.
 
 -->
-<mat-card appearance="outlined">
-  <div class="gio-metadata">
+<mat-card class="gio-metadata">
+  <mat-card-content>
     <div class="gio-metadata__header">
-      <h2>{{ referenceType }} metadata</h2>
-      <button
-        *gioPermission="{ anyOf: [permissionPrefix + '-metadata-c'] }"
-        (click)="onAddMetadataClick()"
-        mat-raised-button
-        color="primary"
-        aria-label="add-metadata"
-        data-testid="add_metadata_button"
-      >
-        <mat-icon>add</mat-icon> Add {{ referenceType }} Metadata
-      </button>
+      <div class="gio-metadata__header__title">
+        <h3>{{ referenceType }} metadata</h3>
+        <p>{{ description }}</p>
+      </div>
+      <div class="gio-metadata__header__action">
+        <button
+          *gioPermission="{ anyOf: [permissionPrefix + '-metadata-c'] }"
+          (click)="onAddMetadataClick()"
+          mat-raised-button
+          color="primary"
+          aria-label="add-metadata"
+          data-testid="add_metadata_button"
+        >
+          <mat-icon>add</mat-icon> Add {{ referenceType }} Metadata
+        </button>
+      </div>
     </div>
-    <div class="mat-body gio-metadata__description">{{ description }}</div>
     <div class="gio-metadata__table">
       <table mat-table [dataSource]="dataSource" matSort class="gio-metadata__table">
         <caption style="display: none">
@@ -126,5 +130,5 @@
         <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="metadata_table_row"></tr>
       </table>
     </div>
-  </div>
+  </mat-card-content>
 </mat-card>

--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.scss
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.component.scss
@@ -1,14 +1,15 @@
 .gio-metadata {
-  padding: 24px 18px;
-
   &__header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
-    margin-bottom: 16px;
 
-    h2 {
-      margin-bottom: 0;
+    &__title {
+      display: flex;
+      flex-direction: column;
+    }
+
+    &__action {
+      align-self: center;
     }
   }
 

--- a/gravitee-apim-console-webui/src/components/notification-settings/notification-settings-list.component.html
+++ b/gravitee-apim-console-webui/src/components/notification-settings/notification-settings-list.component.html
@@ -15,79 +15,83 @@
     limitations under the License.
 
 -->
-<div class="title">
-  <h1>Notification settings</h1>
-  <button
-    *gioPermission="{ anyOf: ['api-notification-c', 'application-notification-c', 'environment-notification-c'] }"
-    mat-raised-button
-    color="primary"
-    aria-label="Add notification"
-    (click)="addNotification()"
+<mat-card>
+  <mat-card-content>
+    <div class="title">
+      <h3>Notification settings</h3>
+      <button
+        *gioPermission="{ anyOf: ['api-notification-c', 'application-notification-c', 'environment-notification-c'] }"
+        mat-raised-button
+        color="primary"
+        aria-label="Add notification"
+        (click)="addNotification()"
+      >
+        <mat-icon>add</mat-icon>
+        Add notification
+      </button>
+    </div>
+  </mat-card-content>
+  <gio-table-wrapper
+    [filters]="initialFilters"
+    [length]="notificationUnpaginatedLength"
+    [paginationPageSizeOptions]="[5, 10, 25, 50]"
+    (filtersChange)="onPropertiesFiltersChanged($event)"
   >
-    <mat-icon>add</mat-icon>
-    Add notification
-  </button>
-</div>
-<gio-table-wrapper
-  [filters]="initialFilters"
-  [length]="notificationUnpaginatedLength"
-  [paginationPageSizeOptions]="[5, 10, 25, 50]"
-  (filtersChange)="onPropertiesFiltersChanged($event)"
->
-  <table
-    mat-table
-    [dataSource]="filteredNotificationsSettingsTable"
-    class="notifications__table"
-    id="notificationsTable"
-    aria-label="Notifications table"
-  >
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef id="name">Name</th>
-      <td mat-cell *matCellDef="let element">
-        <a [routerLink]="'./' + (element.id || element.configType)">
-          {{ element.name }}
-        </a>
-      </td>
-    </ng-container>
+    <table
+      mat-table
+      [dataSource]="filteredNotificationsSettingsTable"
+      class="notifications__table"
+      id="notificationsTable"
+      aria-label="Notifications table"
+    >
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+        <td mat-cell *matCellDef="let element">
+          <a [routerLink]="'./' + (element.id || element.configType)">
+            {{ element.name }}
+          </a>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="notifier">
-      <th mat-header-cell *matHeaderCellDef id="notifier">Notifier</th>
-      <td mat-cell *matCellDef="let element">
-        <span class="gio-badge-neutral" *ngIf="element.notifierName">{{ element.notifierName }}</span>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="notifier">
+        <th mat-header-cell *matHeaderCellDef id="notifier">Notifier</th>
+        <td mat-cell *matCellDef="let element">
+          <span class="gio-badge-neutral" *ngIf="element.notifierName">{{ element.notifierName }}</span>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef id="actions" width="1%"></th>
-      <td mat-cell *matCellDef="let element">
-        <div class="notifications-list__table__actions">
-          <ng-container *ngIf="element.id">
-            <button
-              *gioPermission="{ anyOf: ['api-notification-d', 'application-notification-d', 'environment-notification-d'] }"
-              mat-icon-button
-              (click)="deleteNotification(element.name, element.id)"
-              aria-label="Delete notification"
-              id="deleteNotification"
-              matTooltip="Delete notification"
-            >
-              <mat-icon svgIcon="gio:trash"></mat-icon>
-            </button>
-          </ng-container>
-        </div>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions" width="1%"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="notifications-list__table__actions">
+            <ng-container *ngIf="element.id">
+              <button
+                *gioPermission="{ anyOf: ['api-notification-d', 'application-notification-d', 'environment-notification-d'] }"
+                mat-icon-button
+                (click)="deleteNotification(element.name, element.id)"
+                aria-label="Delete notification"
+                id="deleteNotification"
+                matTooltip="Delete notification"
+              >
+                <mat-icon svgIcon="gio:trash"></mat-icon>
+              </button>
+            </ng-container>
+          </div>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 
-    <!-- Row shown when there is no data -->
-    <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-      <td *ngIf="!isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
-        {{ 'No notifications to display.' }}
-      </td>
-      <td *ngIf="isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
-        {{ 'Loading...' }}
-      </td>
-    </tr>
-  </table>
-</gio-table-wrapper>
+      <!-- Row shown when there is no data -->
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td *ngIf="!isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+          {{ 'No notifications to display.' }}
+        </td>
+        <td *ngIf="isLoadingData" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+          {{ 'Loading...' }}
+        </td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/components/notification-settings/notification-settings-list.component.scss
+++ b/gravitee-apim-console-webui/src/components/notification-settings/notification-settings-list.component.scss
@@ -12,9 +12,4 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
-
-  h1 {
-    margin-bottom: 0;
-  }
 }

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.scss
@@ -12,7 +12,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-bottom: 8px;
 
     &__text {
       padding-right: 48px;

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation-tabs/application-navigation-tabs.component.html
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation-tabs/application-navigation-tabs.component.html
@@ -40,7 +40,5 @@
   </ng-container>
 </nav>
 <mat-tab-nav-panel #tabPanel>
-  <div class="gv-sub-content">
-    <ng-content></ng-content>
-  </div>
+  <ng-content></ng-content>
 </mat-tab-nav-panel>

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.html
@@ -15,43 +15,47 @@
     limitations under the License.
 
 -->
-<div class="application-navigation" *ngIf="application">
-  <div class="application-navigation__menu">
-    <gio-submenu class="application-navigation__submenu">
-      <div gioSubmenuTitle class="application-navigation__submenu__title">{{ application.name }}</div>
-      <ng-container *ngFor="let item of this.subMenuItems">
-        <ng-container *ngIf="!item.tabs?.length">
-          <a *ngIf="item.routerLink" [routerLink]="item.routerLink">
-            <gio-submenu-item tabIndex="1" [active]="isActive(item)">{{ item.displayName }}</gio-submenu-item>
-          </a>
+<ng-container *ngIf="application">
+  <div class="application-navigation">
+    <div class="application-navigation__menu">
+      <gio-submenu class="application-navigation__submenu">
+        <div gioSubmenuTitle class="application-navigation__submenu__title">{{ application.name }}</div>
+        <ng-container *ngFor="let item of this.subMenuItems">
+          <ng-container *ngIf="!item.tabs?.length">
+            <a *ngIf="item.routerLink" [routerLink]="item.routerLink">
+              <gio-submenu-item tabIndex="1" [active]="isActive(item)">{{ item.displayName }}</gio-submenu-item>
+            </a>
+          </ng-container>
+          <ng-container *ngIf="item.tabs?.length">
+            <a [routerLink]="item.tabs[0].routerLink">
+              <gio-submenu-item tabIndex="1" [active]="isTabActive(item.tabs)">{{ item.displayName }}</gio-submenu-item>
+            </a>
+          </ng-container>
         </ng-container>
-        <ng-container *ngIf="item.tabs?.length">
-          <a [routerLink]="item.tabs[0].routerLink">
-            <gio-submenu-item tabIndex="1" [active]="isTabActive(item.tabs)">{{ item.displayName }}</gio-submenu-item>
-          </a>
-        </ng-container>
-      </ng-container>
-    </gio-submenu>
-  </div>
-  <div class="application-navigation__content">
-    <gio-breadcrumb *ngIf="hasBreadcrumb" class="application-navigation__breadcrumb">
-      <span *gioBreadcrumbItem class="application-navigation__breadcrumb__item">Applications</span>
-      <div *gioBreadcrumbItem gioSubmenuTitle class="application-navigation__menu__title">{{ application.name }}</div>
-      <ng-template ngFor let-item [ngForOf]="this.computeBreadcrumbItems()">
-        <span *gioBreadcrumbItem class="application-navigation__breadcrumb__item">{{ item }}</span>
-      </ng-template>
-    </gio-breadcrumb>
+      </gio-submenu>
+    </div>
+    <div class="application-navigation__content">
+      <div class="application-navigation__content__view">
+        <gio-breadcrumb *ngIf="hasBreadcrumb" class="application-navigation__breadcrumb">
+          <span *gioBreadcrumbItem class="application-navigation__breadcrumb__item">Applications</span>
+          <div *gioBreadcrumbItem gioSubmenuTitle class="application-navigation__menu__title">{{ application.name }}</div>
+          <ng-template ngFor let-item [ngForOf]="this.computeBreadcrumbItems()">
+            <span *gioBreadcrumbItem class="application-navigation__breadcrumb__item">{{ item }}</span>
+          </ng-template>
+        </gio-breadcrumb>
 
-    <application-navigation-tabs
-      *ngIf="selectedItemWithTabs"
-      class="application-navigation__content__tabs"
-      [tabMenuItems]="this.selectedItemWithTabs.tabs"
-      [menuItemHeader]="this.selectedItemWithTabs?.header"
-    >
-      <router-outlet></router-outlet>
-    </application-navigation-tabs>
-    <ng-container *ngIf="!selectedItemWithTabs">
-      <router-outlet></router-outlet>
-    </ng-container>
+        <application-navigation-tabs
+          *ngIf="selectedItemWithTabs"
+          class="application-navigation__content__tabs"
+          [tabMenuItems]="this.selectedItemWithTabs.tabs"
+          [menuItemHeader]="this.selectedItemWithTabs?.header"
+        >
+          <router-outlet></router-outlet>
+        </application-navigation-tabs>
+        <ng-container *ngIf="!selectedItemWithTabs">
+          <router-outlet></router-outlet>
+        </ng-container>
+      </div>
+    </div>
   </div>
-</div>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.scss
@@ -64,7 +64,17 @@ $borderColor: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter80');
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
-    height: 100%;
-    overflow: auto;
+
+    &__view {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      height: 100%;
+      margin: 12px 24px 0 24px;
+
+      &__ui {
+        height: 100%;
+      }
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<form *ngIf="applicationForm" [formGroup]="applicationForm" autocomplete="off" gioFormFocusInvalid>
+<form class="application-general__content" *ngIf="applicationForm" [formGroup]="applicationForm" autocomplete="off" gioFormFocusInvalid>
   <mat-card class="details-card">
     <mat-card-content>
       <div class="details-card__header">
@@ -93,21 +93,21 @@
   </mat-card>
 
   <ng-container *ngIf="initialApplication.type === 'SIMPLE'">
-    <h2 class="details-title-oauth">OAuth2 Integration</h2>
     <mat-card class="details-card" formGroupName="OAuth2Form">
       <mat-card-content>
         <div class="details-card__header">
-          <div class="details-card__header__info-inputs">
-            <div class="details-card__header__info-inputs__client_id-row">
-              <mat-form-field>
-                <mat-label>Client ID</mat-label>
-                <input formControlName="client_id" matInput type="text" maxlength="300" minlength="1" gioClipboardCopyWrapper />
-                <mat-hint align="start"
-                  >The <code>Client_id</code> of the application. This field is required to subscribe to certain type of API Plan (OAuth2,
-                  JWT).
-                </mat-hint>
-              </mat-form-field>
-            </div>
+          <h3>OAuth2 Integration</h3>
+        </div>
+        <div class="details-card__header__info-inputs">
+          <div class="details-card__header__info-inputs__client_id-row">
+            <mat-form-field>
+              <mat-label>Client ID</mat-label>
+              <input formControlName="client_id" matInput type="text" maxlength="300" minlength="1" gioClipboardCopyWrapper />
+              <mat-hint align="start"
+                >The <code>Client_id</code> of the application. This field is required to subscribe to certain type of API Plan (OAuth2,
+                JWT).
+              </mat-hint>
+            </mat-form-field>
           </div>
         </div>
       </mat-card-content>
@@ -117,7 +117,10 @@
   <ng-container *ngIf="initialApplication.type !== 'SIMPLE'">
     <h2 class="details-title-openid">OpenID Connect Integration</h2>
     <mat-card class="details-card-openid" formGroupName="OpenIDForm">
-      <div class="details-card__header">
+      <mat-card-content>
+        <div class="details-card__header">
+          <h3>OpenID Connect Integration</h3>
+        </div>
         <div class="details-card__header__info-inputs">
           <div class="details-card__header__right-coll__media coll-oauth">
             <mat-form-field class="oauth">
@@ -146,7 +149,7 @@
             </mat-form-field>
           </div>
         </div>
-      </div>
+      </mat-card-content>
     </mat-card>
   </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.scss
@@ -10,6 +10,14 @@ $typography: map.get(gio.$mat-theme, typography);
   @include gio-layout.gio-responsive-margin-container;
 }
 
+.application-general {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
 .details-card {
   &__header {
     display: flex;

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.scss
@@ -1,0 +1,5 @@
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}

--- a/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/metadata/application-metadata.component.ts
@@ -22,6 +22,7 @@ import { MetadataSaveServices } from '../../../../components/gio-metadata/gio-me
 @Component({
   selector: 'application-metadata',
   templateUrl: './application-metadata.component.html',
+  styleUrls: ['./application-metadata.component.scss'],
 })
 export class ApplicationMetadataComponent implements OnInit {
   metadataSaveServices: MetadataSaveServices;

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.html
@@ -45,52 +45,52 @@
           aria-label="Enable notifications when members are added to this Application"
         ></mat-slide-toggle>
       </gio-form-slide-toggle>
+      <table
+        mat-table
+        *ngIf="membersTable"
+        [dataSource]="membersTable"
+        class="card__table"
+        id="membersTable"
+        formGroupName="members"
+        aria-label="Direct members table"
+      >
+        <ng-container matColumnDef="picture">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let member">
+            <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="displayName">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
+            {{ member.displayName }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="role">
+          <th mat-header-cell *matHeaderCellDef>Role</th>
+          <td mat-cell *matCellDef="let member">
+            <mat-form-field>
+              <mat-select [formControlName]="member.id">
+                <mat-option *ngFor="let role of roles" [value]="role" [disabled]="role === 'PRIMARY_OWNER'">{{ role }}</mat-option>
+              </mat-select>
+              <mat-error *ngIf="form.get('members').get(member.id).hasError('required')"> Role is required. </mat-error>
+            </mat-form-field>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="delete">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let member">
+            <div class="action-cell" *ngIf="member.role !== 'PRIMARY_OWNER'">
+              <button type="button" mat-icon-button aria-label="Delete member" (click)="removeMember(member)">
+                <mat-icon svgIcon="gio:trash"></mat-icon>
+              </button>
+            </div>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
     </mat-card-content>
-    <table
-      mat-table
-      *ngIf="membersTable"
-      [dataSource]="membersTable"
-      class="card__table"
-      id="membersTable"
-      formGroupName="members"
-      aria-label="Direct members table"
-    >
-      <ng-container matColumnDef="picture">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let member">
-          <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="displayName">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
-          {{ member.displayName }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="role">
-        <th mat-header-cell *matHeaderCellDef>Role</th>
-        <td mat-cell *matCellDef="let member">
-          <mat-form-field>
-            <mat-select [formControlName]="member.id">
-              <mat-option *ngFor="let role of roles" [value]="role" [disabled]="role === 'PRIMARY_OWNER'">{{ role }}</mat-option>
-            </mat-select>
-            <mat-error *ngIf="form.get('members').get(member.id).hasError('required')"> Role is required. </mat-error>
-          </mat-form-field>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="delete">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let member">
-          <div class="action-cell" *ngIf="member.role !== 'PRIMARY_OWNER'">
-            <button type="button" mat-icon-button aria-label="Delete member" (click)="removeMember(member)">
-              <mat-icon svgIcon="gio:trash"></mat-icon>
-            </button>
-          </div>
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
   </mat-card>
 
   <gio-save-bar [form]="form" (resetClicked)="onReset()" (submitted)="onSubmit()"></gio-save-bar>

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.scss
@@ -11,7 +11,7 @@
     align-items: flex-start;
 
     &__addBtn {
-      flex: 1 0 auto;
+      align-self: center;
     }
   }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.scss
@@ -34,7 +34,6 @@ $foreground: map.get(gio.$mat-theme, foreground);
     &__content {
       display: flex;
       flex-direction: column;
-      padding-bottom: 16px;
 
       &__form-field {
         &__icon {

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
@@ -14,9 +14,10 @@ $typography: map.get(gio.$mat-theme, typography);
   @include mat.elevation(3); // default elevation
 }
 
-// default elevation when table is inside a card
+// when table is inside a card
 :host-context(.mat-mdc-card) {
   @include mat.elevation(0);
+  margin-top: 16px;
 }
 
 .gio-table-wrapper {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3918

## Description

First PR to just format all of the migrated Application pages to be more uniform.

Global settings
![Screenshot 2024-02-19 at 17 46 14](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/16b3f337-eea2-42ed-b656-f29646a195ff)

User and group access
![Screenshot 2024-02-19 at 17 46 23](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/e481e81b-481d-4a0e-8240-8351c1538379)

Metadata
![Screenshot 2024-02-20 at 12 22 20](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/e8ce04c0-51d5-403a-944b-9a50f8bbbf63)

Notification settings
![Screenshot 2024-02-20 at 12 14 00](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/a9fc9461-dde5-4816-a559-b9c04f90777f)

Next: Add title and subtitle to pages like for Api V4 pages.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xjrzxfrmkj.chromatic.com)
<!-- Storybook placeholder end -->
