### PR TITLE
fix(hc-improvement): await for HC call to finish before calling another one

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
@@ -59,8 +59,7 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
 
         // Set timeout on request
         if (rule.endpoint().getHttpClientOptions() != null) {
-            // We want to ensure that the read/write timeout will expire BEFORE an other HC will be executed
-            options.setTimeout(Math.min(getDelayMillis(), rule.endpoint().getHttpClientOptions().getReadTimeout()));
+            options.setTimeout(rule.endpoint().getHttpClientOptions().getReadTimeout());
         }
 
         return options;
@@ -82,8 +81,7 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
                 .setKeepAlive(endpoint.getHttpClientOptions().isKeepAlive())
                 .setTcpKeepAlive(endpoint.getHttpClientOptions().isKeepAlive())
                 .setIdleTimeout((int) (endpoint.getHttpClientOptions().getIdleTimeout() / 1000))
-                // We want to ensure that the connect timeout will expire BEFORE an other HC will be executed
-                .setConnectTimeout((int) Math.min(getDelayMillis(), endpoint.getHttpClientOptions().getConnectTimeout()))
+                .setConnectTimeout((int) endpoint.getHttpClientOptions().getConnectTimeout())
                 .setTryUseCompression(endpoint.getHttpClientOptions().isUseCompression());
 
             if (endpoint.getHttpClientOptions().getVersion() == ProtocolVersion.HTTP_2) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
@@ -48,8 +48,7 @@ public class EndpointRuleCronHandler<T extends Endpoint> implements Handler<Long
 
     @Override
     public void handle(final Long timerId) {
-        this.timerId = vertx.setTimer(handler.getDelayMillis(), this);
-        handler.handle(timerId);
+        handler.handle(hcResponseHandler -> this.timerId = vertx.setTimer(handler.getDelayMillis(), this));
     }
 
     public void cancel() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3967

## Description
Removed request timeout to be minimum of next cron execution time vs client configuration. With this implementation timer will be scheduled only if previous one has finished. To enable that  Health-Check handler has been added to the EndpointRuleCronHandler.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jyicvpoqii.chromatic.com)
<!-- Storybook placeholder end -->
