### PR TITLE
fix(import): Primary Owner should be always added to the API group on import update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -458,6 +458,24 @@ public class ApiService_UpdateTest {
         fail("should throw InvalidDataException");
     }
 
+    @Test
+    public void shouldUpdateWithPOGroupsWhenGroupsAreNotProvided() throws TechnicalException {
+        prepareUpdate();
+
+        PrimaryOwnerEntity po = mock(PrimaryOwnerEntity.class);
+        when(po.getType()).thenReturn(MembershipMemberType.GROUP.name());
+        when(po.getId()).thenReturn("group-with-po");
+        when(primaryOwnerService.getPrimaryOwner(any(), eq(API_ID))).thenReturn(po);
+
+        updateApiEntity.setGroups(Sets.newSet());
+
+        final ApiEntity apiEntity = apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        assertNotNull(apiEntity);
+        assertEquals(API_NAME, apiEntity.getName());
+        verify(apiRepository).update(argThat(api -> api.getId().equals(API_ID) && api.getGroups().equals(Sets.newSet("group-with-po"))));
+    }
+
     private void prepareUpdate() throws TechnicalException {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(apiRepository.update(any())).thenReturn(updatedApi);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4168

## Description

Always add group from PO when updating API on import flow. It will ensure groups being populated even when user will not provide valid groups.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

