### PR TITLE
fix: fill endpoint configuration on group creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,6 +17,6 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <mat-card *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema"></gio-form-json-schema>
+    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema" (ready)="onSchemaFormReady()"></gio-form-json-schema>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,6 +17,10 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <mat-card *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema" (ready)="onSchemaFormReady()"></gio-form-json-schema>
+    <gio-form-json-schema
+      formControlName="groupConfiguration"
+      [jsonSchema]="sharedConfigurationSchema"
+      (ready)="onSchemaFormReady()"
+    ></gio-form-json-schema>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
@@ -33,6 +33,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   @Input() endpointGroupType: string;
 
   public sharedConfigurationSchema: GioJsonSchema;
+  private initialValues: unknown;
 
   constructor(private readonly connectorPluginsV2Service: ConnectorPluginsV2Service) {}
 
@@ -43,6 +44,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
       .subscribe({
         next: (sharedConfigSchema) => {
           this.sharedConfigurationSchema = sharedConfigSchema;
+          this.initialValues = this.configurationForm.getRawValue();
         },
       });
   }
@@ -50,5 +52,11 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);
     this.unsubscribe$.complete();
+  }
+
+  onSchemaFormReady() {
+    // schema-form component is overriding the form with all the fields from the schema.
+    // We set back the initial value to avoid sending invalid data to the backend
+    this.configurationForm.setValue(this.initialValues, { emitEvent: false });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -63,8 +63,13 @@
           <span gioBannerBody>Configuration is disabled for Mock endpoint groups.</span>
         </gio-banner-info>
         <gio-form-json-schema
-          *ngIf="sharedConfigurationSchema"
+          *ngIf="configurationSchema"
           formControlName="configuration"
+          [jsonSchema]="configurationSchema"
+        ></gio-form-json-schema>
+        <gio-form-json-schema
+          *ngIf="sharedConfigurationSchema"
+          formControlName="sharedConfiguration"
           [jsonSchema]="sharedConfigurationSchema"
         ></gio-form-json-schema>
         <div class="api-endpoint-group-create__footer">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3916

## Description
- Do not init form with optional object coming from schema form to avoid saving invalid configuration
- add endpoint configuration when creating a group to avoid creating an invalid default endpoint


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lobqexhhtr.chromatic.com)
<!-- Storybook placeholder end -->
