### PR TITLE
Apim 4185 fix use openapi in doc syntax 

### DIFF
--- a/gravitee-apim-portal-webui/src/app/services/markdown.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/markdown.service.spec.ts
@@ -162,6 +162,13 @@ describe('MarkdownService', () => {
         expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/doc?page=22">text</a>');
       });
 
+      it('should find SWAGGER page by OPENAPI file reference', () => {
+        const renderedLink = renderer.link('/#!/documentation/api/myPage#OPENAPI', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/doc?page=22">text</a>');
+      });
+
       it('should find page by its name with spaces', () => {
         const renderedLink = renderer.link('/#!/documentation/api/my%20Page#MARKDOWN', 'title', 'text');
 

--- a/gravitee-apim-portal-webui/src/app/services/markdown.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/markdown.service.ts
@@ -62,7 +62,7 @@ export class MarkdownService {
       link(href, title, text) {
         const parsedSettingsUrl = /\/#!\/settings\/pages\/([\w-]+)/g.exec(href);
         const parsedApisUrl = /\/#!\/apis\/(?:[\w-]+)\/documentation\/([\w-]+)/g.exec(href);
-        const parsedRelativeDocApiUrl = /\/#!\/documentation\/api\/(.*)#([MARKDOWN|SWAGGER|ASYNCAPI|ASCIIDOC]+)/g.exec(href);
+        const parsedRelativeDocApiUrl = /\/#!\/documentation\/api\/(.*)#([MARKDOWN|SWAGGER|OPENAPI|ASYNCAPI|ASCIIDOC]+)/g.exec(href);
 
         let pageId: string;
 
@@ -109,6 +109,7 @@ const INTERNAL_LINK_CLASSNAME = 'internal-link';
  * If the page is not found, the page name is returned.
  *
  * @param parsedDocApiUrl - ex. ['/#!/documentation/api/my/doc%20page#MARKDOWN', 'my/doc%20page', 'MARKDOWN']
+ * @param pages - pages to search for locating the relative documentation
  */
 const pageIdFromParsedRelativeDocApiUrl = (parsedDocApiUrl: RegExpExecArray, pages: Page[]) => {
   const pagePath = parsedDocApiUrl[1];
@@ -116,7 +117,7 @@ const pageIdFromParsedRelativeDocApiUrl = (parsedDocApiUrl: RegExpExecArray, pag
   const splitPath = pathWithSpaces.split('/');
   const pageName = splitPath[splitPath.length - 1];
 
-  const pageType = parsedDocApiUrl[2];
+  const pageType = parsedDocApiUrl[2] === 'OPENAPI' ? 'SWAGGER' : parsedDocApiUrl[2];
 
   const pageId = findPageId(pageType, undefined, 0, splitPath, pages);
   return pageId ?? pageName;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4185

## Description

Allow relative doc syntax to include OPENAPI in order to find pages of type "SWAGGER"

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

