### PR TITLE
fix(deps): update bcprov-jdk15on to bcprov-jdk18on

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -121,7 +121,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
 
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
@@ -51,7 +51,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -233,7 +233,7 @@
         -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,13 @@
         <gravitee-bom.version>7.0.12</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.6.2</gravitee-cockpit-api.version>
-        <gravitee-common.version>3.4.0</gravitee-common.version>
+        <gravitee-common.version>3.4.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>5.9.0</gravitee-node.version>
+        <gravitee-node.version>5.9.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
@@ -83,7 +83,7 @@
         <angus-activation.version>2.0.0</angus-activation.version>
         <asm.version>9.2</asm.version>
         <batik-transcoder.version>1.17</batik-transcoder.version>
-        <bcpkix-jdk15on.version>1.70</bcpkix-jdk15on.version>
+        <bcpkix-jdk18on.version>1.77</bcpkix-jdk18on.version>
         <classgraph.version>4.8.138</classgraph.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
@@ -191,8 +191,8 @@
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.7.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
-        <gravitee-policy-jws.version>1.6.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>4.1.1</gravitee-policy-jwt.version>
+        <gravitee-policy-jws.version>1.6.1</gravitee-policy-jws.version>
+        <gravitee-policy-jwt.version>4.1.2</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>3.0.1</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>
@@ -879,8 +879,8 @@
 
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bcpkix-jdk15on.version}</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcpkix-jdk18on.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4028

## Description

Update dependencies to use artifacts with bcprov-jdk15on updated to bcprov-jdk18on and bcpkix-jdk15on to bcpkix-jdk18on

## Additional context

The main goal of this task is to update the library and resolve vulnerability issues:
https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6084022

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rkwzihjvjs.chromatic.com)
<!-- Storybook placeholder end -->
