### PR TITLE
fix: multi-tenancy for dashboards

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.components.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.components.ts
@@ -58,8 +58,9 @@ const DashboardComponent: ng.IComponentOptions = {
         });
       } else {
         this.dashboard = {
-          reference_type: $state.params.type,
-          reference_id: 'DEFAULT',
+          type: $state.params.type,
+          reference_type: 'ENVIRONMENT',
+          reference_id: $state.params.environmentId,
           enabled: true,
           definition: [],
         };

--- a/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.html
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/dashboard/dashboard.html
@@ -17,8 +17,8 @@
 -->
 <div class="gv-forms gv-forms-fluid" layout="column">
   <div class="gv-forms-header">
-    <h1 ng-if="!$ctrl.editMode">New dashboard [{{$ctrl.dashboard.reference_type}}]</h1>
-    <h1 ng-if="$ctrl.editMode">{{::$ctrl.dashboard.name}} [{{$ctrl.dashboard.reference_type}}]</h1>
+    <h1 ng-if="!$ctrl.editMode">New dashboard [{{$ctrl.dashboard.type}}]</h1>
+    <h1 ng-if="$ctrl.editMode">{{::$ctrl.dashboard.name}} [{{$ctrl.dashboard.type}}]</h1>
     <a ui-sref="management.settings.analytics.list">Back to dashboards</a>
   </div>
 

--- a/gravitee-apim-console-webui/src/services/dashboard.service.ts
+++ b/gravitee-apim-console-webui/src/services/dashboard.service.ts
@@ -37,8 +37,8 @@ class DashboardService {
     return this.$http.get(`${this.Constants.env.baseURL}/configuration/dashboards/` + dashboardId);
   }
 
-  list(referenceType: string, silent = false) {
-    return this.$http.get(`${this.Constants.env.baseURL}/configuration/dashboards/` + '?reference_type=' + referenceType, {
+  list(type: string, silent = false) {
+    return this.$http.get(`${this.Constants.env.baseURL}/configuration/dashboards/` + '?type=' + type, {
       silentCall: silent,
     });
   }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
@@ -18,11 +18,14 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Dashboard;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface DashboardRepository extends CrudRepository<Dashboard, String> {
-    List<Dashboard> findByReferenceType(String referenceType) throws TechnicalException;
+    List<Dashboard> findByReference(String referenceType, String referenceId) throws TechnicalException;
+    List<Dashboard> findByReferenceAndType(String referenceType, String referenceId, String type) throws TechnicalException;
+    Optional<Dashboard> findByReferenceAndId(String referenceType, String referenceId, String id) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Dashboard.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Dashboard.java
@@ -17,11 +17,21 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@EqualsAndHashCode(of = "id")
 public class Dashboard {
 
     public enum AuditEvent implements Audit.AuditEvent {
@@ -36,135 +46,9 @@ public class Dashboard {
     private String name;
     private String queryFilter;
     private String definition;
+    private String type;
     private int order;
     private boolean enabled;
     private Date createdAt;
     private Date updatedAt;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(String referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getQueryFilter() {
-        return queryFilter;
-    }
-
-    public void setQueryFilter(String queryFilter) {
-        this.queryFilter = queryFilter;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Dashboard dashboard = (Dashboard) o;
-        return Objects.equals(id, dashboard.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "Dashboard{" +
-            "id='" +
-            id +
-            '\'' +
-            ", referenceType='" +
-            referenceType +
-            '\'' +
-            ", referenceId='" +
-            referenceId +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", queryFilter='" +
-            queryFilter +
-            '\'' +
-            ", definition='" +
-            definition +
-            '\'' +
-            ", order=" +
-            order +
-            ", enabled=" +
-            enabled +
-            ", createdAt=" +
-            createdAt +
-            ", updatedAt=" +
-            updatedAt +
-            '}'
-        );
-    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/DashboardType.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/DashboardType.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export class Dashboard {
-  public id: string;
-  public reference_type: string;
-  public reference_id: string;
-  public type: string;
-  public name: string;
-  public query_filter: string;
-  public order: number;
-  public enabled: boolean;
-  public definition: string;
-  public created_at: number;
-  public updated_at: number;
+package io.gravitee.repository.management.model;
+
+/**
+ * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum DashboardType {
+    PLATFORM,
+    API,
+    APPLICATION,
+    HOME,
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_20/schema-dashboards.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_20/schema-dashboards.yml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.0.20-dashboards
+      author: GraviteeSource Team
+      changes:
+        # ################
+        # Dashboards changes
+        # ################
+        - addColumn:
+            tableName: ${gravitee_prefix}dashboards
+            columns:
+              - column:
+                  name: type
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: false
+        - sql:
+            sql: update ${gravitee_prefix}dashboards set type = reference_type
+        - sql:
+            sql: update ${gravitee_prefix}dashboards set reference_type = 'ENVIRONMENT'

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -159,3 +159,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_0_0/schema.yml
   - include:
       - file: liquibase/changelogs/v4_0_3/schema.yml
+  - include:
+      - file: liquibase/changelogs/v4_0_20/schema-dashboards.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDashboardRepository.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.repository.mongodb.management;
 
-import static java.util.stream.Collectors.toList;
-
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DashboardRepository;
 import io.gravitee.repository.management.model.Dashboard;
@@ -123,8 +121,30 @@ public class MongoDashboardRepository implements DashboardRepository {
     }
 
     @Override
-    public List<Dashboard> findByReferenceType(String referenceType) throws TechnicalException {
-        final List<DashboardMongo> dashboards = internalDashboardRepo.findByReferenceTypeOrderByOrder(referenceType);
-        return dashboards.stream().map(dashboardMongo -> mapper.map(dashboardMongo)).collect(toList());
+    public List<Dashboard> findByReference(String referenceType, String referenceId) throws TechnicalException {
+        final List<DashboardMongo> dashboards = internalDashboardRepo.findByReferenceTypeAndReferenceId(referenceType, referenceId);
+        return dashboards.stream().map(dashboardMongo -> mapper.map(dashboardMongo)).toList();
+    }
+
+    @Override
+    public List<Dashboard> findByReferenceAndType(String referenceType, String referenceId, String type) throws TechnicalException {
+        final List<DashboardMongo> dashboards = internalDashboardRepo.findByReferenceTypeAndReferenceIdAndTypeOrderByOrder(
+            referenceType,
+            referenceId,
+            type
+        );
+        return dashboards.stream().map(dashboardMongo -> mapper.map(dashboardMongo)).toList();
+    }
+
+    @Override
+    public Optional<Dashboard> findByReferenceAndId(String referenceType, String referenceId, String id) throws TechnicalException {
+        LOGGER.debug("Find dashboard by ID [{}-{}-{}]", referenceType, referenceId, id);
+
+        final DashboardMongo dashboard = internalDashboardRepo
+            .findByReferenceTypeAndReferenceIdAndId(referenceType, referenceId, id)
+            .orElse(null);
+
+        LOGGER.debug("Find dashboard by ID [{}-{}-{}] - Done", referenceType, referenceId, id);
+        return Optional.ofNullable(mapper.map(dashboard));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/DashboardMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/DashboardMongoRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal;
 
 import io.gravitee.repository.mongodb.management.internal.model.DashboardMongo;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -26,5 +27,8 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface DashboardMongoRepository extends MongoRepository<DashboardMongo, String> {
-    List<DashboardMongo> findByReferenceTypeOrderByOrder(String referenceType);
+    List<DashboardMongo> findByReferenceTypeAndReferenceId(String referenceType, String referenceId);
+    List<DashboardMongo> findByReferenceTypeAndReferenceIdAndTypeOrderByOrder(String referenceType, String referenceId, String type);
+
+    Optional<DashboardMongo> findByReferenceTypeAndReferenceIdAndId(String referenceType, String referenceId, String id);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DashboardMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/DashboardMongo.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.repository.mongodb.management.internal.model;
 
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -24,6 +27,10 @@ import org.springframework.data.mongodb.core.mapping.Document;
  * @author GraviteeSource Team
  */
 @Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}dashboards")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id", callSuper = false)
 public class DashboardMongo extends Auditable {
 
     @Id
@@ -34,113 +41,7 @@ public class DashboardMongo extends Auditable {
     private String name;
     private String queryFilter;
     private String definition;
+    private String type;
     private int order;
     private boolean enabled;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(String referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getQueryFilter() {
-        return queryFilter;
-    }
-
-    public void setQueryFilter(String queryFilter) {
-        this.queryFilter = queryFilter;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DashboardMongo that = (DashboardMongo) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "DashboardMongo{" +
-            "id='" +
-            id +
-            '\'' +
-            ", referenceType='" +
-            referenceType +
-            '\'' +
-            ", referenceId='" +
-            referenceId +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", queryFilter='" +
-            queryFilter +
-            '\'' +
-            ", definition='" +
-            definition +
-            '\'' +
-            ", order=" +
-            order +
-            ", enabled=" +
-            enabled +
-            '}'
-        );
-    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/dashboards/DashboardTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/dashboards/DashboardTypeUpgrader.java
@@ -13,29 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.upgrade.upgrader.promotions;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.dashboards;
+
+import static io.gravitee.repository.mongodb.management.upgrade.upgrader.promotions.RemovePromotionAuthorPictureUpgrader.REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER;
 
 import com.mongodb.client.model.Updates;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import java.util.List;
 import org.bson.BsonDocument;
 import org.springframework.stereotype.Component;
 
 /**
+ * Rename 'referenceType' to 'type' and set 'referenceType' to 'ENVIRONMENT'
+ * This allows to distinguish the type of dashboard from the reference it belongs to.
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Component("RemovePromotionAuthorPictureUpgrader")
-public class RemovePromotionAuthorPictureUpgrader extends MongoUpgrader {
-
-    public static final int REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER = 0;
+@Component
+public class DashboardTypeUpgrader extends MongoUpgrader {
 
     @Override
     public boolean upgrade() {
-        var updateResult = template.getCollection("promotions").updateMany(new BsonDocument(), Updates.unset("author.picture"));
+        var updateResult = template
+            .getCollection("dashboards")
+            .updateMany(new BsonDocument(), List.of(Updates.set("type", "$referenceType"), Updates.set("referenceType", "ENVIRONMENT")));
         return updateResult.wasAcknowledged();
     }
 
     @Override
     public int getOrder() {
-        return REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER;
+        return REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER + 1;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/dashboard-tests/dashboards.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/dashboard-tests/dashboards.json
@@ -1,7 +1,8 @@
 [
    {
       "id": "2535437f-ee99-4ab8-b543-7fee995ab847",
-      "referenceType": "PLATFORM",
+      "type": "PLATFORM",
+      "referenceType": "ENVIRONMENT",
       "referenceId": "DEFAULT",
       "name": "Global dashboard",
       "order": 0,
@@ -11,7 +12,8 @@
       "updatedAt": 1111111111111
    }, {
       "id": "6e0d09f0-ba5d-4571-8d09-f0ba5d7571c3",
-      "referenceType": "PLATFORM",
+      "type": "PLATFORM",
+      "referenceType": "ENVIRONMENT",
       "referenceId": "DEFAULT",
       "name": "Device dashboard",
       "order": 2,
@@ -20,7 +22,8 @@
       "updatedAt": 1111111111111
    }, {
       "id": "4eeb1c56-6f4a-4925-ab1c-566f4aa925b8",
-      "referenceType": "PLATFORM",
+      "type": "PLATFORM",
+      "referenceType": "ENVIRONMENT",
       "referenceId": "DEFAULT",
       "name": "Geo dashboard",
       "order": 1,
@@ -30,11 +33,38 @@
       "updatedAt": 1111111111111
    }, {
       "id": "7589ef82-02ae-4fc7-89ef-8202ae3fc7cf",
-      "referenceType": "API",
+      "type": "API",
+      "referenceType": "ENVIRONMENT",
       "referenceId": "DEFAULT",
       "name": "Global dashboard",
       "queryFilter": "api:b741b061-5377-43ea-81b0-61537793ea91",
       "order": 0,
+      "enabled": true,
+      "definition": "{\"def\": \"value\"}",
+      "createdAt": 1000000000000,
+      "updatedAt": 1111111111111
+   },
+   {
+      "id": "c9d5390e-6387-4943-a123-603df96a429f",
+      "type": "API",
+      "referenceType": "ENVIRONMENT",
+      "referenceId": "OTHER_ENV",
+      "name": "Global dashboard",
+      "queryFilter": "api:b741b061-5377-43ea-81b0-61537793ea91",
+      "order": 0,
+      "enabled": true,
+      "definition": "{\"def\": \"value\"}",
+      "createdAt": 1000000000000,
+      "updatedAt": 1111111111111
+   },
+   {
+      "id": "c9d5390e-6387-4943-a123-613df16a419f",
+      "type": "API",
+      "referenceType": "ENVIRONMENT",
+      "referenceId": "OTHER_ENV",
+      "name": "Geo dashboard - the only one of OTHER_ENV",
+      "queryFilter": "api:b741b061-5377-43ea-81b0-61537793ea91",
+      "order": 1,
       "enabled": true,
       "definition": "{\"def\": \"value\"}",
       "createdAt": 1000000000000,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
@@ -16,10 +16,11 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.repository.management.model.DashboardReferenceType;
+import io.gravitee.repository.management.model.DashboardType;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.DashboardEntity;
+import io.gravitee.rest.api.model.DashboardReferenceType;
 import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -62,7 +63,7 @@ public class DashboardsResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public List<DashboardEntity> getDashboards(final @QueryParam("reference_type") DashboardReferenceType referenceType) {
+    public List<DashboardEntity> getDashboards(final @QueryParam("type") DashboardType type) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
             !hasPermission(
@@ -78,14 +79,14 @@ public class DashboardsResource extends AbstractResource {
                 RolePermissionAction.READ
             ) &&
             !canReadAPIConfiguration() &&
-            !DashboardReferenceType.HOME.equals(referenceType)
+            !DashboardType.HOME.equals(type)
         ) {
             throw new ForbiddenAccessException();
         }
-        if (referenceType == null) {
-            return dashboardService.findAll();
+        if (type == null) {
+            return dashboardService.findAllByReference(DashboardReferenceType.ENVIRONMENT, executionContext.getEnvironmentId());
         } else {
-            return dashboardService.findByReferenceType(referenceType);
+            return dashboardService.findByReferenceAndType(DashboardReferenceType.ENVIRONMENT, executionContext.getEnvironmentId(), type);
         }
     }
 
@@ -104,6 +105,8 @@ public class DashboardsResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.CREATE) })
     public DashboardEntity createDashboard(@Valid @NotNull final NewDashboardEntity dashboard) {
+        dashboard.setReferenceType(DashboardReferenceType.ENVIRONMENT);
+        dashboard.setReferenceId(GraviteeContext.getCurrentEnvironment());
         return dashboardService.create(GraviteeContext.getExecutionContext(), dashboard);
     }
 
@@ -122,7 +125,11 @@ public class DashboardsResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.READ) })
     public DashboardEntity getDashboard(final @PathParam("dashboardId") String dashboardId) {
-        return dashboardService.findById(dashboardId);
+        return dashboardService.findByReferenceAndId(
+            DashboardReferenceType.ENVIRONMENT,
+            GraviteeContext.getCurrentEnvironment(),
+            dashboardId
+        );
     }
 
     @Path("{dashboardId}")
@@ -145,7 +152,12 @@ public class DashboardsResource extends AbstractResource {
         @Valid @NotNull final UpdateDashboardEntity dashboard
     ) {
         dashboard.setId(dashboardId);
-        return dashboardService.update(GraviteeContext.getExecutionContext(), dashboard);
+        return dashboardService.update(
+            GraviteeContext.getExecutionContext(),
+            DashboardReferenceType.ENVIRONMENT,
+            GraviteeContext.getCurrentEnvironment(),
+            dashboard
+        );
     }
 
     @Path("{dashboardId}")
@@ -159,6 +171,11 @@ public class DashboardsResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.DELETE) })
     public void deleteDashboard(@PathParam("dashboardId") String dashboardId) {
-        dashboardService.delete(GraviteeContext.getExecutionContext(), dashboardId);
+        dashboardService.delete(
+            GraviteeContext.getExecutionContext(),
+            DashboardReferenceType.ENVIRONMENT,
+            GraviteeContext.getExecutionContext().getEnvironmentId(),
+            dashboardId
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardEntity.java
@@ -17,12 +17,21 @@ package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(of = "id")
+@Builder
 public class DashboardEntity {
 
     private String id;
@@ -41,137 +50,11 @@ public class DashboardEntity {
     private int order;
     private boolean enabled;
     private String definition;
+    private String type;
 
     @JsonProperty("created_at")
     private Date createdAt;
 
     @JsonProperty("updated_at")
     private Date updatedAt;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(String referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getQueryFilter() {
-        return queryFilter;
-    }
-
-    public void setQueryFilter(String queryFilter) {
-        this.queryFilter = queryFilter;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DashboardEntity that = (DashboardEntity) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "DashboardEntity{" +
-            "id='" +
-            id +
-            '\'' +
-            ", referenceType='" +
-            referenceType +
-            '\'' +
-            ", referenceId='" +
-            referenceId +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", queryFilter='" +
-            queryFilter +
-            '\'' +
-            ", order=" +
-            order +
-            ", enabled=" +
-            enabled +
-            ", definition='" +
-            definition +
-            '\'' +
-            ", createdAt=" +
-            createdAt +
-            ", updatedAt=" +
-            updatedAt +
-            '}'
-        );
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardReferenceType.java
@@ -18,13 +18,11 @@ package io.gravitee.rest.api.model;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Schema(enumAsRef = true)
 public enum DashboardReferenceType {
-    API,
-    APPLICATION,
-    PLATFORM,
-    HOME,
+    ENVIRONMENT,
+    ORGANIZATION,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/DashboardType.java
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.model;
+package io.gravitee.rest.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public enum DashboardReferenceType {
-    PLATFORM,
+@Schema(enumAsRef = true)
+public enum DashboardType {
     API,
     APPLICATION,
+    PLATFORM,
     HOME,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/EnvironmentEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/EnvironmentEntity.java
@@ -18,12 +18,21 @@ package io.gravitee.rest.api.model;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(of = { "id", "cockpitId", "hrids", "name", "description", "organizationId", "domainRestrictions" })
 public class EnvironmentEntity {
 
     private String id;
@@ -42,108 +51,4 @@ public class EnvironmentEntity {
     private String organizationId;
 
     private List<String> domainRestrictions;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getOrganizationId() {
-        return organizationId;
-    }
-
-    public void setOrganizationId(String organizationId) {
-        this.organizationId = organizationId;
-    }
-
-    public List<String> getDomainRestrictions() {
-        return domainRestrictions;
-    }
-
-    public void setDomainRestrictions(List<String> domainRestrictions) {
-        this.domainRestrictions = domainRestrictions;
-    }
-
-    public List<String> getHrids() {
-        return hrids;
-    }
-
-    public void setHrids(List<String> hrids) {
-        this.hrids = hrids;
-    }
-
-    public String getCockpitId() {
-        return cockpitId;
-    }
-
-    public void setCockpitId(String cockpitId) {
-        this.cockpitId = cockpitId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EnvironmentEntity that = (EnvironmentEntity) o;
-        return (
-            Objects.equals(id, that.id) &&
-            Objects.equals(cockpitId, that.cockpitId) &&
-            Objects.equals(hrids, that.hrids) &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(description, that.description) &&
-            Objects.equals(organizationId, that.organizationId) &&
-            Objects.equals(domainRestrictions, that.domainRestrictions)
-        );
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, cockpitId, hrids, name, description, organizationId, domainRestrictions);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "EnvironmentEntity{" +
-            "id='" +
-            id +
-            '\'' +
-            ", cockpitId='" +
-            cockpitId +
-            '\'' +
-            ", hrids=" +
-            hrids +
-            ", name='" +
-            name +
-            '\'' +
-            ", description='" +
-            description +
-            '\'' +
-            ", organizationId='" +
-            organizationId +
-            '\'' +
-            ", domainRestrictions=" +
-            domainRestrictions +
-            '}'
-        );
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewDashboardEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewDashboardEntity.java
@@ -19,11 +19,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(of = { "referenceType", "referenceId", "name", "queryFilter", "enabled", "definition", "type" })
 public class NewDashboardEntity {
 
     @NotNull
@@ -44,96 +54,5 @@ public class NewDashboardEntity {
 
     private boolean enabled;
     private String definition;
-
-    public DashboardReferenceType getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(DashboardReferenceType referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getQueryFilter() {
-        return queryFilter;
-    }
-
-    public void setQueryFilter(String queryFilter) {
-        this.queryFilter = queryFilter;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        NewDashboardEntity that = (NewDashboardEntity) o;
-        return (
-            enabled == that.enabled &&
-            referenceType == that.referenceType &&
-            Objects.equals(referenceId, that.referenceId) &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(queryFilter, that.queryFilter) &&
-            Objects.equals(definition, that.definition)
-        );
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(referenceType, referenceId, name, queryFilter, enabled, definition);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "NewDashboardEntity{" +
-            "referenceType=" +
-            referenceType +
-            ", referenceId='" +
-            referenceId +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", queryFilter='" +
-            queryFilter +
-            '\'' +
-            ", enabled=" +
-            enabled +
-            ", definition='" +
-            definition +
-            '\'' +
-            '}'
-        );
-    }
+    private DashboardType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateDashboardEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateDashboardEntity.java
@@ -18,12 +18,21 @@ package io.gravitee.rest.api.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode(of = "id")
 public class UpdateDashboardEntity {
 
     private String id;
@@ -50,109 +59,6 @@ public class UpdateDashboardEntity {
     private boolean enabled;
     private String definition;
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public DashboardReferenceType getReferenceType() {
-        return referenceType;
-    }
-
-    public void setReferenceType(DashboardReferenceType referenceType) {
-        this.referenceType = referenceType;
-    }
-
-    public String getReferenceId() {
-        return referenceId;
-    }
-
-    public void setReferenceId(String referenceId) {
-        this.referenceId = referenceId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getQueryFilter() {
-        return queryFilter;
-    }
-
-    public void setQueryFilter(String queryFilter) {
-        this.queryFilter = queryFilter;
-    }
-
-    public int getOrder() {
-        return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public String getDefinition() {
-        return definition;
-    }
-
-    public void setDefinition(String definition) {
-        this.definition = definition;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UpdateDashboardEntity that = (UpdateDashboardEntity) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "UpdateDashboardEntity{" +
-            "id='" +
-            id +
-            '\'' +
-            ", referenceType=" +
-            referenceType +
-            ", referenceId='" +
-            referenceId +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", queryFilter='" +
-            queryFilter +
-            '\'' +
-            ", order=" +
-            order +
-            ", enabled=" +
-            enabled +
-            ", definition='" +
-            definition +
-            '\'' +
-            '}'
-        );
-    }
+    @NotNull
+    private DashboardType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/DashboardsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/DashboardsResource.java
@@ -15,14 +15,15 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
-import static io.gravitee.repository.management.model.DashboardReferenceType.APPLICATION;
-import static java.util.stream.Collectors.toList;
+import static io.gravitee.repository.management.model.DashboardType.APPLICATION;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.DashboardEntity;
+import io.gravitee.rest.api.model.DashboardReferenceType;
 import io.gravitee.rest.api.portal.rest.mapper.DashboardMapper;
 import io.gravitee.rest.api.portal.rest.model.Dashboard;
 import io.gravitee.rest.api.service.DashboardService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
@@ -45,11 +46,11 @@ public class DashboardsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response list() {
         final List<Dashboard> dashboards = dashboardService
-            .findByReferenceType(APPLICATION)
+            .findByReferenceAndType(DashboardReferenceType.ENVIRONMENT, GraviteeContext.getCurrentEnvironment(), APPLICATION)
             .stream()
             .filter(DashboardEntity::isEnabled)
             .map(dashboardMapper::convert)
-            .collect(toList());
+            .toList();
         return Response.ok(dashboards).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/DashboardService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/DashboardService.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.rest.api.service;
 
-import io.gravitee.repository.management.model.DashboardReferenceType;
+import io.gravitee.repository.management.model.DashboardType;
 import io.gravitee.rest.api.model.DashboardEntity;
+import io.gravitee.rest.api.model.DashboardReferenceType;
 import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -28,9 +29,22 @@ import java.util.List;
  */
 public interface DashboardService {
     List<DashboardEntity> findAll();
-    List<DashboardEntity> findByReferenceType(DashboardReferenceType referenceType);
-    DashboardEntity findById(String dashboardId);
+    List<DashboardEntity> findAllByReference(DashboardReferenceType referenceType, String referenceId);
+    List<DashboardEntity> findByReferenceAndType(DashboardReferenceType referenceType, String referenceId, DashboardType type);
+    DashboardEntity findByReferenceAndId(DashboardReferenceType referenceType, String referenceId, String dashboardId);
     DashboardEntity create(ExecutionContext executionContext, NewDashboardEntity dashboard);
-    DashboardEntity update(ExecutionContext executionContext, UpdateDashboardEntity dashboard);
-    void delete(ExecutionContext executionContext, String dashboardId);
+
+    /**
+     * Initializes the default dashboards for an environment.
+     * @param executionContext containing the environment to create dashboards for.
+     */
+    void initialize(ExecutionContext executionContext);
+
+    DashboardEntity update(
+        ExecutionContext executionContext,
+        DashboardReferenceType referenceType,
+        String referenceId,
+        UpdateDashboardEntity dashboard
+    );
+    void delete(ExecutionContext executionContext, DashboardReferenceType referenceType, String referenceId, String dashboardId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.UpdateEnvironmentEntity;
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -43,4 +44,6 @@ public interface EnvironmentService {
     EnvironmentEntity findByCockpitId(String cockpitId);
 
     EnvironmentEntity getDefaultOrInitialize();
+
+    Set<EnvironmentEntity> findAllOrInitialize();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DashboardServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DashboardServiceTest.java
@@ -16,11 +16,16 @@
 package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.repository.management.model.Audit.AuditProperties.DASHBOARD;
-import static io.gravitee.rest.api.model.DashboardReferenceType.PLATFORM;
+import static io.gravitee.rest.api.model.DashboardReferenceType.ENVIRONMENT;
+import static io.gravitee.rest.api.model.DashboardType.API;
+import static io.gravitee.rest.api.model.DashboardType.APPLICATION;
+import static io.gravitee.rest.api.model.DashboardType.PLATFORM;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.throwable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
@@ -30,28 +35,37 @@ import com.google.common.collect.ImmutableMap;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DashboardRepository;
 import io.gravitee.repository.management.model.Dashboard;
-import io.gravitee.repository.management.model.DashboardReferenceType;
+import io.gravitee.repository.management.model.DashboardType;
 import io.gravitee.rest.api.model.DashboardEntity;
+import io.gravitee.rest.api.model.DashboardReferenceType;
 import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.DashboardService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.DashboardNotFoundException;
 import java.util.Date;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import lombok.SneakyThrows;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
-public class DashboardServiceTest {
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DashboardServiceTest {
 
     private static final String DASHBOARD_ID = "id-dashboard";
 
@@ -65,135 +79,148 @@ public class DashboardServiceTest {
     private AuditService auditService;
 
     @Test
-    public void shouldFindByReferenceType() throws TechnicalException {
-        final Dashboard dashboard = mock(Dashboard.class);
-        when(dashboard.getId()).thenReturn(DASHBOARD_ID);
-        when(dashboard.getName()).thenReturn("NAME");
-        when(dashboard.getDefinition()).thenReturn("DEFINITION");
-        when(dashboard.getOrder()).thenReturn(1);
-        when(dashboard.getReferenceId()).thenReturn("REF_ID");
-        when(dashboard.getReferenceType()).thenReturn(PLATFORM.name());
-        when(dashboard.getQueryFilter()).thenReturn("QUERY FILTER");
-        when(dashboard.getCreatedAt()).thenReturn(new Date(1));
-        when(dashboard.getUpdatedAt()).thenReturn(new Date(2));
-        when(dashboardRepository.findByReferenceType(PLATFORM.name())).thenReturn(singletonList(dashboard));
+    void should_find_by_reference_and_type() throws TechnicalException {
+        final Dashboard dashboard = Dashboard
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT.name())
+            .type(PLATFORM.name())
+            .queryFilter("QUERY FILTER")
+            .createdAt(new Date(1))
+            .updatedAt(new Date(2))
+            .build();
+        when(dashboardRepository.findByReferenceAndType("ENVIRONMENT", "REF_ID", PLATFORM.name())).thenReturn(singletonList(dashboard));
 
-        final List<DashboardEntity> dashboards = dashboardService.findByReferenceType(DashboardReferenceType.PLATFORM);
+        final List<DashboardEntity> dashboards = dashboardService.findByReferenceAndType(ENVIRONMENT, "REF_ID", DashboardType.PLATFORM);
         final DashboardEntity dashboardEntity = dashboards.iterator().next();
-        assertEquals(DASHBOARD_ID, dashboardEntity.getId());
-        assertEquals("NAME", dashboardEntity.getName());
-        assertEquals("DEFINITION", dashboardEntity.getDefinition());
-        assertEquals(1, dashboardEntity.getOrder());
-        assertEquals("REF_ID", dashboardEntity.getReferenceId());
-        assertEquals(PLATFORM.name(), dashboardEntity.getReferenceType());
-        assertEquals("QUERY FILTER", dashboardEntity.getQueryFilter());
-        assertEquals(new Date(1), dashboardEntity.getCreatedAt());
-        assertEquals(new Date(2), dashboardEntity.getUpdatedAt());
+        assertThat(dashboardEntity.getId()).isEqualTo(DASHBOARD_ID);
+        assertThat(dashboardEntity.getName()).isEqualTo("NAME");
+        assertThat(dashboardEntity.getDefinition()).isEqualTo("DEFINITION");
+        assertThat(dashboardEntity.getOrder()).isOne();
+        assertThat(dashboardEntity.getReferenceId()).isEqualTo("REF_ID");
+        assertThat(dashboardEntity.getReferenceType()).isEqualTo(ENVIRONMENT.name());
+        assertThat(dashboardEntity.getType()).isEqualTo(PLATFORM.name());
+        assertThat(dashboardEntity.getQueryFilter()).isEqualTo("QUERY FILTER");
+        assertThat(dashboardEntity.getCreatedAt()).isEqualTo(new Date(1));
+        assertThat(dashboardEntity.getUpdatedAt()).isEqualTo(new Date(2));
     }
 
     @Test
-    public void shouldFindById() throws TechnicalException {
-        final Dashboard dashboard = mock(Dashboard.class);
-        when(dashboard.getId()).thenReturn(DASHBOARD_ID);
-        when(dashboard.getName()).thenReturn("NAME");
-        when(dashboard.getDefinition()).thenReturn("DEFINITION");
-        when(dashboard.getOrder()).thenReturn(1);
-        when(dashboard.getReferenceId()).thenReturn("REF_ID");
-        when(dashboard.getReferenceType()).thenReturn(PLATFORM.name());
-        when(dashboard.getQueryFilter()).thenReturn("QUERY FILTER");
-        when(dashboard.getCreatedAt()).thenReturn(new Date(1));
-        when(dashboard.getUpdatedAt()).thenReturn(new Date(2));
-        when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(of(dashboard));
+    void should_find_by_reference_and_id() throws TechnicalException {
+        final Dashboard dashboard = Dashboard
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("ENV_ID")
+            .referenceType(ENVIRONMENT.name())
+            .type(PLATFORM.name())
+            .queryFilter("QUERY FILTER")
+            .createdAt(new Date(1))
+            .updatedAt(new Date(2))
+            .build();
+        when(dashboardRepository.findByReferenceAndId("ENVIRONMENT", "ENV_ID", DASHBOARD_ID)).thenReturn(of(dashboard));
 
-        final DashboardEntity dashboardEntity = dashboardService.findById(DASHBOARD_ID);
-        assertEquals(DASHBOARD_ID, dashboardEntity.getId());
-        assertEquals("NAME", dashboardEntity.getName());
-        assertEquals("DEFINITION", dashboardEntity.getDefinition());
-        assertEquals(1, dashboardEntity.getOrder());
-        assertEquals("REF_ID", dashboardEntity.getReferenceId());
-        assertEquals(PLATFORM.name(), dashboardEntity.getReferenceType());
-        assertEquals("QUERY FILTER", dashboardEntity.getQueryFilter());
-        assertEquals(new Date(1), dashboardEntity.getCreatedAt());
-        assertEquals(new Date(2), dashboardEntity.getUpdatedAt());
-    }
-
-    @Test(expected = DashboardNotFoundException.class)
-    public void shouldNotFindById() throws TechnicalException {
-        when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(empty());
-        dashboardService.findById(DASHBOARD_ID);
+        final DashboardEntity dashboardEntity = dashboardService.findByReferenceAndId(ENVIRONMENT, "ENV_ID", DASHBOARD_ID);
+        assertThat(dashboardEntity.getId()).isEqualTo(DASHBOARD_ID);
+        assertThat(dashboardEntity.getName()).isEqualTo("NAME");
+        assertThat(dashboardEntity.getDefinition()).isEqualTo("DEFINITION");
+        assertThat(dashboardEntity.getOrder()).isOne();
+        assertThat(dashboardEntity.getReferenceId()).isEqualTo("ENV_ID");
+        assertThat(dashboardEntity.getReferenceType()).isEqualTo(ENVIRONMENT.name());
+        assertThat(dashboardEntity.getType()).isEqualTo(PLATFORM.name());
+        assertThat(dashboardEntity.getQueryFilter()).isEqualTo("QUERY FILTER");
+        assertThat(dashboardEntity.getCreatedAt()).isEqualTo(new Date(1));
+        assertThat(dashboardEntity.getUpdatedAt()).isEqualTo(new Date(2));
     }
 
     @Test
-    public void shouldFindAll() throws TechnicalException {
-        final Dashboard dashboard = mock(Dashboard.class);
-        when(dashboard.getId()).thenReturn(DASHBOARD_ID);
-        when(dashboard.getName()).thenReturn("NAME");
-        when(dashboard.getDefinition()).thenReturn("DEFINITION");
-        when(dashboard.getOrder()).thenReturn(1);
-        when(dashboard.getReferenceId()).thenReturn("REF_ID");
-        when(dashboard.getReferenceType()).thenReturn(PLATFORM.name());
-        when(dashboard.getQueryFilter()).thenReturn("QUERY FILTER");
-        when(dashboard.getCreatedAt()).thenReturn(new Date(1));
-        when(dashboard.getUpdatedAt()).thenReturn(new Date(2));
+    void should_not_find_by_id() throws TechnicalException {
+        when(dashboardRepository.findByReferenceAndId(ENVIRONMENT.name(), "ENV_ID", DASHBOARD_ID)).thenReturn(empty());
+        Assertions
+            .assertThatThrownBy(() -> dashboardService.findByReferenceAndId(ENVIRONMENT, "ENV_ID", DASHBOARD_ID))
+            .isInstanceOf(DashboardNotFoundException.class);
+    }
+
+    @Test
+    void should_find_all() throws TechnicalException {
+        final Dashboard dashboard = Dashboard
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT.name())
+            .type(PLATFORM.name())
+            .queryFilter("QUERY FILTER")
+            .createdAt(new Date(1))
+            .updatedAt(new Date(2))
+            .build();
         when(dashboardRepository.findAll()).thenReturn(singleton(dashboard));
 
         final List<DashboardEntity> dashboards = dashboardService.findAll();
         final DashboardEntity dashboardEntity = dashboards.iterator().next();
-        assertEquals(DASHBOARD_ID, dashboardEntity.getId());
-        assertEquals("NAME", dashboardEntity.getName());
-        assertEquals("DEFINITION", dashboardEntity.getDefinition());
-        assertEquals(1, dashboardEntity.getOrder());
-        assertEquals("REF_ID", dashboardEntity.getReferenceId());
-        assertEquals(PLATFORM.name(), dashboardEntity.getReferenceType());
-        assertEquals("QUERY FILTER", dashboardEntity.getQueryFilter());
-        assertEquals(new Date(1), dashboardEntity.getCreatedAt());
-        assertEquals(new Date(2), dashboardEntity.getUpdatedAt());
+        assertThat(dashboardEntity.getId()).isEqualTo(DASHBOARD_ID);
+        assertThat(dashboardEntity.getName()).isEqualTo("NAME");
+        assertThat(dashboardEntity.getDefinition()).isEqualTo("DEFINITION");
+        assertThat(dashboardEntity.getOrder()).isOne();
+        assertThat(dashboardEntity.getReferenceId()).isEqualTo("REF_ID");
+        assertThat(dashboardEntity.getReferenceType()).isEqualTo(ENVIRONMENT.name());
+        assertThat(dashboardEntity.getType()).isEqualTo(PLATFORM.name());
+        assertThat(dashboardEntity.getQueryFilter()).isEqualTo("QUERY FILTER");
+        assertThat(dashboardEntity.getCreatedAt()).isEqualTo(new Date(1));
+        assertThat(dashboardEntity.getUpdatedAt()).isEqualTo(new Date(2));
     }
 
     @Test
-    public void shouldCreate() throws TechnicalException {
-        final NewDashboardEntity newDashboardEntity = new NewDashboardEntity();
-        newDashboardEntity.setName("NAME");
-        newDashboardEntity.setDefinition("DEFINITION");
-        newDashboardEntity.setReferenceId("REF_ID");
-        newDashboardEntity.setReferenceType(PLATFORM);
-        newDashboardEntity.setQueryFilter("QUERY FILTER");
+    void should_create() throws TechnicalException {
+        final NewDashboardEntity newDashboardEntity = NewDashboardEntity
+            .builder()
+            .name("NAME")
+            .definition("DEFINITION")
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT)
+            .type(PLATFORM)
+            .queryFilter("QUERY FILTER")
+            .build();
 
-        final Dashboard createdDashboard = new Dashboard();
-        createdDashboard.setId(DASHBOARD_ID);
-        createdDashboard.setName("NAME");
-        createdDashboard.setDefinition("DEFINITION");
-        createdDashboard.setOrder(1);
-        createdDashboard.setReferenceId("REF_ID");
-        createdDashboard.setReferenceType(PLATFORM.name());
-        createdDashboard.setQueryFilter("QUERY FILTER");
-        createdDashboard.setCreatedAt(new Date());
-        createdDashboard.setUpdatedAt(new Date());
+        final Dashboard createdDashboard = Dashboard
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT.name())
+            .type(PLATFORM.name())
+            .queryFilter("QUERY FILTER")
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
         when(dashboardRepository.create(any())).thenReturn(createdDashboard);
 
         final Dashboard d = new Dashboard();
         d.setOrder(0);
-        when(dashboardRepository.findByReferenceType(PLATFORM.name())).thenReturn(singletonList(d));
+        when(dashboardRepository.findByReferenceAndType("ENVIRONMENT", "DEFAULT", PLATFORM.name())).thenReturn(singletonList(d));
 
         final DashboardEntity dashboardEntity = dashboardService.create(GraviteeContext.getExecutionContext(), newDashboardEntity);
 
-        assertNotNull(dashboardEntity.getId());
-        assertEquals("NAME", dashboardEntity.getName());
-        assertEquals("DEFINITION", dashboardEntity.getDefinition());
-        assertEquals(1, dashboardEntity.getOrder());
-        assertEquals("REF_ID", dashboardEntity.getReferenceId());
-        assertEquals(PLATFORM.name(), dashboardEntity.getReferenceType());
-        assertEquals("QUERY FILTER", dashboardEntity.getQueryFilter());
-        assertNotNull(dashboardEntity.getCreatedAt());
-        assertNotNull(dashboardEntity.getUpdatedAt());
-
-        final Dashboard dashboard = new Dashboard();
-        dashboard.setName("NAME");
-        dashboard.setDefinition("DEFINITION");
-        dashboard.setOrder(1);
-        dashboard.setReferenceId("REF_ID");
-        dashboard.setReferenceType(PLATFORM.name());
-        dashboard.setQueryFilter("QUERY FILTER");
+        assertThat(dashboardEntity.getId()).isNotNull();
+        assertThat(dashboardEntity.getName()).isEqualTo("NAME");
+        assertThat(dashboardEntity.getDefinition()).isEqualTo("DEFINITION");
+        assertThat(dashboardEntity.getOrder()).isOne();
+        assertThat(dashboardEntity.getReferenceId()).isEqualTo("REF_ID");
+        assertThat(dashboardEntity.getReferenceType()).isEqualTo(ENVIRONMENT.name());
+        assertThat(dashboardEntity.getType()).isEqualTo(PLATFORM.name());
+        assertThat(dashboardEntity.getQueryFilter()).isEqualTo("QUERY FILTER");
+        assertThat(dashboardEntity.getCreatedAt()).isNotNull();
+        assertThat(dashboardEntity.getUpdatedAt()).isNotNull();
 
         verify(dashboardRepository, times(1))
             .create(
@@ -201,7 +228,8 @@ public class DashboardServiceTest {
                     "NAME".equals(argument.getName()) &&
                     "DEFINITION".equals(argument.getDefinition()) &&
                     "REF_ID".equals(argument.getReferenceId()) &&
-                    PLATFORM.name().equals(argument.getReferenceType()) &&
+                    ENVIRONMENT.name().equals(argument.getReferenceType()) &&
+                    PLATFORM.name().equals(argument.getType()) &&
                     "QUERY FILTER".equals(argument.getQueryFilter()) &&
                     Integer.valueOf(1).equals(argument.getOrder()) &&
                     !argument.getId().isEmpty() &&
@@ -221,48 +249,52 @@ public class DashboardServiceTest {
     }
 
     @Test
-    public void shouldUpdate() throws TechnicalException {
-        final UpdateDashboardEntity updateDashboardEntity = new UpdateDashboardEntity();
-        updateDashboardEntity.setId(DASHBOARD_ID);
-        updateDashboardEntity.setName("NAME");
-        updateDashboardEntity.setDefinition("DEFINITION");
-        updateDashboardEntity.setOrder(1);
-        updateDashboardEntity.setReferenceId("REF_ID");
-        updateDashboardEntity.setReferenceType(PLATFORM);
-        updateDashboardEntity.setQueryFilter("QUERY FILTER");
+    void should_update() throws TechnicalException {
+        final UpdateDashboardEntity updateDashboardEntity = UpdateDashboardEntity
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT)
+            .type(PLATFORM)
+            .queryFilter("QUERY FILTER")
+            .build();
 
-        final Dashboard updatedDashboard = new Dashboard();
-        updatedDashboard.setId(DASHBOARD_ID);
-        updatedDashboard.setName("NAME");
-        updatedDashboard.setDefinition("DEFINITION");
-        updatedDashboard.setOrder(1);
-        updatedDashboard.setReferenceId("REF_ID");
-        updatedDashboard.setReferenceType(PLATFORM.name());
-        updatedDashboard.setQueryFilter("QUERY FILTER");
-        updatedDashboard.setCreatedAt(new Date());
-        updatedDashboard.setUpdatedAt(new Date());
+        final Dashboard updatedDashboard = Dashboard
+            .builder()
+            .id(DASHBOARD_ID)
+            .name("NAME")
+            .definition("DEFINITION")
+            .order(1)
+            .referenceId("REF_ID")
+            .referenceType(ENVIRONMENT.name())
+            .type(PLATFORM.name())
+            .queryFilter("QUERY FILTER")
+            .createdAt(new Date())
+            .updatedAt(new Date())
+            .build();
         when(dashboardRepository.update(any())).thenReturn(updatedDashboard);
-        when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(of(updatedDashboard));
+        when(dashboardRepository.findByReferenceAndId(ENVIRONMENT.name(), "REF_ID", DASHBOARD_ID)).thenReturn(of(updatedDashboard));
 
-        final DashboardEntity dashboardEntity = dashboardService.update(GraviteeContext.getExecutionContext(), updateDashboardEntity);
+        final DashboardEntity dashboardEntity = dashboardService.update(
+            GraviteeContext.getExecutionContext(),
+            ENVIRONMENT,
+            "REF_ID",
+            updateDashboardEntity
+        );
 
-        assertNotNull(dashboardEntity.getId());
-        assertEquals("NAME", dashboardEntity.getName());
-        assertEquals("DEFINITION", dashboardEntity.getDefinition());
-        assertEquals(1, dashboardEntity.getOrder());
-        assertEquals("REF_ID", dashboardEntity.getReferenceId());
-        assertEquals(PLATFORM.name(), dashboardEntity.getReferenceType());
-        assertEquals("QUERY FILTER", dashboardEntity.getQueryFilter());
-        assertNotNull(dashboardEntity.getCreatedAt());
-        assertNotNull(dashboardEntity.getUpdatedAt());
-
-        final Dashboard dashboard = new Dashboard();
-        dashboard.setName("NAME");
-        dashboard.setDefinition("DEFINITION");
-        dashboard.setOrder(1);
-        dashboard.setReferenceId("REF_ID");
-        dashboard.setReferenceType(PLATFORM.name());
-        dashboard.setQueryFilter("QUERY FILTER");
+        assertThat(dashboardEntity.getId()).isNotNull();
+        assertThat(dashboardEntity.getName()).isEqualTo("NAME");
+        assertThat(dashboardEntity.getDefinition()).isEqualTo("DEFINITION");
+        assertThat(dashboardEntity.getOrder()).isOne();
+        assertThat(dashboardEntity.getReferenceId()).isEqualTo("REF_ID");
+        assertThat(dashboardEntity.getReferenceType()).isEqualTo("ENVIRONMENT");
+        assertThat(dashboardEntity.getType()).isEqualTo(PLATFORM.name());
+        assertThat(dashboardEntity.getQueryFilter()).isEqualTo("QUERY FILTER");
+        assertThat(dashboardEntity.getCreatedAt()).isNotNull();
+        assertThat(dashboardEntity.getUpdatedAt()).isNotNull();
 
         verify(dashboardRepository, times(1))
             .update(
@@ -270,7 +302,8 @@ public class DashboardServiceTest {
                     "NAME".equals(argument.getName()) &&
                     "DEFINITION".equals(argument.getDefinition()) &&
                     "REF_ID".equals(argument.getReferenceId()) &&
-                    PLATFORM.name().equals(argument.getReferenceType()) &&
+                    ENVIRONMENT.name().equals(argument.getReferenceType()) &&
+                    PLATFORM.name().equals(argument.getType()) &&
                     "QUERY FILTER".equals(argument.getQueryFilter()) &&
                     Integer.valueOf(1).equals(argument.getOrder()) &&
                     DASHBOARD_ID.equals(argument.getId()) &&
@@ -289,22 +322,25 @@ public class DashboardServiceTest {
             );
     }
 
-    @Test(expected = DashboardNotFoundException.class)
-    public void shouldNotUpdate() throws TechnicalException {
-        final UpdateDashboardEntity updateDashboardEntity = new UpdateDashboardEntity();
-        updateDashboardEntity.setId(DASHBOARD_ID);
+    @Test
+    void should_not_update() throws TechnicalException {
+        final UpdateDashboardEntity updateDashboardEntity = UpdateDashboardEntity.builder().id(DASHBOARD_ID).build();
 
-        when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(empty());
+        when(dashboardRepository.findByReferenceAndId(ENVIRONMENT.name(), "REF_ID", DASHBOARD_ID)).thenReturn(empty());
 
-        dashboardService.update(GraviteeContext.getExecutionContext(), updateDashboardEntity);
+        Assertions
+            .assertThatThrownBy(() ->
+                dashboardService.update(GraviteeContext.getExecutionContext(), ENVIRONMENT, "REF_ID", updateDashboardEntity)
+            )
+            .isInstanceOf(DashboardNotFoundException.class);
     }
 
     @Test
-    public void shouldDelete() throws TechnicalException {
+    void should_delete() throws TechnicalException {
         final Dashboard dashboard = mock(Dashboard.class);
-        when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(of(dashboard));
+        when(dashboardRepository.findByReferenceAndId(ENVIRONMENT.name(), "REF_ID", DASHBOARD_ID)).thenReturn(of(dashboard));
 
-        dashboardService.delete(GraviteeContext.getExecutionContext(), DASHBOARD_ID);
+        dashboardService.delete(GraviteeContext.getExecutionContext(), ENVIRONMENT, "REF_ID", DASHBOARD_ID);
 
         verify(dashboardRepository, times(1)).delete(DASHBOARD_ID);
         verify(auditService, times(1))
@@ -315,6 +351,74 @@ public class DashboardServiceTest {
                 any(Date.class),
                 isNull(),
                 eq(dashboard)
+            );
+    }
+
+    @SneakyThrows
+    @Test
+    void should_find_all_by_reference() {
+        var firstApiDashboard = Dashboard
+            .builder()
+            .id("firstApiDashboard")
+            .referenceType(ENVIRONMENT.name())
+            .referenceId("ENV_ID")
+            .type(API.name())
+            .order(0)
+            .build();
+        var secondApiDashboard = firstApiDashboard.toBuilder().id("secondApiDashboard").order(1).build();
+        var thirdApiDashboard = firstApiDashboard.toBuilder().id("thirdApiDashboard").order(2).build();
+        var firstAppDashboard = firstApiDashboard.toBuilder().id("firstAppDashboard").type(APPLICATION.name()).build();
+        var secondAppDashboard = secondApiDashboard.toBuilder().id("secondAppDashboard").type(APPLICATION.name()).build();
+        var firstPlatformDashboard = firstApiDashboard.toBuilder().id("firstPlatformDashboard").type(PLATFORM.name()).build();
+
+        when(dashboardRepository.findByReference(ENVIRONMENT.name(), "ENV_ID"))
+            // returns an unordered list
+            .thenReturn(
+                List.of(
+                    secondApiDashboard,
+                    firstPlatformDashboard,
+                    thirdApiDashboard,
+                    firstAppDashboard,
+                    firstApiDashboard,
+                    secondAppDashboard
+                )
+            );
+        final List<DashboardEntity> result = dashboardService.findAllByReference(ENVIRONMENT, "ENV_ID");
+        assertThat(result)
+            .hasSize(6)
+            .extracting(DashboardEntity::getId)
+            .containsExactly(
+                "firstApiDashboard",
+                "secondApiDashboard",
+                "thirdApiDashboard",
+                "firstAppDashboard",
+                "secondAppDashboard",
+                "firstPlatformDashboard"
+            );
+    }
+
+    @SneakyThrows
+    @Test
+    void should_initialize_environment() {
+        when(dashboardRepository.findByReferenceAndType(eq(ENVIRONMENT.name()), eq("ENV_ID"), any())).thenReturn(List.of());
+        when(dashboardRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        dashboardService.initialize(new ExecutionContext("ORG_ID", "ENV_ID"));
+        final ArgumentCaptor<Dashboard> dashboardArgumentCaptor = ArgumentCaptor.forClass(Dashboard.class);
+        verify(dashboardRepository, times(9)).create(dashboardArgumentCaptor.capture());
+
+        assertThat(dashboardArgumentCaptor.getAllValues())
+            .hasSize(9)
+            .extracting(Dashboard::getReferenceId, Dashboard::getType, Dashboard::getName)
+            .containsExactly(
+                Tuple.tuple("ENV_ID", PLATFORM.name(), "Global dashboard"),
+                Tuple.tuple("ENV_ID", PLATFORM.name(), "Geo dashboard"),
+                Tuple.tuple("ENV_ID", PLATFORM.name(), "User dashboard"),
+                Tuple.tuple("ENV_ID", API.name(), "Global dashboard"),
+                Tuple.tuple("ENV_ID", API.name(), "Geo dashboard"),
+                Tuple.tuple("ENV_ID", API.name(), "User dashboard"),
+                Tuple.tuple("ENV_ID", APPLICATION.name(), "Global dashboard"),
+                Tuple.tuple("ENV_ID", APPLICATION.name(), "Geo dashboard"),
+                Tuple.tuple("ENV_ID", APPLICATION.name(), "User dashboard")
             );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EnvironmentServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EnvironmentServiceTest.java
@@ -16,10 +16,8 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -29,6 +27,7 @@ import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.service.ApiHeaderService;
+import io.gravitee.rest.api.service.DashboardService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.PageService;
@@ -45,7 +44,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,8 +76,11 @@ public class EnvironmentServiceTest {
     @Mock
     private MembershipService mockMembershipService;
 
+    @Mock
+    private DashboardService mockDashboardService;
+
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         GraviteeContext.cleanContext();
     }
 
@@ -87,19 +88,19 @@ public class EnvironmentServiceTest {
     class FindById {
 
         @Test
-        public void shouldFindByUserById() throws TechnicalException {
+        void shouldFindByUserById() throws TechnicalException {
             when(mockEnvironmentRepository.findById(any())).thenReturn(Optional.of(getEnvironment("envId", Arrays.asList("env1", "1env"))));
 
             EnvironmentEntity environment = cut.findById("envId");
 
-            assertNotNull(environment);
+            assertThat(environment).isNotNull();
         }
 
         @Test
-        public void shouldThrowAnError() throws TechnicalException {
+        void shouldThrowAnError() throws TechnicalException {
             when(mockEnvironmentRepository.findById(any())).thenReturn(Optional.empty());
 
-            assertThrows(EnvironmentNotFoundException.class, () -> cut.findById("envId"));
+            assertThatThrownBy(() -> cut.findById("envId")).isInstanceOf(EnvironmentNotFoundException.class);
         }
     }
 
@@ -107,7 +108,7 @@ public class EnvironmentServiceTest {
     class FindByUserAndIdOrHridTest {
 
         @Test
-        public void shouldFindByUserFilteredByEnvId() throws TechnicalException {
+        void shouldFindByUserFilteredByEnvId() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
             List<EnvironmentEntity> environments = cut.findByUserAndIdOrHrid(GraviteeContext.getCurrentOrganization(), null, "envId");
@@ -116,7 +117,7 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldFindByUserIdFilteredByEnvId() throws TechnicalException {
+        void shouldFindByUserIdFilteredByEnvId() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
             MembershipEntity member = mock(MembershipEntity.class);
             when(member.getReferenceId()).thenReturn("envId");
@@ -136,7 +137,7 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldFindByUserFilteredByEnvHrid() throws TechnicalException {
+        void shouldFindByUserFilteredByEnvHrid() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
             List<EnvironmentEntity> environments = cut.findByUserAndIdOrHrid(GraviteeContext.getCurrentOrganization(), null, "2env");
@@ -145,7 +146,7 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldFindByUserFilteredByEnvHridAndId_noResult() throws TechnicalException {
+        void shouldFindByUserFilteredByEnvHridAndId_noResult() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
             List<EnvironmentEntity> environments = cut.findByUserAndIdOrHrid(GraviteeContext.getCurrentOrganization(), null, "fake-env");
@@ -158,7 +159,7 @@ public class EnvironmentServiceTest {
     class FindByOrgAndIdOrHridTest {
 
         @Test
-        public void shouldFindByOrgAndId() throws TechnicalException {
+        void shouldFindByOrgAndId() throws TechnicalException {
             Environment env1 = new Environment();
             env1.setId("envId");
             env1.setOrganizationId("org1");
@@ -173,7 +174,7 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldFindByOrgAndHrid() throws TechnicalException {
+        void shouldFindByOrgAndHrid() throws TechnicalException {
             Environment env1 = new Environment();
             env1.setId("envId");
             env1.setOrganizationId("org1");
@@ -188,21 +189,20 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldNotFind() throws TechnicalException {
+        void shouldNotFind() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(eq(GraviteeContext.getCurrentOrganization())))
                 .thenReturn(Collections.emptySet());
 
-            assertThrows(
-                EnvironmentNotFoundException.class,
-                () -> cut.findByOrgAndIdOrHrid(GraviteeContext.getCurrentOrganization(), "1env")
-            );
+            assertThatThrownBy(() -> cut.findByOrgAndIdOrHrid(GraviteeContext.getCurrentOrganization(), "1env"))
+                .isInstanceOf(EnvironmentNotFoundException.class);
         }
 
         @Test
-        public void shouldThrowAnError() throws TechnicalException {
+        void shouldThrowAnError() throws TechnicalException {
             when(mockEnvironmentRepository.findByOrganization(GraviteeContext.getCurrentOrganization())).thenReturn(getEnvironments());
 
-            assertThrows(IllegalStateException.class, () -> cut.findByOrgAndIdOrHrid(GraviteeContext.getCurrentOrganization(), "env1"));
+            assertThatThrownBy(() -> cut.findByOrgAndIdOrHrid(GraviteeContext.getCurrentOrganization(), "env1"))
+                .isInstanceOf(IllegalStateException.class);
         }
     }
 
@@ -210,7 +210,7 @@ public class EnvironmentServiceTest {
     class CreateTest {
 
         @Test
-        public void shouldCreateEnvironment() throws TechnicalException {
+        void shouldCreateEnvironment() throws TechnicalException {
             when(mockOrganizationService.findById(any())).thenReturn(null);
             when(mockEnvironmentRepository.findById(any())).thenReturn(Optional.empty());
 
@@ -227,7 +227,7 @@ public class EnvironmentServiceTest {
 
             EnvironmentEntity environment = cut.createOrUpdate("DEFAULT", "env_id", env1);
 
-            assertNotNull("result is null", environment);
+            assertThat(environment).isNotNull();
             verify(mockEnvironmentRepository, times(1))
                 .create(
                     argThat(arg ->
@@ -243,15 +243,16 @@ public class EnvironmentServiceTest {
             ExecutionContext executionContext = new ExecutionContext("DEFAULT", "env_id");
             verify(mockAPIHeaderService, times(1)).initialize(executionContext);
             verify(mockPageService, times(1)).initialize(executionContext);
+            verify(mockDashboardService, times(1)).initialize(executionContext);
         }
 
         @Test
-        public void shouldUpdateEnvironment() throws TechnicalException {
+        void shouldUpdateEnvironment() throws TechnicalException {
             when(mockOrganizationService.findById(any())).thenReturn(null);
             when(mockEnvironmentRepository.findById(any())).thenReturn(Optional.of(new Environment()));
 
             UpdateEnvironmentEntity env1 = new UpdateEnvironmentEntity();
-            env1.setHrids(Arrays.asList("envhrid"));
+            env1.setHrids(List.of("envhrid"));
             env1.setName("env_name");
             env1.setDescription("env_desc");
             List<String> domainRestrictions = Arrays.asList("domain", "restriction");
@@ -262,12 +263,12 @@ public class EnvironmentServiceTest {
 
             EnvironmentEntity environment = cut.createOrUpdate("DEFAULT", "env_id", env1);
 
-            assertNotNull("result is null", environment);
+            assertThat(environment).isNotNull();
             verify(mockEnvironmentRepository, times(1))
                 .update(
                     argThat(arg ->
                         arg != null &&
-                        arg.getHrids().equals(Arrays.asList("envhrid")) &&
+                        arg.getHrids().equals(List.of("envhrid")) &&
                         arg.getName().equals("env_name") &&
                         arg.getDescription().equals("env_desc") &&
                         arg.getDomainRestrictions().equals(domainRestrictions) &&
@@ -278,13 +279,15 @@ public class EnvironmentServiceTest {
             ExecutionContext executionContext = new ExecutionContext("DEFAULT", "env_id");
             verify(mockAPIHeaderService, never()).initialize(executionContext);
             verify(mockPageService, never()).initialize(executionContext);
+            verify(mockDashboardService, never()).initialize(executionContext);
         }
 
         @Test
-        public void shouldHaveBadOrganizationExceptionWhenNoOrganizationInEntity() {
+        void shouldHaveBadOrganizationExceptionWhenNoOrganizationInEntity() {
             when(mockOrganizationService.findById("UNKNOWN")).thenThrow(new OrganizationNotFoundException("UNKNOWN"));
 
-            assertThrows(OrganizationNotFoundException.class, () -> cut.createOrUpdate("UNKNOWN", "env_id", new UpdateEnvironmentEntity()));
+            assertThatThrownBy(() -> cut.createOrUpdate("UNKNOWN", "env_id", new UpdateEnvironmentEntity()))
+                .isInstanceOf(OrganizationNotFoundException.class);
         }
     }
 
@@ -292,7 +295,7 @@ public class EnvironmentServiceTest {
     class GetDefaultOrInitializeTest {
 
         @Test
-        public void shouldReturnDefaultEnvironment() throws TechnicalException {
+        void shouldReturnDefaultEnvironment() throws TechnicalException {
             Environment existingDefault = new Environment();
             existingDefault.setId(GraviteeContext.getDefaultEnvironment());
             when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenReturn(Optional.of(existingDefault));
@@ -303,7 +306,7 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldCreateDefaultEnvironment() throws TechnicalException {
+        void shouldCreateDefaultEnvironment() throws TechnicalException {
             when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenReturn(Optional.empty());
 
             EnvironmentEntity environment = cut.getDefaultOrInitialize();
@@ -316,18 +319,18 @@ public class EnvironmentServiceTest {
         }
 
         @Test
-        public void shouldCatchExceptionIfThrow() throws TechnicalException {
+        void shouldCatchExceptionIfThrow() throws TechnicalException {
             when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenThrow(new TechnicalException(""));
 
-            assertThrows(TechnicalManagementException.class, () -> cut.getDefaultOrInitialize());
+            assertThatThrownBy(() -> cut.getDefaultOrInitialize()).isInstanceOf(TechnicalManagementException.class);
         }
     }
 
     public Set<Environment> getEnvironments() {
         HashSet<Environment> envSet = new HashSet<>();
-        envSet.add(getEnvironment("envId", Arrays.asList("env1", "1env")));
-        envSet.add(getEnvironment("env2Id", Arrays.asList("env2", "2env")));
-        envSet.add(getEnvironment("env1", Arrays.asList("another_hrid")));
+        envSet.add(getEnvironment("envId", List.of("env1", "1env")));
+        envSet.add(getEnvironment("env2Id", List.of("env2", "2env")));
+        envSet.add(getEnvironment("env1", List.of("another_hrid")));
 
         return envSet;
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4266

## Description

- change the model of dashboard to properly distinguish `type` from `reference_type`
- BREAKING CHANGE: now the rest-api must be call with `type` instead of `reference_type`
- properly manage multi-tenancy for dashboards
- migrate database schemas
- update existing data to comply to the new model
- properly initialize dashboards on environment creation coming from cockpit


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/6960/console](https://pr.team-apim.gravitee.dev/6960/console)
      Portal: [https://pr.team-apim.gravitee.dev/6960/portal](https://pr.team-apim.gravitee.dev/6960/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/6960/api/management](https://pr.team-apim.gravitee.dev/6960/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/6960](https://pr.team-apim.gravitee.dev/6960)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/6960](https://pr.gateway-v3.team-apim.gravitee.dev/6960)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lrcrsluddn.chromatic.com)
<!-- Storybook placeholder end -->
