### PR TITLE
fix(console): snack bar design fix

### DIFF
--- a/gravitee-apim-console-webui/src/scss/gio-global-style.scss
+++ b/gravitee-apim-console-webui/src/scss/gio-global-style.scss
@@ -8,24 +8,30 @@
 
 $background: map.get(gio.$mat-theme, background);
 
-.gio-snack-bar-success {
-  white-space: pre-wrap;
-  background-color: mat.get-color-from-palette(gio.$mat-success-palette, default);
-  color: mat.get-color-from-palette(gio.$mat-success-palette, default-contrast);
+$error-background-color: mat.get-color-from-palette(gio.$mat-error-palette, default);
+$error-color: mat.get-color-from-palette(gio.$mat-error-palette, default-contrast);
 
-  .mat-button {
-    color: mat.get-color-from-palette(gio.$mat-success-palette, default-contrast);
-  }
+$success-background-color: mat.get-color-from-palette(gio.$mat-success-palette, default);
+$success-color: mat.get-color-from-palette(gio.$mat-success-palette, default-contrast);
+
+$snackbar-button: mat.get-color-from-palette(gio.$mat-basic-palette, white);
+
+.gio-snack-bar-success {
+  --mdc-snackbar-container-color: #{$success-background-color};
+  --mdc-snackbar-supporting-text-color: #{$success-color};
+  --mat-snack-bar-button-color: #{$snackbar-button};
+  white-space: pre-wrap;
 }
 
 .gio-snack-bar-error {
+  --mdc-snackbar-container-color: #{$error-background-color};
+  --mdc-snackbar-supporting-text-color: #{$error-color};
+  --mat-snack-bar-button-color: #{$snackbar-button};
   white-space: pre-wrap;
-  background-color: mat.get-color-from-palette(gio.$mat-error-palette, default);
-  color: mat.get-color-from-palette(gio.$mat-error-palette, default-contrast);
+}
 
-  .mat-button {
-    color: mat.get-color-from-palette(gio.$mat-error-palette, default-contrast);
-  }
+.mdc-button__label {
+  white-space: nowrap;
 }
 
 /**


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4279

## Description

Snack bar design fix

## Additional context

Screenshots:
<img width="190" alt="Screenshot 2024-03-26 at 10 26 16 AM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/c9544775-61a4-45dd-af86-10fd5ed14c75">
<img width="379" alt="Screenshot 2024-03-26 at 10 27 56 AM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/df23c5c1-1759-41eb-9fe0-a3b69fc8c5f3">


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7024/console](https://pr.team-apim.gravitee.dev/7024/console)
      Portal: [https://pr.team-apim.gravitee.dev/7024/portal](https://pr.team-apim.gravitee.dev/7024/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7024/api/management](https://pr.team-apim.gravitee.dev/7024/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7024](https://pr.team-apim.gravitee.dev/7024)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7024](https://pr.gateway-v3.team-apim.gravitee.dev/7024)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-onoesevumd.chromatic.com)
<!-- Storybook placeholder end -->
