### PR TITLE
fix: fill endpoint configuration on group creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,6 +17,6 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <mat-card *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema"></gio-form-json-schema>
+    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema" (ready)="onSchemaFormReady()"></gio-form-json-schema>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,6 +17,10 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <mat-card *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema" (ready)="onSchemaFormReady()"></gio-form-json-schema>
+    <gio-form-json-schema
+      formControlName="groupConfiguration"
+      [jsonSchema]="sharedConfigurationSchema"
+      (ready)="onSchemaFormReady()"
+    ></gio-form-json-schema>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
@@ -33,6 +33,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   @Input() endpointGroupType: string;
 
   public sharedConfigurationSchema: GioJsonSchema;
+  private initialValues: unknown;
 
   constructor(private readonly connectorPluginsV2Service: ConnectorPluginsV2Service) {}
 
@@ -43,6 +44,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
       .subscribe({
         next: (sharedConfigSchema) => {
           this.sharedConfigurationSchema = sharedConfigSchema;
+          this.initialValues = this.configurationForm.getRawValue();
         },
       });
   }
@@ -50,5 +52,11 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);
     this.unsubscribe$.complete();
+  }
+
+  onSchemaFormReady() {
+    // schema-form component is overriding the form with all the fields from the schema.
+    // We set back the initial value to avoid sending invalid data to the backend
+    this.configurationForm.setValue(this.initialValues, { emitEvent: false });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -63,8 +63,13 @@
           <span gioBannerBody>Configuration is disabled for Mock endpoint groups.</span>
         </gio-banner-info>
         <gio-form-json-schema
-          *ngIf="sharedConfigurationSchema"
+          *ngIf="configurationSchema"
           formControlName="configuration"
+          [jsonSchema]="configurationSchema"
+        ></gio-form-json-schema>
+        <gio-form-json-schema
+          *ngIf="sharedConfigurationSchema"
+          formControlName="sharedConfiguration"
           [jsonSchema]="sharedConfigurationSchema"
         ></gio-form-json-schema>
         <div class="api-endpoint-group-create__footer">

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
@@ -15,10 +15,10 @@
  */
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit, ViewChild } from '@angular/core';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import { of, Subject } from 'rxjs';
+import { combineLatest, of, Subject } from 'rxjs';
 import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { distinctUntilChanged, switchMap, takeUntil } from 'rxjs/operators';
+import { distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { StateService } from '@uirouter/angular';
 
 import { ApiEndpointGroupSelectionComponent } from '../selection/api-endpoint-group-selection.component';
@@ -59,6 +59,8 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
   public endpointGroupTypeForm: FormGroup;
   public generalForm: FormGroup;
   public configuration: FormControl;
+  public sharedConfiguration: FormControl;
+  public configurationSchema: GioJsonSchema;
   public sharedConfigurationSchema: GioJsonSchema;
   public apiType: ApiType;
 
@@ -95,35 +97,47 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
         distinctUntilChanged(),
         switchMap((type) => {
           // Hide GioJsonSchemaForm to reset
+          this.configurationSchema = undefined;
           this.sharedConfigurationSchema = undefined;
+
+          this.createForm.setControl('configuration', new FormControl({}, Validators.required));
+          this.createForm.setControl('sharedConfiguration', new FormControl({}, Validators.required));
 
           if (!type || type === 'mock') {
             this.createForm.removeControl('configuration');
-            return of(undefined);
+            return of([undefined, undefined]);
           }
 
-          this.createForm.setControl('configuration', new FormControl({}, Validators.required));
-          return this.connectorPluginsV2Service.getEndpointPluginSharedConfigurationSchema(type);
+          return combineLatest([
+            this.connectorPluginsV2Service.getEndpointPluginSchema(type),
+            this.connectorPluginsV2Service.getEndpointPluginSharedConfigurationSchema(type),
+          ]);
+        }),
+        tap(([schema, sharedSchema]) => {
+          this.configurationSchema = schema;
+          this.sharedConfigurationSchema = sharedSchema;
         }),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe({
-        next: (schema) => {
-          this.sharedConfigurationSchema = schema;
-        },
-      });
+      .subscribe();
   }
 
   createEndpointGroup() {
     const formValue = this.createForm.getRawValue();
-    const sharedConfiguration = formValue.configuration;
+    const configuration = formValue.configuration;
+    const sharedConfiguration = formValue.sharedConfiguration;
     const cleanName = formValue.general.name.trim();
 
     const newEndpointGroup: EndpointGroupV4 = {
       name: cleanName,
       loadBalancer: { type: formValue.general.loadBalancerType },
       type: formValue.type.endpointGroupType,
-      endpoints: [EndpointV4Default.byTypeAndGroupName(formValue.type.endpointGroupType, cleanName)],
+      endpoints: [
+        {
+          ...EndpointV4Default.byTypeAndGroupName(formValue.type.endpointGroupType, cleanName),
+          ...(configuration ? { configuration } : {}),
+        },
+      ],
       ...(sharedConfiguration ? { sharedConfiguration } : {}),
     };
 
@@ -161,11 +175,13 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
     });
 
     this.configuration = new FormControl({}, Validators.required);
+    this.sharedConfiguration = new FormControl({}, Validators.required);
 
     this.createForm = new FormGroup({
       type: this.endpointGroupTypeForm,
       general: this.generalForm,
       configuration: this.configuration,
+      sharedConfiguration: this.sharedConfiguration,
     });
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3916

## Description

- Do not init form with optional object coming from schema form to avoid saving invalid configuration
- add endpoint configuration when creating a group to avoid creating an invalid default endpoint

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hnilgbsyla.chromatic.com)
<!-- Storybook placeholder end -->
