### PR TITLE
Console: fix no more possible to compare published et to deploy status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -210,7 +210,7 @@ class ApiHistoryController {
         this.events = [...(this.events ?? []), ...response.data.content];
         this.hasNextEventPageToLoad =
           response.data.totalElements > response.data.pageNumber * this.eventPageSize + response.data.pageElements;
-        this.initTimeline(this.events);
+        this.reloadEventsTimeline(this.events);
       },
     );
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3782

## Description

display of the "TO_DEPLOY" history event to compare the APIDefinition not yet deployed

## Additional context
This TO_DEPLOY : 

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/440d28f9-68ed-4884-8bd4-83060b5ecd1f)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qkosatfgqg.chromatic.com)
<!-- Storybook placeholder end -->
