### PR TITLE
Console : fix error when clicking on top failed api in platform dashboard 

### DIFF
--- a/gravitee-apim-console-webui/src/components/dashboard/widget/table/widget-data-table.component.ts
+++ b/gravitee-apim-console-webui/src/components/dashboard/widget/table/widget-data-table.component.ts
@@ -110,11 +110,11 @@ const WidgetDataTableComponent: ng.IComponentOptions = {
         if (this.ngRouter.url.includes('/dashboard')) {
           if (this.widget.chart.request.field === 'api') {
             this.ngRouter.navigate([this.constants.org.currentEnv.id, 'apis', key, 'v2', 'analytics-overview'], {
-              queryParams: { from: this.widget.chart.request.from, to: this.widget.chart.request.to, q: this.widget.chart.request.query },
+              queryParams: { from: this.widget.chart.request.from, to: this.widget.chart.request.to },
             });
           } else if (this.widget.chart.request.field === 'application') {
             this.ngRouter.navigate([this.constants.org.currentEnv.id, 'applications', key, 'analytics'], {
-              queryParams: { from: this.widget.chart.request.from, to: this.widget.chart.request.to, q: this.widget.chart.request.query },
+              queryParams: { from: this.widget.chart.request.from, to: this.widget.chart.request.to },
             });
           }
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3828

## Description

The links targeting by the widget don't know how to interpret the "q". And we mainly want a link that redirects to the API analytics page with the right period of time.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pcgppgcxen.chromatic.com)
<!-- Storybook placeholder end -->
