### PR TITLE
fix(console): add nginx server redirect on 404 to `/`

### DIFF
--- a/gravitee-apim-console-webui/docker/config/default.conf
+++ b/gravitee-apim-console-webui/docker/config/default.conf
@@ -24,6 +24,7 @@ server {
 
     location / {
         try_files $uri $uri/ =404;
+        error_page 404 /;
         root /usr/share/nginx/html;
         sub_filter '<base href="/"' '<base href="$CONSOLE_BASE_HREF"';
         sub_filter_once on;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4311

## Description

Redirect 404 to `/` by changing the nginx conf

When url is invalid (i.e. `https://pr.team-apim.gravitee.dev/7029/console/boop`)
- Redirects to home
- Reponds:

![Screenshot 2024-03-27 at 12 03 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/72a941b3-1b5b-4b28-9097-9746f7374524)


When image is missing:
![Screenshot 2024-03-27 at 12 02 37](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/5558bc76-cfc1-48a2-b56f-846f8aec6b0e)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7029/console](https://pr.team-apim.gravitee.dev/7029/console)
      Portal: [https://pr.team-apim.gravitee.dev/7029/portal](https://pr.team-apim.gravitee.dev/7029/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7029/api/management](https://pr.team-apim.gravitee.dev/7029/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7029](https://pr.team-apim.gravitee.dev/7029)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7029](https://pr.gateway-v3.team-apim.gravitee.dev/7029)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cpfpsgetkr.chromatic.com)
<!-- Storybook placeholder end -->
