### PR TITLE
chore(deps): upgrade gravitee-bom to 7.0.10

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -20,6 +20,7 @@ import static java.util.Comparator.reverseOrder;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.*;
@@ -57,14 +58,14 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
     public T deserialize(JsonParser jp, DeserializationContext ctxt, T api, JsonNode node) throws IOException {
         JsonNode idNode = node.get("id");
         if (idNode == null) {
-            throw ctxt.mappingException("ID property is required");
+            throw JsonMappingException.from(ctxt, "ID property is required");
         } else {
             api.setId(idNode.asText());
         }
 
         JsonNode nameNode = node.get("name");
         if (nameNode == null) {
-            throw ctxt.mappingException("Name property is required");
+            throw JsonMappingException.from(ctxt, "Name property is required");
         } else {
             api.setName(nameNode.asText());
         }
@@ -82,7 +83,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
             api.setProxy(proxyNode.traverse(jp.getCodec()).readValueAs(Proxy.class));
         } else {
             logger.error("A proxy property is required for {}", api.getName());
-            throw ctxt.mappingException("A proxy property is required for " + api.getName());
+            throw JsonMappingException.from(ctxt, "A proxy property is required for " + api.getName());
         }
 
         JsonNode servicesNode = node.get("services");
@@ -114,7 +115,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
                         if (!api.getResources().contains(resource)) {
                             api.getResources().add(resource);
                         } else {
-                            throw ctxt.mappingException("A resource already exists with name " + resource.getName());
+                            throw JsonMappingException.from(ctxt, "A resource already exists with name " + resource.getName());
                         }
                     } catch (IOException e) {
                         logger.error("An error occurred during api deserialization", e);
@@ -130,7 +131,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
 
         if (api.getDefinitionVersion() == DefinitionVersion.V1) {
             if (node.get("flows") != null) {
-                throw ctxt.mappingException("Flows are only available for definition >= 2.x.x ");
+                throw JsonMappingException.from(ctxt, "Flows are only available for definition >= 2.x.x ");
             }
 
             JsonNode pathsNode = node.get("paths");
@@ -153,7 +154,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
 
         if (api.getDefinitionVersion() == DefinitionVersion.V2) {
             if (node.get("paths") != null) {
-                throw ctxt.mappingException("Paths are only available for definition 1.x.x ");
+                throw JsonMappingException.from(ctxt, "Paths are only available for definition 1.x.x ");
             }
 
             JsonNode flowsNode = node.get("flows");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ConsumerDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ConsumerDeserializer.java
@@ -15,24 +15,14 @@
  */
 package io.gravitee.definition.jackson.datatype.api.deser;
 
-import static java.util.Comparator.reverseOrder;
-
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
-import io.gravitee.definition.model.*;
-import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.flow.Consumer;
 import io.gravitee.definition.model.flow.ConsumerType;
-import io.gravitee.definition.model.flow.Flow;
-import io.gravitee.definition.model.plugins.resources.Resource;
-import io.gravitee.definition.model.services.Services;
-import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import java.io.IOException;
-import java.util.*;
-import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +48,7 @@ public class ConsumerDeserializer extends StdScalarDeserializer<Consumer> {
 
         JsonNode consumerIdNode = node.get("consumerId");
         if (consumerIdNode == null) {
-            throw ctxt.mappingException("Consumer ID property is required");
+            throw JsonMappingException.from(ctxt, "Consumer ID property is required");
         } else {
             consumer.setConsumerId(consumerIdNode.asText());
         }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/DebugApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/DebugApiDeserializer.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.Api;
@@ -45,7 +46,7 @@ public class DebugApiDeserializer extends StdScalarDeserializer<DebugApi> {
     }
 
     @Override
-    public DebugApi deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public DebugApi deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         JsonNode node = jp.getCodec().readTree(jp);
         DebugApi debugApi = (DebugApi) this.base.deserialize(jp, ctxt, new DebugApi(), node);
         JsonNode requestNode = node.get("request");
@@ -53,7 +54,7 @@ public class DebugApiDeserializer extends StdScalarDeserializer<DebugApi> {
             debugApi.setRequest(requestNode.traverse(jp.getCodec()).readValueAs(HttpRequest.class));
         } else {
             logger.error("A request property is required for {}", debugApi.getName());
-            throw ctxt.mappingException("A request property is required for " + debugApi.getName());
+            throw JsonMappingException.from(ctxt, "A request property is required for " + debugApi.getName());
         }
 
         JsonNode responseNode = node.get("response");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointDeserializer.java
@@ -18,17 +18,20 @@ package io.gravitee.definition.jackson.datatype.api.deser;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.Endpoint;
-import io.gravitee.definition.model.ssl.pem.PEMTrustStore;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -53,14 +56,14 @@ public class EndpointDeserializer extends StdScalarDeserializer<Endpoint> {
         if (nameNode != null) {
             name = nameNode.asText();
         } else {
-            throw ctxt.mappingException("Endpoint name is required");
+            throw JsonMappingException.from(ctxt, "Endpoint name is required");
         }
 
         JsonNode targetNode = node.get("target");
         if (targetNode != null) {
             target = targetNode.asText();
         } else {
-            throw ctxt.mappingException("Endpoint target is required");
+            throw JsonMappingException.from(ctxt, "Endpoint target is required");
         }
 
         JsonNode typeNode = node.get("type");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointGroupDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/EndpointGroupDeserializer.java
@@ -16,17 +16,29 @@
 package io.gravitee.definition.jackson.datatype.api.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpHeaders;
-import io.gravitee.definition.model.*;
+import io.gravitee.definition.model.Endpoint;
+import io.gravitee.definition.model.EndpointGroup;
+import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.HttpClientSslOptions;
+import io.gravitee.definition.model.HttpProxy;
+import io.gravitee.definition.model.LoadBalancer;
 import io.gravitee.definition.model.services.Services;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -42,7 +54,7 @@ public class EndpointGroupDeserializer extends StdScalarDeserializer<EndpointGro
     }
 
     @Override
-    public EndpointGroup deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public EndpointGroup deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
         JsonNode node = jp.getCodec().readTree(jp);
 
         final EndpointGroup group = new EndpointGroup();
@@ -61,7 +73,7 @@ public class EndpointGroupDeserializer extends StdScalarDeserializer<EndpointGro
                 if (endpoint != null) {
                     boolean added = endpoints.add(endpoint);
                     if (!added) {
-                        throw ctxt.mappingException("[api] API endpoint names must be unique");
+                        throw JsonMappingException.from(ctxt, "[api] API endpoint names must be unique");
                     }
                 }
             }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/PropertyDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/PropertyDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.api.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.model.Property;
 import java.io.IOException;
@@ -40,14 +41,14 @@ public class PropertyDeserializer extends AbstractStdScalarDeserializer<Property
 
         JsonNode keyNode = node.get("key");
         if (keyNode == null) {
-            throw ctxt.mappingException("Key property is required");
+            throw JsonMappingException.from(ctxt, "Key property is required");
         } else {
             key = keyNode.asText();
         }
 
         JsonNode valueNode = node.get("value");
         if (valueNode == null) {
-            throw ctxt.mappingException("Value property is required");
+            throw JsonMappingException.from(ctxt, "Value property is required");
         } else {
             value = valueNode.asText();
         }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/plugins/resource/deser/ResourceDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/plugins/resource/deser/ResourceDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.plugins.resource.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.plugins.resources.Resource;
@@ -42,21 +43,21 @@ public class ResourceDeserializer extends StdScalarDeserializer<Resource> {
         if (nameNode != null) {
             resource.setName(nameNode.asText());
         } else {
-            throw ctxt.mappingException("[resource] Name is required");
+            throw JsonMappingException.from(ctxt, "[resource] Name is required");
         }
 
         final JsonNode typeNode = node.get("type");
         if (typeNode != null) {
             resource.setType(typeNode.asText());
         } else {
-            throw ctxt.mappingException("[resource] Type is required");
+            throw JsonMappingException.from(ctxt, "[resource] Type is required");
         }
 
         final JsonNode configurationNode = node.get("configuration");
         if (configurationNode != null) {
             resource.setConfiguration(configurationNode.toString());
         } else {
-            throw ctxt.mappingException("[resource] Configuration is required");
+            throw JsonMappingException.from(ctxt, "[resource] Configuration is required");
         }
 
         final JsonNode enabledNode = node.get("enabled");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ScheduledServiceDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ScheduledServiceDeserializer.java
@@ -18,6 +18,7 @@ package io.gravitee.definition.jackson.datatype.services.core.deser;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.model.services.schedule.ScheduledService;
 import java.io.IOException;
@@ -36,8 +37,7 @@ public abstract class ScheduledServiceDeserializer<T extends ScheduledService> e
     }
 
     @Override
-    protected void deserialize(T service, JsonParser jsonParser, JsonNode node, DeserializationContext ctxt)
-        throws IOException, JsonProcessingException {
+    protected void deserialize(T service, JsonParser jsonParser, JsonNode node, DeserializationContext ctxt) throws IOException {
         super.deserialize(service, jsonParser, node, ctxt);
 
         final JsonNode scheduleNode = node.get("schedule");
@@ -54,14 +54,14 @@ public abstract class ScheduledServiceDeserializer<T extends ScheduledService> e
                 if (rateNode != null) {
                     rate = rateNode.asLong();
                 } else {
-                    throw ctxt.mappingException("[scheduled-service] Rate is required");
+                    throw JsonMappingException.from(ctxt, "[scheduled-service] Rate is required");
                 }
 
                 final JsonNode unitNode = triggerNode.get("unit");
                 if (unitNode != null) {
                     unit = TimeUnit.valueOf(unitNode.asText().toUpperCase());
                 } else {
-                    throw ctxt.mappingException("[scheduled-service] Unit is required");
+                    throw JsonMappingException.from(ctxt, "[scheduled-service] Unit is required");
                 }
             } else if (node.has("interval")) {
                 // Ensure backward compatibility
@@ -74,7 +74,7 @@ public abstract class ScheduledServiceDeserializer<T extends ScheduledService> e
                     if (unitNode != null) {
                         unit = TimeUnit.valueOf(unitNode.asText().toUpperCase());
                     } else {
-                        throw ctxt.mappingException("[scheduled-service] Unit is required");
+                        throw JsonMappingException.from(ctxt, "[scheduled-service] Unit is required");
                     }
                 }
             }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ServiceDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ServiceDeserializer.java
@@ -18,6 +18,7 @@ package io.gravitee.definition.jackson.datatype.services.core.deser;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.Service;
@@ -44,7 +45,7 @@ public abstract class ServiceDeserializer<T extends Service> extends StdScalarDe
 
             return service;
         } catch (Exception ex) {
-            throw deserializationContext.mappingException(ex.getMessage());
+            throw JsonMappingException.from(deserializationContext, ex.getMessage());
         }
     }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ServicesDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/core/deser/ServicesDeserializer.java
@@ -18,6 +18,7 @@ package io.gravitee.definition.jackson.datatype.services.core.deser;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.Service;
@@ -27,7 +28,11 @@ import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyServ
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -78,7 +83,7 @@ public class ServicesDeserializer extends StdScalarDeserializer<Services> {
                     }
                 }
             } catch (IOException ioe) {
-                throw ctxt.mappingException(ioe.getMessage());
+                throw JsonMappingException.from(ctxt, ioe.getMessage());
             }
         }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/discovery/deser/EndpointDiscoveryDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/discovery/deser/EndpointDiscoveryDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.services.discovery.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.datatype.services.core.deser.ServiceDeserializer;
 import io.gravitee.definition.jackson.datatype.services.discovery.EndpointDiscoveryProviderMapper;
@@ -45,7 +46,7 @@ public class EndpointDiscoveryDeserializer extends ServiceDeserializer<EndpointD
                 String providerPlugin = EndpointDiscoveryProviderMapper.getProvider(provider);
                 service.setProvider(providerPlugin);
             } else {
-                throw ctxt.mappingException("[endpoint-discovery] Provider is required");
+                throw JsonMappingException.from(ctxt, "[endpoint-discovery] Provider is required");
             }
 
             service.setConfiguration(node.get("configuration").toString());

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/dynamicproperty/deser/DynamicPropertyDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/dynamicproperty/deser/DynamicPropertyDeserializer.java
@@ -16,8 +16,8 @@
 package io.gravitee.definition.jackson.datatype.services.dynamicproperty.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.datatype.services.core.deser.ScheduledServiceDeserializer;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyProvider;
@@ -37,14 +37,14 @@ public class DynamicPropertyDeserializer extends ScheduledServiceDeserializer<Dy
 
     @Override
     protected void deserialize(DynamicPropertyService service, JsonParser jsonParser, JsonNode node, DeserializationContext ctxt)
-        throws IOException, JsonProcessingException {
+        throws IOException {
         super.deserialize(service, jsonParser, node, ctxt);
 
         final JsonNode providerNode = node.get("provider");
         if (providerNode != null) {
             service.setProvider(DynamicPropertyProvider.valueOf(providerNode.asText().toUpperCase()));
         } else {
-            throw ctxt.mappingException("[dynamic-property] Provider is required");
+            throw JsonMappingException.from(ctxt, "[dynamic-property] Provider is required");
         }
 
         final JsonNode configurationNode = node.get("configuration");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/dynamicproperty/deser/http/HttpDynamicPropertyProviderConfigurationDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/dynamicproperty/deser/http/HttpDynamicPropertyProviderConfigurationDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.services.dynamicproperty.deser.h
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.common.http.HttpHeader;
@@ -46,14 +47,14 @@ public class HttpDynamicPropertyProviderConfigurationDeserializer extends StdSca
         if (urlNode != null) {
             configuration.setUrl(urlNode.asText());
         } else {
-            throw ctxt.mappingException("[dynamic-property] [HTTP] URL is required");
+            throw JsonMappingException.from(ctxt, "[dynamic-property] [HTTP] URL is required");
         }
 
         final JsonNode specificationNode = node.get("specification");
         if (specificationNode != null) {
             configuration.setSpecification(specificationNode.asText());
         } else {
-            throw ctxt.mappingException("[dynamic-property] [HTTP] Specification is required");
+            throw JsonMappingException.from(ctxt, "[dynamic-property] [HTTP] Specification is required");
         }
 
         final JsonNode useSystemProxy = node.get("useSystemProxy");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/HealthCheckDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/HealthCheckDeserializer.java
@@ -16,8 +16,8 @@
 package io.gravitee.definition.jackson.datatype.services.healthcheck.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.jackson.datatype.services.core.deser.ScheduledServiceDeserializer;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
@@ -40,8 +40,7 @@ public class HealthCheckDeserializer<T extends HealthCheckService> extends Sched
     }
 
     @Override
-    protected void deserialize(T service, JsonParser jsonParser, JsonNode node, DeserializationContext ctxt)
-        throws IOException, JsonProcessingException {
+    protected void deserialize(T service, JsonParser jsonParser, JsonNode node, DeserializationContext ctxt) throws IOException {
         super.deserialize(service, jsonParser, node, ctxt);
 
         if (service.isEnabled()) {
@@ -64,7 +63,7 @@ public class HealthCheckDeserializer<T extends HealthCheckService> extends Sched
                 if (requestNode != null) {
                     step.setRequest(requestNode.traverse(jsonParser.getCodec()).readValueAs(HealthCheckRequest.class));
                 } else {
-                    throw ctxt.mappingException("[health-check] Request is required");
+                    throw JsonMappingException.from(ctxt, "[health-check] Request is required");
                 }
 
                 final JsonNode expectationNode = node.get("expectation");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/RequestDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/RequestDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.services.healthcheck.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.common.http.HttpHeader;
@@ -51,7 +52,7 @@ public class RequestDeserializer extends StdScalarDeserializer<HealthCheckReques
             if (uriNode != null) {
                 request.setPath(uriNode.asText());
             } else {
-                throw ctxt.mappingException("[healthcheck] URI is required");
+                throw JsonMappingException.from(ctxt, "[healthcheck] URI is required");
             }
         }
 
@@ -59,7 +60,7 @@ public class RequestDeserializer extends StdScalarDeserializer<HealthCheckReques
         if (methodNode != null) {
             request.setMethod(HttpMethod.valueOf(methodNode.asText().toUpperCase()));
         } else {
-            throw ctxt.mappingException("[healthcheck] Method is required");
+            throw JsonMappingException.from(ctxt, "[healthcheck] Method is required");
         }
 
         JsonNode bodyNode = node.get("body");

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/StepDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/healthcheck/deser/StepDeserializer.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.jackson.datatype.services.healthcheck.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
@@ -45,7 +46,7 @@ public class StepDeserializer extends StdScalarDeserializer<HealthCheckStep> {
         if (requestNode != null) {
             step.setRequest(requestNode.traverse(jsonParser.getCodec()).readValueAs(HealthCheckRequest.class));
         } else {
-            throw ctxt.mappingException("[health-check] Step request is required");
+            throw JsonMappingException.from(ctxt, "[health-check] Step request is required");
         }
 
         final JsonNode responseNode = node.get("response");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -58,11 +58,6 @@
         </dependency>
 
         <!-- Runtime scope -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/HostIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/HostIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.accesspoints;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("AccessPointsHostIndexUpgrader")
+public class HostIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("access_points")
+            .name("h1")
+            .key("host", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/ReferenceIdReferenceTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/ReferenceIdReferenceTypeIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.accesspoints;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("AccessPointsReferenceIdReferenceTypeIndexUpgrader")
+public class ReferenceIdReferenceTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("access_points")
+            .name("rt_ri1")
+            .key("referenceType", ascending())
+            .key("referenceId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/ReferenceIdReferenceTypeTargetIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/ReferenceIdReferenceTypeTargetIndexUpgrader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.accesspoints;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("AccessPointsReferenceIdReferenceTypeTargetIndexUpgrader")
+public class ReferenceIdReferenceTypeTargetIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("access_points")
+            .name("ri_rt_t1")
+            .key("referenceId", ascending())
+            .key("referenceType", ascending())
+            .key("target", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/TargetIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/accesspoints/TargetIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.accesspoints;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("AccessPointsTargetIndexUpgrader")
+public class TargetIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("access_points")
+            .name("t1")
+            .key("target", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/IdReferenceIdReferenceTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/IdReferenceIdReferenceTypeIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.licenses;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("LicensesIdReferenceIdReferenceTypeIndexUpgrader")
+public class IdReferenceIdReferenceTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("licenses")
+            .name("id_rt_ri1")
+            .key("_id.referenceType", ascending())
+            .key("_id.referenceId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/ReferenceIdReferenceTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/ReferenceIdReferenceTypeIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.licenses;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("LicensesReferenceIdReferenceTypeIndexUpgrader")
+public class ReferenceIdReferenceTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("licenses")
+            .name("rt_ri1")
+            .key("referenceType", ascending())
+            .key("referenceId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/UpdatedAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/licenses/UpdatedAtIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.licenses;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("LicensesUpdatedAtIndexUpgrader")
+public class UpdatedAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("licenses")
+            .name("f_t1")
+            .key("updatedAt", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/organizations/CockpitIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/organizations/CockpitIdIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.organizations;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("OrganizationsCockpitIdIndexUpgrader")
+public class CockpitIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("organizations")
+            .name("cid1")
+            .key("cockpitId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pages/ParentIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/pages/ParentIdIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.pages;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("PagesParentIdIndexUpgrader")
+public class ParentIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("pages")
+            .name("pid1")
+            .key("parentId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/qualityrules/ReferenceIdReferenceTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/qualityrules/ReferenceIdReferenceTypeIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.qualityrules;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("QualityRulesReferenceIdReferenceTypeIndexUpgrader")
+public class ReferenceIdReferenceTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("qualityrules")
+            .name("ri1rt1")
+            .key("referenceId", ascending())
+            .key("referenceType", ascending())
+            .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2
              in gravitee-apim-gateway-tests-sdk and gravitee-apim-integration-tests
              along with the grpc libs to create test clients and servers -->
-        <vertx.version>4.5.1</vertx.version>
+        <vertx.version>4.5.3</vertx.version>
         <protobuf-java.version>3.24.0</protobuf-java.version>
         <grpc-java.version>1.50.2</grpc-java.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>7.0.4</gravitee-bom.version>
+        <gravitee-bom.version>7.0.10</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.6.2</gravitee-cockpit-api.version>
         <gravitee-common.version>3.4.0</gravitee-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>
         <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <spring-data-mongodb.version>4.2.2</spring-data-mongodb.version>
+        <spring-data-mongodb.version>4.2.3</spring-data-mongodb.version>
 
         <!-- javax dependencies still required for compatibility or test -->
         <jaxb-impl.version>4.0.2</jaxb-impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <swagger-parser.version>2.1.20</swagger-parser.version>
         <!-- !! Transitive dependency !! need to remove when swagger parser will include a version higher than 1.7.12 -->
         <rhino.version>1.7.14</rhino.version>
-        <testcontainers.version>1.18.3</testcontainers.version>
+        <testcontainers.version>1.19.6</testcontainers.version>
         <xmlbeans.version>3.1.0</xmlbeans.version>
         <wiremock.version>3.0.4</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>


### PR DESCRIPTION
## Description

To fix vulnerabilities:
- https://app.snyk.io/org/gravitee-apim/project/c1cafe76-dd0f-4bf7-878a-bca81fbe4957#issue-SNYK-JAVA-IOVERTX-6231834
- https://app.snyk.io/org/gravitee-apim/project/c1cafe76-dd0f-4bf7-878a-bca81fbe4957#issue-SNYK-JAVA-ORGSPRINGFRAMEWORK-6261586
- https://app.snyk.io/org/gravitee-apim/project/c1cafe76-dd0f-4bf7-878a-bca81fbe4957#issue-SNYK-JAVA-IOVERTX-6209366

⚠️ Jackson 2.16 has removed several deprecated methods. We were massively using `DeserializationContext#mappingException`, but this one has been deprecated since Jackson 2.9
I used `JsonMappingException#from` as an alternative to creating the same exception created with the deprecated method.

## Additional context

With the upgrade of the `gravitee-bom`, some Mongo Repositories tests were failing. After a bit of investigation, all failing tests were missing indexes.
I don't really understand what dependencies make this required...


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rgygggfslh.chromatic.com)
<!-- Storybook placeholder end -->
