### PR TITLE
fix(repository): set default value for licenses updated at

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/schema.yml
@@ -13,7 +13,7 @@ databaseChangeLog:
               - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: license, type: nvarchar(256), constraints: { nullable: false } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
-              - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false } }
+              - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
 
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}licenses


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The first non-null timestamp is automatically handled by MySQL to set the default value to `CURRENT_TIMESTAMP(6)`. However, the second non-null timestamp is not handled. An explicit value needs to be set for subsequent non-null timestamps.

More information: https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_explicit_defaults_for_timestamp

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zumiagbnjv.chromatic.com)
<!-- Storybook placeholder end -->
