### PR TITLE
fix(shared key): update apikey atomically to avoid concurrency issue

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -92,4 +93,13 @@ public interface ApiKeyRepository extends FindAllRepository<ApiKey> {
     Set<ApiKey> findByPlan(String plan) throws TechnicalException;
 
     List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException;
+
+    /**
+     *
+     * @param id apikey ID
+     * @param subscriptionId subscription ID to add to this shared apikey
+     * @return the updated apikey if found
+     * @throws TechnicalException
+     */
+    Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
@@ -80,6 +80,11 @@ public class HttpApiKeyRepository extends AbstractRepository implements ApiKeyRe
     }
 
     @Override
+    public Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
     @ExcludeMethodFromGeneratedCoverage
     public Set<ApiKey> findAll() throws TechnicalException {
         throw new IllegalStateException();

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -193,6 +193,17 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
         }
     }
 
+    @Override
+    public Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException {
+        LOGGER.debug("JdbcApiKeyRepository.addSubscription({}, {})", id, subscriptionId);
+        Optional<ApiKey> apiKey = findById(id);
+        if (apiKey.isEmpty()) {
+            return apiKey;
+        }
+        jdbcTemplate.update("insert into " + keySubscriptions + " ( key_id, subscription_id ) values ( ?, ? )", id, subscriptionId);
+        return findById(id);
+    }
+
     private boolean addClause(boolean first, StringBuilder query) {
         if (first) {
             query.append(" where ");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management;
 
 import static java.util.stream.Collectors.*;
 
+import com.mongodb.client.result.UpdateResult;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
@@ -80,6 +81,15 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) {
         return mapper.collection2list(internalApiKeyRepo.search(filter), ApiKeyMongo.class, ApiKey.class);
+    }
+
+    @Override
+    public Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException {
+        UpdateResult result = internalApiKeyRepo.addSubscription(id, subscriptionId);
+        if (result.getMatchedCount() == 0) {
+            return Optional.empty();
+        }
+        return findById(id);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.mongodb.management.internal.key;
 
+import com.mongodb.client.result.UpdateResult;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo;
@@ -34,4 +35,6 @@ public interface ApiKeyMongoRepositoryCustom {
     List<ApiKeyMongo> findByKeyAndApi(String key, String api);
 
     List<ApiKeyMongo> findByPlan(String plan);
+
+    UpdateResult addSubscription(String id, String subscriptionId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
@@ -19,9 +19,11 @@ import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Filters.*;
 import static com.mongodb.client.model.Projections.exclude;
 import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Updates.push;
 
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.result.UpdateResult;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
@@ -151,6 +153,13 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
             .aggregate(pipeline);
 
         return getListFromAggregate(aggregate);
+    }
+
+    @Override
+    public UpdateResult addSubscription(String id, String subscriptionId) {
+        return mongoTemplate
+            .getCollection(mongoTemplate.getCollectionName(ApiKeyMongo.class))
+            .updateOne(eq("_id", id), push("subscriptions", subscriptionId));
     }
 
     private List<ApiKeyMongo> getListFromAggregate(AggregateIterable<Document> aggregate) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.api.search.ApiKeyCriteria.Builder;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
@@ -328,5 +329,27 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
                     apiKey.getId().equals("id-of-apikey-8") && apiKey.getSubscriptions() != null && apiKey.getSubscriptions().isEmpty()
                 )
         );
+    }
+
+    @Test
+    public void should_add_subscription_to_apikey() throws TechnicalException {
+        Optional<ApiKey> apiKey = apiKeyRepository.findById("id-of-apikey-2");
+        assertTrue(apiKey.isPresent());
+
+        List<String> subscriptions = apiKey.get().getSubscriptions();
+        Assertions.assertThat(subscriptions).hasSize(2);
+        Assertions.assertThat(subscriptions).contains("subscription2", "subscriptionX");
+
+        Optional<ApiKey> updatedApiKey = apiKeyRepository.addSubscription("id-of-apikey-2", "newSubscription");
+        assertTrue(updatedApiKey.isPresent());
+        List<String> updatedSubscriptions = updatedApiKey.get().getSubscriptions();
+        Assertions.assertThat(updatedSubscriptions).hasSize(3);
+        Assertions.assertThat(updatedSubscriptions).contains("subscription2", "subscriptionX", "newSubscription");
+    }
+
+    @Test
+    public void return_empty_if_apikey_does_not_exist() throws TechnicalException {
+        Optional<ApiKey> updatedApiKey = apiKeyRepository.addSubscription("unknown_apikey_id", "newSubscription");
+        assertTrue(updatedApiKey.isEmpty());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -136,6 +136,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void shouldGenerateReusingSharedKey() throws TechnicalException {
+        // Existing api key
         String sharedApiKeyValue = "shared-api-key-value";
         String sharedApiKeyId = "shared-api-key-id";
         String sharedSubscriptionId = "shared-subscription-id";
@@ -143,23 +144,38 @@ public class ApiKeyServiceTest {
         ApiKey sharedKey = new ApiKey();
         sharedKey.setId(sharedApiKeyId);
         sharedKey.setKey(sharedApiKeyValue);
-        sharedKey.setSubscriptions(List.of(SUBSCRIPTION_ID));
+        sharedKey.setSubscriptions(List.of(sharedSubscriptionId));
+        when(apiKeyRepository.findByApplication(APPLICATION_ID)).thenReturn(List.of(sharedKey));
 
+        // Existing subscription
+        SubscriptionEntity sharedSubscription = new SubscriptionEntity();
+        sharedSubscription.setId(sharedSubscriptionId);
+        when(subscriptionService.findByIdIn(List.of(sharedSubscriptionId))).thenReturn(Set.of(sharedSubscription));
+
+        // Existing application
         ApplicationEntity application = new ApplicationEntity();
         application.setId(APPLICATION_ID);
         application.setApiKeyMode(ApiKeyMode.SHARED);
 
-        SubscriptionEntity firstSubscription = new SubscriptionEntity();
-        firstSubscription.setId(sharedSubscriptionId);
+        // Subscription to add
+        when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
 
-        when(apiKeyRepository.findById(sharedApiKeyId)).thenReturn(Optional.of(sharedKey));
-        when(apiKeyRepository.findByApplication(APPLICATION_ID)).thenReturn(List.of(sharedKey));
-        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(firstSubscription, subscription));
-        when(apiKeyRepository.update(any())).then(returnsFirstArg());
+        // Updated api key
+        ApiKey updatedSharedKey = new ApiKey();
+        updatedSharedKey.setId(sharedApiKeyId);
+        updatedSharedKey.setKey(sharedApiKeyValue);
+        updatedSharedKey.setSubscriptions(List.of(sharedSubscriptionId, SUBSCRIPTION_ID));
+        when(apiKeyRepository.addSubscription(sharedApiKeyId, SUBSCRIPTION_ID)).thenReturn(Optional.of(updatedSharedKey));
+        when(subscriptionService.findByIdIn(List.of(sharedSubscriptionId, SUBSCRIPTION_ID)))
+            .thenReturn(Set.of(sharedSubscription, subscription));
+
+        // Call
         ApiKeyEntity newKey = apiKeyService.generate(GraviteeContext.getExecutionContext(), application, subscription, null);
+
+        // Verify
         assertEquals(sharedApiKeyValue, newKey.getKey());
         assertEquals(sharedApiKeyId, newKey.getId());
-        assertEquals(Set.of(firstSubscription, subscription), newKey.getSubscriptions());
+        assertEquals(Set.of(sharedSubscription, subscription), newKey.getSubscriptions());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3848

## Description

When subscribing to an API Key plan with a shared api key, instead of creating a new api key, we add the subscription if to the existing apikey.
To avoid concurrency issues, we now add directly the subscription in database instead of doing GET, modify and UPDATE (which can be interrupted)