### PR TITLE
fix: do not delete installation when goodbye asks for a reconnection

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/GoodByeCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/GoodByeCommandHandler.java
@@ -50,14 +50,14 @@ public class GoodByeCommandHandler implements CommandHandler<GoodByeCommand, Goo
 
     @Override
     public Single<GoodByeReply> handle(GoodByeCommand command) {
-        final Map<String, String> additionalInformation = this.installationService.getOrInitialize().getAdditionalInformation();
-        additionalInformation.put(InstallationService.COCKPIT_INSTALLATION_STATUS, DELETED_STATUS);
-
-        rejectAllPromotionToValidate();
-
         try {
-            this.installationService.setAdditionalInformation(additionalInformation);
-            log.info("Installation status is [{}].", DELETED_STATUS);
+            if (!command.getPayload().isReconnect()) {
+                final Map<String, String> additionalInformation = this.installationService.getOrInitialize().getAdditionalInformation();
+                additionalInformation.put(InstallationService.COCKPIT_INSTALLATION_STATUS, DELETED_STATUS);
+                rejectAllPromotionToValidate();
+                this.installationService.setAdditionalInformation(additionalInformation);
+                log.info("Installation status is [{}].", DELETED_STATUS);
+            }
             return Single.just(new GoodByeReply(command.getId(), new GoodByeReplyPayload()));
         } catch (Exception ex) {
             String errorDetails = "Error occurred when deleting installation.";


### PR DESCRIPTION
## Description

When reconnect is true, it means cockpit is asking to reconnect and not to delete the installation.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ofamyyretb.chromatic.com)
<!-- Storybook placeholder end -->
