### PR TITLE
feat(cockpit): add command handlers to disable environment and organization

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.access_point.model.AccessPoint;
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandHandler;
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.environment.*;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiStateService;
+import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DisableEnvironmentCommandHandler implements CommandHandler<DisableEnvironmentCommand, DisableEnvironmentReply> {
+
+    private final EnvironmentService environmentService;
+    private final ApiRepository apiRepository;
+    private final ApiStateService apiStateService;
+    private final AccessPointCrudService accessPointService;
+
+    public DisableEnvironmentCommandHandler(
+        EnvironmentService environmentService,
+        ApiStateService apiStateService,
+        @Lazy ApiRepository apiRepository,
+        AccessPointCrudService accessPointService
+    ) {
+        this.environmentService = environmentService;
+        this.apiStateService = apiStateService;
+        this.apiRepository = apiRepository;
+        this.accessPointService = accessPointService;
+    }
+
+    @Override
+    public Command.Type handleType() {
+        return Command.Type.DISABLE_ENVIRONMENT_COMMAND;
+    }
+
+    @Override
+    public Single<DisableEnvironmentReply> handle(DisableEnvironmentCommand command) {
+        var payload = command.getPayload();
+
+        try {
+            var environment = environmentService.findByCockpitId(payload.getCockpitId());
+            var executionContext = new ExecutionContext(environment);
+
+            // Stop all Environment APIs
+            apiRepository
+                .search(
+                    new ApiCriteria.Builder().state(LifecycleState.STARTED).environmentId(environment.getId()).build(),
+                    new ApiFieldFilter.Builder().excludeDefinition().excludePicture().build()
+                )
+                .forEach(api -> apiStateService.stop(executionContext, api.getId(), payload.getUserId()));
+
+            // Delete related access points
+            this.accessPointService.deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, environment.getId());
+
+            log.info("Environment [{}] with id [{}] has been disabled.", environment.getName(), environment.getId());
+            return Single.just(new DisableEnvironmentReply(command.getId(), CommandStatus.SUCCEEDED));
+        } catch (Exception e) {
+            log.error("Error occurred when disabling environment [{}] with id [{}].", payload.getName(), payload.getId(), e);
+            return Single.just(new DisableEnvironmentReply(command.getId(), CommandStatus.ERROR));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableOrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableOrganizationCommandHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.access_point.model.AccessPoint;
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandHandler;
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationCommand;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationReply;
+import io.gravitee.rest.api.service.OrganizationService;
+import io.reactivex.rxjava3.core.Single;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class DisableOrganizationCommandHandler implements CommandHandler<DisableOrganizationCommand, DisableOrganizationReply> {
+
+    private final OrganizationService organizationService;
+    private final AccessPointCrudService accessPointService;
+
+    public DisableOrganizationCommandHandler(OrganizationService organizationService, AccessPointCrudService accessPointService) {
+        this.organizationService = organizationService;
+        this.accessPointService = accessPointService;
+    }
+
+    @Override
+    public Command.Type handleType() {
+        return Command.Type.DISABLE_ORGANIZATION_COMMAND;
+    }
+
+    @Override
+    public Single<DisableOrganizationReply> handle(DisableOrganizationCommand command) {
+        var organizationPayload = command.getPayload();
+        try {
+            var organization = organizationService.findByCockpitId(organizationPayload.getCockpitId());
+
+            // Delete related access points
+            this.accessPointService.deleteAccessPoints(AccessPoint.ReferenceType.ORGANIZATION, organization.getId());
+
+            log.info("Organization [{}] with id [{}] has been disabled.", organization.getName(), organization.getId());
+            return Single.just(new DisableOrganizationReply(command.getId(), CommandStatus.SUCCEEDED));
+        } catch (Exception e) {
+            log.error(
+                "Error occurred when disabling organization [{}] with id [{}].",
+                organizationPayload.getName(),
+                organizationPayload.getId(),
+                e
+            );
+            return Single.just(new DisableOrganizationReply(command.getId(), CommandStatus.ERROR));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableEnvironmentCommandHandlerTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.access_point.model.AccessPoint;
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.environment.DisableEnvironmentCommand;
+import io.gravitee.cockpit.api.command.environment.DisableEnvironmentPayload;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
+import io.gravitee.rest.api.service.v4.ApiStateService;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DisableEnvironmentCommandHandlerTest {
+
+    private static final String ENV_COCKPIT_ID = "env#cockpit#id";
+    private static final String ENV_APIM_ID = "env#apim#id";
+    private static final String API_ID = "env#api#id";
+    private static final String USER_ID = "user#id";
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private ApiStateService apiStateService;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private AccessPointCrudService accessPointService;
+
+    private DisableEnvironmentCommandHandler cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DisableEnvironmentCommandHandler(environmentService, apiStateService, apiRepository, accessPointService);
+    }
+
+    @Test
+    void handleType() {
+        assertEquals(Command.Type.DISABLE_ENVIRONMENT_COMMAND, cut.handleType());
+    }
+
+    @Test
+    void handleSuccessfulCommand() {
+        when(environmentService.findByCockpitId(ENV_COCKPIT_ID)).thenReturn(EnvironmentEntity.builder().id(ENV_APIM_ID).build());
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId(ENV_APIM_ID).state(LifecycleState.STARTED).build()),
+                any(ApiFieldFilter.class)
+            )
+        )
+            .thenReturn(List.of(Api.builder().id(API_ID).build()));
+
+        cut
+            .handle(aDisableEnvCommand())
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(apiStateService).stop(any(ExecutionContext.class), eq(API_ID), eq(USER_ID));
+        verify(accessPointService).deleteAccessPoints(AccessPoint.ReferenceType.ENVIRONMENT, ENV_APIM_ID);
+    }
+
+    @Test
+    void handleThrowsException() {
+        when(environmentService.findByCockpitId(ENV_COCKPIT_ID)).thenThrow(new EnvironmentNotFoundException(ENV_COCKPIT_ID));
+
+        cut
+            .handle(aDisableEnvCommand())
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    private DisableEnvironmentCommand aDisableEnvCommand() {
+        var payload = new DisableEnvironmentPayload();
+        payload.setCockpitId(ENV_COCKPIT_ID);
+        payload.setUserId(USER_ID);
+        return new DisableEnvironmentCommand(payload);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableOrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DisableOrganizationCommandHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.access_point.model.AccessPoint;
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationCommand;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationPayload;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.exceptions.OrganizationNotFoundException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DisableOrganizationCommandHandlerTest {
+
+    private static final String ORG_COCKPIT_ID = "org#cockpit#id";
+    private static final String ORG_APIM_ID = "org#apim#id";
+
+    @Mock
+    private OrganizationService organizationService;
+
+    @Mock
+    private AccessPointCrudService accessPointService;
+
+    private DisableOrganizationCommandHandler cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DisableOrganizationCommandHandler(organizationService, accessPointService);
+    }
+
+    @Test
+    void handleType() {
+        assertEquals(Command.Type.DISABLE_ORGANIZATION_COMMAND, cut.handleType());
+    }
+
+    @Test
+    void handleSuccessfulCommand() {
+        var apimOrg = new OrganizationEntity();
+        apimOrg.setId(ORG_APIM_ID);
+
+        when(organizationService.findByCockpitId(ORG_COCKPIT_ID)).thenReturn(apimOrg);
+
+        cut
+            .handle(aDisableOrgCommand())
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(accessPointService).deleteAccessPoints(AccessPoint.ReferenceType.ORGANIZATION, ORG_APIM_ID);
+    }
+
+    @Test
+    void handleThrowsException() {
+        when(organizationService.findByCockpitId(ORG_COCKPIT_ID)).thenThrow(new OrganizationNotFoundException(ORG_COCKPIT_ID));
+
+        cut
+            .handle(aDisableOrgCommand())
+            .test()
+            .awaitDone(1, TimeUnit.SECONDS)
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.ERROR));
+    }
+
+    private DisableOrganizationCommand aDisableOrgCommand() {
+        var payload = new DisableOrganizationPayload();
+        payload.setCockpitId(ORG_COCKPIT_ID);
+        return new DisableOrganizationCommand(payload);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <gravitee-resource-oauth2-provider-generic.version>2.0.2</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>4.0.2</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>4.0.4</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.1</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>1.8.2</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>7.0.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>2.5.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>2.6.2</gravitee-cockpit-api.version>
         <gravitee-common.version>3.4.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-996
https://gravitee.atlassian.net/browse/CJ-1125

## Description

Add two independent handlers to allow disabling environments and organizations.

The current scenario where these commands will be used is to disable running trials in a multi-tenant APIM installation.

## Relate PRs

Cockpit: https://github.com/gravitee-io/gravitee-cockpit/pull/4226
Cockpit API: https://github.com/gravitee-io/gravitee-cockpit-api/pull/133

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jzbgcryynq.chromatic.com)
<!-- Storybook placeholder end -->
