### PR TITLE
fix: additional check for url to validate dangerous characters

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class UrlSanitizerUtils {
 
     public static void checkAllowed(String url, List<String> whitelist, boolean allowPrivate) {
+        checkUrlForbiddenCharacters(url);
         checkUriSyntax(url);
         if (whitelist != null && !whitelist.isEmpty()) {
             if (
@@ -70,6 +71,17 @@ public class UrlSanitizerUtils {
         try {
             new URI(url);
         } catch (Exception e) {
+            throw new UrlForbiddenException();
+        }
+    }
+
+    /**
+     * Check if url contains characters that may be used to enforce HTTP header injection attack
+     */
+    public static void checkUrlForbiddenCharacters(String url) {
+        String urlEncodedCarriageReturn = "%0D";
+        String urlEncodedLineFeed = "%0A";
+        if (url.contains(urlEncodedCarriageReturn) || url.contains(urlEncodedLineFeed)) {
             throw new UrlForbiddenException();
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4206
https://gravitee.atlassian.net/browse/APIM-3796

## Description

PR contains fix for HTTP header injection vulnerability.
It checks url for special characters (CR and LF) that may lead to escaping url and injecting some malicious header in the request.

## Additional Context

Here's the response from APIM when malicious link is being sent to the backend: 

<img width="2557" alt="Zrzut ekranu 2024-03-14 o 08 54 57" src="https://github.com/gravitee-io/gravitee-api-management/assets/155629548/27b3aa58-27be-4f50-90cc-ad22fdd312c9">

I decided to go with the same behaviour as the rest of Url checks so I throw and error when I find some suspicious characters in the link instead of just removing them. Pentest report suggested focusing mainly on \r and \n characters so I check for them only. 

At the bottom of this article https://www.w3schools.com/tags/ref_urlencode.ASP I found also the list of all possible ascii control characters that may appear in url but I don't know if they are potentially dangerous so I didn't add them. If you think that expanding this list with the rest of characters might be good idea please let me know.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qobchthkpd.chromatic.com)
<!-- Storybook placeholder end -->
