### PR TITLE
test: fix promote pop-up test in API Info test set

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-info.spec.ts
@@ -173,7 +173,7 @@ describe('API Info Page functionality', () => {
   it('Verify Promote pop-up on info page (v2)', () => {
     cy.visit(`/#!/DEFAULT/apis/${api.id}`);
     cy.getByDataTestId('api_info_promote').click();
-    cy.contains('Meet Cockpit').should('be.visible');
+    cy.contains('Meet Gravitee Cloud').should('be.visible');
     cy.getByDataTestId('api_info_promote_ok').click();
   });
 


### PR DESCRIPTION
## Description

Fixes the failing API Info Cypress test (cause by a UI change).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vbxbkwjahq.chromatic.com)
<!-- Storybook placeholder end -->
