### PR TITLE
Rest-api: fix "Deleted users still appear in query" on multi tenancy env

### DIFF
--- a/gravitee-apim-console-webui/src/components/user-autocomplete/user-autocomplete.html
+++ b/gravitee-apim-console-webui/src/components/user-autocomplete/user-autocomplete.html
@@ -16,6 +16,7 @@
 
 -->
 <md-autocomplete
+  md-no-cache="true"
   md-selected-item="selectedItem"
   md-search-text="$ctrl.searchText"
   md-selected-item-change="$ctrl.selectUser(user)"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImpl.java
@@ -21,9 +21,12 @@ import io.gravitee.node.api.Node;
 import io.gravitee.repository.management.model.MessageRecipient;
 import io.gravitee.rest.api.model.command.CommandEntity;
 import io.gravitee.rest.api.model.command.CommandQuery;
+import io.gravitee.rest.api.model.command.CommandTags;
 import io.gravitee.rest.api.service.CommandService;
 import io.gravitee.rest.api.service.ScheduledCommandService;
 import io.gravitee.rest.api.service.event.CommandEvent;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +42,12 @@ import org.springframework.stereotype.Component;
 public class ScheduledCommandsRefresherServiceImpl
     extends AbstractService<ScheduledCommandsRefresherServiceImpl>
     implements ScheduledCommandService<ScheduledCommandsRefresherServiceImpl>, Runnable {
+
+    // We exclude the DATA_TO_INDEX tag because it is processed by another service
+    public static final List<CommandTags> SUPPORTED_COMMAND_TAGS = Arrays
+        .stream(CommandTags.values())
+        .filter(commandTags -> commandTags != CommandTags.DATA_TO_INDEX)
+        .toList();
 
     private final CommandService commandService;
 
@@ -84,6 +93,7 @@ public class ScheduledCommandsRefresherServiceImpl
         CommandQuery commandQuery = new CommandQuery();
         commandQuery.setTo(MessageRecipient.MANAGEMENT_APIS.name());
         commandQuery.setNotAckBy(node.id());
+        commandQuery.setTags(SUPPORTED_COMMAND_TAGS);
 
         return commandService.search(commandQuery);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImplTest.java
@@ -99,7 +99,9 @@ public class ScheduledCommandsRefresherServiceImplTest {
         when(
             commandService.search(
                 ArgumentMatchers.argThat(query ->
-                    query.getTo().equals(MessageRecipient.MANAGEMENT_APIS.name()) && query.getNotAckBy().equals("node-id")
+                    query.getTo().equals(MessageRecipient.MANAGEMENT_APIS.name()) &&
+                    query.getNotAckBy().equals("node-id") &&
+                    !query.getTags().contains(CommandTags.DATA_TO_INDEX)
                 )
             )
         )


### PR DESCRIPTION



## Issue
https://gravitee.atlassian.net/browse/APIM-3614

## Description
- the ScheduledCommandsRefresherService manages all commands except with the DATA_TO_INDEX tag
- the ScheduledSearchIndexerService manages commands with the DATA_TO_INDEX tag only


They can't compete with each other, otherwise it makes their execution random.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-urqfqlibjn.chromatic.com)
<!-- Storybook placeholder end -->
