### PR TITLE
fix(console): verify if api can be deployed in danger zone

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
@@ -43,7 +43,7 @@
           <button
             mat-button
             color="warn"
-            [disabled]="canStart$ | async"
+            [disabled]="isReadOnly || shouldUpgrade"
             data-testid="api_info_dangerzone_start_api"
             (click)="changeLifecycle('START')"
           >
@@ -51,7 +51,7 @@
           </button>
         </div>
 
-        <div *ngIf="shouldUpgrade$ | async">
+        <div *ngIf="shouldUpgrade">
           <gio-license-banner [license]="license$ | async" [isOEM]="isOEM$ | async" (onRequestUpgrade)="onRequestUpgrade()">
           </gio-license-banner>
         </div>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
@@ -21,10 +21,9 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
-import { GioConfirmAndValidateDialogHarness, GioLicenseService, LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
+import { GioConfirmAndValidateDialogHarness, LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { SimpleChange } from '@angular/core';
-import { of } from 'rxjs';
 import { Router } from '@angular/router';
 
 import { ApiGeneralInfoDangerZoneComponent } from './api-general-info-danger-zone.component';
@@ -220,10 +219,7 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
     });
 
     createComponent(api);
-
-    const licenseService = fixture.debugElement.injector.get(GioLicenseService);
-    jest.spyOn(licenseService, 'isMissingFeature$').mockReturnValue(of(true));
-    fixture.detectChanges();
+    expectApiVerifyDeployment(api, false);
 
     const upgradeButton = fixture.debugElement.query(
       (elem) => elem.name === 'button' && elem.nativeElement.textContent === 'Request upgrade',
@@ -277,6 +273,13 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
 
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectApiVerifyDeployment(api: Api, ok: boolean) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/deployments/_verify`, method: 'GET' }).flush({
+      ok,
+    });
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
@@ -24,7 +24,7 @@ import {
   GioLicenseService,
   License,
 } from '@gravitee/ui-particles-angular';
-import { EMPTY, Observable, of, Subject } from 'rxjs';
+import { EMPTY, Observable, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -70,24 +70,7 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
   public isReadOnly = false;
   public license$: Observable<License>;
   public isOEM$: Observable<boolean>;
-
-  public get shouldUpgrade$(): Observable<boolean> {
-    if (this.api.definitionVersion === 'V2') {
-      return of(false);
-    }
-    const api = this.api as ApiV4;
-    if (api.type === 'PROXY') {
-      return of(false);
-    }
-    return this.licenseService?.isMissingFeature$(this.licenseOptions.feature);
-  }
-
-  public get canStart$(): Observable<boolean> {
-    if (this.isReadOnly) {
-      return of(false);
-    }
-    return this.shouldUpgrade$;
-  }
+  public shouldUpgrade: boolean;
 
   constructor(
     private readonly router: Router,
@@ -101,14 +84,22 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
   ) {}
 
   ngOnInit(): void {
+    this.isReadOnly = this.api.definitionVersion === 'V1' || this.api.definitionContext?.origin === 'KUBERNETES';
+
     this.license$ = this.licenseService.getLicense$();
     this.isOEM$ = this.licenseService.isOEM$();
+
+    if (this.api.definitionVersion !== 'V4' || (this.api as ApiV4).type === 'PROXY') {
+      this.shouldUpgrade = false;
+    } else {
+      this.apiService.verifyDeploy(this.api.id).subscribe((resp) => {
+        this.shouldUpgrade = resp?.ok !== true;
+      });
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.api) {
-      this.isReadOnly = this.api.definitionVersion === 'V1' || this.api.definitionContext?.origin === 'KUBERNETES';
-
       this.dangerActions = {
         canAskForReview:
           this.constants.env?.settings?.apiReview?.enabled &&

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -162,8 +162,6 @@ describe('ApiGeneralInfoComponent', () => {
       const categoriesInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="categories"]' }));
       expect(await categoriesInput.isDisabled()).toEqual(true);
 
-      expectLicenseGetRequest();
-
       await Promise.all(
         [/Import/, /Duplicate/, /Promote/].map(async (btnText) => {
           const button = await loader.getHarness(MatButtonHarness.with({ text: btnText }));
@@ -493,7 +491,7 @@ describe('ApiGeneralInfoComponent', () => {
 
       // Expect fetch api and update
       expectApiGetRequest(api);
-      expectLicenseGetRequest();
+      expectApiVerifyDeployment(api, true);
 
       // Wait image to be covert to base64
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -572,7 +570,7 @@ describe('ApiGeneralInfoComponent', () => {
       const categoriesInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="categories"]' }));
       expect(await categoriesInput.isDisabled()).toEqual(true);
 
-      expectLicenseGetRequest();
+      expectApiVerifyDeployment(api, true);
 
       await Promise.all(
         [/Import/, /Duplicate/, /Promote/].map(async (btnText) => {
@@ -603,7 +601,7 @@ describe('ApiGeneralInfoComponent', () => {
       await button.click();
 
       await waitImageCheck();
-      expectLicenseGetRequest();
+      expectApiVerifyDeployment(api, true);
 
       await expectExportV4GetRequest(API_ID);
     });
@@ -622,7 +620,7 @@ describe('ApiGeneralInfoComponent', () => {
       const button = await loader.getHarness(MatButtonHarness.with({ text: /Duplicate/ }));
       expect(await button.isDisabled()).toBeFalsy();
       await button.click();
-      expectLicenseGetRequest();
+      expectApiVerifyDeployment(api, true);
 
       const confirmDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#duplicateApiDialog' }));
 
@@ -725,8 +723,10 @@ describe('ApiGeneralInfoComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectLicenseGetRequest() {
-    httpTestingController.expectOne({ url: LICENSE_CONFIGURATION_TESTING.resourceURL, method: 'GET' }).flush({ features: [], packs: [] });
+  function expectApiVerifyDeployment(api: Api, ok: boolean) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/deployments/_verify`, method: 'GET' }).flush({
+      ok,
+    });
   }
 });
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3973

## Description

Use `/deployments/_verify` in the Danger Zone to check if the user needs to upgrade their license to deploy.

![Screenshot 2024-02-28 at 16 18 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/20cad48c-459e-4916-8cb7-0a2539d5d21a)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rtuqenwiov.chromatic.com)
<!-- Storybook placeholder end -->
