### PR TITLE
Console: fix no more possible to compare published et to deploy status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.ts
@@ -178,23 +178,51 @@ class ApiHistoryControllerAjs {
       });
     }
 
-    this.ApiService.get(this.activatedRoute.snapshot.params.apiId).then((api) => {
+    Promise.all([
+      this.ApiService.get(this.activatedRoute.snapshot.params.apiId),
+      this.ApiService.isAPISynchronized(this.activatedRoute.snapshot.params.apiId),
+    ]).then(([api, apiIsSynchronizedResult]) => {
       this.api = api.data;
 
       this.eventPage = -1;
       this.events = [];
-      this.appendNextPage();
+      const toDeployEventTimeline = !apiIsSynchronizedResult.data.is_synchronized
+        ? {
+            event: {
+              payload: this.stringifyCurrentApi(),
+            },
+            badgeClass: 'warning',
+            badgeIconClass: 'notification:sync',
+            title: 'TO_DEPLOY',
+            isCurrentAPI: true,
+          }
+        : undefined;
+      this.appendNextPage(toDeployEventTimeline);
     });
   }
 
-  appendNextPage() {
+  appendNextPage(toDeployEventTimeline?: any) {
     this.eventPage++;
     this.ApiService.searchApiEvents(this.eventTypes, this.api.id, undefined, undefined, this.eventPage, this.eventPageSize, true).then(
       (response) => {
         this.events = [...(this.events ?? []), ...response.data.content];
         this.hasNextEventPageToLoad =
           response.data.totalElements > response.data.pageNumber * this.eventPageSize + response.data.pageElements;
-        this.initTimeline(this.events);
+
+        this.eventsTimeline = this.events.map((event) => ({
+          event: event,
+          badgeClass: 'info',
+          badgeIconClass: 'action:check_circle',
+          title: event.type,
+          when: event.created_at,
+          user: event.user,
+          deploymentLabel: event.properties.deployment_label,
+          deploymentNumber: event.properties.deployment_number,
+        }));
+
+        if (toDeployEventTimeline) {
+          this.eventsTimeline.unshift(toDeployEventTimeline);
+        }
       },
     );
   }
@@ -209,19 +237,6 @@ class ApiHistoryControllerAjs {
       flow_mode: api.flow_mode,
     };
     this.studio.services = api.services || {};
-  }
-
-  initTimeline(events) {
-    this.eventsTimeline = events.map((event) => ({
-      event: event,
-      badgeClass: 'info',
-      badgeIconClass: 'action:check_circle',
-      title: event.type,
-      when: event.created_at,
-      user: event.user,
-      deploymentLabel: event.properties.deployment_label,
-      deploymentNumber: event.properties.deployment_number,
-    }));
   }
 
   selectEvent(_eventTimeline) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3782

## Description

display of the "TO_DEPLOY" history event to compare the APIDefinition not yet deployed

## Additional context
This TO_DEPLOY : 

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/440d28f9-68ed-4884-8bd4-83060b5ecd1f)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ovbbgctcau.chromatic.com)
<!-- Storybook placeholder end -->
