### PR TITLE
Test/fix several cypress tests after another UI change run e2e

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
@@ -20,8 +20,8 @@
   <div>
     <mat-form-field *ngIf="!disableSearchInput" class="gio-table-wrapper__header-bar__search-field">
       <mat-icon matIconPrefix svgIcon="gio:search"></mat-icon>
-      <mat-label>{{ searchLabel }}</mat-label>
-      <input class="search-input" [formControl]="inputSearch" type="search" matInput data-testid="search" />
+      <mat-label data-testid="search">{{ searchLabel }}</mat-label>
+      <input class="search-input" [formControl]="inputSearch" type="search" matInput />
     </mat-form-field>
   </div>
 

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -150,12 +150,12 @@ describe('API List feature', { defaultCommandTimeout: 10000 }, () => {
         cy.getByDataTestId('api_list_table_row').should('have.length', noOfApis * 2);
       });
 
-      it(`should only display 5 APIs when limited to 5`, function () {
+      it(`should switch view to 50 when 50 items per page selected`, function () {
         cy.getByDataTestId('paginator-header').within(() => {
-          cy.get('.mat-select-arrow-wrapper').click();
+          cy.get('.mat-mdc-select-trigger').click();
         });
-        cy.get('mat-option').contains('5').first().click();
-        cy.url().should('include', 'size=5');
+        cy.get('mat-option').contains('50').first().click();
+        cy.url().should('include', 'size=50');
       });
     });
 

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-plans.spec.ts
@@ -99,7 +99,7 @@ describe('API Plans Feature', () => {
     cy.getByDataTestId('api_plans_description_field').type(`${planDescription} OAuth2`);
     cy.getByDataTestId('api_plans_nextstep').click();
     cy.contains('h2', 'OAuth2 authentication configuration').scrollIntoView().should('be.visible');
-    cy.contains('OAuth2 resource').closest('div').find('input').type('Dummy OAuth2 resource');
+    cy.contains('OAuth2 resource').type('Dummy OAuth2 resource');
     cy.getByDataTestId('api_plans_nextstep').click();
 
     cy.contains('Rate Limiting').scrollIntoView().should('be.visible');


### PR DESCRIPTION
## Description
After a change in the UI (migration to material MDC) some Cypress tests broke. This PR offers fixes for:

- Cypress API info tests
- Cypress API list tests
- Cypress API plan tests
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tnlxcujrsy.chromatic.com)
<!-- Storybook placeholder end -->
