### PR TITLE
fix: add columnDataType in not null constraint

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_20/schema-dashboards.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_20/schema-dashboards.yml
@@ -18,6 +18,7 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: ${gravitee_prefix}dashboards
             columnName: type
+            columnDataType: nvarchar(64)
             defaultNullValue: PLATFORM
         - sql:
             sql: update ${gravitee_prefix}dashboards set reference_type = 'ENVIRONMENT'


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4307

## Description

Add columnDataType, which is mandatory for some databases, in addNotNullConstraint changeset. In my previous PR I tested it with Postgres and it fail in the CI with sqlServer.

Mysql:
<img width="1754" alt="Capture d’écran 2024-03-26 à 14 48 14" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/bdb85f60-7875-4d6d-8f1b-f29a95fd5b6e">

MariaDB:
<img width="1792" alt="Capture d’écran 2024-03-26 à 14 52 21" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/b2808a9f-3615-4a24-a631-7df71808d09f">

Postgres:
<img width="1792" alt="Capture d’écran 2024-03-26 à 14 55 45" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/a9e72cd0-312e-4c8d-b96e-9f96f764cd4d">

sqlServer:
<img width="1791" alt="Capture d’écran 2024-03-26 à 15 00 33" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/b2e62fdc-d4fd-488c-910f-b5c346261b86">



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

