### PR TITLE
fix: http redirection to https

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.25
+
+- BREAKING CHANGE: In gateway ingress controller, change ssl-redirect option from "false" to default. More info [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect)
+
 ### 4.0.24
 
 - Improve redis ratelimit configuration [issues/9726](https://github.com/gravitee-io/issues/issues/9726). Thanks [@gh0stsrc](https://github.com/gh0stsrc) 

--- a/helm/tests/gateway/ingress_annotations_test.yaml
+++ b/helm/tests/gateway/ingress_annotations_test.yaml
@@ -15,4 +15,3 @@ tests:
             acme.com/team: api
             acme.com/feature: products
             kubernetes.io/ingress.class: nginx 
-            nginx.ingress.kubernetes.io/ssl-redirect: "false" 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1103,7 +1103,7 @@ gateway:
       - apim.example.com
     annotations:
       kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
       # nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
       # kubernetes.io/tls-acme: "true"
     #tls:


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-4817

## Description

Previously, our default configuration say that even if you enable TLS, we don't redirect HTTP to HTTPS.
By default (without our overwrite config) nginx says:

```
By default the controller redirects (308) to HTTPS if TLS is enabled for that ingress.
```
https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#server-side-https-enforcement-through-redirect

So both case:

- customer keep default and use HTTP
- customer only enable TLS

will be handled correctly with default nginx configuration.

As we add nginx.ingress.kubernetes.io/ssl-redirect: "false" which is ok by default without TLS.
This mean that even if we enable TLS, the redirection is still disabled.

My proposal is to remove our default setting and keep the nginx default one to make both case (TLS or not) work properly:
enable redirection only if TLS is used.
