### PR TITLE
feat(ui-health-check-endpoint): Enable health-check config for the en…

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointServices.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointServices.ts
@@ -17,5 +17,5 @@
 import { ServiceV4 } from './serviceV4';
 
 export interface EndpointServices {
-  healthcheck?: ServiceV4;
+  healthCheck?: ServiceV4;
 }

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.html
@@ -22,6 +22,16 @@
   </div>
 
   <form *ngIf="healthCheckForm" [formGroup]="healthCheckForm" autocomplete="off">
+    <gio-form-slide-toggle *ngIf="healthCheckForm.controls['inherit'] != undefined" class="health-check__inherit-field">
+      <gio-form-label>Inherit configuration</gio-form-label>
+      Inherit health check service configuration from the endpoint group.
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="inherit"
+        aria-label="Inherit health check service configuration from the endpoint group"
+        name="inherit"
+      ></mat-slide-toggle>
+    </gio-form-slide-toggle>
     <gio-form-slide-toggle class="health-check__enable-field">
       <gio-form-label>Enabled</gio-form-label>
       This service is requiring an API deployment. Do not forget to deploy API to start health-check service.

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.scss
@@ -1,4 +1,8 @@
 .health-check {
+  &__inherit-field {
+    width: 100%;
+    padding-bottom: 24px;
+  }
   &__enable-field {
     width: 100%;
     padding-bottom: 24px;

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-v4-form/api-health-check-v4-form.component.ts
@@ -17,6 +17,7 @@
 import { Component, Input } from '@angular/core';
 
 import { EndpointGroupHealthCheckFormType } from '../../endpoints-v4/endpoint-group/api-endpoint-group.component';
+import { EndpointHealthCheckFormType } from '../../endpoints-v4/endpoint/api-endpoint.component';
 
 @Component({
   selector: 'api-health-check-v4-form',
@@ -24,7 +25,7 @@ import { EndpointGroupHealthCheckFormType } from '../../endpoints-v4/endpoint-gr
   styleUrls: ['./api-health-check-v4-form.component.scss'],
 })
 export class ApiHealthCheckV4FormComponent {
-  @Input() healthCheckForm: EndpointGroupHealthCheckFormType;
+  @Input() healthCheckForm: EndpointGroupHealthCheckFormType | EndpointHealthCheckFormType;
   @Input() healthCheckSchema: unknown;
 
   public static readonly HTTP_HEALTH_CHECK = 'http-health-check';

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
@@ -74,12 +74,6 @@ function expectApiPutRequest(api: ApiV4, fixture: ComponentFixture<any>, httpTes
   return httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'PUT' });
 }
 
-/**
- * Expect that a single PUT request has been made which matches the specified URL
- *
- * @param fixture testing fixture
- * @param httpTestingController http testing controller
- */
 function expectHealthCheckSchemaGet(
   fixture: ComponentFixture<any>,
   httpTestingController: HttpTestingController,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -76,6 +76,16 @@
               ></gio-form-json-schema>
             </div>
           </mat-tab>
+          <mat-tab label="Health-check" *ngIf="healthCheckForm && isHttpProxyApi">
+            <!-- Health check tab content -->
+            <div class="tab-body-wrapper">
+              <api-health-check-v4-form
+                *ngIf="healthCheckSchema"
+                [healthCheckForm]="healthCheckForm"
+                [healthCheckSchema]="healthCheckSchema"
+              ></api-health-check-v4-form>
+            </div>
+          </mat-tab>
         </mat-tab-group>
       </div>
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -30,8 +30,29 @@ import { ApiEndpointModule } from './api-endpoint.module';
 import { ApiEndpointHarness } from './api-endpoint.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
-import { ApiV4, fakeApiV4, fakeConnectorPlugin } from '../../../../entities/management-api-v2';
-import { fakeEndpointGroupV4 } from '../../../../entities/management-api-v2/api/v4/endpointGroupV4.fixture';
+import { ApiV4, fakeApiV4, fakeConnectorPlugin, fakeProxyApiV4 } from '../../../../entities/management-api-v2';
+import { fakeEndpointGroupV4, fakeHTTPProxyEndpointGroupV4 } from '../../../../entities/management-api-v2/api/v4/endpointGroupV4.fixture';
+
+const healthCheckSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    dummy: {
+      title: 'dummy',
+      type: 'string',
+      description: 'A dummy string',
+      readOnly: true,
+    },
+  },
+  required: ['dummy'],
+};
+
+function expectHealthCheckSchemaGet(fixture: ComponentFixture<any>, httpTestingController: HttpTestingController): void {
+  httpTestingController
+    .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/api-services/http-health-check/schema`, method: 'GET' })
+    .flush(healthCheckSchema);
+  fixture.detectChanges();
+}
 
 @Component({
   template: `<api-endpoint #apiEndpoint></api-endpoint>`,
@@ -74,6 +95,7 @@ describe('ApiEndpointComponent', () => {
     expectEndpointSchemaGetRequest(api.endpointGroups[0].type);
     expectEndpointsSharedConfigurationSchemaGetRequest(api.endpointGroups[0].type);
     expectEndpointPluginGetRequest(api.endpointGroups[0].type);
+    expectHealthCheckSchemaGet(fixture, httpTestingController);
   };
 
   afterEach(() => {
@@ -105,6 +127,8 @@ describe('ApiEndpointComponent', () => {
         ],
       };
       afterEach(async () => {
+        expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
+
         expect(await componentHarness.isSaveButtonDisabled()).toBeFalsy();
         await componentHarness.clickSaveButton();
 
@@ -174,6 +198,8 @@ describe('ApiEndpointComponent', () => {
         });
 
         await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
+
+        expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
 
         fixture.detectChanges();
         expect(await componentHarness.getEndpointName()).toStrictEqual('default');
@@ -409,6 +435,8 @@ describe('ApiEndpointComponent', () => {
         });
         await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
 
+        expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
+
         await componentHarness.fillInputName(apiV4.endpointGroups[0].endpoints[1].name + ' ');
         expect(await componentHarness.isSaveButtonDisabled()).toEqual(true);
 
@@ -447,6 +475,8 @@ describe('ApiEndpointComponent', () => {
 
         await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
 
+        expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
+
         await componentHarness.fillInputName('a spacey name');
         expect(await componentHarness.isSaveButtonDisabled()).toEqual(true);
 
@@ -481,6 +511,8 @@ describe('ApiEndpointComponent', () => {
       });
       await initComponent(anApi, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
 
+      expect(await componentHarness.healthCheckTabIsVisible()).toEqual(false);
+
       await componentHarness.clickConfigurationTab();
 
       expect(await componentHarness.isConfigurationButtonToggled()).toBeTruthy();
@@ -491,6 +523,27 @@ describe('ApiEndpointComponent', () => {
       expect(await inputHarness.getValue()).toStrictEqual('test');
 
       await componentHarness.toggleConfigurationButton();
+      fixture.detectChanges();
+    });
+
+    it('should inherit health-check from parent', async () => {
+      const anApi = fakeProxyApiV4({
+        id: API_ID,
+        endpointGroups: [fakeHTTPProxyEndpointGroupV4()],
+      });
+      await initComponent(anApi, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
+
+      expect(await componentHarness.healthCheckTabIsVisible()).toEqual(true);
+
+      await componentHarness.clickHealthCheckTab();
+
+      expect(await componentHarness.isHealthCheckInheritButtonToggled()).toBeTruthy();
+      fixture.detectChanges();
+
+      const inputHarness = await loader.getHarness(MatInputHarness.with({ selector: '[id*="dummy"]' }));
+      expect(await inputHarness.isDisabled()).toBeTruthy();
+
+      await componentHarness.toggleHealthCheckInheritButton();
       fixture.detectChanges();
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.harness.ts
@@ -28,6 +28,8 @@ export class ApiEndpointHarness extends ComponentHarness {
   private getConfigurationToggle = this.locatorFor(MatSlideToggleHarness);
   private getWeightButton = this.locatorFor(MatInputHarness.with({ selector: '#weight' }));
   private getConfigurationTab = this.locatorFor(MatTabHarness.with({ label: 'Configuration' }));
+  private getHealthCheckTab = this.locatorFor(MatTabHarness.with({ label: 'Health-check' }));
+  private getHealthCheckInheritToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName=inherit]' }));
 
   public async fillInputName(name: string) {
     return this.getNameInput().then((input) => input.setValue(name));
@@ -57,11 +59,29 @@ export class ApiEndpointHarness extends ComponentHarness {
     return this.getConfigurationToggle().then((toggle) => toggle.toggle());
   }
 
+  public async isHealthCheckInheritButtonToggled() {
+    return this.getHealthCheckInheritToggle().then((toggle) => toggle.isChecked());
+  }
+
+  public async toggleHealthCheckInheritButton() {
+    return this.getHealthCheckInheritToggle().then((toggle) => toggle.toggle());
+  }
+
   public async fillWeightButton(weight: number) {
     return this.getWeightButton().then((button) => button.setValue(weight.toString()));
   }
 
   public async clickConfigurationTab() {
     return this.getConfigurationTab().then((tab) => tab.select());
+  }
+
+  public async clickHealthCheckTab() {
+    return this.getHealthCheckTab().then((tab) => tab.select());
+  }
+
+  public healthCheckTabIsVisible(): Promise<boolean> {
+    return this.getHealthCheckTab()
+      .then((_) => true)
+      .catch((_) => false);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.module.ts
@@ -33,6 +33,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { ApiEndpointComponent } from './api-endpoint.component';
 
 import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
+import { ApiHealthCheckV4FormModule } from '../../component/health-check-v4-form/api-health-check-v4-form.module';
 
 @NgModule({
   declarations: [ApiEndpointComponent],
@@ -56,6 +57,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
     GioFormSlideToggleModule,
     GioGoBackButtonModule,
     MatTabsModule,
+    ApiHealthCheckV4FormModule,
   ],
 })
 export class ApiEndpointModule {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -40,7 +40,6 @@ import io.gravitee.rest.api.service.v4.exception.EndpointTypeInvalidException;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -164,7 +163,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
         }
     }
 
-    private void validateHealthCheck(Service healthCheck) {
+    private void validateAndSetHealthCheckConfiguration(Service healthCheck) {
         if (isBlank(healthCheck.getType())) {
             logger.debug("HealthCheck requires a type");
             throw new HealthcheckInvalidException(healthCheck.getType());
@@ -207,7 +206,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
                 validateDiscovery(services.getDiscovery());
             }
             if (services.getHealthCheck() != null) {
-                validateHealthCheck(services.getHealthCheck());
+                validateAndSetHealthCheckConfiguration(services.getHealthCheck());
             }
         }
     }
@@ -217,7 +216,9 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
             if (services.getHealthCheck() != null) {
                 final var serviceHealthCheck = services.getHealthCheck();
 
-                validateHealthCheck(serviceHealthCheck);
+                if (serviceHealthCheck.isEnabled()) {
+                    validateAndSetHealthCheckConfiguration(serviceHealthCheck);
+                }
 
                 final var hcGroupWithoutConfig =
                     (


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1418

## Description

Enable health-check schema config on the endpoint edit 

## Additional context

![image](https://github.com/gravitee-io/gravitee-api-management/assets/158490653/249756e0-1a8d-4bc3-a151-8cd18b884fcf)

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6704/console](https://pr.team-apim.gravitee.dev/6704/console)
      Portal: [https://pr.team-apim.gravitee.dev/6704/portal](https://pr.team-apim.gravitee.dev/6704/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6704/api/management](https://pr.team-apim.gravitee.dev/6704/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6704](https://pr.team-apim.gravitee.dev/6704)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6704](https://pr.gateway-v3.team-apim.gravitee.dev/6704)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iffdyohbth.chromatic.com)
<!-- Storybook placeholder end -->
