### PR TITLE
fix: use the envId from route in dashboards component

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/analytics/dashboard/settings-analytics-dashboard.components.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/settings/analytics/dashboard/settings-analytics-dashboard.components.ajs.ts
@@ -20,6 +20,7 @@ import { cloneDeep, every, forEach, isEqual, merge } from 'lodash';
 
 import DashboardService from '../../../../services/dashboard.service';
 import NotificationService from '../../../../services/notification.service';
+import { Constants } from '../../../../entities/Constants';
 const SettingsAnalyticsDashboardComponentAjs: ng.IComponentOptions = {
   template: require('html-loader!./settings-analytics-dashboard.html').default, // eslint-disable-line @typescript-eslint/no-var-requires
   controller: [
@@ -30,6 +31,7 @@ const SettingsAnalyticsDashboardComponentAjs: ng.IComponentOptions = {
     '$mdDialog',
     '$timeout',
     'ngRouter',
+    'Constants',
     function (
       DashboardService: DashboardService,
       NotificationService: NotificationService,
@@ -38,6 +40,7 @@ const SettingsAnalyticsDashboardComponentAjs: ng.IComponentOptions = {
       $mdDialog,
       $timeout,
       ngRouter: Router,
+      constants: Constants,
     ) {
       let previousPristine = true;
       this.fields = DashboardService.getIndexedFields();
@@ -68,7 +71,7 @@ const SettingsAnalyticsDashboardComponentAjs: ng.IComponentOptions = {
         } else {
           this.dashboard = {
             type: this.activatedRoute.snapshot.params.type,
-            reference_id: 'DEFAULT',
+            reference_id: constants.org.currentEnv.id,
             reference_type: 'ENVIRONMENT',
             enabled: true,
             definition: [],


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-4266

## Description

Use the dynamic envId instead of default one

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bpsmwkrvch.chromatic.com)
<!-- Storybook placeholder end -->
