### PR TITLE
fix(e2e): unique enum for desc sort params during mapi-v2 sdk generation

### DIFF
--- a/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
+++ b/gravitee-apim-e2e/scripts/update-management-v2-sdk.sh
@@ -29,8 +29,13 @@ npx @openapitools/openapi-generator-cli@2.7.0 generate \
   --type-mappings=DateTime=Date,object=any \
   --reserved-words-mappings=configuration=configuration
 
+  # Create unique enum entry for descending sort params
   sed -i.bak "s|NAME: '-name'|_NAME: '-name'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
   sed -i.bak "s|PATHS: '-paths'|_PATHS: '-paths'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
+  sed -i.bak "s|KEY: '-key'|_KEY: '-key'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
+  sed -i.bak "s|FORMAT: '-format'|_FORMAT: '-format'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
+  sed -i.bak "s|VALUE: '-value'|_VALUE: '-value'|" lib/management-v2-webclient-sdk/src/lib/apis/APIsApi.ts
+
   # Remove duplicate `HttpEndpointV2FromJSONTyped` import
   sed -i.bak "s|     HttpEndpointV2FromJSONTyped,||" lib/management-v2-webclient-sdk/src/lib/models/BaseEndpointV2.ts
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Fix error in e2e tests when creating mapi-v2 sdk.

Error in pipeline: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/32450/workflows/2b07c700-9611-4c49-adc7-8e24c682cfc5/jobs/595638

![Screenshot 2024-02-23 at 17 52 19](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/863f2c0a-a032-4994-9be6-6273b15c39f7)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ifrsxshbgj.chromatic.com)
<!-- Storybook placeholder end -->
