### PR TITLE
Rest api - fix creating application with "@" in name

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/sanitizer/HtmlSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/sanitizer/HtmlSanitizer.java
@@ -38,7 +38,8 @@ public final class HtmlSanitizer {
             .replaceAll("&#39;", "'")
             .replaceAll("&#43;", "+")
             .replaceAll("&#61;", "=")
-            .replaceAll("&#96;", "`");
+            .replaceAll("&#96;", "`")
+            .replaceAll("&#64;", "@");
     }
 
     public static String sanitize(String content) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/sanitizer/HtmlSanitizerTest.java
@@ -35,8 +35,8 @@ class HtmlSanitizerTest {
         sanitized = HtmlSanitizer.sanitize("A <a href=\"https://www.gravitee.io\">Test</a> Text");
         assertEquals("A Test Text", sanitized);
 
-        sanitized = HtmlSanitizer.sanitize("Allowed chars: (&lt; &gt; &amp; &quot; &apos;) (< > & \" ' + = `)");
-        assertEquals("Allowed chars: (< > & \" ') (< > & \" ' + = `)", sanitized);
+        sanitized = HtmlSanitizer.sanitize("Allowed chars: (&lt; &gt; &amp; &quot; &apos; &commat;) (< > & \" ' + = ` @)");
+        assertEquals("Allowed chars: (< > & \" ' @) (< > & \" ' + = ` @)", sanitized);
 
         sanitized = HtmlSanitizer.sanitize("&lt;a data-bind=&#39;style: alert(1)&#39;&gt;&lt;/a&gt;"); // <a data-bind='style: alert(1)'></a>
         assertEquals("", sanitized);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3882

## Description

Allow @ char with HtmlSanitizer

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6734/console](https://pr.team-apim.gravitee.dev/6734/console)
      Portal: [https://pr.team-apim.gravitee.dev/6734/portal](https://pr.team-apim.gravitee.dev/6734/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6734/api/management](https://pr.team-apim.gravitee.dev/6734/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6734](https://pr.team-apim.gravitee.dev/6734)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6734](https://pr.gateway-v3.team-apim.gravitee.dev/6734)

<!-- Environment placeholder end -->
