### PR TITLE
fix(service): cockpit -- apply sanitized paths when verifying swagger

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/model/ContextPathValidationResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/model/ContextPathValidationResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.model;
+
+import io.gravitee.apim.core.api.model.Path;
+import io.gravitee.definition.model.VirtualHost;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ContextPathValidationResult {
+
+    @Builder.Default
+    private List<Path> sanitizedPaths = new ArrayList<>();
+
+    private String error;
+
+    public List<VirtualHost> toVirtualHosts() {
+        return this.sanitizedPaths.stream().map(p -> new VirtualHost(p.getHost(), p.getPath(), p.isOverrideAccess())).toList();
+    }
+
+    public boolean hasError() {
+        return Objects.nonNull(error);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -446,7 +446,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                         .getProxy()
                         .getVirtualHosts()
                         .stream()
-                        .map(vh -> Path.builder().host(vh.getHost()).path(vh.getPath()).build())
+                        .map(vh -> Path.builder().host(vh.getHost()).path(vh.getPath()).overrideAccess(vh.isOverrideEntrypoint()).build())
                         .collect(toList())
                 )
                 .stream()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4326

## Description

When creating an API in APIM from Cockpit in multi-tenant mode, the context paths were modified when sanitized, but the change was never applied to the Swagger entity. 

What was happening:
- The context path of the Swagger entity was sanitized, but never saved
- The Swagger entity was then transformed to an `ApiDefinition`
- When calling the method `updateFromApiDefinition`, the saved API entity with sanitized virtual hosts was merged with an incoming Swagger entity with un-sanitized virtual hosts 
- The updated API that was then saved had duplicated context paths

The Fix:
By applying the sanitized virtual hosts in the Cockpit service to Swagger entities, the `ApiServiceImpl` always receives sanitized virtual hosts via creation + update.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

