### PR TITLE
fix: expand swagger ui models button zone

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
@@ -3,5 +3,13 @@
     .swagger-ui .info .title small {
       line-height: 12px;
     }
+
+    // reset models expand control paddings so that the whole zone is clickable
+    .swagger-ui section.models h4 {
+      padding: 0;
+      button {
+        padding: 10px 20px;
+      }
+    }
   }
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-4037

<img width="645" alt="Screenshot 2024-03-01 at 14 25 41" src="https://github.com/gravitee-io/gravitee-api-management/assets/3619261/64bfb6e4-7e0f-4fac-adcb-177b2ac3e270">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ivfpuhkyys.chromatic.com)
<!-- Storybook placeholder end -->
