### PR TITLE
fix: setting isPrimaryOwner on group

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -918,7 +918,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         GroupEntity entity = new GroupEntity();
         entity.setId(group.getId());
         entity.setName(group.getName());
-        entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
+        if (group.getApiPrimaryOwner() != null && !group.getApiPrimaryOwner().isEmpty()) {
+            entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
+            entity.setPrimaryOwner(true);
+        }
 
         if (group.getEventRules() != null && !group.getEventRules().isEmpty()) {
             List<GroupEventRuleEntity> groupEventRules = new ArrayList<>();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4027

## Description

When mapping a single group into a groupEntity, the `primaryOwner` boolean was not set.
As a consequence the method `group.isPrimaryOwner()` was always false

And fixing a e2e test to add a PO user in a PO group.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-buymjslyta.chromatic.com)
<!-- Storybook placeholder end -->
