### PR TITLE
fix(console): fix the validation of the form with a partial input

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.html
@@ -17,10 +17,6 @@
 -->
 <form *ngIf="!!configurationForm" [formGroup]="configurationForm">
   <ng-container *ngIf="sharedConfigurationSchema">
-    <gio-form-json-schema
-      formControlName="groupConfiguration"
-      [jsonSchema]="sharedConfigurationSchema"
-      (ready)="onSchemaFormReady()"
-    ></gio-form-json-schema>
+    <gio-form-json-schema formControlName="groupConfiguration" [jsonSchema]="sharedConfigurationSchema"></gio-form-json-schema>
   </ng-container>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/configuration/api-endpoint-group-configuration.component.ts
@@ -53,10 +53,4 @@ export class ApiEndpointGroupConfigurationComponent implements OnInit, OnDestroy
     this.unsubscribe$.next(true);
     this.unsubscribe$.complete();
   }
-
-  onSchemaFormReady() {
-    // schema-form component is overriding the form with all the fields from the schema.
-    // We set back the initial value to avoid sending invalid data to the backend
-    this.configurationForm.setValue(this.initialValues, { emitEvent: false });
-  }
 }


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-3969

## Description
Delete this code because we want the jsonSchema to initialise the mandatory fields so that it can manage its validity status correctly.

I didn't find any problem in removing this code. except that we send more empty properties o back. but it's up to the back to ignore them correctly. 🤔  

but perhaps it needs to be tested more thoroughly. perhaps to be seen with @ytvnr 
---
The problem is for an existing api with the keystore and truststore with the wrong name. It is no longer possible to validate this form. 
With this change it is possible to save and this correctly initialises the `keyStore` and  `trustStore` properties.
And deletes the old properties (with the wrong name) with bad name because they are not in the jsonSchema.

For the client with the problem, just tell him to reconfigure this part and it will work. 
for the other apis no change



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

