### PR TITLE
fix: add secret converter for all IdP plugin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/plugin/impl/IdentityProviderManagerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/src/main/java/io/gravitee/rest/api/idp/core/plugin/impl/IdentityProviderManagerImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.idp.core.plugin.impl;
 
 import io.gravitee.common.util.RelaxedPropertySource;
+import io.gravitee.node.api.secrets.model.Secret;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import io.gravitee.plugin.core.internal.AnnotationBasedPluginContextConfigurer;
@@ -129,6 +130,8 @@ public class IdentityProviderManagerImpl implements IdentityProviderManager {
                             protected void customizePropertySources(MutablePropertySources propertySources) {
                                 propertySources.addFirst(new RelaxedPropertySource(plugin.id(), properties));
                                 super.customizePropertySources(propertySources);
+                                this.getConversionService().addConverter(Secret.class, byte[].class, Secret::asBytes);
+                                this.getConversionService().addConverter(Secret.class, String.class, Secret::asString);
                             }
                         };
                     }


### PR DESCRIPTION
## Issue

`No converter found capable of converting from type [io.gravitee.node.api.secrets.model.Secret] to type [java.lang.String]` 
when setting up in memory users

## Fix

Add converter where they lacked


