### PR TITLE
fix: add synchronized on getOrInitialize installation to avoid installation duplication

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
@@ -66,7 +66,7 @@ public class InstallationServiceImpl implements InstallationService {
     }
 
     @Override
-    public InstallationEntity getOrInitialize() {
+    public synchronized InstallationEntity getOrInitialize() {
         try {
             final Optional<Installation> optInstallation = this.installationRepository.find();
             if (optInstallation.isPresent()) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3073

## Description

Add synchronized on getOrInitialize installation to avoid installation duplication. The use of a initializer/upgrader is impossible as they are executed too late after node metadata resolution or cockpit hello command.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

