### PR TITLE
fix: allow update or deletion of endpoint and groups used as dead letter queue

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/api-endpoint-v4-matching-dlq.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/api-endpoint-v4-matching-dlq.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiV4, Entrypoint } from '../../../entities/management-api-v2';
+
+export const getMatchingDlqEntrypointsForGroup = (api: ApiV4, currentGroup: string): Entrypoint[] => {
+  if (!api) {
+    return [];
+  }
+  const endpointNames = api.endpointGroups.find((group) => group.name === currentGroup).endpoints.map((endpoint) => endpoint.name);
+  return getEntrypointsWithDlq(api).filter(
+    (entrypoint) => entrypoint.dlq.endpoint === currentGroup || endpointNames.includes(entrypoint.dlq.endpoint),
+  );
+};
+
+export const getMatchingDlqEntrypoints = (api: ApiV4, currentEndpoint: string): Entrypoint[] => {
+  if (!api) {
+    return [];
+  }
+  return getEntrypointsWithDlq(api).filter((entrypoint) => entrypoint.dlq.endpoint === currentEndpoint);
+};
+
+export const updateDlqEntrypoint = (api: ApiV4, dlqEntrypoints: Entrypoint[], newName: string): void => {
+  api.listeners
+    .flatMap((listener) => listener.entrypoints)
+    .filter((entrypoint) => dlqEntrypoints.map((dlqEntrypoint) => dlqEntrypoint.type).includes(entrypoint.type))
+    .forEach((dlqEntrypoint) => (dlqEntrypoint.dlq.endpoint = newName));
+};
+
+export const disableDlqEntrypoint = (api: ApiV4, dlqEntrypoints: Entrypoint[]): void => {
+  api.listeners
+    .flatMap((listener) => listener.entrypoints)
+    .filter((entrypoint) => dlqEntrypoints.map((dlqEntrypoint) => dlqEntrypoint.type).includes(entrypoint.type))
+    .forEach((dlqEntrypoint) => (dlqEntrypoint.dlq = null));
+};
+
+function getEntrypointsWithDlq(api: ApiV4): Entrypoint[] {
+  const entrypoints = api.listeners?.flatMap((listeners) => listeners.entrypoints);
+  if (!entrypoints) {
+    return [];
+  }
+
+  return entrypoints.filter((entrypoint) => !!entrypoint.dlq);
+}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
@@ -28,48 +28,10 @@ import { ApiEndpointGroupHarness } from './api-endpoint-group.harness';
 import { ApiEndpointGroupModule } from './api-endpoint-group.module';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
-import { ApiV4, EndpointGroupV4, fakeApiV4, fakeProxyApiV4, fakeProxyTcpApiV4 } from '../../../../entities/management-api-v2';
+import { ApiV4, fakeApiV4, fakeProxyApiV4, fakeProxyTcpApiV4 } from '../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { fakeEndpointGroupV4, fakeHTTPProxyEndpointGroupV4 } from '../../../../entities/management-api-v2/api/v4/endpointGroupV4.fixture';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
-
-/**
- * Test data
- */
-const API_ID = 'apiId';
-const DEFAULT_GROUP_NAME = 'default-group';
-const VALID_ENDPOINT_GROUP_NAME = 'New Endpoint Group Name';
-const INVALID_ENDPOINT_GROUP_NAME = '';
-const DEFAULT_LOAD_BALANCER_TYPE = 'ROUND_ROBIN';
-const ALTERNATE_LOAD_BALANCER_TYPE = 'RANDOM';
-const ALTERNATE_LOAD_BALANCER_TYPE_2 = 'WEIGHTED_RANDOM';
-const GROUP_INDEX = 0;
-const VALID_HEALTH_CHECK_VALUE = 'New health check value';
-const INVALID_HEALTH_CHECK_VALUE = '';
-const healthCheckSchema = {
-  $schema: 'http://json-schema.org/draft-07/schema#',
-  type: 'object',
-  properties: {
-    dummy: {
-      title: 'dummy',
-      type: 'string',
-      description: 'A dummy string',
-      readOnly: true,
-    },
-  },
-  required: ['dummy'],
-};
-
-/**
- * Given the api and the updated endpoint group attributes
- * return the newly modified endpoint group
- *
- * @param api api object
- * @param endpointGroupAttributes endpoint group attributes that will be updated
- */
-function getExpectedEndpoints(api: ApiV4, endpointGroupAttributes): EndpointGroupV4[] {
-  return [{ ...api.endpointGroups[GROUP_INDEX], ...endpointGroupAttributes }];
-}
 
 /**
  * Expect that a single GET request has been made which matches the specified URL
@@ -115,7 +77,11 @@ function expectApiPutRequest(api: ApiV4, fixture: ComponentFixture<any>, httpTes
  * @param fixture testing fixture
  * @param httpTestingController http testing controller
  */
-function expectHealthCheckSchemaGet(fixture: ComponentFixture<any>, httpTestingController: HttpTestingController): void {
+function expectHealthCheckSchemaGet(
+  fixture: ComponentFixture<any>,
+  httpTestingController: HttpTestingController,
+  healthCheckSchema: any,
+): void {
   httpTestingController
     .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/api-services/http-health-check/schema`, method: 'GET' })
     .flush(healthCheckSchema);
@@ -123,16 +89,26 @@ function expectHealthCheckSchemaGet(fixture: ComponentFixture<any>, httpTestingC
 }
 
 describe('ApiEndpointGroupComponent', () => {
+  const API_ID = 'apiId';
+  const HEALTH_CHECK_SCHEMA = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    properties: {
+      dummy: {
+        title: 'dummy',
+        type: 'string',
+        description: 'A dummy string',
+        readOnly: true,
+      },
+    },
+    required: ['dummy'],
+  };
   let fixture: ComponentFixture<ApiEndpointGroupComponent>;
   let httpTestingController: HttpTestingController;
   let componentHarness: ApiEndpointGroupHarness;
   let api: ApiV4;
 
-  const initComponent = async (testApi: ApiV4) => {
-    const routerParams: unknown = { apiId: API_ID, groupIndex: GROUP_INDEX };
-
-    api = testApi;
-
+  const initComponent = async (api: ApiV4, routerParams: unknown = { apiId: API_ID, groupIndex: 0 }) => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiEndpointGroupModule, MatIconTestingModule, FormsModule],
       providers: [
@@ -148,6 +124,7 @@ describe('ApiEndpointGroupComponent', () => {
 
     await TestBed.compileComponents();
     fixture = TestBed.createComponent(ApiEndpointGroupComponent);
+    fixture.componentInstance.api = api;
     httpTestingController = TestBed.inject(HttpTestingController);
     componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiEndpointGroupHarness);
 
@@ -161,202 +138,145 @@ describe('ApiEndpointGroupComponent', () => {
     httpTestingController.verify();
   });
 
-  describe('GIVEN the current page is the endpoint group page', () => {
-    beforeEach(async () => {
+  describe('endpoint group update - configuration', () => {
+    it('should not update endpoint group with invalid name', async () => {
       api = fakeApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4()] });
       await initComponent(api);
+      await componentHarness.clickGeneralTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
+
+      expect(await componentHarness.readEndpointGroupNameInput()).toEqual('default-group');
+
+      // empty string is not a valid name
+      await componentHarness.writeToEndpointGroupNameInput('');
+      expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeTruthy();
+
+      // reset change will restore initial value
+      await componentHarness.clickEndpointGroupDismissButton();
+      expect(await componentHarness.readEndpointGroupNameInput()).toEqual('default-group');
+      expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
     });
 
-    // General Tab
-    describe('WHEN the general tab is selected', () => {
-      beforeEach(async () => {
-        await componentHarness.clickGeneralTab();
-        expectApiSchemaGetRequests(api, fixture, httpTestingController);
-      });
+    it('should update endpoint group with valid name', async () => {
+      api = fakeApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4()] });
+      await initComponent(api);
+      await componentHarness.clickGeneralTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
 
-      // General Tab -> Endpoint Group Name
-      it('THEN the endpoint group name field should be visible with a default value', async () => {
-        expect(await componentHarness.readEndpointGroupNameInput()).toEqual(DEFAULT_GROUP_NAME);
-      });
+      expect(await componentHarness.readEndpointGroupNameInput()).toEqual('default-group');
 
-      describe('AND WHEN the endpoint group name is modified with a valid value', () => {
-        beforeEach(async () => {
-          await componentHarness.writeToEndpointGroupNameInput(VALID_ENDPOINT_GROUP_NAME);
-        });
-        it('THEN the endpoint group name field should be updated with the expected value', async () => {
-          expect(await componentHarness.readEndpointGroupNameInput()).toEqual(VALID_ENDPOINT_GROUP_NAME);
-        });
+      // change to a valid name
+      await componentHarness.writeToEndpointGroupNameInput('default-group updated');
+      expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeFalsy();
 
-        it('THEN the save button should be valid', async () => {
-          expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeFalsy();
-        });
+      // save the correct value
+      await componentHarness.clickEndpointGroupSaveButton();
+      expectApiGetRequest(api, fixture, httpTestingController);
+      const endpointsGroup = expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups;
+      expect(endpointsGroup[0].name).toEqual('default-group updated');
+      expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
+    });
 
-        describe('AND WHEN the save button is clicked', () => {
-          it('THEN the endpoint group name field should be saved', async () => {
-            await componentHarness.clickEndpointGroupSaveButton();
-            expectApiGetRequest(api, fixture, httpTestingController);
-            expect(expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups).toEqual(
-              getExpectedEndpoints(api, { name: VALID_ENDPOINT_GROUP_NAME }),
-            );
-          });
-        });
+    it('should update endpoint group load balancing', async () => {
+      api = fakeApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4()] });
+      await initComponent(api);
+      await componentHarness.clickGeneralTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
 
-        describe('AND WHEN the endpoint group is modified with an invalid value', () => {
-          beforeEach(async () => {
-            await componentHarness.writeToEndpointGroupNameInput(INVALID_ENDPOINT_GROUP_NAME);
-          });
+      expect(await componentHarness.readEndpointGroupLoadBalancerSelector()).toEqual('ROUND_ROBIN');
 
-          it('THEN the save button should be invalid', async () => {
-            expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeTruthy();
-          });
-        });
+      // change load balancing strategy
+      await componentHarness.writeToEndpointGroupLoadBalancerSelector('RANDOM');
+      expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeFalsy();
 
-        describe('AND WHEN the changes made have been dismissed', () => {
-          beforeEach(async () => {
-            await componentHarness.writeToEndpointGroupNameInput('TEST');
-
-            await componentHarness.clickEndpointGroupDismissButton();
-          });
-
-          it('THEN the endpoint group name should reset back to the original value', async () => {
-            expect(await componentHarness.readEndpointGroupNameInput()).toEqual(DEFAULT_GROUP_NAME);
-          });
-        });
-      });
-
-      // General Tab -> Endpoint Group Load Balancer Type
-      it('THEN the endpoint group load balancer field should be visible with a default value', async () => {
-        expect(await componentHarness.readEndpointGroupLoadBalancerSelector()).toEqual(DEFAULT_LOAD_BALANCER_TYPE);
-      });
-
-      describe('AND WHEN the endpoint group load balancer type is modified', () => {
-        beforeEach(async () => {
-          await componentHarness.writeToEndpointGroupLoadBalancerSelector(ALTERNATE_LOAD_BALANCER_TYPE);
-        });
-
-        it('THEN the endpoint group name field should be updated with the expected value', async () => {
-          expect(await componentHarness.readEndpointGroupLoadBalancerSelector()).toEqual(ALTERNATE_LOAD_BALANCER_TYPE);
-        });
-
-        describe('AND WHEN the save button is clicked', () => {
-          it('THEN the endpoint group load balancer type field should be saved', async () => {
-            await componentHarness.clickEndpointGroupSaveButton();
-            expectApiGetRequest(api, fixture, httpTestingController);
-            expect(expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups).toEqual(
-              getExpectedEndpoints(api, {
-                name: DEFAULT_GROUP_NAME,
-                loadBalancer: { type: ALTERNATE_LOAD_BALANCER_TYPE },
-              }),
-            );
-          });
-        });
-
-        describe('AND WHEN the changes made have been dismissed', () => {
-          beforeEach(async () => {
-            await componentHarness.writeToEndpointGroupLoadBalancerSelector(ALTERNATE_LOAD_BALANCER_TYPE_2);
-
-            await componentHarness.clickEndpointGroupDismissButton();
-          });
-
-          it('THEN the endpoint group load balancer type should reset back to the original value', async () => {
-            expect(await componentHarness.readEndpointGroupLoadBalancerSelector()).toEqual(DEFAULT_LOAD_BALANCER_TYPE);
-          });
-        });
-      });
-      it('THEN should show the configuration tab', async () => {
-        expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
-      });
+      // save the new strategy
+      await componentHarness.clickEndpointGroupSaveButton();
+      expectApiGetRequest(api, fixture, httpTestingController);
+      const endpointsGroup = expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups;
+      expect(endpointsGroup[0].name).toEqual('default-group');
+      expect(endpointsGroup[0].loadBalancer.type).toEqual('RANDOM');
+      expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
     });
   });
-
-  // Health-check Tab
-  describe('WHEN the Health-check tab is selected', () => {
-    beforeEach(async () => {
-      api = fakeProxyApiV4({
-        id: API_ID,
-        endpointGroups: [fakeHTTPProxyEndpointGroupV4()],
-      });
+  describe('endpoint group update - health check', () => {
+    it('should not update endpoint group health check with invalid configuration', async () => {
+      api = fakeProxyApiV4({ id: API_ID, endpointGroups: [fakeHTTPProxyEndpointGroupV4()] });
       await initComponent(api);
       await componentHarness.clickHealthCheckTab();
       expectApiSchemaGetRequests(api, fixture, httpTestingController);
-      expectHealthCheckSchemaGet(fixture, httpTestingController);
-    });
+      expectHealthCheckSchemaGet(fixture, httpTestingController, HEALTH_CHECK_SCHEMA);
 
-    it('should fill and save the configuration form', async () => {
+      // enable health check configuration
       expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeTruthy();
       await componentHarness.toggleEnableHealthCheckInput();
       expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeFalsy();
 
-      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', VALID_HEALTH_CHECK_VALUE);
-      expect(await componentHarness.readHealthCheckConfigurationValueInput('dummy')).toEqual(VALID_HEALTH_CHECK_VALUE);
-
-      expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeFalsy();
-      await componentHarness.clickEndpointGroupSaveButton();
-      expectApiGetRequest(api, fixture, httpTestingController);
-      expect(expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups).toEqual(
-        getExpectedEndpoints(api, {
-          services: {
-            healthCheck: {
-              enabled: true,
-              overrideConfiguration: false,
-              type: 'http-health-check',
-              configuration: { dummy: VALID_HEALTH_CHECK_VALUE },
-            },
-          },
-        }),
-      );
-    });
-
-    it('should fill invalid value and save should be disabled', async () => {
-      expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeTruthy();
-      await componentHarness.toggleEnableHealthCheckInput();
-      expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeFalsy();
-
-      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', INVALID_HEALTH_CHECK_VALUE);
-      expect(await componentHarness.readHealthCheckConfigurationValueInput('dummy')).toEqual(INVALID_HEALTH_CHECK_VALUE);
-
+      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', '');
       expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeTruthy();
     });
 
-    it('should fill and dismiss', async () => {
+    it('should reset health check not saved configuration', async () => {
+      api = fakeProxyApiV4({ id: API_ID, endpointGroups: [fakeHTTPProxyEndpointGroupV4()] });
+      await initComponent(api);
+      await componentHarness.clickHealthCheckTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
+      expectHealthCheckSchemaGet(fixture, httpTestingController, HEALTH_CHECK_SCHEMA);
+
+      // enable health check configuration
       expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeTruthy();
       await componentHarness.toggleEnableHealthCheckInput();
       expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeFalsy();
 
-      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', VALID_HEALTH_CHECK_VALUE);
-      await componentHarness.clickEndpointGroupDismissButton();
+      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', 'a value');
 
+      // cancel update
+      await componentHarness.clickEndpointGroupDismissButton();
       expect(await componentHarness.readHealthCheckConfigurationValueInput('dummy')).toEqual('');
     });
-  });
 
-  describe('GIVEN the current page is a mock endpoint group page', () => {
-    beforeEach(async () => {
-      const apiWithMockEndpointGroup = fakeApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4({ type: 'mock' })] });
-      await initComponent(apiWithMockEndpointGroup);
+    it('should update endpoint group health check', async () => {
+      api = fakeProxyApiV4({ id: API_ID, endpointGroups: [fakeHTTPProxyEndpointGroupV4()] });
+      await initComponent(api);
+      await componentHarness.clickHealthCheckTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
+      expectHealthCheckSchemaGet(fixture, httpTestingController, HEALTH_CHECK_SCHEMA);
+
+      // enable health check configuration
+      expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeTruthy();
+      await componentHarness.toggleEnableHealthCheckInput();
+      expect(await componentHarness.isHealthCheckConfigurationInputDisabled('dummy')).toBeFalsy();
+
+      await componentHarness.writeToHealthCheckConfigurationValueInput('dummy', 'New health check value');
+      expect(await componentHarness.isGeneralTabSaveButtonInvalid()).toBeFalsy();
+
+      // save the new health check value
+      await componentHarness.clickEndpointGroupSaveButton();
+      expectApiGetRequest(api, fixture, httpTestingController);
+      const endpointsGroup = expectApiPutRequest(api, fixture, httpTestingController).request.body.endpointGroups;
+      expect(endpointsGroup[0].services.healthCheck).toEqual({
+        enabled: true,
+        overrideConfiguration: false,
+        type: 'http-health-check',
+        configuration: { dummy: 'New health check value' },
+      });
     });
-
-    it('THEN the configuration tab and health-check tab is not visible', async () => {
+  });
+  describe('endpoint group specific cases limitations', () => {
+    it('should not display configuration and health check for Mock endpoint group', async () => {
+      const api = fakeApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4({ type: 'mock' })] });
+      await initComponent(api);
       expect(await componentHarness.configurationTabIsVisible()).toEqual(false);
       expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
     });
-  });
-
-  describe('GIVEN the current page is a TCP Proxy endpoint group page', () => {
-    beforeEach(async () => {
-      const apiWithMockEndpointGroup = fakeProxyTcpApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4({ services: {} })] });
-      await initComponent(apiWithMockEndpointGroup);
+    it('should not display health check for TCP-Proxy endpoint group', async () => {
+      const api = fakeProxyTcpApiV4({ id: API_ID, endpointGroups: [fakeEndpointGroupV4({ services: {} })] });
+      await initComponent(api);
       expectApiSchemaGetRequests(api, fixture, httpTestingController);
-    });
-
-    it('THEN the health-check tab is not visible', async () => {
+      expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
       expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
     });
-  });
-
-  describe('GIVEN the current page is a Message endpoint group page', () => {
-    beforeEach(async () => {
-      const apiWithMockEndpointGroup = fakeApiV4({
+    it('should not display health check for Message endpoint group', async () => {
+      const api = fakeApiV4({
         id: API_ID,
         endpointGroups: [
           fakeEndpointGroupV4({
@@ -366,16 +286,13 @@ describe('ApiEndpointGroupComponent', () => {
           }),
         ],
       });
-      await initComponent(apiWithMockEndpointGroup);
+      await initComponent(api);
       expectApiSchemaGetRequests(api, fixture, httpTestingController);
-    });
-
-    it('THEN the health-check tab is not visible', async () => {
+      expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
       expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
     });
   });
-
-  describe('Endpoint group name validation', () => {
+  describe('endpoint group name validation', () => {
     const TRIM_ENDPOINT_GROUP_NAME = 'Neat and trim';
     const SPACEY_ENDPOINT_GROUP_NAME = 'Space after ';
     const TRIM_ENDPOINT_NAME = 'Trim and neat';

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
@@ -22,6 +22,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { GioLicenseTestingModule } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
+import { deepClone } from '@gravitee/ui-components/src/lib/utils';
 
 import { ApiEndpointGroupsComponent } from './api-endpoint-groups.component';
 import { ApiEndpointGroupsHarness } from './api-endpoint-groups.harness';
@@ -69,6 +70,31 @@ describe('ApiEndpointGroupsComponent', () => {
         weight: 1,
         inheritConfiguration: true,
         secondary: false,
+      },
+    ],
+  };
+  const dlqGroup: EndpointGroupV4 = {
+    name: 'dlq-group',
+    type: 'kafka',
+    loadBalancer: { type: 'WEIGHTED_RANDOM' },
+    endpoints: [
+      {
+        name: 'dlq-endpoint-one',
+        type: 'kafka',
+        weight: 1,
+        inheritConfiguration: false,
+        configuration: {
+          bootstrapServers: 'localhost:9092',
+        },
+      },
+      {
+        name: 'dlq-endpoint-two',
+        type: 'kafka',
+        weight: 5,
+        inheritConfiguration: false,
+        configuration: {
+          bootstrapServers: 'localhost:9093',
+        },
       },
     ],
   };
@@ -126,7 +152,7 @@ describe('ApiEndpointGroupsComponent', () => {
     it('should delete the endpoint', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
-        endpointGroups: [group1, group2],
+        endpointGroups: [deepClone(group1), deepClone(group2)],
       });
       await initComponent(apiV4);
       expect(await componentHarness.isEndpointDeleteButtonVisible()).toEqual(true);
@@ -137,6 +163,52 @@ describe('ApiEndpointGroupsComponent', () => {
       expectApiPutRequest({
         ...apiV4,
         endpointGroups: [{ ...group1, endpoints: [{ ...group1.endpoints[0] }] }, { ...group2 }],
+      });
+      expectApiGetRequest(apiV4);
+      expectEndpointsGetRequest();
+    });
+
+    it('should delete the endpoint if used as dead letter queue', async () => {
+      const apiV4 = deepClone(
+        fakeApiV4({
+          id: API_ID,
+          endpointGroups: [deepClone(group1), deepClone(dlqGroup)],
+          listeners: [
+            {
+              type: 'SUBSCRIPTION',
+              entrypoints: [
+                {
+                  type: 'webhook',
+                  dlq: {
+                    endpoint: 'dlq-endpoint-one',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      await initComponent(apiV4);
+      expect(await componentHarness.isEndpointDeleteButtonVisible()).toEqual(true);
+
+      // deleting the third endpoint of the flatten list of buttons: dlq-endpoint-one
+      await componentHarness.deleteEndpoint(2, rootLoader);
+
+      expectApiGetRequest(apiV4);
+      expectApiPutRequest({
+        ...apiV4,
+        endpointGroups: [{ ...group1 }, { ...dlqGroup, endpoints: [{ ...dlqGroup.endpoints[1] }] }],
+        listeners: [
+          {
+            type: 'SUBSCRIPTION',
+            entrypoints: [
+              {
+                type: 'webhook',
+                dlq: null,
+              },
+            ],
+          },
+        ],
       });
       expectApiGetRequest(apiV4);
       expectEndpointsGetRequest();
@@ -163,6 +235,92 @@ describe('ApiEndpointGroupsComponent', () => {
 
       expectApiGetRequest(apiV4);
       expectApiPutRequest({ ...apiV4, endpointGroups: [group2] });
+      expectApiGetRequest(apiV4);
+      expectEndpointsGetRequest();
+    });
+
+    it('should delete the endpoint group if used as dead letter queue', async () => {
+      const apiV4 = deepClone(
+        fakeApiV4({
+          id: API_ID,
+          endpointGroups: [group1, dlqGroup],
+          listeners: [
+            {
+              type: 'SUBSCRIPTION',
+              entrypoints: [
+                {
+                  type: 'webhook',
+                  dlq: {
+                    endpoint: 'dlq-group',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      await initComponent(apiV4);
+      await componentHarness.deleteEndpointGroup(1, rootLoader);
+
+      expectApiGetRequest(apiV4);
+      expectApiPutRequest({
+        ...apiV4,
+        endpointGroups: [group1],
+        listeners: [
+          {
+            type: 'SUBSCRIPTION',
+            entrypoints: [
+              {
+                type: 'webhook',
+                dlq: null,
+              },
+            ],
+          },
+        ],
+      });
+      expectApiGetRequest(apiV4);
+      expectEndpointsGetRequest();
+    });
+
+    it('should delete the endpoint group if one of its item is used as dead letter queue', async () => {
+      const apiV4 = deepClone(
+        fakeApiV4({
+          id: API_ID,
+          endpointGroups: [group1, dlqGroup],
+          listeners: [
+            {
+              type: 'SUBSCRIPTION',
+              entrypoints: [
+                {
+                  type: 'webhook',
+                  dlq: {
+                    endpoint: 'dlq-endpoint-one',
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      await initComponent(apiV4);
+      await componentHarness.deleteEndpointGroup(1, rootLoader);
+
+      expectApiGetRequest(apiV4);
+      expectApiPutRequest({
+        ...apiV4,
+        endpointGroups: [group1],
+        listeners: [
+          {
+            type: 'SUBSCRIPTION',
+            entrypoints: [
+              {
+                type: 'webhook',
+                dlq: null,
+              },
+            ],
+          },
+        ],
+      });
       expectApiGetRequest(apiV4);
       expectEndpointsGetRequest();
     });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
@@ -29,6 +29,7 @@ import { ApiV4, ConnectorPlugin, UpdateApi } from '../../../../entities/manageme
 import { ConnectorPluginsV2Service } from '../../../../services-ngx/connector-plugins-v2.service';
 import { IconService } from '../../../../services-ngx/icon.service';
 import { ApimFeature, UTMTags } from '../../../../shared/components/gio-license/gio-license-data';
+import { disableDlqEntrypoint, getMatchingDlqEntrypoints, getMatchingDlqEntrypointsForGroup } from '../api-endpoint-v4-matching-dlq';
 
 @Component({
   selector: 'api-endpoint-groups',
@@ -44,6 +45,7 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   public shouldUpgrade = false;
   public license$: Observable<License>;
   public isOEM$: Observable<boolean>;
+  public api: ApiV4;
 
   private licenseOptions = {
     feature: ApimFeature.APIM_EN_MESSAGE_REACTOR,
@@ -65,6 +67,7 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
     combineLatest([this.apiService.get(this.activatedRoute.snapshot.params.apiId), this.connectorPluginsV2Service.listEndpointPlugins()])
       .pipe(
         tap(([apiV4, plugins]: [ApiV4, ConnectorPlugin[]]) => {
+          this.api = apiV4;
           this.groupsTableData = toEndpoints(apiV4);
 
           this.plugins = new Map(
@@ -93,12 +96,17 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   }
 
   public deleteGroup(groupName: string): void {
+    const matchingDlqEntrypoint = getMatchingDlqEntrypointsForGroup(this.api, groupName);
+    const dlqDeleteMessage =
+      matchingDlqEntrypoint.length > 0
+        ? '<br> This endpoint group is used as dead letter queue. Deleting it will disable dead letter queue for related entrypoints.'
+        : '';
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
         width: '500px',
         data: {
           title: 'Delete Endpoint Group',
-          content: `Are you sure you want to delete the Group <strong>${groupName}</strong>?`,
+          content: `Are you sure you want to delete the Group <strong>${groupName}</strong>?${dlqDeleteMessage}`,
           confirmButton: 'Delete',
         },
         role: 'alertdialog',
@@ -110,6 +118,7 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
         switchMap(() => this.apiService.get(this.activatedRoute.snapshot.params.apiId)),
         switchMap((api: ApiV4) => {
           remove(api.endpointGroups, (g) => g.name === groupName);
+          disableDlqEntrypoint(api, matchingDlqEntrypoint);
           return this.apiService.update(api.id, { ...api } as UpdateApi);
         }),
         catchError(({ error }) => {
@@ -126,12 +135,17 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   }
 
   public deleteEndpoint(groupName: string, endpointName: string): void {
+    const matchingDlqEntrypoint = getMatchingDlqEntrypoints(this.api, endpointName);
+    const dlqDeleteMessage =
+      matchingDlqEntrypoint.length > 0
+        ? '<br> This endpoint is used as dead letter queue. Deleting it will disable dead letter queue for related entrypoints.'
+        : '';
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
         width: '500px',
         data: {
           title: 'Delete Endpoint',
-          content: `Are you sure you want to delete the Endpoint <strong>${endpointName}</strong>?`,
+          content: `Are you sure you want to delete the Endpoint <strong>${endpointName}</strong>?${dlqDeleteMessage}`,
           confirmButton: 'Delete',
         },
         role: 'alertdialog',
@@ -143,6 +157,7 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
         switchMap(() => this.apiService.get(this.activatedRoute.snapshot.params.apiId)),
         switchMap((api: ApiV4) => {
           remove(find(api.endpointGroups, (g) => g.name === groupName).endpoints, (e) => e.name === endpointName);
+          disableDlqEntrypoint(api, matchingDlqEntrypoint);
           return this.apiService.update(api.id, { ...api } as UpdateApi);
         }),
         catchError(({ error }) => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -193,9 +193,10 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
 
   private initForm() {
     let name = null;
-    let inheritConfiguration = true;
     let configuration = null;
     let sharedConfigurationOverride = this.endpointGroup.sharedConfiguration;
+    // Inherit configuration only if there is a sharedConfiguration (that is not the case of mock endppoint)
+    let inheritConfiguration = !!sharedConfigurationOverride;
     let weight = null;
 
     if (this.mode === 'edit') {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { combineLatest, EMPTY, Subject } from 'rxjs';
-import { GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, Subject } from 'rxjs';
+import { GioConfirmDialogComponent, GioConfirmDialogData, GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
-import { ApiV4, ConnectorPlugin, EndpointGroupV4, EndpointV4 } from '../../../../entities/management-api-v2';
+import { Api, ApiV4, ConnectorPlugin, EndpointGroupV4, EndpointV4, Entrypoint } from '../../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../../services-ngx/connector-plugins-v2.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { IconService } from '../../../../services-ngx/icon.service';
 import { isEndpointNameUnique, isEndpointNameUniqueAndDoesNotMatchDefaultValue } from '../api-endpoint-v4-unique-name';
+import { getMatchingDlqEntrypoints, updateDlqEntrypoint } from '../api-endpoint-v4-matching-dlq';
 
 @Component({
   selector: 'api-endpoint',
@@ -52,6 +54,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
     private readonly snackBarService: SnackBarService,
     private readonly iconService: IconService,
+    private readonly matDialog: MatDialog,
   ) {}
 
   public ngOnInit(): void {
@@ -109,24 +112,24 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
       inheritConfiguration,
     };
 
-    this.apiService
-      .get(this.activatedRoute.snapshot.params.apiId)
+    let apiUpdate$: Observable<Api>;
+    if (this.mode === 'edit') {
+      const matchingDlqEntrypoint = getMatchingDlqEntrypoints(this.api, this.endpoint.name);
+      if (updatedEndpoint.name !== this.endpoint.name && matchingDlqEntrypoint.length > 0) {
+        apiUpdate$ = this.updateApiWithDlq(matchingDlqEntrypoint, updatedEndpoint);
+      } else {
+        apiUpdate$ = this.apiService
+          .get(this.activatedRoute.snapshot.params.apiId)
+          .pipe(switchMap((api: ApiV4) => this.updateApi(api, updatedEndpoint)));
+      }
+    } else {
+      apiUpdate$ = this.apiService
+        .get(this.activatedRoute.snapshot.params.apiId)
+        .pipe(switchMap((api: ApiV4) => this.updateApi(api, updatedEndpoint)));
+    }
+
+    apiUpdate$
       .pipe(
-        switchMap((api: ApiV4) => {
-          const endpointGroups = api.endpointGroups.map((group, i) => {
-            if (i === this.groupIndex) {
-              return {
-                ...group,
-                endpoints:
-                  this.endpointIndex !== undefined
-                    ? group.endpoints.map((endpoint, j) => (j === this.endpointIndex ? updatedEndpoint : endpoint))
-                    : [...group.endpoints, updatedEndpoint],
-              };
-            }
-            return group;
-          });
-          return this.apiService.update(api.id, { ...api, endpointGroups });
-        }),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;
@@ -138,6 +141,46 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
       )
       .subscribe();
+  }
+
+  private updateApiWithDlq(matchingDlqEntrypoint: Entrypoint[], updatedEndpoint: EndpointV4): Observable<Api> {
+    return this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Rename Endpoint',
+          content: `Some entrypoints use this endpoint as Dead letter queue. They will be modified to reference the new name.`,
+          confirmButton: 'Update',
+        },
+        role: 'alertdialog',
+        id: 'updateEndpointNameDlqConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirm) => confirm === true),
+        switchMap(() => this.apiService.get(this.api.id)),
+        map((api: ApiV4) => {
+          updateDlqEntrypoint(api, matchingDlqEntrypoint, updatedEndpoint.name);
+          return api;
+        }),
+        switchMap((api: ApiV4) => this.updateApi(api, updatedEndpoint)),
+      );
+  }
+
+  private updateApi(api: ApiV4, updatedEndpoint: EndpointV4): Observable<Api> {
+    const endpointGroups = api.endpointGroups.map((group, i) => {
+      if (i === this.groupIndex) {
+        return {
+          ...group,
+          endpoints:
+            this.endpointIndex !== undefined
+              ? group.endpoints.map((endpoint, j) => (j === this.endpointIndex ? updatedEndpoint : endpoint))
+              : [...group.endpoints, updatedEndpoint],
+        };
+      }
+      return group;
+    });
+    return this.apiService.update(api.id, { ...api, endpointGroups });
   }
 
   public onInheritConfigurationChange() {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.module.ts
@@ -28,6 +28,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTabsModule } from '@angular/material/tabs';
 import { RouterModule } from '@angular/router';
+import { MatDialogModule } from '@angular/material/dialog';
 
 import { ApiEndpointComponent } from './api-endpoint.component';
 
@@ -43,6 +44,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
 
     MatButtonModule,
     MatCardModule,
+    MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
     MatProgressBarModule,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3915


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6695/console](https://pr.team-apim.gravitee.dev/6695/console)
      Portal: [https://pr.team-apim.gravitee.dev/6695/portal](https://pr.team-apim.gravitee.dev/6695/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6695/api/management](https://pr.team-apim.gravitee.dev/6695/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6695](https://pr.team-apim.gravitee.dev/6695)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6695](https://pr.gateway-v3.team-apim.gravitee.dev/6695)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ulzzpmouet.chromatic.com)
<!-- Storybook placeholder end -->
