### PR TITLE
refactor(rest-api-flow): Added flow id to the v2 management model version 4.2

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/Flow.java
@@ -43,6 +43,8 @@ import lombok.*;
 @With
 public class Flow implements Serializable {
 
+    private String id;
+
     private String name;
 
     @Builder.Default

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FlowRepository.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.repository.management.api;/**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,6 +32,7 @@ package io.gravitee.repository.management.api;/**
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.flow.Flow;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -42,4 +43,6 @@ public interface FlowRepository extends CrudRepository<Flow, String> {
     List<Flow> findByReference(FlowReferenceType referenceType, String referenceId) throws TechnicalException;
 
     void deleteByReference(FlowReferenceType referenceType, String referenceId) throws TechnicalException;
+
+    void deleteAllById(Collection<String> ids) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.repository.mongodb.management.internal.flow.FlowMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.FlowMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -95,6 +96,13 @@ public class MongoFlowRepository implements FlowRepository {
     @Override
     public void deleteByReference(FlowReferenceType referenceType, String referenceId) {
         internalRepository.deleteAll(internalRepository.findAll(referenceType.name(), referenceId));
+    }
+
+    @Override
+    public void deleteAllById(Collection<String> ids) {
+        logger.debug("Delete flows [{}]", ids);
+        internalRepository.deleteAllById(ids);
+        logger.debug("Delete flows [{}] - Done", ids);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 /**
@@ -212,6 +214,17 @@ public class FlowRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(2, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-deleted").size());
 
         flowRepository.deleteByReference(FlowReferenceType.ORGANIZATION, "orga-deleted");
+
+        assertEquals(0, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-deleted").size());
+    }
+
+    @Test
+    public void shouldDeleteByIds() throws TechnicalException {
+        List<Flow> flows = flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-deleted");
+        assertEquals(2, flows.size());
+        Set<String> ids = flows.stream().map(Flow::getId).collect(Collectors.toSet());
+
+        flowRepository.deleteAllById(ids);
 
         assertEquals(0, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-deleted").size());
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
@@ -31,6 +31,7 @@ import io.gravitee.repository.management.model.flow.selector.FlowOperator;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.Test;
 
 /**
@@ -243,6 +244,17 @@ public class FlowV4RepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(2, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-v4-deleted").size());
 
         flowRepository.deleteByReference(FlowReferenceType.ORGANIZATION, "orga-v4-deleted");
+
+        assertEquals(0, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-v4-deleted").size());
+    }
+
+    @Test
+    public void shouldDeleteByIds() throws TechnicalException {
+        List<Flow> flows = flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-v4-deleted");
+        assertEquals(2, flows.size());
+        Set<String> ids = flows.stream().map(Flow::getId).collect(Collectors.toSet());
+
+        flowRepository.deleteAllById(ids);
 
         assertEquals(0, flowRepository.findByReference(FlowReferenceType.ORGANIZATION, "orga-v4-deleted").size());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2802,6 +2802,10 @@ components:
         FlowV4:
             type: object
             properties:
+                id:
+                    type: string
+                    description: Flow's uuid.
+                    example: 4e6abbd2-c0c6-462d-be9e-6371209af34b
                 name:
                     type: string
                     description: Flow's name.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
@@ -20,4 +20,6 @@ import java.util.List;
 
 public interface FlowCrudService {
     List<Flow> savePlanFlows(String planId, List<Flow> flows);
+
+    List<Flow> saveApiFlows(String apiId, List<Flow> flows);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/FlowAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/FlowAdapter.java
@@ -29,6 +29,7 @@ import io.gravitee.repository.management.model.flow.selector.FlowSelector;
 import io.gravitee.rest.api.service.common.UuidString;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(imports = { UuidString.class, TimeProvider.class })
@@ -39,6 +40,10 @@ public interface FlowAdapter {
     @Mapping(target = "createdAt", expression = "java(java.util.Date.from(TimeProvider.instantNow()))")
     @Mapping(target = "updatedAt", expression = "java(java.util.Date.from(TimeProvider.instantNow()))")
     Flow toRepository(io.gravitee.definition.model.v4.flow.Flow source, FlowReferenceType referenceType, String referenceId, int order);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "updatedAt", expression = "java(java.util.Date.from(TimeProvider.instantNow()))")
+    Flow toRepositoryUpdate(@MappingTarget Flow repository, io.gravitee.definition.model.v4.flow.Flow source, int order);
 
     @Mapping(target = "id", expression = "java(UuidString.generateRandom())")
     @Mapping(target = "createdAt", expression = "java(java.util.Date.from(TimeProvider.instantNow()))")
@@ -76,11 +81,14 @@ public interface FlowAdapter {
     }
 
     FlowHttpSelector toRepository(HttpSelector source);
+
     HttpSelector toModel(FlowHttpSelector source);
 
     FlowChannelSelector toRepository(ChannelSelector source);
+
     ChannelSelector toModel(FlowChannelSelector source);
 
     FlowConditionSelector toRepository(ConditionSelector source);
+
     ConditionSelector toModel(FlowConditionSelector source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/FlowService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/FlowService.java
@@ -28,6 +28,4 @@ public interface FlowService {
     String getPlatformFlowSchemaForm(final ExecutionContext executionContext);
 
     List<Flow> findByReference(final FlowReferenceType flowReferenceType, final String referenceId);
-
-    List<Flow> save(final FlowReferenceType flowReferenceType, final String referenceId, final List<Flow> flows);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
@@ -41,7 +42,6 @@ import io.gravitee.repository.management.model.GroupEvent;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.Visibility;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
@@ -98,7 +98,6 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.ApiNotificationService;
 import io.gravitee.rest.api.service.v4.ApiService;
-import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
@@ -143,7 +142,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private final MembershipService membershipService;
     private final GenericNotificationConfigService genericNotificationConfigService;
     private final ApiMetadataService apiMetadataService;
-    private final FlowService flowService;
+    private final FlowCrudService flowCrudService;
     private final SearchEngineService searchEngineService;
     private final PlanService planService;
     private final PlanSearchService planSearchService;
@@ -175,7 +174,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final MembershipService membershipService,
         final GenericNotificationConfigService genericNotificationConfigService,
         @Lazy final ApiMetadataService apiMetadataService,
-        final FlowService flowService,
+        final FlowCrudService flowCrudService,
         @Lazy final SearchEngineService searchEngineService,
         final PlanService planService,
         final PlanSearchService planSearchService,
@@ -204,7 +203,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         this.membershipService = membershipService;
         this.genericNotificationConfigService = genericNotificationConfigService;
         this.apiMetadataService = apiMetadataService;
-        this.flowService = flowService;
+        this.flowCrudService = flowCrudService;
         this.searchEngineService = searchEngineService;
         this.planService = planService;
         this.planSearchService = planSearchService;
@@ -259,7 +258,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             createDefaultSupportEmailMetadata(executionContext, createdApi);
 
             // create the API flows
-            flowService.save(FlowReferenceType.API, createdApi.getId(), newApiEntity.getFlows());
+            flowCrudService.saveApiFlows(createdApi.getId(), newApiEntity.getFlows());
 
             //TODO add membership log
             ApiEntity apiEntity = apiMapper.toEntity(executionContext, createdApi, primaryOwner, null, true);
@@ -367,7 +366,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         createDefaultSupportEmailMetadata(executionContext, createdApi);
 
         // create the API flows
-        flowService.save(FlowReferenceType.API, createdApi.getId(), apiEntity.getFlows());
+        flowCrudService.saveApiFlows(createdApi.getId(), apiEntity.getFlows());
 
         ApiEntity createdApiEntity = apiMapper.toEntity(executionContext, createdApi, primaryOwner, null, true);
         GenericApiEntity apiWithMetadata = apiMetadataService.fetchMetadataForApi(executionContext, createdApiEntity);
@@ -525,7 +524,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             Api updatedApi = apiRepository.update(api);
 
             // update API flows
-            flowService.save(FlowReferenceType.API, api.getId(), updateApiEntity.getFlows());
+            flowCrudService.saveApiFlows(api.getId(), updateApiEntity.getFlows());
 
             // update API plans
             updateApiEntity
@@ -617,7 +616,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             plans.forEach(plan -> planService.delete(executionContext, plan.getId()));
 
             // Delete flows
-            flowService.save(FlowReferenceType.API, apiId, null);
+            flowCrudService.saveApiFlows(apiId, null);
 
             // Delete events
             eventService.deleteApiEvents(apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/FlowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/FlowServiceImpl.java
@@ -36,7 +36,6 @@ import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.mapper.FlowMapper;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -130,30 +129,6 @@ public class FlowServiceImpl extends TransactionalService implements FlowService
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
             final String error = "An error occurs while find flows by reference";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
-        }
-    }
-
-    @Override
-    public List<Flow> save(final FlowReferenceType flowReferenceType, final String referenceId, final List<Flow> flows) {
-        try {
-            log.debug("Save flows for reference {},{}", flowReferenceType, flowReferenceType);
-            flowRepository.deleteByReference(flowReferenceType, referenceId);
-            if (flows == null) {
-                return List.of();
-            } else {
-                List<Flow> createdFlows = new ArrayList<>();
-                for (int order = 0; order < flows.size(); ++order) {
-                    io.gravitee.repository.management.model.flow.Flow createdFlow = flowRepository.create(
-                        flowMapper.toRepository(flows.get(order), flowReferenceType, referenceId, order)
-                    );
-                    createdFlows.add(flowMapper.toDefinition(createdFlow));
-                }
-                return createdFlows;
-            }
-        } catch (TechnicalException ex) {
-            final String error = "An error occurs while save flows";
             log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -25,6 +25,7 @@ import static io.gravitee.repository.management.model.Plan.AuditEvent.PLAN_UPDAT
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -146,6 +147,9 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
     private FlowService flowService;
 
     @Autowired
+    private FlowCrudService flowCrudService;
+
+    @Autowired
     private TagsValidationService tagsValidationService;
 
     @Autowired
@@ -202,7 +206,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             Plan plan = planMapper.toRepository(newPlan);
             plan = planRepository.create(plan);
 
-            flowService.save(FlowReferenceType.PLAN, plan.getId(), newPlan.getFlows());
+            flowCrudService.savePlanFlows(plan.getId(), newPlan.getFlows());
 
             auditService.createApiAuditLog(
                 executionContext,
@@ -350,7 +354,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             } else {
                 PlanEntity oldPlanEntity = mapToEntity(oldPlan);
 
-                flowService.save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+                flowCrudService.savePlanFlows(updatePlan.getId(), updatePlan.getFlows());
                 PlanEntity newPlanEntity = mapToEntity(newPlan);
 
                 if (
@@ -497,7 +501,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             }
 
             // Delete plan and his flows
-            flowService.save(FlowReferenceType.PLAN, planId, null);
+            flowCrudService.savePlanFlows(planId, null);
             planRepository.delete(planId);
 
             // Audit

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
@@ -47,6 +47,7 @@ public class FlowMapper {
             throw new IllegalArgumentException("Flow to map cannot be null");
         }
         Flow definitionFlow = new Flow();
+        definitionFlow.setId(repositoryFlow.getId());
         definitionFlow.setName(repositoryFlow.getName());
         definitionFlow.setEnabled(repositoryFlow.isEnabled());
         definitionFlow.setRequest(repositoryFlow.getRequest().stream().map(this::toDefinition).collect(Collectors.toList()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
@@ -34,6 +34,12 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
     }
 
     @Override
+    public List<Flow> saveApiFlows(String apiId, List<Flow> flows) {
+        planFlows.put(apiId, flows);
+        return flows;
+    }
+
+    @Override
     public void initWith(List<Flow> items) {
         throw new UnsupportedOperationException();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionContext;
@@ -248,6 +249,9 @@ public class ApiServiceImplTest {
     private TopApiService topApiService;
 
     @Mock
+    private FlowCrudService flowCrudService;
+
+    @Mock
     private FlowService flowService;
 
     @Mock
@@ -335,7 +339,7 @@ public class ApiServiceImplTest {
                 membershipService,
                 genericNotificationConfigService,
                 apiMetadataService,
-                flowService,
+                flowCrudService,
                 searchEngineService,
                 planService,
                 planSearchService,
@@ -536,7 +540,7 @@ public class ApiServiceImplTest {
                 new MembershipService.MembershipMember(USER_NAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
             );
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, apiFlows);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, apiFlows);
     }
 
     @Test(expected = ApiRunningStateException.class)
@@ -564,7 +568,7 @@ public class ApiServiceImplTest {
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, null);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, null);
     }
 
     @Test(expected = ApiNotDeletableException.class)
@@ -599,7 +603,7 @@ public class ApiServiceImplTest {
 
         verify(planService, times(1)).delete(GraviteeContext.getExecutionContext(), PLAN_ID);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, null);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, null);
     }
 
     @Test
@@ -621,7 +625,7 @@ public class ApiServiceImplTest {
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, null);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, null);
     }
 
     @Test
@@ -643,7 +647,7 @@ public class ApiServiceImplTest {
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, null);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, null);
     }
 
     @Test
@@ -763,7 +767,7 @@ public class ApiServiceImplTest {
                     newApiMetadataEntity.getName().equals(DefaultMetadataInitializer.METADATA_EMAIL_SUPPORT_KEY)
                 )
             );
-        verify(flowService).save(FlowReferenceType.API, API_ID, apiEntity.getFlows());
+        verify(flowCrudService).saveApiFlows(API_ID, apiEntity.getFlows());
         verify(apiMetadataService).fetchMetadataForApi(eq(executionContext), any(ApiEntity.class));
         verify(searchEngineService).index(eq(executionContext), any(GenericApiEntity.class), eq(false));
     }
@@ -821,7 +825,7 @@ public class ApiServiceImplTest {
 
         apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME);
 
-        verify(flowService, times(1)).save(FlowReferenceType.API, API_ID, apiFlows);
+        verify(flowCrudService, times(1)).saveApiFlows(API_ID, apiFlows);
     }
 
     @Test(expected = ApiNotFoundException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
@@ -135,6 +136,9 @@ public class ApiServiceImpl_findAllTest {
     private FlowService flowService;
 
     @Mock
+    private FlowCrudService flowCrudService;
+
+    @Mock
     private PortalNotificationConfigService portalNotificationConfigService;
 
     @Mock
@@ -209,7 +213,7 @@ public class ApiServiceImpl_findAllTest {
                 membershipService,
                 genericNotificationConfigService,
                 apiMetadataService,
-                flowService,
+                flowCrudService,
                 searchEngineService,
                 planService,
                 planSearchService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/FlowServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/FlowServiceImplTest.java
@@ -18,10 +18,13 @@ package io.gravitee.rest.api.service.v4.impl;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.apim.infra.crud_service.flow.FlowCrudServiceImpl;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.FlowRepository;
 import io.gravitee.repository.management.model.flow.Flow;
@@ -45,6 +48,8 @@ public class FlowServiceImplTest {
 
     private FlowService flowService;
 
+    private FlowCrudService flowCrudService;
+
     @Mock
     private FlowRepository flowRepository;
 
@@ -54,6 +59,7 @@ public class FlowServiceImplTest {
     @Before
     public void before() {
         flowService = new FlowServiceImpl(flowRepository, tagService, new FlowMapper());
+        flowCrudService = new FlowCrudServiceImpl(flowRepository);
     }
 
     @Test
@@ -98,8 +104,7 @@ public class FlowServiceImplTest {
 
         when(flowRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-        List<io.gravitee.definition.model.v4.flow.Flow> flowServiceByReference = flowService.save(
-            FlowReferenceType.API,
+        List<io.gravitee.definition.model.v4.flow.Flow> flowServiceByReference = flowCrudService.saveApiFlows(
             "apiId",
             List.of(flow1, flow2)
         );
@@ -108,7 +113,7 @@ public class FlowServiceImplTest {
         assertThat(flowServiceByReference.get(0).getName()).isEqualTo("flow1");
         assertThat(flowServiceByReference.get(1).getName()).isEqualTo("flow2");
 
-        verify(flowRepository).deleteByReference(FlowReferenceType.API, "apiId");
+        verify(flowRepository, never()).deleteByReference(FlowReferenceType.API, "apiId");
         verify(flowRepository, times(2)).create(any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateOrUpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateOrUpdateTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -124,6 +125,9 @@ public class PlanService_CreateOrUpdateTest {
 
     @Mock
     private FlowService flowService;
+
+    @Mock
+    private FlowCrudService flowCrudService;
 
     @Before
     public void setup() throws Exception {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
@@ -20,13 +20,13 @@ import static io.gravitee.repository.management.model.Plan.AuditEvent.PLAN_CREAT
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.v4.plan.NewPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
@@ -100,6 +100,9 @@ public class PlanService_CreateTest {
 
     @Mock
     private FlowService flowService;
+
+    @Mock
+    private FlowCrudService flowCrudService;
 
     @Mock
     private TagsValidationService tagsValidationService;
@@ -188,7 +191,7 @@ public class PlanService_CreateTest {
 
         planService.create(GraviteeContext.getExecutionContext(), this.newPlanEntity);
 
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, newPlanEntity.getId(), newPlanEntity.getFlows());
+        verify(flowCrudService, times(1)).savePlanFlows(newPlanEntity.getId(), newPlanEntity.getFlows());
         verify(flowValidationService, times(1)).validateAndSanitize(api.getType(), List.of());
         verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeleteTest.java
@@ -20,10 +20,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.SubscriptionService;
@@ -32,7 +32,6 @@ import io.gravitee.rest.api.service.exceptions.PlanWithSubscriptionsException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanService;
-import io.gravitee.rest.api.service.v4.impl.PlanServiceImpl;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.Test;
@@ -73,6 +72,9 @@ public class PlanService_DeleteTest {
     @Mock
     private FlowService flowService;
 
+    @Mock
+    private FlowCrudService flowCrudService;
+
     @Test(expected = PlanWithSubscriptionsException.class)
     public void shouldNotDeleteBecauseSubscriptionsExist() throws TechnicalException {
         when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
@@ -94,7 +96,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
+        verify(flowCrudService, times(1)).savePlanFlows(PLAN_ID, null);
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -115,7 +117,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
+        verify(flowCrudService, times(1)).savePlanFlows(PLAN_ID, null);
     }
 
     @Test
@@ -129,7 +131,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
+        verify(flowCrudService, times(1)).savePlanFlows(PLAN_ID, null);
     }
 
     @Test
@@ -142,6 +144,6 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
+        verify(flowCrudService, times(1)).savePlanFlows(PLAN_ID, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -38,7 +39,6 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
-import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -125,6 +125,9 @@ public class PlanService_UpdateTest {
 
     @Mock
     private FlowService flowService;
+
+    @Mock
+    private FlowCrudService flowCrudService;
 
     @Mock
     private TagsValidationService tagsValidationService;
@@ -275,7 +278,7 @@ public class PlanService_UpdateTest {
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
 
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+        verify(flowCrudService, times(1)).savePlanFlows(updatePlan.getId(), updatePlan.getFlows());
         verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
@@ -323,7 +326,7 @@ public class PlanService_UpdateTest {
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
 
-        verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+        verify(flowCrudService, times(1)).savePlanFlows(updatePlan.getId(), updatePlan.getFlows());
         verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4184

## Description

Added flow id to the v2 management model.
Implement flow save based on ID provided by UI to stop recreating flow id on the database. 
Moved FlowServiceImpl.save method to the FlowCrudServiceImpl

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-myjncwztno.chromatic.com)
<!-- Storybook placeholder end -->
