### PR TITLE
fix: add keep-alive timeout

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -4459,6 +4459,11 @@ components:
                     format: int32
                     description: The idle timeout of the http client in ms
                     default: 60000
+                keepAliveTimeout:
+                    type: integer
+                    format: int32
+                    description: The keep-alive timeout of the http client in ms
+                    default: 30000
                 connectTimeout:
                     type: integer
                     format: int32


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3966

## Description

Add missing `keepAliveTimeout` field in the mAPI v2 OpenAPI.