### PR TITLE
feat(portal): doc menu automatically open if more than one page

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.html
@@ -24,7 +24,12 @@
 
 <div *ngIf="isLoaded && !isEmpty()" class="gv-documentation">
   <div #treeMenu class="gv-documentation__menu" [ngClass]="{ show: isLoaded }">
-    <gv-tree [items]="menu" [selectedItem]="currentMenuItem" closedTooltip="Expand to see all documentation pages for this API"></gv-tree>
+    <gv-tree
+      [items]="menu"
+      [selectedItem]="currentMenuItem"
+      [closed]="hasOneOrLessPages"
+      closedTooltip="Expand to see all documentation pages for this API"
+    ></gv-tree>
   </div>
   <app-gv-page
     *ngIf="currentPage"

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -57,6 +57,7 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
         }
         if (pageToDisplay) {
           this.selectPage(pageToDisplay.id);
+          this.initMenuDisplay(pages);
           this.menu = this.initTree(pages, pageToDisplay.id);
           this.expandMenu(this.menu);
         } else {
@@ -81,6 +82,7 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
   menu: TreeItem[];
   isLoaded = false;
   hasTreeClosed = true;
+  hasOneOrLessPages = true;
 
   @Input() rootDir: string;
   private _pages: Page[];
@@ -125,6 +127,11 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
       menuElement.style.position = `fixed`;
       this.updateMenuHeight(menuElement);
     }
+  }
+
+  private initMenuDisplay(pages: Page[]) {
+    this.hasOneOrLessPages = pages.filter(p => !(p.type === 'FOLDER' || p.type === 'ROOT' || p.type === 'LINK')).length <= 1;
+    this.hasTreeClosed = this.hasOneOrLessPages;
   }
 
   private initTree(pages: Page[], selectedPage?: string) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4148

## Description

Menu should be automatically open if more than one content page exists for the given API.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ubgdlmcaig.chromatic.com)
<!-- Storybook placeholder end -->
