### PR TITLE
fix(gateway-hc): handle failing scenarios to always start a new timer

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
@@ -42,13 +42,14 @@ public class EndpointRuleCronHandler<T extends Endpoint> implements Handler<Long
             throw new IllegalArgumentException("Handler is null.");
         }
         this.handler = handler;
+        handler.setRescheduleHandler(v -> this.timerId = vertx.setTimer(handler.getDelayMillis(), this));
         timerId = vertx.setTimer(handler.getDelayMillis(), this);
         return this;
     }
 
     @Override
     public void handle(final Long timerId) {
-        handler.handle(hcResponseHandler -> this.timerId = vertx.setTimer(handler.getDelayMillis(), this));
+        handler.handle(this.timerId);
     }
 
     public void cancel() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3967

## Description

Before only successful scenario was handled and new timer was scheduled. To allow error handling we should always start a new timer. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

