### PR TITLE
fix: keep folder icons aligned in v4 pages list

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-list/api-documentation-v4-pages-list.component.html
@@ -121,6 +121,9 @@
               </ng-container>
             </ng-container>
 
+            <!-- insert empty slot so that flex keeps everything aligned when publish icon is missing -->
+            <div *ngIf="page.type === 'FOLDER'"></div>
+
             <button
               mat-icon-button
               (click)="onMoveUp.emit(page)"


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-4019

<img width="1283" alt="Screenshot 2024-03-01 at 12 23 56" src="https://github.com/gravitee-io/gravitee-api-management/assets/3619261/a7d250a5-33a6-4b47-bf12-5d17b46d6572">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bfstubmyhj.chromatic.com)
<!-- Storybook placeholder end -->
