### PR TITLE
fix: update apikey when transferrin apikey subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1447,6 +1447,13 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             SubscriptionEntity subscriptionEntity = convert(subscription);
 
+            apiKeyService
+                .findBySubscription(executionContext, subscriptionEntity.getId())
+                .forEach(apiKeyEntity -> {
+                    apiKeyEntity.getSubscriptions().add(subscriptionEntity);
+                    apiKeyService.update(executionContext, apiKeyEntity);
+                });
+
             final Map<String, Object> params = new NotificationParamsBuilder()
                 .owner(owner)
                 .application(application)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3948

## Description

When transferring an ApiKey subscription, the Apikey itslef needs to be updated with the new subscription, so the gateway is aware that this apikey is now affected to another plan.

The fix is only for 3.20 because starting with version 4, the subscription synchronization mechanism has changed and the problem does not occur.