### PR TITLE
fix(portal): documentation menu expanded by default

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
@@ -24,7 +24,7 @@
 
 <div *ngIf="isLoaded && !isEmpty()" class="gv-documentation">
   <div #treeMenu class="gv-documentation__menu" [ngClass]="{ show: isLoaded }">
-    <gv-tree [items]="menu" [selectedItem]="currentMenuItem"></gv-tree>
+    <gv-tree [items]="menu" [selectedItem]="currentMenuItem" [closed]="false"></gv-tree>
   </div>
   <app-gv-page
     *ngIf="currentPage"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4084

## Description

This 4.3.0 [feature](https://gravitee.atlassian.net/browse/APIM-3740) has been mistakenly backported to 3.20, 4.0, 4.1 and 4.2.

This PR restores the default behaviour for these versions.