### PR TITLE
fix(portal): match site.title to how console references portal

### DIFF
--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -1118,7 +1118,7 @@
     }
   },
   "site": {
-    "title": "API portál Gravitee.io"
+    "title": "Developer Portal"
   },
   "subscriptions": {
     "applications": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -1118,7 +1118,7 @@
     }
   },
   "site": {
-    "title": "API portal of Gravitee.io"
+    "title": "Developer Portal"
   },
   "subscriptions": {
     "applications": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -1118,7 +1118,7 @@
     }
   },
   "site": {
-    "title": "Portail d'API de Gravitee.io"
+    "title": "Developer Portal"
   },
   "subscriptions": {
     "applications": {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4186

## Description

Match the i18n site.title to how the console references portal in the top bar --> `Developer Portal` for each language.

![Screenshot 2024-03-08 at 14 52 27](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/18de163b-b19a-4878-8fa6-0a0885c593e4)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xwfqhrdhqz.chromatic.com)
<!-- Storybook placeholder end -->
