### PR TITLE
List api alerts

### DIFF
--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - storage
 
   alert_engine:
-    image: graviteeio/ae-engine:${AE_VERSION:-1.4.0}
+    image: graviteeio/ae-engine:${AE_VERSION:-2.1.5}
     container_name: gio_ae_engine
     restart: always
     ports:

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/index.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/index.ts
@@ -13,17 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
-
-@Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
-})
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
-}
+export * from './runtime-alert-list';
+export * from './runtime-alert-list-empty-state';

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/index.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/index.ts
@@ -13,17 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
-
-@Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
-})
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
-}
+export * from './runtime-alert-list-empty-state.module';
+export * from './runtime-alert-list-empty-state.component';

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.html
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.html
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="runtime-alerts">
+  <mat-card-header>
+    <div class="runtime-alerts__header">
+      <div class="runtime-alerts__header__titles">
+        <mat-card-title>Custom alerts</mat-card-title>
+        <mat-card-subtitle>Set up alerting conditions for the Gateway</mat-card-subtitle>
+      </div>
+      <div>
+        <button [disabled]="true" color="primary" aria-label="Add alert" mat-raised-button>
+          <mat-icon svgIcon="gio:plus"></mat-icon>Add alert
+        </button>
+      </div>
+    </div>
+  </mat-card-header>
+  <mat-card-content>
+    <gio-card-empty-state
+      icon="search"
+      title="No alerts found"
+      subtitle="No runtime alerts found. Please try again or create a custom alert."
+    ></gio-card-empty-state>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.scss
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.scss
@@ -1,0 +1,18 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.runtime-alerts {
+  &__header {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+}

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.component.ts
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
 
 @Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
+  selector: 'runtime-alert-list-empty-state',
+  templateUrl: './runtime-alert-list-empty-state.component.html',
+  styleUrls: ['./runtime-alert-list-empty-state.component.scss'],
 })
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
-}
+export class RuntimeAlertListEmptyStateComponent {}

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.harness.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.harness.ts
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ComponentHarness } from '@angular/cdk/testing';
 
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
-
-@Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
-})
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
+export class RuntimeAlertListEmptyStateHarness extends ComponentHarness {
+  static hostSelector = 'runtime-alert-list-empty-state';
 }

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.module.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.module.ts
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { NgModule } from '@angular/core';
+import { GioCardEmptyStateModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
-import { ApiRuntimeAlertsComponent } from './api-runtime-alerts.component';
-
-import { RuntimeAlertListEmptyStateModule, RuntimeAlertListModule } from '../../../components/runtime-alerts';
+import { RuntimeAlertListEmptyStateComponent } from './runtime-alert-list-empty-state.component';
 
 @NgModule({
-  declarations: [ApiRuntimeAlertsComponent],
-  imports: [CommonModule, RuntimeAlertListModule, RuntimeAlertListEmptyStateModule],
+  declarations: [RuntimeAlertListEmptyStateComponent],
+  exports: [RuntimeAlertListEmptyStateComponent],
+  imports: [CommonModule, MatButtonModule, MatCardModule, MatIconModule, GioIconsModule, GioCardEmptyStateModule],
 })
-export class ApiRuntimeAlertsModule {}
+export class RuntimeAlertListEmptyStateModule {}

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/index.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/index.ts
@@ -13,17 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
-
-@Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
-})
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
-}
+export * from './runtime-alert-list.component';
+export * from './runtime-alert-list.module';

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.html
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.html
@@ -1,0 +1,129 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="runtime-alerts">
+  <mat-card-header>
+    <div class="runtime-alerts__header">
+      <div class="runtime-alerts__header__titles">
+        <mat-card-title>Custom alerts</mat-card-title>
+        <mat-card-subtitle>Set up alerting conditions for the Gateway</mat-card-subtitle>
+      </div>
+      <div>
+        <button [disabled]="true" color="primary" aria-label="Add alert" mat-raised-button>
+          <mat-icon svgIcon="gio:plus"></mat-icon>Add alert
+        </button>
+      </div>
+    </div>
+  </mat-card-header>
+
+  <gio-table-wrapper [disableSearchInput]="true" [disablePageSize]="true" [length]="alerts.length">
+    <table mat-table [dataSource]="alerts" class="runtime-alerts__table" id="apiAlertsTable" aria-label="API Alerts table">
+      <!-- Name column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+        <td mat-cell *matCellDef="let alert">{{ alert.name }}</td>
+      </ng-container>
+
+      <!-- Severity Column -->
+      <ng-container matColumnDef="severity">
+        <th mat-header-cell *matHeaderCellDef id="severity"></th>
+        <td mat-cell *matCellDef="let alert">
+          <span *ngIf="alert.severity === 'INFO'" class="gio-badge-primary">{{ alert.severity }}</span>
+          <span *ngIf="alert.severity === 'WARNING'" class="gio-badge-warning">{{ alert.severity }}</span>
+          <span *ngIf="alert.severity === 'CRITICAL'" class="gio-badge-error">{{ alert.severity }}</span>
+        </td>
+      </ng-container>
+
+      <!-- Description Column -->
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef id="description">description</th>
+        <td mat-cell *matCellDef="let alert">{{ alert.description }}</td>
+      </ng-container>
+
+      <!-- Counters column -->
+      <ng-container matColumnDef="counters">
+        <th mat-header-cell *matHeaderCellDef id="counters">Last 5m / 1h / 1d / 1M</th>
+        <td mat-cell *matCellDef="let alert">
+          <ng-container *ngIf="!!alert.counters; else countersEmptyBlock">
+            <span [matTooltip]="alert.counters['5m'] + ' during the last 5 minutes'">{{ alert.counters['5m'] }} </span>
+            /
+            <span [matTooltip]="alert.counters['1h'] + ' during the last 1 hour'">{{ alert.counters['1h'] }}</span>
+            /
+            <span [matTooltip]="alert.counters['1d'] + ' during the last 1 day'">{{ alert.counters['1d'] }}</span>
+            /
+            <span [matTooltip]="alert.counters['1M'] + ' during the last 1 month'">{{ alert.counters['1M'] }}</span>
+          </ng-container>
+          <ng-template #countersEmptyBlock> - </ng-template>
+        </td>
+      </ng-container>
+
+      <!-- Last alert column -->
+      <ng-container matColumnDef="lastAlert">
+        <th mat-header-cell *matHeaderCellDef id="lastAlert">Last alert</th>
+        <td mat-cell *matCellDef="let alert">
+          <ng-container *ngIf="!!alert.last_alert_at; else lastAlertEmptyBlock">
+            {{ alert.last_alert_at | date : 'short' }}
+          </ng-container>
+          <ng-template #lastAlertEmptyBlock> - </ng-template>
+        </td>
+      </ng-container>
+
+      <!-- Last message column -->
+      <ng-container matColumnDef="lastMessage">
+        <th mat-header-cell *matHeaderCellDef id="lastMessage">Last message</th>
+        <td mat-cell *matCellDef="let alert">
+          <ng-container *ngIf="!!alert.last_alert_at; else lastAlertMessageEmptyBlock">
+            {{ alert.last_alert_message }}
+          </ng-container>
+          <ng-template #lastAlertMessageEmptyBlock> - </ng-template>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let alert">
+          <div class="runtime-alerts__actions">
+            <button
+              mat-icon-button
+              aria-label="Button to edit an alert"
+              matTooltip="Edit an alert"
+              *gioPermission="{ anyOf: ['api-definition-u'] }"
+              [disabled]="true"
+            >
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <button
+              *gioPermission="{ anyOf: ['api-definition-u'] }"
+              mat-icon-button
+              aria-label="Button to delete an alert"
+              matTooltip="Delete an alert"
+              [disabled]="true"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No Alerts</td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.scss
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.scss
@@ -3,10 +3,8 @@
 @use '@gravitee/ui-particles-angular' as gio;
 @use '../../../scss/gio-layout' as gio-layout;
 
-$foreground: map.get(gio.$mat-theme, foreground);
-
 :host {
-  @include gio-layout.gio-responsive-margin-container;
+  @include gio-layout.gio-responsive-content-container;
 }
 
 .runtime-alerts {
@@ -16,5 +14,10 @@ $foreground: map.get(gio.$mat-theme, foreground);
     align-items: center;
     justify-content: space-between;
     margin-bottom: 20px;
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: row;
   }
 }

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+
+import { RuntimeAlertListModule } from './runtime-alert-list.module';
+import { RuntimeAlertListHarness } from './runtime-alert-list.harness';
+
+import { AlertTriggerEntity } from '../../../entities/alerts/alertTriggerEntity';
+import { fakeAlertTriggerEntity } from '../../../entities/alerts/alertTriggerEntity.fixtures';
+import { GioHttpTestingModule } from '../../../shared/testing';
+
+@Component({
+  selector: 'test-component',
+  template: ` <runtime-alert-list [alerts]="alerts"></runtime-alert-list>`,
+})
+class TestComponent {
+  alerts: AlertTriggerEntity[] = [
+    fakeAlertTriggerEntity({ counters: { '5m': 1, '1h': 2, '1d': 3, '1M': 4 } }),
+    fakeAlertTriggerEntity({ last_alert_at: undefined, last_alert_message: undefined }),
+  ];
+}
+
+describe('RuntimeAlertListComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+  let runtimeAlertListHarness: RuntimeAlertListHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, RuntimeAlertListModule, MatIconTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    runtimeAlertListHarness = await loader.getHarness(RuntimeAlertListHarness);
+  });
+
+  it('should display alerts table', async () => {
+    const { headerCells, rowCells } = await runtimeAlertListHarness.computeTableCells();
+    expect(headerCells).toStrictEqual([
+      {
+        actions: '',
+        counters: 'Last 5m / 1h / 1d / 1M',
+        description: 'description',
+        lastAlert: 'Last alert',
+        lastMessage: 'Last message',
+        name: 'Name',
+        severity: '',
+      },
+    ]);
+    expect(rowCells).toHaveLength(2);
+    expect(rowCells[0]).toStrictEqual(['', 'INFO', 'description', '1  / 2 / 3 / 4', expect.anything(), 'last alert message', '']);
+    expect(rowCells[1]).toStrictEqual(['', 'INFO', 'description', '-', '-', '-', '']);
+  });
+});

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.ts
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, Input } from '@angular/core';
 
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
+import { AlertTriggerEntity } from '../../../entities/alerts/alertTriggerEntity';
 
 @Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
+  selector: 'runtime-alert-list',
+  templateUrl: './runtime-alert-list.component.html',
+  styleUrls: ['./runtime-alert-list.component.scss'],
 })
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
-
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
+export class RuntimeAlertListComponent {
+  @Input() public alerts: AlertTriggerEntity[];
+  public displayedColumns = ['name', 'severity', 'description', 'counters', 'lastAlert', 'lastMessage', 'actions'];
 }

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.harness.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.harness.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class RuntimeAlertListHarness extends ComponentHarness {
+  static hostSelector = 'runtime-alert-list';
+
+  private getAlertTable = () => this.locatorFor(MatTableHarness)();
+
+  async computeTableCells() {
+    const table = await this.getAlertTable();
+
+    const headerRows = await table.getHeaderRows();
+    const headerCells = await parallel(() => headerRows.map((row) => row.getCellTextByColumnName()));
+
+    const rows = await table.getRows();
+    const rowCells = await parallel(() => rows.map((row) => row.getCellTextByIndex()));
+    return { headerCells, rowCells };
+  }
+}

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.module.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.module.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+
+import { RuntimeAlertListComponent } from './runtime-alert-list.component';
+
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+
+@NgModule({
+  declarations: [RuntimeAlertListComponent],
+  exports: [RuntimeAlertListComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatTableModule,
+    GioTableWrapperModule,
+    MatTooltipModule,
+    GioPermissionModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
+})
+export class RuntimeAlertListModule {}

--- a/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.fixtures.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AlertTriggerEntity } from './alertTriggerEntity';
+
+export function fakeAlertTriggerEntity(attributes?: Partial<AlertTriggerEntity>): AlertTriggerEntity {
+  const base: AlertTriggerEntity = {
+    description: 'description',
+    reference_type: 'API',
+    referenceId: 'api-id',
+    created_at: new Date(),
+    updated_at: new Date(),
+    type: 'alert-type',
+    last_alert_at: new Date(),
+    last_alert_message: 'last alert message',
+    counters: undefined,
+    template: false,
+    event_rules: [],
+    parent_id: 'parent-id',
+    environment_id: 'env-id',
+    severity: 'INFO',
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.ts
@@ -13,17 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+export type AlertReferenceType = 'API' | 'APPLICATION' | 'ENVIRONMENT';
 
-import { ApiAlertsService } from '../../../services-ngx/api-alerts.service';
+export type AlertSeverity = 'INFO' | 'WARNING' | 'CRITICAL';
 
-@Component({
-  selector: 'api-runtime-alerts',
-  templateUrl: './api-runtime-alerts.component.html',
-})
-export class ApiRuntimeAlertsComponent {
-  public alerts$ = this.apiAlertsService.listAlerts(this.activatedRoute.snapshot.params.apiId, true);
+export interface AlertEventRuleEntity {
+  event: string;
+}
 
-  constructor(private readonly activatedRoute: ActivatedRoute, private readonly apiAlertsService: ApiAlertsService) {}
+export interface AlertTriggerEntity {
+  description: string;
+  reference_type: AlertReferenceType;
+  referenceId: string;
+  created_at: Date;
+  updated_at: Date;
+  type: string;
+  last_alert_at: Date;
+  last_alert_message: string;
+  counters: Record<string, number>;
+  template: boolean;
+  event_rules: AlertEventRuleEntity[];
+  parent_id: string;
+  environment_id: string;
+  severity: AlertSeverity;
 }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -337,13 +337,4 @@ export class ApiV4MenuService implements ApiMenuService {
       tabs,
     };
   }
-
-  private getGeneralGroup(): MenuGroupItem {
-    const generalGroup: MenuGroupItem = {
-      title: 'General',
-      items: [],
-    };
-
-    return generalGroup;
-  }
 }

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -79,6 +79,7 @@ import { ApiDeploymentConfigurationComponent } from './deployment-configuration-
 import { ApiDynamicPropertiesComponent } from './properties/components/dynamic-properties-v2/api-dynamic-properties.component';
 import { ApiPropertiesComponent } from './properties/properties/api-properties.component';
 import { ApiNotificationComponent } from './api-notification/api-notification.component';
+import { ApiRuntimeAlertsComponent } from './runtime-alerts';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -460,6 +461,19 @@ const apisRoutes: Routes = [
           },
           docs: {
             page: 'management-alerts',
+          },
+        },
+      },
+      {
+        path: 'ng/alerts',
+        component: ApiRuntimeAlertsComponent,
+        data: {
+          requireLicense: {
+            license: { feature: ApimFeature.ALERT_ENGINE },
+            redirect: '/',
+          },
+          apiPermissions: {
+            only: ['api-alert-r'],
           },
         },
       },

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -51,6 +51,7 @@ import { ApiNotificationModule } from './api-notification/api-notification.modul
 import { ApiCorsModule } from './cors/api-cors.module';
 import { ApiPropertiesModule } from './properties/properties/api-properties.module';
 import { ApiProxyHealthCheckDashboardModule } from './health-check-dashboard/api-proxy-health-check-dashboard.module';
+import { ApiRuntimeAlertsModule } from './runtime-alerts';
 
 import { SpecificJsonSchemaTypeModule } from '../../shared/components/specific-json-schema-type/specific-json-schema-type.module';
 import { DocumentationModule } from '../../components/documentation/documentation.module';
@@ -66,6 +67,7 @@ import { AlertsModule } from '../../components/alerts/alerts.module';
     AlertsModule,
     ApiAnalyticsModule,
     ApiAuditModule,
+    ApiAuditLogsModule,
     ApiAuditListModule,
     ApiCorsModule,
     ApiCreationGetStartedModule,
@@ -84,14 +86,14 @@ import { AlertsModule } from '../../components/alerts/alerts.module';
     ApiHealthCheckModule,
     ApiListModule,
     ApiNavigationModule,
+    ApiNotificationModule,
     ApiNotificationSettingsModule,
     ApiPlansModule,
     ApiPropertiesModule,
     ApiResourcesModule,
     ApiResponseTemplatesModule,
     ApiRuntimeLogsV4Module,
-    ApiAuditLogsModule,
-    ApiNotificationModule,
+    ApiRuntimeAlertsModule,
     ApiSubscriptionsModule,
     ApiV4PolicyStudioModule,
     ApiUserGroupModule,

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="runtime-alerts">
+  <mat-card-header>
+    <div class="runtime-alerts__header">
+      <div class="runtime-alerts__header__titles">
+        <mat-card-title>Custom alerts</mat-card-title>
+        <mat-card-subtitle>Set up alerting conditions for the Gateway</mat-card-subtitle>
+      </div>
+      <div>
+        <button color="primary" aria-label="Add alert" mat-raised-button><mat-icon svgIcon="gio:plus"></mat-icon>Add alert</button>
+      </div>
+    </div>
+  </mat-card-header>
+  <mat-card-content>
+    <gio-card-empty-state
+      icon="search"
+      title="No alerts found"
+      subtitle="No runtime alert found. Please try again or create a custom alert."
+    ></gio-card-empty-state>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
@@ -15,23 +15,11 @@
     limitations under the License.
 
 -->
-<mat-card class="runtime-alerts">
-  <mat-card-header>
-    <div class="runtime-alerts__header">
-      <div class="runtime-alerts__header__titles">
-        <mat-card-title>Custom alerts</mat-card-title>
-        <mat-card-subtitle>Set up alerting conditions for the Gateway</mat-card-subtitle>
-      </div>
-      <div>
-        <button color="primary" aria-label="Add alert" mat-raised-button><mat-icon svgIcon="gio:plus"></mat-icon>Add alert</button>
-      </div>
-    </div>
-  </mat-card-header>
-  <mat-card-content>
-    <gio-card-empty-state
-      icon="search"
-      title="No alerts found"
-      subtitle="No runtime alert found. Please try again or create a custom alert."
-    ></gio-card-empty-state>
-  </mat-card-content>
-</mat-card>
+<ng-container *ngIf="alerts$ | async as alerts">
+  <ng-container *ngIf="alerts?.length > 0; else emptyBlock">
+    <runtime-alert-list [alerts]="alerts"></runtime-alert-list>
+  </ng-container>
+  <ng-template #emptyBlock>
+    <runtime-alert-list-empty-state></runtime-alert-list-empty-state>
+  </ng-template>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.scss
@@ -1,0 +1,20 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
+
+$foreground: map.get(gio.$mat-theme, foreground);
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.runtime-alerts {
+  &__header {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.spec.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ActivatedRoute } from '@angular/router';
+
+import { ApiRuntimeAlertsComponent } from './api-runtime-alerts.component';
+import { ApiRuntimeAlertsModule } from './api-runtime-alerts.module';
+
+import { RuntimeAlertListHarness } from '../../../components/runtime-alerts/runtime-alert-list/runtime-alert-list.harness';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
+import { fakeAlertTriggerEntity } from '../../../entities/alerts/alertTriggerEntity.fixtures';
+import { RuntimeAlertListEmptyStateHarness } from '../../../components/runtime-alerts/runtime-alert-list-empty-state/runtime-alert-list-empty-state.harness';
+
+describe('ApiRuntimeAlertsComponent', () => {
+  const API_ID = 'apiId';
+  const ENVIRONMENT_ID = 'envId';
+  const ALERT = fakeAlertTriggerEntity();
+  let fixture: ComponentFixture<ApiRuntimeAlertsComponent>;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ApiRuntimeAlertsComponent],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule, ApiRuntimeAlertsModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { apiId: API_ID, envId: ENVIRONMENT_ID } },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiRuntimeAlertsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should get alerts and display the table list', async () => {
+    expectAlertsGetRequest();
+    const listComponentHarness = await loader.getHarness(RuntimeAlertListHarness);
+    expect(listComponentHarness).toBeTruthy();
+
+    const { rowCells } = await listComponentHarness.computeTableCells();
+    expect(rowCells).toHaveLength(1);
+  });
+
+  it('should get alerts and display empty state page', async () => {
+    expectAlertsGetRequest([]);
+    expect(await loader.getHarness(RuntimeAlertListEmptyStateHarness)).toBeTruthy();
+  });
+
+  function expectAlertsGetRequest(response = [ALERT]) {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}/alerts?event_counts=true`).flush(response);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'api-runtime-alerts',
+  templateUrl: './api-runtime-alerts.component.html',
+  styleUrls: ['./api-runtime-alerts.component.scss'],
+})
+export class ApiRuntimeAlertsComponent {}

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.module.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { GioCardEmptyStateModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+
+import { ApiRuntimeAlertsComponent } from './api-runtime-alerts.component';
+
+@NgModule({
+  declarations: [ApiRuntimeAlertsComponent],
+  imports: [CommonModule, MatCardModule, GioIconsModule, GioCardEmptyStateModule, MatButtonModule],
+})
+export class ApiRuntimeAlertsModule {}

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/index.ts
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './api-runtime-alerts.module';
+export * from './api-runtime-alerts.component';

--- a/gravitee-apim-console-webui/src/services-ngx/api-alerts.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-alerts.service.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiAlertsService } from './api-alerts.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { fakeAlertTriggerEntity } from '../entities/alerts/alertTriggerEntity.fixtures';
+
+describe('ApiAlertsService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ApiAlertsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject<ApiAlertsService>(ApiAlertsService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list alerts for an API', () => {
+    it('should get API alerts', (done) => {
+      const apiId = 'test_api';
+      const fakeAlerts = [fakeAlertTriggerEntity({ referenceId: apiId })];
+
+      service.listAlerts(apiId, false).subscribe((response) => {
+        expect(response).toMatchObject(fakeAlerts);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/alerts?event_counts=false`,
+      });
+
+      req.flush(fakeAlerts);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-alerts.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-alerts.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AlertTriggerEntity } from 'src/entities/alerts/alertTriggerEntity';
+
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiAlertsService {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  listAlerts(apiId: string, withEventCounts: boolean): Observable<AlertTriggerEntity[]> {
+    return this.http.get<AlertTriggerEntity[]>(`${this.constants.env.baseURL}/apis/${apiId}/alerts?event_counts=${withEventCounts}`);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1427

## Description

This PR add an hidden route to list API alerts. To test it easily we can use the console on a V2 API and change the list route from `/alerts` to `/ng/alerts` 

<img width="1790" alt="Capture d’écran 2024-02-19 à 18 25 40" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/4f140e56-2bad-4a64-84af-5a37346654d7">

<img width="1792" alt="Capture d’écran 2024-02-19 à 18 26 03" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/4e977318-b5b6-470b-baa7-2c1c8fc6254c">


👉🏼 Next step is to create and edit an existing alert. That's why we already have the buttons but they are all disabled

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6676/console](https://pr.team-apim.gravitee.dev/6676/console)
      Portal: [https://pr.team-apim.gravitee.dev/6676/portal](https://pr.team-apim.gravitee.dev/6676/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6676/api/management](https://pr.team-apim.gravitee.dev/6676/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6676](https://pr.team-apim.gravitee.dev/6676)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6676](https://pr.gateway-v3.team-apim.gravitee.dev/6676)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-odxcuoibbt.chromatic.com)
<!-- Storybook placeholder end -->
