### PR TITLE
fix: fill endpoint configuration on group creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,6 +17,10 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <ng-container *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema"></gio-form-json-schema>
+    <gio-form-json-schema
+      formControlName="groupConfiguration"
+      [jsonSchema]="sharedConfigurationSchema"
+      (ready)="onSchemaFormReady()"
+    ></gio-form-json-schema>
   </ng-container>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
@@ -33,6 +33,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   @Input() endpointGroupType: string;
 
   public sharedConfigurationSchema: GioJsonSchema;
+  private initialValues: unknown;
 
   constructor(private readonly connectorPluginsV2Service: ConnectorPluginsV2Service) {}
 
@@ -43,6 +44,7 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
       .subscribe({
         next: (sharedConfigSchema) => {
           this.sharedConfigurationSchema = sharedConfigSchema;
+          this.initialValues = this.configurationForm.getRawValue();
         },
       });
   }
@@ -50,5 +52,11 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
   ngOnDestroy(): void {
     this.unsubscribe$.next(true);
     this.unsubscribe$.complete();
+  }
+
+  onSchemaFormReady() {
+    // schema-form component is overriding the form with all the fields from the schema.
+    // We set back the initial value to avoid sending invalid data to the backend
+    this.configurationForm.setValue(this.initialValues, { emitEvent: false });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -67,8 +67,13 @@
             <span gioBannerBody>Configuration is disabled for Mock endpoint groups.</span>
           </gio-banner-info>
           <gio-form-json-schema
-            *ngIf="sharedConfigurationSchema"
+            *ngIf="configurationSchema"
             formControlName="configuration"
+            [jsonSchema]="configurationSchema"
+          ></gio-form-json-schema>
+          <gio-form-json-schema
+            *ngIf="sharedConfigurationSchema"
+            formControlName="sharedConfiguration"
             [jsonSchema]="sharedConfigurationSchema"
           ></gio-form-json-schema>
           <div class="api-endpoint-group-create__footer">

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
@@ -36,7 +36,7 @@ import { fakeEndpointGroupV4 } from '../../../../../entities/management-api-v2/a
 
 const API_ID = 'api-id';
 const ENDPOINT_GROUP_NAME = 'My Endpoint Group';
-const fakeKafkaSchema = {
+const fakeKafkaSharedSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   properties: {
@@ -54,6 +54,20 @@ const fakeRabbitMqSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   properties: {
+    server: {
+      title: 'Server',
+      type: 'string',
+      description: 'Server',
+    },
+  },
+  additionalProperties: false,
+  required: ['server'],
+};
+
+const fakeRabbitMqSharedSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
     rabbitFood: {
       title: 'Rabbit food',
       type: 'string',
@@ -64,7 +78,35 @@ const fakeRabbitMqSchema = {
   required: ['rabbitFood'],
 };
 
+const fakeKafkaSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    bootstrapServers: {
+      title: 'bootstrapServers',
+      type: 'string',
+      description: 'bootstrap servers',
+    },
+  },
+  additionalProperties: false,
+  required: ['bootstrapServers'],
+};
+
 const fakeHttpProxySchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    target: {
+      title: 'Target',
+      type: 'string',
+      description: 'Target',
+    },
+  },
+  additionalProperties: false,
+  required: ['target'],
+};
+
+const fakeHttpProxySharedSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   type: 'object',
   properties: {
@@ -220,7 +262,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
         expect(await harness.getConfigurationInputValue('topic')).toEqual('my-kafka-topic');
 
         expect(await harness.isConfigurationStepValid()).toEqual(true);
-        expect(await harness.canCreateEndpointGroup()).toEqual(true);
+        expect(await harness.canCreateEndpointGroup()).toEqual(false);
       });
     });
 
@@ -229,6 +271,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
         await initComponent(fakeApiV4({ id: API_ID }));
         await fillOutAndValidateEndpointSelection();
         await fillOutAndValidateGeneralInformation();
+        await harness.setConfigurationInputValue('bootstrapServers', 'a new server');
         await harness.setConfigurationInputValue('topic', 'my-kafka-topic');
         expect(await harness.isConfigurationStepValid()).toEqual(true);
       });
@@ -238,7 +281,9 @@ describe('ApiEndpointGroupCreateComponent', () => {
           name: ENDPOINT_GROUP_NAME,
           type: 'kafka',
           loadBalancer: { type: 'ROUND_ROBIN' },
-          endpoints: [EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME)],
+          endpoints: [
+            { ...EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME), configuration: { bootstrapServers: 'a new server' } },
+          ],
           sharedConfiguration: {
             topic: 'my-kafka-topic',
           },
@@ -246,14 +291,17 @@ describe('ApiEndpointGroupCreateComponent', () => {
       });
 
       it('should show error in configuration after changing endpoint type to RabbitMQ', async () => {
-        await chooseEndpointTypeAndGoToConfiguration('rabbitmq', fakeRabbitMqSchema);
+        await chooseEndpointTypeAndGoToConfiguration('rabbitmq', fakeRabbitMqSchema, fakeRabbitMqSharedSchema);
+        await harness.setConfigurationInputValue('server', 'lettuce-server:8888');
         await harness.setConfigurationInputValue('rabbitFood', 'lettuce');
 
         await createEndpointGroup({
           name: ENDPOINT_GROUP_NAME,
           type: 'rabbitmq',
           loadBalancer: { type: 'ROUND_ROBIN' },
-          endpoints: [EndpointV4Default.byTypeAndGroupName('rabbitmq', ENDPOINT_GROUP_NAME)],
+          endpoints: [
+            { ...EndpointV4Default.byTypeAndGroupName('rabbitmq', ENDPOINT_GROUP_NAME), configuration: { server: 'lettuce-server:8888' } },
+          ],
           sharedConfiguration: {
             rabbitFood: 'lettuce',
           },
@@ -267,6 +315,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
           type: 'mock',
           loadBalancer: { type: 'ROUND_ROBIN' },
           endpoints: [EndpointV4Default.byTypeAndGroupName('mock', ENDPOINT_GROUP_NAME)],
+          sharedConfiguration: {},
         });
       });
     });
@@ -286,12 +335,14 @@ describe('ApiEndpointGroupCreateComponent', () => {
           type: 'mock',
           loadBalancer: { type: 'ROUND_ROBIN' },
           endpoints: [EndpointV4Default.byTypeAndGroupName('mock', ENDPOINT_GROUP_NAME)],
+          sharedConfiguration: {},
         });
       });
 
       it('should invalidate configuration if user switches to Kafka endpoint type', async () => {
         await chooseEndpointTypeAndGoToConfiguration();
 
+        await harness.setConfigurationInputValue('bootstrapServers', 'bootstrap');
         await harness.setConfigurationInputValue('topic', 'my-kafka-topic');
         expect(await harness.isConfigurationStepValid()).toEqual(true);
 
@@ -299,7 +350,9 @@ describe('ApiEndpointGroupCreateComponent', () => {
           name: ENDPOINT_GROUP_NAME,
           type: 'kafka',
           loadBalancer: { type: 'ROUND_ROBIN' },
-          endpoints: [EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME)],
+          endpoints: [
+            { ...EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME), configuration: { bootstrapServers: 'bootstrap' } },
+          ],
           sharedConfiguration: {
             topic: 'my-kafka-topic',
           },
@@ -345,6 +398,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
         await fillOutAndValidateEndpointSelection('kafka');
         await fillOutAndValidateGeneralInformation(endpointGroupName);
         await harness.setConfigurationInputValue('topic', 'my-kafka-topic');
+        await harness.setConfigurationInputValue('bootstrapServers', 'bootstrap');
         expect(await harness.isConfigurationStepValid()).toEqual(true);
       }
 
@@ -355,7 +409,10 @@ describe('ApiEndpointGroupCreateComponent', () => {
             name: 'dlq group',
             type: 'kafka',
             loadBalancer: { type: 'ROUND_ROBIN' },
-            endpoints: [EndpointV4Default.byTypeAndGroupName('kafka', 'dlq group')],
+
+            endpoints: [
+              { ...EndpointV4Default.byTypeAndGroupName('kafka', 'dlq group'), configuration: { bootstrapServers: 'bootstrap' } },
+            ],
             sharedConfiguration: {
               topic: 'my-kafka-topic',
             },
@@ -374,7 +431,9 @@ describe('ApiEndpointGroupCreateComponent', () => {
           name: ENDPOINT_GROUP_NAME,
           type: 'kafka',
           loadBalancer: { type: 'ROUND_ROBIN' },
-          endpoints: [EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME)],
+          endpoints: [
+            { ...EndpointV4Default.byTypeAndGroupName('kafka', ENDPOINT_GROUP_NAME), configuration: { bootstrapServers: 'bootstrap' } },
+          ],
           sharedConfiguration: {
             topic: 'my-kafka-topic',
           },
@@ -386,7 +445,8 @@ describe('ApiEndpointGroupCreateComponent', () => {
   describe('V4 API - Proxy', () => {
     beforeEach(async () => {
       await initComponent(fakeApiV4({ id: API_ID, type: 'PROXY' }));
-      expectSchemaGet('http-proxy', fakeHttpProxySchema);
+      expectConfigurationSchemaGet('http-proxy', fakeHttpProxySchema);
+      expectSharedConfigurationSchemaGet('http-proxy', fakeHttpProxySharedSchema);
     });
 
     describe('Stepper', () => {
@@ -402,13 +462,16 @@ describe('ApiEndpointGroupCreateComponent', () => {
         await fillOutAndValidateGeneralInformation();
         expect(await harness.canCreateEndpointGroup()).toEqual(false);
         await harness.setConfigurationInputValue('proxyParam', 'my-proxy-param');
+        await harness.setConfigurationInputValue('target', 'http://target.gio');
         expect(await harness.isConfigurationStepValid()).toEqual(true);
 
         await createEndpointGroup({
           name: ENDPOINT_GROUP_NAME,
           type: 'http-proxy',
           loadBalancer: { type: 'ROUND_ROBIN' },
-          endpoints: [EndpointV4Default.byTypeAndGroupName('http-proxy', ENDPOINT_GROUP_NAME)],
+          endpoints: [
+            { ...EndpointV4Default.byTypeAndGroupName('http-proxy', ENDPOINT_GROUP_NAME), configuration: { target: 'http://target.gio' } },
+          ],
           sharedConfiguration: {
             proxyParam: 'my-proxy-param',
           },
@@ -424,7 +487,13 @@ describe('ApiEndpointGroupCreateComponent', () => {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
   }
 
-  function expectSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSchema): void {
+  function expectConfigurationSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSchema): void {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${endpointId}/schema`, method: 'GET' })
+      .flush(schema);
+  }
+
+  function expectSharedConfigurationSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSharedSchema): void {
     httpTestingController
       .expectOne({ url: `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/endpoints/${endpointId}/shared-configuration-schema`, method: 'GET' })
       .flush(schema);
@@ -458,7 +527,8 @@ describe('ApiEndpointGroupCreateComponent', () => {
     expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(true);
     await harness.selectEndpointGroup(type);
     if (type !== 'mock') {
-      expectSchemaGet(type);
+      expectConfigurationSchemaGet(type);
+      expectSharedConfigurationSchemaGet(type);
     }
     await harness.validateEndpointGroupSelection();
     expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(false);
@@ -474,13 +544,18 @@ describe('ApiEndpointGroupCreateComponent', () => {
     expect(await isStepActive(harness.getConfigurationStep())).toEqual(true);
   }
 
-  async function chooseEndpointTypeAndGoToConfiguration(type = 'kafka', schema: any = fakeKafkaSchema): Promise<void> {
+  async function chooseEndpointTypeAndGoToConfiguration(
+    type = 'kafka',
+    schema: any = fakeKafkaSchema,
+    sharedSchema: any = fakeKafkaSharedSchema,
+  ): Promise<void> {
     // Choose endpoint type
     await harness.getEndpointGroupTypeStep().then((step) => step.select());
     await harness.selectEndpointGroup(type);
 
     if (type !== 'mock') {
-      expectSchemaGet(type, schema);
+      expectConfigurationSchemaGet(type, schema);
+      expectSharedConfigurationSchemaGet(type, sharedSchema);
     }
 
     // Go to configuration page


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3916

## Description

- Do not init form with optional object coming from schema form to avoid saving invalid configuration
- add endpoint configuration when creating a group to avoid creating an invalid default endpoint

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sfsfkkgwix.chromatic.com)
<!-- Storybook placeholder end -->
