### PR TITLE
feat: add integration controller

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/README.adoc
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/README.adoc
@@ -37,7 +37,7 @@ Bellow you will find a full `http-dynamic-properties` service configuration exam
     "headers": [
       {
         "name": "X-Custom-Header",
-        "value": "Custom-header-value"
+        "value": "Custom-authorizationHeader-value"
       }
     ],
     "method": "GET",
@@ -47,4 +47,3 @@ Bellow you will find a full `http-dynamic-properties` service configuration exam
   }
 }
 ```
-

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/README.adoc
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/README.adoc
@@ -63,7 +63,7 @@ Bellow you will find a full `http-health-check` service configuration example:
         "body": "xxxxx",
         "headers": [{
             "name": "X-CUSTOM-HEADAR",
-            "value": "{#api.properties['x-custom-header-value']}"
+            "value": "{#api.properties['x-custom-authorizationHeader-value']}"
         }],
         "overrideEndpointPath": false,
         "assertion": "{#response.status == 200}",
@@ -72,4 +72,3 @@ Bellow you will find a full `http-health-check` service configuration example:
     }
 }
 ```
-

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Token.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Token.java
@@ -17,11 +17,17 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
 public class Token {
 
     public enum AuditEvent implements Audit.AuditEvent {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
@@ -45,6 +45,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-integration-controller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.rest.api.idp</groupId>
             <artifactId>gravitee-apim-rest-api-idp-api</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.gravitee.apim.rest.api</groupId>
+        <artifactId>gravitee-apim-rest-api</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-rest-api-integration-controller</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Gravitee.io APIM - Management API - Integration Controller</name>
+    <description>Controller interacting with Integration Agents</description>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.exchange</groupId>
+            <artifactId>gravitee-exchange-api</artifactId>
+            <version>${gravitee-exchange.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.exchange</groupId>
+            <artifactId>gravitee-exchange-controller-core</artifactId>
+            <version>${gravitee-exchange.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.exchange</groupId>
+            <artifactId>gravitee-exchange-controller-websocket</artifactId>
+            <version>${gravitee-exchange.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.integration</groupId>
+            <artifactId>gravitee-integration-api</artifactId>
+            <version>${gravitee-integration-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-service</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-service</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
@@ -13,35 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.model;
+package io.gravitee.integration.controller.command;
 
-import java.util.Date;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import io.gravitee.exchange.api.controller.ControllerCommandContext;
+import java.util.Set;
 
-/**
- * @author Remi Baptiste (remi.baptiste at graviteesource.com)
- * @author GraviteeSource Team
- */
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
-@Data
-public class Integration {
-
-    private String id;
-
-    private String name;
-
-    private String description;
-
-    private String provider;
-
-    private String environmentId;
-
-    private Date createdAt;
-
-    private Date updatedAt;
+public record IntegrationCommandContext(boolean valid) implements ControllerCommandContext {
+    @Override
+    public boolean isValid() {
+        return valid;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.command;
+
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.exchange.api.controller.ControllerCommandContext;
+import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
+import io.gravitee.integration.controller.command.hello.HelloCommandHandler;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class IntegrationControllerCommandHandlerFactory implements ControllerCommandHandlersFactory {
+
+    private final IntegrationCrudService integrationCrudService;
+
+    @Override
+    public List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> buildCommandHandlers(
+        final ControllerCommandContext controllerCommandContext
+    ) {
+        return List.of(new HelloCommandHandler(integrationCrudService));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.command.hello;
+
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.hello.HelloReply;
+import io.gravitee.exchange.api.command.hello.HelloReplyPayload;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.hello.HelloCommand;
+import io.gravitee.integration.api.command.hello.HelloCommandPayload;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class HelloCommandHandler implements CommandHandler<HelloCommand, HelloReply> {
+
+    private final IntegrationCrudService integrationCrudService;
+
+    @Override
+    public String supportType() {
+        return IntegrationCommandType.HELLO.name();
+    }
+
+    @Override
+    public Single<HelloReply> handle(HelloCommand command) {
+        return Single
+            .fromCallable(() -> {
+                HelloCommandPayload payload = command.getPayload();
+
+                return integrationCrudService
+                    .findById(payload.getTargetId())
+                    .map(integration -> {
+                        if (integration.getProvider().equals(payload.getProvider())) {
+                            return new HelloReply(command.getId(), HelloReplyPayload.builder().targetId(integration.getId()).build());
+                        }
+                        return new HelloReply(
+                            command.getId(),
+                            String.format(
+                                "Integration [id=%s] does not match. Expected provider [provider=%s]",
+                                integration.getId(),
+                                integration.getProvider()
+                            )
+                        );
+                    })
+                    .orElse(new HelloReply(command.getId(), String.format("Integration [id=%s] not found", payload.getTargetId())));
+            })
+            .doOnError(throwable ->
+                log.error("Unable to process hello command payload for target [{}]", command.getPayload().getTargetId(), throwable)
+            )
+            .onErrorReturn(throwable -> new HelloReply(command.getId(), throwable.getMessage()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.spring;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
+import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.exchange.api.websocket.command.ExchangeSerDe;
+import io.gravitee.exchange.controller.websocket.WebSocketExchangeController;
+import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
+import io.gravitee.integration.api.websocket.command.IntegrationExchangeSerDe;
+import io.gravitee.integration.controller.command.IntegrationControllerCommandHandlerFactory;
+import io.gravitee.integration.controller.websocket.auth.IntegrationWebsocketControllerAuthentication;
+import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.node.api.certificate.KeyStoreLoaderFactoryRegistry;
+import io.gravitee.node.api.certificate.KeyStoreLoaderOptions;
+import io.gravitee.node.api.certificate.TrustStoreLoaderOptions;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.rest.api.service.TokenService;
+import io.vertx.rxjava3.core.Vertx;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
+
+@Configuration
+public class IntegrationControllerConfiguration {
+
+    @Bean("integrationWebsocketControllerAuthentication")
+    public IntegrationWebsocketControllerAuthentication integrationWebsocketControllerAuthentication(
+        final TokenService tokenService,
+        final UserCrudService userCrudService
+    ) {
+        return new IntegrationWebsocketControllerAuthentication(tokenService, userCrudService);
+    }
+
+    @Bean("integrationExchangeSerDe")
+    public IntegrationExchangeSerDe integrationExchangeSerDe() {
+        return new IntegrationExchangeSerDe(objectMapper());
+    }
+
+    @Bean("integrationIdentifyConfiguration")
+    public IdentifyConfiguration integrationPrefixConfiguration(final Environment environment) {
+        return new IdentifyConfiguration(environment, "integration");
+    }
+
+    @Bean("integrationControllerCommandHandlerFactory")
+    public IntegrationControllerCommandHandlerFactory integrationControllerCommandHandlerFactory(
+        final IntegrationCrudService integrationCrudService
+    ) {
+        return new IntegrationControllerCommandHandlerFactory(integrationCrudService);
+    }
+
+    @Bean("integrationExchangeController")
+    public ExchangeController integrationExchangeController(
+        final @Lazy ClusterManager clusterManager,
+        final @Lazy CacheManager cacheManager,
+        final Vertx vertx,
+        final KeyStoreLoaderFactoryRegistry<KeyStoreLoaderOptions> keyStoreLoaderFactoryRegistry,
+        final KeyStoreLoaderFactoryRegistry<TrustStoreLoaderOptions> trustStoreLoaderFactoryRegistry,
+        final @Qualifier("integrationIdentifyConfiguration") IdentifyConfiguration identifyConfiguration,
+        final @Qualifier(
+            "integrationWebsocketControllerAuthentication"
+        ) WebSocketControllerAuthentication<?> integrationWebsocketControllerAuthentication,
+        final @Qualifier(
+            "integrationControllerCommandHandlerFactory"
+        ) ControllerCommandHandlersFactory integrationControllerCommandHandlerFactory,
+        final @Qualifier("integrationExchangeSerDe") ExchangeSerDe integrationExchangeSerDe
+    ) {
+        return new WebSocketExchangeController(
+            identifyConfiguration,
+            clusterManager,
+            cacheManager,
+            vertx,
+            keyStoreLoaderFactoryRegistry,
+            trustStoreLoaderFactoryRegistry,
+            integrationWebsocketControllerAuthentication,
+            integrationControllerCommandHandlerFactory,
+            integrationExchangeSerDe
+        );
+    }
+
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.websocket.auth;
+
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
+import io.gravitee.integration.controller.command.IntegrationCommandContext;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("integrationWebsocketControllerAuthentication")
+@RequiredArgsConstructor
+public class IntegrationWebsocketControllerAuthentication implements WebSocketControllerAuthentication<IntegrationCommandContext> {
+
+    static final String AUTHORIZATION_HEADER = HttpHeaderNames.AUTHORIZATION.toString();
+    static final String ORGANIZATION_HEADER = "X-Gravitee-Organization-Id";
+    static final String AUTHORIZATION_HEADER_BEARER = "bearer";
+
+    private final TokenService tokenService;
+    private final UserCrudService userCrudService;
+
+    @Override
+    public IntegrationCommandContext authenticate(final HttpServerRequest httpServerRequest) {
+        var headers = httpServerRequest.headers();
+        var tokenValue = Optional
+            .ofNullable(headers.get(AUTHORIZATION_HEADER))
+            .map(authorizationHeader -> authorizationHeader.substring(AUTHORIZATION_HEADER_BEARER.length()).trim());
+        var organizationId = headers.get(ORGANIZATION_HEADER);
+
+        if (tokenValue.isPresent()) {
+            try {
+                var token = tokenService.findByToken(tokenValue.get());
+                return userCrudService
+                    .findBaseUserById(token.getReferenceId())
+                    .filter(u -> u.getOrganizationId().equalsIgnoreCase(organizationId))
+                    .map(user -> new IntegrationCommandContext(true))
+                    .orElseThrow(() -> new UserNotFoundException(token.getReferenceId()));
+            } catch (Exception e) {
+                log.warn("Unable to authenticate incoming websocket controller request");
+            }
+        }
+
+        log.warn("No authentication authorizationHeader in the incoming websocket controller request");
+        return new IntegrationCommandContext(false);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/command/hello/HelloCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/command/hello/HelloCommandHandlerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.command.hello;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+import fixtures.core.model.IntegrationFixture;
+import inmemory.IntegrationCrudServiceInMemory;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.exchange.api.command.hello.HelloReplyPayload;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.hello.HelloCommand;
+import io.gravitee.integration.api.command.hello.HelloCommandPayload;
+import io.gravitee.integration.controller.command.IntegrationCommandContext;
+import io.gravitee.integration.controller.command.IntegrationControllerCommandHandlerFactory;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class HelloCommandHandlerTest {
+
+    private static final String COMMAND_ID = "command-id";
+    private static final String INTEGRATION_ID = "my-integration-id";
+    private static final String INTEGRATION_PROVIDER = "amazon";
+
+    private static final HelloCommand COMMAND = new HelloCommand(
+        COMMAND_ID,
+        HelloCommandPayload.builder().targetId(INTEGRATION_ID).provider(INTEGRATION_PROVIDER).build()
+    );
+
+    IntegrationCrudServiceInMemory integrationCrudServiceInMemory = new IntegrationCrudServiceInMemory();
+    HelloCommandHandler commandHandler;
+
+    @BeforeEach
+    void setUp() {
+        var factory = new IntegrationControllerCommandHandlerFactory(integrationCrudServiceInMemory);
+
+        commandHandler =
+            (HelloCommandHandler) factory
+                .buildCommandHandlers(new IntegrationCommandContext(true))
+                .stream()
+                .filter(handler -> handler.supportType().equals(IntegrationCommandType.HELLO.name()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No handler found for type [HELLO]"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        integrationCrudServiceInMemory.reset();
+    }
+
+    @Test
+    void should_reply_succeeded_when_integration_exists() {
+        var integration = givenIntegration(
+            IntegrationFixture.anIntegration().toBuilder().id(INTEGRATION_ID).provider(INTEGRATION_PROVIDER).build()
+        );
+
+        commandHandler
+            .handle(COMMAND)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(reply -> {
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(reply.getCommandStatus()).isEqualTo(CommandStatus.SUCCEEDED);
+                    soft.assertThat(reply.getCommandId()).isEqualTo(COMMAND_ID);
+                    soft.assertThat(reply.getPayload()).isEqualTo(HelloReplyPayload.builder().targetId(integration.getId()).build());
+                });
+
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    @Test
+    void should_reply_error_when_integration_does_not_exist() {
+        commandHandler
+            .handle(COMMAND)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(reply -> {
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(reply.getCommandStatus()).isEqualTo(CommandStatus.ERROR);
+                    soft.assertThat(reply.getCommandId()).isEqualTo(COMMAND_ID);
+                    soft.assertThat(reply.getErrorDetails()).isEqualTo("Integration [id=my-integration-id] not found");
+                });
+
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    @Test
+    void should_reply_error_when_integration_exist_but_provider_mismatch() {
+        givenIntegration(IntegrationFixture.anIntegration().toBuilder().id("my-integration-id").provider("other").build());
+
+        commandHandler
+            .handle(COMMAND)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(reply -> {
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(reply.getCommandStatus()).isEqualTo(CommandStatus.ERROR);
+                    soft.assertThat(reply.getCommandId()).isEqualTo(COMMAND_ID);
+                    soft
+                        .assertThat(reply.getErrorDetails())
+                        .isEqualTo("Integration [id=my-integration-id] does not match. Expected provider [provider=other]");
+                });
+
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    @Test
+    void should_reply_error_when_exception_occurs() {
+        var spied = Mockito.spy(integrationCrudServiceInMemory);
+        lenient().when(spied.findById(any())).thenThrow(new TechnicalDomainException("error"));
+        commandHandler = new HelloCommandHandler(spied);
+
+        commandHandler
+            .handle(COMMAND)
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(reply -> {
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(reply.getCommandStatus()).isEqualTo(CommandStatus.ERROR);
+                    soft.assertThat(reply.getCommandId()).isEqualTo(COMMAND_ID);
+                    soft.assertThat(reply.getErrorDetails()).isEqualTo("error");
+                });
+
+                return true;
+            })
+            .assertNoErrors();
+    }
+
+    private Integration givenIntegration(Integration integration) {
+        integrationCrudServiceInMemory.initWith(List.of(integration));
+        return integration;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthenticationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthenticationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.websocket.auth;
+
+import static io.gravitee.integration.controller.websocket.auth.IntegrationWebsocketControllerAuthentication.AUTHORIZATION_HEADER_BEARER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.integration.controller.command.IntegrationCommandContext;
+import io.gravitee.repository.management.model.Token;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.exceptions.TokenNotFoundException;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.http.HttpHeaders;
+import io.vertx.rxjava3.core.http.HttpServerRequest;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationWebsocketControllerAuthenticationTest {
+
+    private static final String TOKEN_VALUE = "my-token-value";
+    private static final String ORGANIZATION_ID = "organization-id";
+
+    @Mock
+    TokenService tokenService;
+
+    @Mock
+    HttpServerRequest request;
+
+    UserCrudServiceInMemory userCrudServiceInMemory = new UserCrudServiceInMemory();
+
+    IntegrationWebsocketControllerAuthentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        authentication = new IntegrationWebsocketControllerAuthentication(tokenService, userCrudServiceInMemory);
+
+        MultiMap requestHeaders = HttpHeaders.headers();
+        requestHeaders
+            .add(IntegrationWebsocketControllerAuthentication.AUTHORIZATION_HEADER, AUTHORIZATION_HEADER_BEARER + TOKEN_VALUE)
+            .add(IntegrationWebsocketControllerAuthentication.ORGANIZATION_HEADER, ORGANIZATION_ID);
+        lenient().when(request.headers()).thenReturn(requestHeaders);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userCrudServiceInMemory.reset();
+    }
+
+    @Test
+    void should_return_a_valid_IntegrationCommandContext_when_authentication_succeed() {
+        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+        givenUser(BaseUserEntity.builder().id(token.getReferenceId()).organizationId(ORGANIZATION_ID).build());
+
+        var result = authentication.authenticate(request);
+
+        assertThat(result).isEqualTo(new IntegrationCommandContext(true));
+    }
+
+    @Test
+    void should_return_an_invalid_IntegrationCommandContext_when_no_token_found() {
+        givenNoToken();
+
+        var result = authentication.authenticate(request);
+
+        assertThat(result).isEqualTo(new IntegrationCommandContext(false));
+    }
+
+    @Test
+    void should_return_an_invalid_IntegrationCommandContext_when_no_user_found() {
+        givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+
+        var result = authentication.authenticate(request);
+
+        assertThat(result).isEqualTo(new IntegrationCommandContext(false));
+    }
+
+    @Test
+    void should_return_an_invalid_IntegrationCommandContext_when_organization_id_mismatch() {
+        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+        givenUser(BaseUserEntity.builder().id(token.getReferenceId()).organizationId("DEFAULT").build());
+
+        var result = authentication.authenticate(request);
+
+        assertThat(result).isEqualTo(new IntegrationCommandContext(false));
+    }
+
+    @Test
+    void should_return_an_invalid_IntegrationCommandContext_when_no_authorization_headers() {
+        lenient().when(request.headers()).thenReturn(HttpHeaders.headers());
+
+        var result = authentication.authenticate(request);
+
+        assertThat(result).isEqualTo(new IntegrationCommandContext(false));
+    }
+
+    private Token givenToken(Token token) {
+        lenient().when(tokenService.findByToken(token.getToken())).thenReturn(token);
+        return token;
+    }
+
+    private void givenNoToken() {
+        lenient().when(tokenService.findByToken(any())).thenThrow(new TokenNotFoundException("token"));
+    }
+
+    private void givenUser(BaseUserEntity user) {
+        userCrudServiceInMemory.initWith(List.of(user));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/crud_service/IntegrationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/crud_service/IntegrationCrudService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.integration.crud_service;
 
 import io.gravitee.apim.core.integration.model.Integration;
+import java.util.Optional;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
@@ -23,4 +24,6 @@ import io.gravitee.apim.core.integration.model.Integration;
  */
 public interface IntegrationCrudService {
     Integration create(Integration integration);
+
+    Optional<Integration> findById(String id);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/integration/IntegrationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/integration/IntegrationCrudServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.infra.crud_service.integration;
 
-import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.infra.adapter.IntegrationAdapter;
@@ -23,6 +22,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.IntegrationRepository;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -48,6 +48,15 @@ public class IntegrationCrudServiceImpl extends AbstractService implements Integ
             return IntegrationAdapter.INSTANCE.toEntity(createdIntegration);
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("Error when creating Integration: " + integration.getName(), e);
+        }
+    }
+
+    @Override
+    public Optional<Integration> findById(String id) {
+        try {
+            return integrationRepository.findById(id).map(IntegrationAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find the integration: " + id, e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/InitializerOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/InitializerOrder.java
@@ -37,4 +37,5 @@ public class InitializerOrder {
     public static final int IDENTITY_PROVIDER_ACTIVATION_INITIALIZER = 400;
     public static final int IDENTITY_PROVIDER_INITIALIZER = 350;
     public static final int SEARCH_INDEX_INITIALIZER = 250;
+    public static final int INTEGRATION_CONTROLLER_INITIALIZER = 400;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.initializer;
+
+import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.node.api.initializer.Initializer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class IntegrationControllerInitializer implements Initializer {
+
+    private final ExchangeController integrationExchangeController;
+
+    public IntegrationControllerInitializer(@Qualifier("integrationExchangeController") ExchangeController integrationExchangeController) {
+        this.integrationExchangeController = integrationExchangeController;
+    }
+
+    @Override
+    public boolean initialize() {
+        try {
+            // TODO check license before starting controller
+            integrationExchangeController.start();
+            log.info("Integrations started.");
+        } catch (Exception e) {
+            log.error("Fail to start Integration Controller", e);
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return InitializerOrder.INTEGRATION_CONTROLLER_INITIALIZER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/IntegrationFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/IntegrationFixture.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package fixtures.core.model;
+package fixtures.repository;
 
-import io.gravitee.apim.core.integration.model.Integration;
-import io.gravitee.rest.api.service.common.UuidString;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import io.gravitee.repository.management.model.Integration;
+import java.time.Instant;
+import java.util.Date;
 import java.util.function.Supplier;
 
 public class IntegrationFixture {
@@ -28,19 +27,15 @@ public class IntegrationFixture {
     public static final Supplier<Integration.IntegrationBuilder> BASE = () ->
         Integration
             .builder()
-            .id(UuidString.generateRandom())
-            .name("Test integration")
-            .description("Test description")
-            .provider("ForTestPurpose")
-            .environmentId("my-env")
-            .createdAt(ZonedDateTime.parse("2020-02-03T20:22:02.00Z").withZoneSameLocal(ZoneId.systemDefault()))
-            .updatedAt(ZonedDateTime.parse("2020-02-03T20:22:02.00Z").withZoneSameLocal(ZoneId.systemDefault()));
+            .id("integration-id")
+            .name("An integration")
+            .description("A description")
+            .provider("amazon")
+            .environmentId("environment-id")
+            .createdAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")));
 
     public static Integration anIntegration() {
         return BASE.get().build();
-    }
-
-    public static Integration anIntegration(String envId) {
-        return BASE.get().environmentId(envId).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationCrudServiceInMemory.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.integration.model.Integration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class IntegrationCrudServiceInMemory implements IntegrationCrudService, InMemoryAlternative<Integration> {
 
@@ -29,6 +30,11 @@ public class IntegrationCrudServiceInMemory implements IntegrationCrudService, I
     public Integration create(Integration integration) {
         storage.add(integration);
         return integration;
+    }
+
+    @Override
+    public Optional<Integration> findById(String id) {
+        return storage.stream().filter(item -> item.getId().equals(id)).findFirst();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.initializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.exchange.api.controller.ExchangeController;
+import lombok.SneakyThrows;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationControllerInitializerTest {
+
+    @Mock
+    ExchangeController exchangeController;
+
+    IntegrationControllerInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        initializer = new IntegrationControllerInitializer(exchangeController);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_start_integration_controller() {
+        initializer.initialize();
+
+        verify(exchangeController).start();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_throw_when_integration_controller_starting_fails() {
+        when(exchangeController.start()).thenThrow(new Exception("error"));
+
+        var throwable = Assertions.catchThrowable(() -> initializer.initialize());
+
+        assertThat(throwable).hasRootCauseMessage("error");
+    }
+
+    @Test
+    void order_check() {
+        assertThat(initializer.getOrder()).isGreaterThanOrEqualTo(400);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -61,6 +61,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-integration-controller</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.rest.api.management</groupId>
             <artifactId>gravitee-apim-rest-api-management-rest</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.integration.controller.spring.IntegrationControllerConfiguration;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.container.NodeFactory;
@@ -40,6 +41,7 @@ import org.springframework.context.annotation.Import;
     {
         RestManagementConfiguration.class,
         io.gravitee.rest.api.management.v2.rest.spring.RestManagementConfiguration.class,
+        IntegrationControllerConfiguration.class,
         RestPortalConfiguration.class,
     }
 )

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -39,6 +39,7 @@
         <module>gravitee-apim-rest-api-fetcher</module>
         <module>gravitee-apim-rest-api-model</module>
         <module>gravitee-apim-rest-api-idp</module>
+        <module>gravitee-apim-rest-api-integration-controller</module>
         <module>gravitee-apim-rest-api-repository</module>
         <module>gravitee-apim-rest-api-rest</module>
         <module>gravitee-apim-rest-api-service</module>

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -23,7 +23,7 @@ sonar.test.inclusions=**/*Test.java
 
 # Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/jacoco.xml
-sonar.coverage.exclusions=**/pom.xml, **/src/test/**, **/model/**, **/exception/**, **/fixtures/**, **/assertions/**
+sonar.coverage.exclusions=**/pom.xml, **/src/test/**, **/model/**, **/exception/**, **/fixtures/**, **/assertions/**, **/spring/**
 
 # Libraries
 sonar.libraries=${env.HOME}/.m2/repository/org/projectlombok/lombok/**/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,11 @@
         <gravitee-cockpit-api.version>3.0.2</gravitee-cockpit-api.version>
         <gravitee-common.version>4.0.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
+        <gravitee-exchange.version>1.1.0</gravitee-exchange.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-integration-api.version>1.0.0-alpha.3</gravitee-integration-api.version>
         <gravitee-node.version>5.10.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.0</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4204

## Description

The Integration Controller is the component that will listen for Federation agents.

When an agent connects, the connection is authenticated using `IntegrationWebsocketControllerAuthentication`. This class will ensure that the provided authentication matches an existing Token/User.

Once authenticated, the agent will send a Hello Command. This command is handled by `HelloCommandHandler` that will check that the integration provided exists and matches with the provider given.


## Additional context

Related to https://github.com/gravitee-io/gravitee-federation-agent/pull/17

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mvwcvtibve.chromatic.com)
<!-- Storybook placeholder end -->
