### PR TITLE
feat(service): only create org license if license non-null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/domain_service/LicenseDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/license/domain_service/LicenseDomainService.java
@@ -32,6 +32,13 @@ public class LicenseDomainService {
         return this.licenseCrudService.getOrganizationLicense(organizationId);
     }
 
+    /**
+     * Create or update license by organization ID.
+     * If on create and license is null, no license is saved in the database.
+     * If on update and license is the same, no license is updated.
+     * @param organizationId -- organization identifier
+     * @param license -- license content to be saved
+     */
     public void createOrUpdateOrganizationLicense(String organizationId, String license) {
         this.licenseCrudService.getOrganizationLicense(organizationId)
             .ifPresentOrElse(
@@ -40,7 +47,11 @@ public class LicenseDomainService {
                         this.licenseCrudService.updateOrganizationLicense(organizationId, license);
                     }
                 },
-                () -> this.licenseCrudService.createOrganizationLicense(organizationId, license)
+                () -> {
+                    if (Objects.nonNull(license)) {
+                        this.licenseCrudService.createOrganizationLicense(organizationId, license);
+                    }
+                }
             );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/license/domain_service/LicenseDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/license/domain_service/LicenseDomainServiceTest.java
@@ -54,6 +54,16 @@ class LicenseDomainServiceTest {
     }
 
     @Test
+    void should_not_create_organization_license_if_null_license() {
+        assertThat(service.getLicenseByOrganizationId("new")).isEmpty();
+
+        service.createOrUpdateOrganizationLicense("new", null);
+
+        var result = service.getLicenseByOrganizationId("new");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     void should_update_organization_license() {
         givenOrganizationLicense("org-to-update", "initialLicense");
         service.createOrUpdateOrganizationLicense("org-to-update", "updatedLicense");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4251

## Description

When receiving a `OrganizationCommand` that has a null license and the organization license does not exist in the database, then no organization license should be persisted in the database.

This is to allow newly created organizations to default on the Platform license if they have never had an organization-specific license.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rnuyqylpoy.chromatic.com)
<!-- Storybook placeholder end -->
