### PR TITLE
fix(service): add createdAt + updatedAt fields to license model

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/License.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/License.java
@@ -42,12 +42,16 @@ public class License {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        License page = (License) o;
-        return Objects.equals(referenceId, page.referenceId) && Objects.equals(referenceType, page.referenceType);
+        License license1 = (License) o;
+        return (
+            Objects.equals(referenceId, license1.referenceId) &&
+            referenceType == license1.referenceType &&
+            Objects.equals(license, license1.license)
+        );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(referenceId, referenceType);
+        return Objects.hash(referenceId, referenceType, license);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/model/License.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/model/License.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.license.model;
 
+import java.time.ZonedDateTime;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -27,6 +28,8 @@ public class License {
     private String referenceId;
     private ReferenceType referenceType;
     private String license;
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
 
     public enum ReferenceType {
         ORGANIZATION,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1242

## Description

Add `createdAt` and `updatedAt` fields for saving licenses. 

The synchronizer does not find the licenses because they are missing an `updatedAt` field 🙃 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-apokplzyyb.chromatic.com)
<!-- Storybook placeholder end -->
