### PR TITLE
Apim 4251 handle deleted org license

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/license/LicenseDeployable.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/license/LicenseDeployable.java
@@ -20,7 +20,6 @@ import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
@@ -33,7 +32,6 @@ import lombok.experimental.Accessors;
 @ToString
 public class LicenseDeployable implements Deployable {
 
-    @NonNull
     private String license;
 
     private String id;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>5.9.1</gravitee-node.version>
+        <gravitee-node.version>5.10.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
-        <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>5.10.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>
@@ -458,12 +457,6 @@
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-resource</artifactId>
                 <version>${gravitee-plugin.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.graviteesource.license</groupId>
-                <artifactId>gravitee-license-node</artifactId>
-                <version>${gravitee-license-node.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4251

## Description

When Cockpit sends an `OrganizationCommand` after deleting an organization license, the payload includes a `null` license. After receiving this update, APIM should use an `OSSLicense`.

What was done:
- Implement `gravitee-node` upgrade from https://github.com/gravitee-io/gravitee-node/pull/297
- Remove `@NonNull` attribute from `LicenseDeployable` to allow null license
- Remove unused old dependency `gravitee-license-node`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dciiqyuogy.chromatic.com)
<!-- Storybook placeholder end -->
