### PR TITLE
fix(console): keep flow id when update API from V2 policy studio

### DIFF
--- a/gravitee-apim-console-webui/src/entities/flow/flow.ts
+++ b/gravitee-apim-console-webui/src/entities/flow/flow.ts
@@ -33,6 +33,7 @@ export interface Consumer {
 }
 
 export interface Flow {
+  id?: string;
   name?: string;
   'path-operator': PathOperator;
   pre: Step[];

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
@@ -210,6 +210,7 @@ export function fakeApiV2(modifier?: Partial<ApiV2> | ((baseApi: ApiV2) => ApiV2
     flowMode: 'DEFAULT',
     flows: [
       {
+        id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
         name: '',
         pathOperator: {
           path: '/',

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
@@ -110,6 +110,7 @@ describe('GioPolicyStudioLayoutComponent', () => {
 
       const apiReq = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}` });
       expect(apiReq.request.body.flowMode).toEqual(apiDefinitionToSave.flow_mode);
+      expect(apiReq.request.body.flows[0].id).toEqual(api.flows[0].id);
 
       const planReq = httpTestingController.expectOne({
         method: 'PUT',

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/models/ApiDefinition.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/models/ApiDefinition.ts
@@ -55,6 +55,7 @@ export function toApiDefinition(api: ApiV2): ApiDefinition {
 
 // Adapt ApiV2 flow to ApiDefinition flow
 const toApiFlowDefinition = (flow: FlowV2): Flow => ({
+  id: flow.id,
   name: flow.name,
   'path-operator': flow.pathOperator,
   pre: flow.pre,
@@ -98,6 +99,7 @@ export const toApiV2 = (apiDefinition: ApiDefinition, api: ApiV2): ApiV2 => {
 };
 
 const toApiFlowV2 = (flow: Flow): FlowV2 => ({
+  id: flow.id,
   name: flow.name,
   pathOperator: flow['path-operator'],
   pre: flow.pre,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4184

## Description

Keep flow id when update API from V2 policy studio

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wydjtxkjyf.chromatic.com)
<!-- Storybook placeholder end -->
