### PR TITLE
delete api runtime alerts

### DIFF
--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.html
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.html
@@ -59,7 +59,7 @@
         <th mat-header-cell *matHeaderCellDef id="counters">Last 5m / 1h / 1d / 1M</th>
         <td mat-cell *matCellDef="let alert">
           <ng-container *ngIf="!!alert.counters; else countersEmptyBlock">
-            <span [matTooltip]="alert.counters['5m'] + ' during the last 5 minutes'">{{ alert.counters['5m'] }} </span>
+            <span [matTooltip]="alert.counters['5m'] + ' during the last 5 minutes'">{{ alert.counters['5m'] }}</span>
             /
             <span [matTooltip]="alert.counters['1h'] + ' during the last 1 hour'">{{ alert.counters['1h'] }}</span>
             /
@@ -101,17 +101,17 @@
               mat-icon-button
               aria-label="Button to edit an alert"
               matTooltip="Edit an alert"
-              *gioPermission="{ anyOf: ['api-definition-u'] }"
+              *gioPermission="{ anyOf: ['api-alert-u'] }"
               [disabled]="true"
             >
               <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
             </button>
             <button
-              *gioPermission="{ anyOf: ['api-definition-u'] }"
+              *gioPermission="{ anyOf: ['api-alert-d'] }"
               mat-icon-button
               aria-label="Button to delete an alert"
               matTooltip="Delete an alert"
-              [disabled]="true"
+              (click)="deleteAlert.emit(alert)"
             >
               <mat-icon svgIcon="gio:trash"></mat-icon>
             </button>

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.spec.ts
@@ -69,7 +69,7 @@ describe('RuntimeAlertListComponent', () => {
       },
     ]);
     expect(rowCells).toHaveLength(2);
-    expect(rowCells[0]).toStrictEqual(['', 'INFO', 'description', '1  / 2 / 3 / 4', expect.anything(), 'last alert message', '']);
-    expect(rowCells[1]).toStrictEqual(['', 'INFO', 'description', '-', '-', '-', '']);
+    expect(rowCells[0]).toStrictEqual(['my alert', 'INFO', 'description', '1 / 2 / 3 / 4', expect.anything(), 'last alert message', '']);
+    expect(rowCells[1]).toStrictEqual(['my alert', 'INFO', 'description', '-', '-', '-', '']);
   });
 });

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.component.ts
@@ -26,5 +26,6 @@ export class RuntimeAlertListComponent {
   @Input() public alerts: AlertTriggerEntity[];
   @Input() canCreateAlert: boolean;
   @Output() public createAlert: EventEmitter<void> = new EventEmitter();
+  @Output() public deleteAlert: EventEmitter<AlertTriggerEntity> = new EventEmitter();
   public displayedColumns = ['name', 'severity', 'description', 'counters', 'lastAlert', 'lastMessage', 'actions'];
 }

--- a/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.harness.ts
+++ b/gravitee-apim-console-webui/src/components/runtime-alerts/runtime-alert-list/runtime-alert-list.harness.ts
@@ -15,11 +15,13 @@
  */
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class RuntimeAlertListHarness extends ComponentHarness {
   static hostSelector = 'runtime-alert-list';
 
   private getAlertTable = () => this.locatorFor(MatTableHarness)();
+  private getDeleteButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Button to delete an alert"]' }));
 
   async computeTableCells() {
     const table = await this.getAlertTable();
@@ -30,5 +32,9 @@ export class RuntimeAlertListHarness extends ComponentHarness {
     const rows = await table.getRows();
     const rowCells = await parallel(() => rows.map((row) => row.getCellTextByIndex()));
     return { headerCells, rowCells };
+  }
+
+  async deleteAlert(index: number) {
+    return this.getDeleteButtons().then((btn) => btn[index].click());
   }
 }

--- a/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.fixtures.ts
@@ -19,6 +19,8 @@ import { Scope } from '../alert';
 
 export function fakeAlertTriggerEntity(attributes?: Partial<AlertTriggerEntity>): AlertTriggerEntity {
   const base: AlertTriggerEntity = {
+    id: 'id',
+    name: 'my alert',
     description: 'description',
     reference_type: Scope.API,
     reference_id: 'api-id',

--- a/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/alertTriggerEntity.ts
@@ -29,6 +29,8 @@ export interface AlertEventRuleEntity {
 }
 
 export interface AlertTriggerEntity {
+  id: string;
+  name: string;
   description: string;
   reference_type: Scope;
   reference_id: string;

--- a/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
+++ b/gravitee-apim-console-webui/src/management/api/runtime-alerts/api-runtime-alerts.component.html
@@ -17,7 +17,12 @@
 -->
 <ng-container *ngIf="alerts$ | async as alerts">
   <ng-container *ngIf="alerts?.length > 0; else emptyBlock">
-    <runtime-alert-list [alerts]="alerts" [canCreateAlert]="canCreateAlert" (createAlert)="createAlert()"></runtime-alert-list>
+    <runtime-alert-list
+      [alerts]="alerts"
+      [canCreateAlert]="canCreateAlert"
+      (createAlert)="createAlert()"
+      (deleteAlert)="deleteAlert($event)"
+    ></runtime-alert-list>
   </ng-container>
   <ng-template #emptyBlock>
     <runtime-alert-list-empty-state [canCreateAlert]="canCreateAlert" (createAlert)="createAlert()"></runtime-alert-list-empty-state>

--- a/gravitee-apim-console-webui/src/services-ngx/alert.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/alert.service.spec.ts
@@ -115,6 +115,22 @@ describe('AlertService', () => {
     });
   });
 
+  describe('delete alert for an API', () => {
+    it('should delete API alert', (done) => {
+      const apiId = 'api_id';
+      const alertId = 'alert_id';
+
+      alertService.deleteAlert(apiId, alertId).subscribe(() => done());
+
+      httpTestingController
+        .expectOne({
+          method: 'DELETE',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/alerts/${alertId}`,
+        })
+        .flush(null);
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/services-ngx/alert.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/alert.service.ts
@@ -60,4 +60,8 @@ export class AlertService {
   createAlert(apiId: string, newAlert: NewAlertTriggerEntity) {
     return this.http.post<NewAlertTriggerEntity>(`${this.constants.env.baseURL}/apis/${apiId}/alerts`, { ...newAlert });
   }
+
+  deleteAlert(apiId: string, alertId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.baseURL}/apis/${apiId}/alerts/${alertId}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1427

## Description

Allow users to delete api alerts.
Need this PR to be merged before https://github.com/gravitee-io/gravitee-api-management/pull/6823

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hrclbwgzrd.chromatic.com)
<!-- Storybook placeholder end -->
