### PR TITLE
fix: fix assertion for test when duplicated id is inserted

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IntegrationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IntegrationRepositoryTest.java
@@ -51,10 +51,7 @@ public class IntegrationRepositoryTest extends AbstractManagementRepositoryTest 
         Integration integration = creatIntegration(uuid, date);
 
         integrationRepository.create(integration);
-        assertThatThrownBy(() -> integrationRepository.create(integration))
-            .isInstanceOf(Exception.class)
-            .cause()
-            .hasMessageContaining("duplicate key");
+        assertThatThrownBy(() -> integrationRepository.create(integration)).isInstanceOf(Exception.class);
     }
 
     private static Integration creatIntegration(String uuid, Date date) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4363

## Description

Not every database error message contains "duplicate key" part when same id item is inserted. I had to remove that check and left exception assertion only to fix integration tests for MariaDB and mySQL databases. 

