### PR TITLE
fix(logging): override http method when capturing endpoint request

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHook.java
@@ -65,6 +65,7 @@ public class LoggingHook implements InvokerHook {
 
             if (log != null && loggingContext != null && loggingContext.endpointRequest()) {
                 log.getEndpointRequest().setHeaders(ctx.request().headers());
+                log.getEndpointRequest().setMethod(ctx.request().method());
             }
 
             if (log != null && loggingContext != null && loggingContext.endpointResponse()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/LoggingHookTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
@@ -144,6 +145,40 @@ class LoggingHookTest {
         obs.assertComplete();
 
         assertNotNull(log.getEndpointRequest().getHeaders());
+    }
+
+    @Test
+    void shouldSetEndpointRequestMethodWhenEndpointRequest() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        Request endpointRequest = new Request();
+        endpointRequest.setMethod(HttpMethod.GET);
+        log.setEndpointRequest(endpointRequest);
+
+        when(metrics.getLog()).thenReturn(log);
+        when(loggingContext.endpointRequest()).thenReturn(true);
+        when(request.method()).thenReturn(HttpMethod.CONNECT);
+
+        final TestObserver<Void> obs = cut.post("test", ctx, ExecutionPhase.REQUEST).test();
+        obs.assertComplete();
+
+        assertEquals(HttpMethod.CONNECT, log.getEndpointRequest().getMethod());
+    }
+
+    @Test
+    void shouldSetEndpointRequestMethodWhenEndpointRequestAndInterrupt() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        Request endpointRequest = new Request();
+        endpointRequest.setMethod(HttpMethod.GET);
+        log.setEndpointRequest(endpointRequest);
+
+        when(metrics.getLog()).thenReturn(log);
+        when(loggingContext.endpointRequest()).thenReturn(true);
+        when(request.method()).thenReturn(HttpMethod.CONNECT);
+
+        final TestObserver<Void> obs = cut.interruptWith("test", ctx, ExecutionPhase.REQUEST, new ExecutionFailure(500)).test();
+        obs.assertComplete();
+
+        assertEquals(HttpMethod.CONNECT, log.getEndpointRequest().getMethod());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3943

## Description

Like http headers, http method could have been modified by a policy during the request flow. We need to update the logged endpoint request.