### PR TITLE
fix(ui-logs-detailed-empty-state): Get rid of snack bar on the logs detailed page when empty state

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/api-runtime-logs-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/api-runtime-logs-details.component.spec.ts
@@ -19,6 +19,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiRuntimeLogsDetailsComponent } from './api-runtime-logs-details.component';
 import { ApiRuntimeLogsDetailsModule } from './api-runtime-logs-details.module';
@@ -36,7 +37,7 @@ describe('ApiRuntimeLogsDetailsComponent', () => {
 
   const initComponent = async () => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, ApiRuntimeLogsDetailsModule, GioTestingModule],
+      imports: [NoopAnimationsModule, ApiRuntimeLogsDetailsModule, GioTestingModule, MatSnackBarModule],
       providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } }],
     });
 
@@ -50,7 +51,7 @@ describe('ApiRuntimeLogsDetailsComponent', () => {
     jest.clearAllMocks();
   });
 
-  it('should display proxy logs details component', async () => {
+  it('should not display proxy logs details component', async () => {
     await initComponent();
     expectApi(fakeApiV4({ id: API_ID, type: 'PROXY' }));
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/components/api-runtime-logs-details-empty-state/api-runtime-logs-details-empty-state.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/components/api-runtime-logs-details-empty-state/api-runtime-logs-details-empty-state.component.html
@@ -21,7 +21,7 @@
     <mat-icon class="icon" svgIcon="gio:search"></mat-icon>
     <div class="mat-h3" aria-label="No runtime logs available">No log available</div>
     <div class="empty-card__body">
-      <span class="empty-card__body__subtitle"> Modify the Runtime Logs settings to record additional data. </span>
+      <span class="empty-card__body__subtitle"> Modify the Runtime Logs settings to record additional data for future requests. </span>
     </div>
 
     <div class="empty-card__actions">

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
@@ -19,6 +19,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiRuntimeLogsMessagesComponent } from './api-runtime-logs-messages.component';
 import { ApiRuntimeLogsMessagesModule } from './api-runtime-logs-messages.module';
@@ -46,7 +47,7 @@ describe('ApiRuntimeLogsMessagesComponent', () => {
 
   const initComponent = async () => {
     TestBed.configureTestingModule({
-      imports: [ApiRuntimeLogsMessagesModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      imports: [ApiRuntimeLogsMessagesModule, GioTestingModule, MatIconTestingModule, NoopAnimationsModule, MatSnackBarModule],
       providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID, requestId: REQUEST_ID } } } }],
     });
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.ts
@@ -20,6 +20,7 @@ import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { uniqBy } from 'lodash';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ApiLogsV2Service } from '../../../../../../services-ngx/api-logs-v2.service';
 import { AggregatedMessageLog, ConnectionLogDetail, ConnectorPlugin, ConnectorType } from '../../../../../../entities/management-api-v2';
@@ -47,6 +48,7 @@ export class ApiRuntimeLogsMessagesComponent implements OnInit, OnDestroy {
     private readonly apiLogsService: ApiLogsV2Service,
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
     private readonly iconService: IconService,
+    private readonly matSnackBar: MatSnackBar,
   ) {}
 
   public ngOnInit(): void {
@@ -66,7 +68,11 @@ export class ApiRuntimeLogsMessagesComponent implements OnInit, OnDestroy {
     return this.apiLogsService
       .searchConnectionLogDetail(this.activatedRoute.snapshot.params.apiId, this.activatedRoute.snapshot.params.requestId)
       .pipe(
-        catchError(() => {
+        catchError((err) => {
+          // normally 404 is intercepted by the HttpErrorInterceptor and displayed as a snack error, but on this page, it should be dismissed.
+          if (err.status === 404) {
+            this.matSnackBar.dismiss();
+          }
           return of(undefined);
         }),
         takeUntil(this.unsubscribe$),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
@@ -18,6 +18,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiRuntimeLogsProxyComponent } from './api-runtime-logs-proxy.component';
 import { ApiRuntimeLogsProxyHarness } from './api-runtime-logs-proxy.harness';
@@ -42,7 +43,7 @@ describe('ApiRuntimeLogsProxyComponent', () => {
 
   const initComponent = async () => {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, ApiRuntimeLogsProxyModule, GioTestingModule],
+      imports: [NoopAnimationsModule, ApiRuntimeLogsProxyModule, GioTestingModule, MatSnackBarModule],
       providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID, requestId: REQUEST_ID } } } }],
     });
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.ts
@@ -17,6 +17,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { catchError, takeUntil } from 'rxjs/operators';
 import { of, Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { ApiLogsV2Service } from '../../../../../../services-ngx/api-logs-v2.service';
 
@@ -30,7 +31,11 @@ export class ApiRuntimeLogsProxyComponent implements OnDestroy {
   public connectionLog$ = this.apiLogsService
     .searchConnectionLogDetail(this.activatedRoute.snapshot.params.apiId, this.activatedRoute.snapshot.params.requestId)
     .pipe(
-      catchError(() => {
+      catchError((err) => {
+        // normally 404 is intercepted by the HttpErrorInterceptor and displayed as a snack error, but on this page, it should be dismissed.
+        if (err.status === 404) {
+          this.matSnackBar.dismiss();
+        }
         return of(undefined);
       }),
       takeUntil(this.unsubscribe$),
@@ -40,6 +45,7 @@ export class ApiRuntimeLogsProxyComponent implements OnDestroy {
     private readonly activatedRoute: ActivatedRoute,
     private readonly router: Router,
     private readonly apiLogsService: ApiLogsV2Service,
+    private readonly matSnackBar: MatSnackBar,
   ) {}
 
   ngOnDestroy(): void {


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-3893

## Description

Instead of throwing an error, we can just show the empty screen. 
message updated to: “Modify the Runtime Logs settings to record additional data for future requests.”
## Additional context


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vubbqwhodm.chromatic.com)
<!-- Storybook placeholder end -->
