### PR TITLE
fix(console):  version history location change

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -97,13 +97,6 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
-    if (this.permissionService.hasAnyMatching(['api-event-r'])) {
-      tabs.push({
-        displayName: 'Version History',
-        routerLink: 'v4/history',
-      });
-    }
-
     if (this.permissionService.hasAnyMatching(['api-audit-r'])) {
       tabs.push({
         displayName: 'Audit Logs',
@@ -257,6 +250,13 @@ export class ApiV4MenuService implements ApiMenuService {
       tabs.push({
         displayName: 'Configuration',
         routerLink: 'deployments',
+      });
+    }
+
+    if (this.permissionService.hasAnyMatching(['api-event-r'])) {
+      tabs.push({
+        displayName: 'Version History',
+        routerLink: 'v4/history',
       });
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4243

## Description

Move Version History to Deployments tab

## Additional context

Screenshot:
<img width="960" alt="Screenshot 2024-03-26 at 4 37 05 PM" src="https://github.com/gravitee-io/gravitee-api-management/assets/144100648/f37e6aed-5976-417b-b350-e9ef0a6c6eca">


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7037/console](https://pr.team-apim.gravitee.dev/7037/console)
      Portal: [https://pr.team-apim.gravitee.dev/7037/portal](https://pr.team-apim.gravitee.dev/7037/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7037/api/management](https://pr.team-apim.gravitee.dev/7037/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7037](https://pr.team-apim.gravitee.dev/7037)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7037](https://pr.gateway-v3.team-apim.gravitee.dev/7037)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ovjiawkely.chromatic.com)
<!-- Storybook placeholder end -->
