### PR TITLE
fix: support default env and org on noop repository

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Environment.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Environment.java
@@ -17,10 +17,7 @@ package io.gravitee.repository.management.model;
 
 import java.util.List;
 import java.util.Objects;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -30,7 +27,18 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode
 @ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Environment {
+
+    public static final Environment DEFAULT = Environment
+        .builder()
+        .id("DEFAULT")
+        .hrids(List.of("default"))
+        .name("Default")
+        .organizationId("DEFAULT")
+        .build();
 
     private String id;
     private String cockpitId;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Organization.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Organization.java
@@ -17,10 +17,7 @@ package io.gravitee.repository.management.model;
 
 import java.util.List;
 import java.util.Objects;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -30,7 +27,12 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode
 @ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Organization {
+
+    public static final Organization DEFAULT = Organization.builder().id("DEFAULT").hrids(List.of("default")).name("Default").build();
 
     private String id;
     private String cockpitId;

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepository.java
@@ -18,27 +18,54 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Organization;
 import java.util.Optional;
 import java.util.Set;
 
 /**
+ * This repository does no operation with any persistent storage but ensures that any call dealing with the 'DEFAULT' hardcoded environment behaves appropriately.
+ * This is to ensure full compatibility with all the APIM components where the 'DEFAULT' environment is used.
+ *
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NoOpEnvironmentRepository extends AbstractNoOpManagementRepository<Environment, String> implements EnvironmentRepository {
 
     @Override
+    public Optional<Environment> findById(String environmentId) throws TechnicalException {
+        if (environmentId.equals(Environment.DEFAULT.getId())) {
+            return Optional.of(Environment.DEFAULT);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
     public Set<Environment> findByOrganization(String organizationId) throws TechnicalException {
+        if (organizationId.equals(Environment.DEFAULT.getOrganizationId())) {
+            return Set.of(Environment.DEFAULT);
+        }
         return Set.of();
     }
 
     @Override
     public Set<Environment> findByOrganizationsAndHrids(Set<String> organizationsHrids, Set<String> hrids) throws TechnicalException {
+        if (
+            organizationsHrids.stream().anyMatch(orgHrid -> Organization.DEFAULT.getHrids().contains(orgHrid)) &&
+            hrids.stream().anyMatch(envHrid -> Environment.DEFAULT.getHrids().contains(envHrid))
+        ) {
+            return Set.of(Environment.DEFAULT);
+        }
         return Set.of();
     }
 
     @Override
     public Optional<Environment> findByCockpitId(String cockpitId) throws TechnicalException {
         return Optional.empty();
+    }
+
+    @Override
+    public Set<Environment> findAll() throws TechnicalException {
+        return Set.of(Environment.DEFAULT);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpOrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpOrganizationRepository.java
@@ -23,6 +23,9 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
+ * This repository does no operation with any persistent storage but ensures that any call dealing with the 'DEFAULT' hardcoded organization behaves appropriately.
+ * This is to ensure full compatibility with all the APIM components where the 'DEFAULT' organization is used.
+ *
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
  */
@@ -30,11 +33,30 @@ public class NoOpOrganizationRepository extends AbstractNoOpManagementRepository
 
     @Override
     public Long count() throws TechnicalException {
-        return null;
+        // 1 single 'DEFAULT' organization.
+        return 1L;
+    }
+
+    @Override
+    public Optional<Organization> findById(String organizationId) throws TechnicalException {
+        if (organizationId.equals(Organization.DEFAULT.getId())) {
+            return Optional.of(Organization.DEFAULT);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<Organization> findAll() throws TechnicalException {
+        return Set.of(Organization.DEFAULT);
     }
 
     @Override
     public Set<Organization> findByHrids(Set<String> hrids) throws TechnicalException {
+        if (hrids.stream().anyMatch(orgHrid -> Organization.DEFAULT.getHrids().contains(orgHrid))) {
+            return Set.of(Organization.DEFAULT);
+        }
+
         return Set.of();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpEnvironmentRepositoryTest.java
@@ -20,7 +20,9 @@ import static org.junit.Assert.*;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Organization;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.Test;
@@ -36,7 +38,7 @@ public class NoOpEnvironmentRepositoryTest extends AbstractNoOpRepositoryTest {
     private EnvironmentRepository cut;
 
     @Test
-    public void findByOrganization() throws TechnicalException {
+    public void should_return_empty_when_find_by_an_organization_other_than_default() throws TechnicalException {
         Set<Environment> environments = cut.findByOrganization("test_org");
 
         assertNotNull(environments);
@@ -44,7 +46,15 @@ public class NoOpEnvironmentRepositoryTest extends AbstractNoOpRepositoryTest {
     }
 
     @Test
-    public void findByOrganizationsAndHrids() throws TechnicalException {
+    public void should_return_default_environment_when_finding_by_default_organization() throws TechnicalException {
+        Set<Environment> environments = cut.findByOrganization(Organization.DEFAULT.getId());
+
+        assertNotNull(environments);
+        assertEquals(Set.of(Environment.DEFAULT), environments);
+    }
+
+    @Test
+    public void should_return_empty_when_finding_by_an_organization_hrid_other_than_default() throws TechnicalException {
         Set<Environment> environments = cut.findByOrganizationsAndHrids(Set.of("test_org"), Set.of("test_hrid"));
 
         assertNotNull(environments);
@@ -52,7 +62,63 @@ public class NoOpEnvironmentRepositoryTest extends AbstractNoOpRepositoryTest {
     }
 
     @Test
-    public void findByCockpitId() throws TechnicalException {
+    public void should_return_empty_when_finding_by_an_organization_other_than_default_and_default_environment() throws TechnicalException {
+        Set<Environment> environments = cut.findByOrganizationsAndHrids(Set.of("test_org"), new HashSet<>(Environment.DEFAULT.getHrids()));
+
+        assertNotNull(environments);
+        assertTrue(environments.isEmpty());
+    }
+
+    @Test
+    public void should_return_empty_when_finding_by_default_organization_but_an_environment_other_than_default() throws TechnicalException {
+        Set<Environment> environments = cut.findByOrganizationsAndHrids(
+            new HashSet<>(Organization.DEFAULT.getHrids()),
+            Set.of("test_hrid")
+        );
+
+        assertNotNull(environments);
+        assertTrue(environments.isEmpty());
+    }
+
+    @Test
+    public void should_return_default_environment_when_finding_by_default_organization_and_default_environment_hrids()
+        throws TechnicalException {
+        Set<Environment> environments = cut.findByOrganizationsAndHrids(
+            new HashSet<>(Organization.DEFAULT.getHrids()),
+            new HashSet<>(Environment.DEFAULT.getHrids())
+        );
+
+        assertNotNull(environments);
+        assertEquals(Set.of(Environment.DEFAULT), environments);
+    }
+
+    @Test
+    public void should_return_default_environment_when_finding_all() throws TechnicalException {
+        Set<Environment> environments = cut.findAll();
+
+        assertNotNull(environments);
+        assertEquals(Set.of(Environment.DEFAULT), environments);
+    }
+
+    @Test
+    public void should_return_default_environment_when_finding_by_default_environment() throws TechnicalException {
+        Optional<Environment> environmentOpt = cut.findById(Environment.DEFAULT.getId());
+
+        assertNotNull(environmentOpt);
+        assertTrue(environmentOpt.isPresent());
+        assertEquals(Environment.DEFAULT, environmentOpt.get());
+    }
+
+    @Test
+    public void should_return_empty_when_finding_by_an_environment() throws TechnicalException {
+        Optional<Environment> environmentOpt = cut.findById("test_id");
+
+        assertNotNull(environmentOpt);
+        assertFalse(environmentOpt.isPresent());
+    }
+
+    @Test
+    public void should_return_empty_when_finding_cockpit_id() throws TechnicalException {
         Optional<Environment> environment = cut.findByCockpitId("test_id");
 
         assertNotNull(environment);

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpOrganizationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/management/NoOpOrganizationRepositoryTest.java
@@ -19,8 +19,11 @@ import static org.junit.Assert.*;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Organization;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,17 +38,56 @@ public class NoOpOrganizationRepositoryTest extends AbstractNoOpRepositoryTest {
     private OrganizationRepository cut;
 
     @Test
-    public void count() throws TechnicalException {
-        Long count = cut.count();
+    public void should_return_default_organization_when_finding_by_default_organization_hrid() throws TechnicalException {
+        Set<Organization> organizations = cut.findByHrids(new HashSet<>(Organization.DEFAULT.getHrids()));
 
-        assertNull(count);
+        assertNotNull(organizations);
+        assertEquals(Set.of(Organization.DEFAULT), organizations);
     }
 
     @Test
-    public void findByHrids() throws TechnicalException {
-        Set<Organization> organizations = cut.findByHrids(Set.of("test_hird"));
+    public void should_return_empty_when_finding_by_an_organization_hrid_other_than_default() throws TechnicalException {
+        Set<Organization> organizations = cut.findByHrids(Set.of("test_org"));
 
         assertNotNull(organizations);
         assertTrue(organizations.isEmpty());
+    }
+
+    @Test
+    public void should_return_default_organization_when_finding_all() throws TechnicalException {
+        Set<Organization> organizations = cut.findAll();
+
+        assertNotNull(organizations);
+        assertEquals(Set.of(Organization.DEFAULT), organizations);
+    }
+
+    @Test
+    public void should_return_default_organization_when_finding_by_default_organization() throws TechnicalException {
+        Optional<Organization> organizationOpt = cut.findById(Organization.DEFAULT.getId());
+
+        assertNotNull(organizationOpt);
+        assertTrue(organizationOpt.isPresent());
+        assertEquals(Organization.DEFAULT, organizationOpt.get());
+    }
+
+    @Test
+    public void should_return_empty_when_finding_by_an_organization() throws TechnicalException {
+        Optional<Organization> organizationOpt = cut.findById("test_id");
+
+        assertNotNull(organizationOpt);
+        assertFalse(organizationOpt.isPresent());
+    }
+
+    @Test
+    public void should_return_empty_when_finding_cockpit_id() throws TechnicalException {
+        Optional<Organization> organization = cut.findByCockpitId("test_id");
+
+        assertNotNull(organization);
+        assertTrue(organization.isEmpty());
+    }
+
+    @Test
+    public void should_count_1_organization() throws TechnicalException {
+        assertEquals(1L, (long) cut.count());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-51

## Description

This PR fixes an issue when resolving the organization of an environment when using `none` repository for GKO (aka `dbless`). GKO assigns APIs to the 'DEFAULT' environment which is supposed to belong to the organization 'DEFAULT'. Since the introduction of the organization license support, the organization identifier is now mandatory information. 
To align the behavior and avoid any future issues when dealing with DEFAULT env and dbless, the noop repositories have been adapted to properly deal with the DEFAULT env & org transparently for the rest of the APIM components.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rxztfazxcd.chromatic.com)
<!-- Storybook placeholder end -->
