### PR TITLE
ci: set the default version for remote docker

### DIFF
--- a/.circleci/ci/src/commands/cmd-setup-remote-docker.ts
+++ b/.circleci/ci/src/commands/cmd-setup-remote-docker.ts
@@ -20,6 +20,6 @@ export class SetupRemoteDockerCommand {
   private static commandName = 'cmd-create-docker-context';
 
   public static get(): SetupRemoteDocker {
-    return new commands.SetupRemoteDocker();
+    return new commands.SetupRemoteDocker({ version: 'default' });
   }
 }

--- a/.circleci/ci/src/commands/cmd-setup-remote-docker.ts
+++ b/.circleci/ci/src/commands/cmd-setup-remote-docker.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { commands } from '@circleci/circleci-config-sdk';
+import { SetupRemoteDocker } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Native/SetupRemoteDocker';
+
+export class SetupRemoteDockerCommand {
+  private static commandName = 'cmd-create-docker-context';
+
+  public static get(): SetupRemoteDocker {
+    return new commands.SetupRemoteDocker();
+  }
+}

--- a/.circleci/ci/src/jobs/frontend/job-webui-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-webui-build.ts
@@ -21,6 +21,7 @@ import { BuildUiImageCommand, NotifyOnFailureCommand, WebuiInstallCommand } from
 import { CircleCIEnvironment } from '../../pipelines';
 import { computeApimVersion } from '../../utils';
 import { config } from '../../config';
+import { SetupRemoteDockerCommand } from '../../commands/cmd-setup-remote-docker';
 
 export class WebuiBuildJob {
   private static jobName = 'job-webui-build';
@@ -46,7 +47,7 @@ export class WebuiBuildJob {
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
-      new commands.SetupRemoteDocker(),
+      SetupRemoteDockerCommand.get(),
       new reusable.ReusedCommand(webUiInstallCommand, { 'apim-ui-project': '<< parameters.apim-ui-project >>' }),
       new commands.Run({
         name: 'Update Build version',

--- a/.circleci/ci/src/jobs/job-build-backend-images.ts
+++ b/.circleci/ci/src/jobs/job-build-backend-images.ts
@@ -21,6 +21,7 @@ import { CircleCIEnvironment } from '../pipelines';
 import { AddDockerImageInSnykCommand, CreateDockerContextCommand, DockerAzureLoginCommand, DockerAzureLogoutCommand } from '../commands';
 import { orbs } from '../orbs';
 import { config } from '../config';
+import { SetupRemoteDockerCommand } from '../commands/cmd-setup-remote-docker';
 
 export class BuildBackendImagesJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
@@ -38,7 +39,7 @@ export class BuildBackendImagesJob {
     const steps: Command[] = [
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
-      new commands.SetupRemoteDocker(),
+      SetupRemoteDockerCommand.get(),
       new reusable.ReusedCommand(createDockerContextCmd),
       new reusable.ReusedCommand(dockerAzureLoginCmd),
       new commands.Run({

--- a/.circleci/ci/src/jobs/job-publish-prod-docker-images.ts
+++ b/.circleci/ci/src/jobs/job-publish-prod-docker-images.ts
@@ -21,6 +21,7 @@ import { config } from '../config';
 import { GraviteeioVersion, isBlank, parse } from '../utils';
 import { CreateDockerContextCommand } from '../commands';
 import { BaseExecutor } from '../executors';
+import { SetupRemoteDockerCommand } from '../commands/cmd-setup-remote-docker';
 
 export class PublishProdDockerImagesJob {
   private static jobName = 'job-publish-prod-docker-images';
@@ -33,7 +34,7 @@ export class PublishProdDockerImagesJob {
     const parsedGraviteeioVersion = parse(environment.graviteeioVersion);
 
     const steps: Command[] = [
-      new commands.SetupRemoteDocker(),
+      SetupRemoteDockerCommand.get(),
       new commands.Checkout(),
       new reusable.ReusedCommand(keeper.commands['env-export'], {
         'secret-url': config.secrets.dockerhubBotUserName,

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-no-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run-as-latest.yml
@@ -61,7 +61,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run.yml
@@ -61,7 +61,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -465,7 +465,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -471,7 +471,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -465,7 +465,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -465,7 +465,7 @@ jobs:
     resource_class: medium
     steps:
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - checkout
       - keeper/env-export:
           secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -224,7 +224,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:
@@ -275,7 +275,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -191,7 +191,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:
@@ -227,7 +227,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -224,7 +224,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:
@@ -275,7 +275,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -567,7 +567,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -676,7 +676,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -199,7 +199,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -199,7 +199,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -534,7 +534,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -567,7 +567,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -676,7 +676,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -534,7 +534,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -534,7 +534,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:
@@ -651,7 +651,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-create-docker-context
       - cmd-docker-azure-login
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -242,7 +242,7 @@ jobs:
       - attach_workspace:
           at: .
       - setup_remote_docker:
-          version: 20.10.6
+          version: default
       - cmd-webui-install:
           apim-ui-project: << parameters.apim-ui-project >>
       - run:


### PR DESCRIPTION
## Description

The version hardcoded in the SDK reached EOL recently.

Use `default` to always have stable version
https://circleci.com/docs/remote-docker-images-support-policy/

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-szybwhzwrc.chromatic.com)
<!-- Storybook placeholder end -->
