### PR TITLE
feat: add `isExpired` to license response

### DIFF
--- a/gravitee-apim-console-webui/src/entities/license/License.ts
+++ b/gravitee-apim-console-webui/src/entities/license/License.ts
@@ -18,5 +18,6 @@ export type License = {
   packs: Array<string>;
   features: Array<string>;
   expiresAt?: Date;
+  isExpired?: boolean;
   scope?: string;
 };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
@@ -53,6 +53,7 @@ public class GraviteeLicenseResource extends AbstractResource {
                 .packs(license.getPacks())
                 .features(license.getFeatures())
                 .expiresAt(license.getExpirationDate())
+                .isExpired(license.isExpired())
                 .scope(license.getReferenceType())
                 .build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResource.java
@@ -76,6 +76,7 @@ public class OrganizationResource extends AbstractResource {
                 .packs(license.getPacks())
                 .features(license.getFeatures())
                 .expiresAt(license.getExpirationDate())
+                .isExpired(license.isExpired())
                 .scope(license.getReferenceType())
                 .build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation-deprecated.yaml
@@ -122,6 +122,10 @@ components:
                     format: date-time
                     description: The date (as timestamp) when the license will expire.
                     example: 1581256457163
+                isExpired:
+                    type: boolean
+                    description: If the license is expired.
+                    example: false
                 scope:
                     type: string
                     description: The scope of the license.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-installation.yaml
@@ -222,6 +222,10 @@ components:
                     format: date-time
                     description: The date (as timestamp) when the license will expire.
                     example: 1581256457163
+                isExpired:
+                    type: boolean
+                    description: If the license is expired.
+                    example: false
                 scope:
                     type: string
                     description: The scope of the license.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
@@ -52,6 +52,7 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         when(license.getPacks()).thenReturn(Set.of("observability"));
         when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
         when(license.getReferenceType()).thenReturn("PLATFORM");
+        when(license.isExpired()).thenReturn(true);
 
         var now = Instant.now();
         var nowDate = Date.from(now);
@@ -67,5 +68,6 @@ public class GraviteeLicenseResourceTest extends AbstractResourceTest {
         assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
         assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
         assertThat(graviteeLicense.getScope()).isEqualTo("PLATFORM");
+        assertThat(graviteeLicense.getIsExpired()).isEqualTo(true);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/OrganizationResourceTest.java
@@ -100,6 +100,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             when(license.getFeatures()).thenReturn(Set.of("apim-reporter-datadog"));
             when(license.getExpirationDate()).thenReturn(nowDate);
             when(license.getReferenceType()).thenReturn("PLATFORM");
+            when(license.isExpired()).thenReturn(true);
 
             var response = rootTarget(ORGANIZATION).path("license").request().get();
             assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
@@ -111,6 +112,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             assertThat(graviteeLicense.getFeatures()).containsExactly("apim-reporter-datadog");
             assertThat(graviteeLicense.getExpiresAt().toInstant().toEpochMilli()).isEqualTo(now.toEpochMilli());
             assertThat(graviteeLicense.getScope()).isEqualTo("PLATFORM");
+            assertThat(graviteeLicense.getIsExpired()).isEqualTo(true);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
@@ -42,5 +42,7 @@ public class GraviteeLicenseEntity {
 
     private Date expiresAt;
 
+    private Boolean isExpired;
+
     private String scope;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Integrate `isExpired` into license response for ui-particles gio-license-service  : https://github.com/gravitee-io/gravitee-ui-particles/pull/367

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ajpoouaoui.chromatic.com)
<!-- Storybook placeholder end -->
