### PR TITLE
chore: bump Solace dependency to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <gravitee-endpoint-kafka.version>2.9.1</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.2.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>1.3.0</gravitee-endpoint-rabbitmq.version>
-        <gravitee-endpoint-solace.version>1.1.0</gravitee-endpoint-solace.version>
+        <gravitee-endpoint-solace.version>1.2.0</gravitee-endpoint-solace.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>3.0.0-alpha.1</gravitee-resource-schema-registry-confluent.version>
         <gravitee-reactor-message.version>2.0.0</gravitee-reactor-message.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3681

## Description

Bump Solace dependency
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cyoqrdsxoh.chromatic.com)
<!-- Storybook placeholder end -->
