### PR TITLE
Cj 1120 add cloud rebrand properties

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -172,16 +172,24 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
 
     private Key getPublicKey() throws Exception {
         final KeyStore trustStore = loadTrustStore();
-        final Certificate cert =
-                trustStore.getCertificate(environment.getProperty("cockpit.keystore.key.alias", environment.getProperty("cloud.keystore.key.alias", "cockpit-client")));
+        final Certificate cert = trustStore.getCertificate(
+            environment.getProperty("cockpit.keystore.key.alias", environment.getProperty("cloud.keystore.key.alias", "cockpit-client"))
+        );
 
         return cert.getPublicKey();
     }
 
     private KeyStore loadTrustStore() throws Exception {
-        final KeyStore keystore = KeyStore.getInstance(environment.getProperty("cockpit.keystore.type", environment.getProperty("cloud.keystore.type")));
+        final KeyStore keystore = KeyStore.getInstance(
+            environment.getProperty("cockpit.keystore.type", environment.getProperty("cloud.keystore.type"))
+        );
 
-        try (InputStream is = new File(environment.getProperty("cockpit.keystore.path", environment.getProperty("cloud.keystore.path"))).toURI().toURL().openStream()) {
+        try (
+            InputStream is = new File(environment.getProperty("cockpit.keystore.path", environment.getProperty("cloud.keystore.path")))
+                .toURI()
+                .toURL()
+                .openStream()
+        ) {
             final String cockpitKeystorePassword = environment.getProperty("cockpit.keystore.password");
             final String cloudKeystorePassword = environment.getProperty("cloud.keystore.password");
             final String password = cockpitKeystorePassword != null ? cockpitKeystorePassword : cloudKeystorePassword;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
@@ -52,7 +52,7 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
     private final InstallationTypeDomainService installationTypeDomainService;
     private final AccessPointQueryService accessPointQueryService;
 
-    @Value("${cockpit.enabled:false}")
+    @Value("${cockpit.enabled:${cloud.enabled:false}}")
     private boolean cockpitEnabled;
 
     @Value("${installation.api.url:#{null}}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -62,10 +62,10 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
     @Value("${installation.api.proxyPath.management:${http.api.management.entrypoint:${http.api.entrypoint:/}management}}")
     private String managementProxyPath;
 
-    @Value("${cockpit.auth.path:/auth/cockpit?token={token}}")
+    @Value("${cockpit.auth.path:${cloud.auth.path:/auth/cockpit?token={token}}}")
     private String authPath;
 
-    @Value("${cockpit.trial:false}")
+    @Value("${cockpit.trial:${cloud.trial:false}}")
     private boolean cockpitTrial;
 
     private final Node node;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
@@ -44,7 +44,7 @@ public class InstallationServiceImpl implements InstallationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstallationServiceImpl.class);
 
-    @Value("${cockpit.url:https://cockpit.gravitee.io}")
+    @Value("${cockpit.url:${cloud.url:https://cockpit.gravitee.io}}")
     private String cockpitURL;
 
     @Lazy

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -176,6 +176,30 @@ spec:
             - name: gravitee_cockpit_ssl_verifyHostname
               value: "{{ .Values.cockpit.ssl.verifyHostname }}"
             {{- end }}
+            {{- if .Values.cloud.enabled }}
+            - name: gravitee_cloud_enabled
+              value: "true"
+            - name: gravitee_cloud_url
+              value: {{ .Values.cloud.url }}
+            - name: gravitee_cloud_ws_endpoints_0
+              value: {{ .Values.cloud.controller }}
+            - name: gravitee_cloud_keystore_type
+              value: pkcs12
+            - name: gravitee_cloud_keystore_path
+              value: /opt/graviteeio-management-api/cloud/keystore.p12
+            - name: gravitee_cloud_keystore_password
+              {{- toYaml .Values.cloud.keystore.password | nindent 14}}
+            {{- if .Values.cloud.truststore }}
+            - name: gravitee_cloud_truststore_type
+              value: pkcs12
+            - name: gravitee_cloud_truststore_path
+              value: /opt/graviteeio-management-api/cloud/truststore.p12
+            - name: gravitee_cloud_truststore_password
+              {{- toYaml .Values.cloud.truststore.password | nindent 14}}
+            {{- end }}
+            - name: gravitee_cloud_ssl_verifyHostname
+              value: "{{ .Values.cloud.ssl.verifyHostname }}"
+            {{- end }}
             {{- if .Values.gateway.enabled }}
             - name: portal.entrypoint
               value: "https://{{ index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}"
@@ -232,6 +256,11 @@ spec:
               mountPath: /opt/graviteeio-management-api/cockpit
               readOnly: true
           {{- end }}
+          {{- if .Values.cloud.enabled }}
+            - name: gravitee-cloud-certificates
+              mountPath: /opt/graviteeio-management-api/cloud
+              readOnly: true
+          {{- end }}
           {{- with .Values.license }}
           {{- if .key }}
             - name: licensekey
@@ -271,6 +300,11 @@ spec:
         - name: gravitee-cockpit-certificates
           secret:
             secretName: {{ template "gravitee.api.fullname" . }}-cockpit-certificates
+        {{- end }}
+        {{- if .Values.cloud.enabled }}
+        - name: gravitee-cloud-certificates
+          secret:
+            secretName: {{ template "gravitee.api.fullname" . }}-cloud-certificates
         {{- end }}
         {{- with .Values.license }}
         {{- if .key }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -121,6 +121,8 @@ spec:
               value: "false"
             - name: GRAVITEE_COCKPIT_ENABLED
               value: "false"
+            - name: GRAVITEE_CLOUD_ENABLED
+              value: "false"
             {{- if $plugins }}
             - name: GRAVITEE_PLUGINS_PATH_0
               value: '${gravitee.home}/plugins'

--- a/helm/templates/cloud/cloud-certificates.yaml
+++ b/helm/templates/cloud/cloud-certificates.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.cloud.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}-cloud-certificates
+data:
+  keystore.p12: {{ .Values.cloud.keystore.value }}
+  {{- if .Values.cloud.truststore }}
+  truststore.p12: {{ .Values.cloud.truststore.value }}
+  {{- end -}}  
+{{- end -}}

--- a/helm/tests/api/deployment_cloud_test.yaml
+++ b/helm/tests/api/deployment_cloud_test.yaml
@@ -1,0 +1,118 @@
+suite: Test Management API with Gravitee Cloud
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+tests:
+  - it: Check Gravitee Cloud deployment
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        keystore: 
+          password: 
+            value: my_password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: "my_password"
+
+  - it: Check cloud deployment with keystore from secretKeyRef
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        keystore: 
+          password:
+            valueFrom:
+              secretKeyRef:
+                name: mysecret
+                key: password-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].valueFrom
+          value:
+            secretKeyRef:
+              name: mysecret
+              key: password-key
+
+  - it: Check cloud deployment with keystore from secretKeyRef
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        keystore: 
+          password:
+            valueFrom: 
+              configMapKeyRef:
+                name: special-config
+                key: password-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].valueFrom
+          value:
+            configMapKeyRef:
+              name: special-config
+              key: password-key

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -73,6 +73,20 @@ tests:
             name: GRAVITEE_COCKPIT_ENABLED
             value: "false"
 
+  - it: Check that cloud has been disabled
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITEE_CLOUD_ENABLED
+            value: "false"
+
   - it: Check if the helm hook annotations are present
     set:
       api:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -425,6 +425,28 @@ cockpit:
   ssl:
     verifyHostname: true
 
+# Support for Gravitee.io Cloud (cloud.gravitee.io)
+cloud:
+  enabled: false
+  keystore:
+    value: "base64 encoded value of the keystore provided by Gravitee Cloud (required)"
+    password:
+    #value: "keystores password provided by Gravitee Cloud"
+    #valueFrom:
+    #secretKeyRef:
+    #configMapKeyRef:
+    #truststore:
+    #value: base64 encoded value of the truststore provided by Gravitee Cloud (optional)
+    #password:
+    #value: "truststore password provided by Gravitee Cloud"
+    #valueFrom:
+    #secretKeyRef:
+    #configMapKeyRef:
+  url: https://cloud.gravitee.io
+  controller: https://cloud-controller.gravitee.io
+  ssl:
+    verifyHostname: true
+
 api:
   enabled: true
   upgrader: false


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1220

## Description

Cockpit is being rebranded Gravitee Cloud. As part of these changes, we want to support cloud.xx properties as well as current cockpit.xx properties.

For now, we don't want to enforce property renames so both cockpit.xx and cloud.xx will be supported with existing cockpit.xx properties taken first. 

