### PR TITLE
fix(repository): map type for apis during search for jdbc

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -390,7 +390,7 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         LOGGER.debug("JdbcApiRepository.search({})", apiCriteria);
 
         String projection =
-            "ac.*, a.id, a.environment_id, a.name, a.description, a.version, a.type, a.deployed_at, a.created_at, a.updated_at, " +
+            "ac.*, a.id, a.environment_id, a.cross_id, a.name, a.description, a.version, a.type, a.deployed_at, a.created_at, a.updated_at, " +
             "a.visibility, a.lifecycle_state, a.api_lifecycle_state, a.definition_version";
 
         if (apiFieldFilter == null || !apiFieldFilter.isDefinitionExcluded()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -390,7 +390,7 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         LOGGER.debug("JdbcApiRepository.search({})", apiCriteria);
 
         String projection =
-            "ac.*, a.id, a.environment_id, a.name, a.description, a.version, a.deployed_at, a.created_at, a.updated_at, " +
+            "ac.*, a.id, a.environment_id, a.name, a.description, a.version, a.type, a.deployed_at, a.created_at, a.updated_at, " +
             "a.visibility, a.lifecycle_state, a.api_lifecycle_state, a.definition_version";
 
         if (apiFieldFilter == null || !apiFieldFilter.isDefinitionExcluded()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -400,6 +400,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("async-api", apis.get(0).getId());
         assertEquals(DefinitionVersion.V4, apis.get(0).getDefinitionVersion());
         assertEquals(ApiType.MESSAGE, apis.get(0).getType());
+        assertEquals("async-searched-crossId", apis.get(0).getCrossId());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -398,6 +399,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(1, apis.size());
         assertEquals("async-api", apis.get(0).getId());
         assertEquals(DefinitionVersion.V4, apis.get(0).getDefinitionVersion());
+        assertEquals(ApiType.MESSAGE, apis.get(0).getType());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
@@ -159,6 +159,7 @@
     "name": "async-api-to-findById name",
     "crossId": "async-searched-crossId",
     "definitionVersion": "4.0.0",
+    "type": "message",
     "version": "1.1",
     "definition" : "{\"id\" : \"product\",\"name\" : \"Product\",\"version\" : \"1\",\"proxy\" : {  \"context_path\" : \"/another_product\",  \"endpoint\" : \"http://toto.com\",  \"endpoints\" : [ {    \"target\" : \"http://toto.com\",    \"weight\" : 1,    \"name\" : \"endpointName\"  } ],  \"strip_context_path\" : false,  \"http\" : {    \"configuration\" : {      \"connectTimeout\" : 5000,      \"idleTimeout\" : 60000,      \"keepAliveTimeout\" : 30000,      \"keepAlive\" : true,      \"dumpRequest\" : false    }  }},\"paths\" : {  \"/\" : [ {    \"methods\" : [ ],    \"api-key\" : {}  } ]},\"tags\" : [ ]\n}",
     "visibility" : "PRIVATE",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4434

## Description

In a Docker environment using Postgres, after importing a new API with the attached file `Kafka-1-0-0.json`, the API List in Console shows that the API is `V4`, but its type is `Undefined`.

Instead, it should show `V4 - Message`.

This has been observed when denoting the `APIM_VERSION` as `4.2.6` and `4.2.x-latest`.

It is reproducible with any type of V4 API.

Initially mentioned in slack conversation: https://graviteeio.slack.com/archives/C01R65MG162/p1711719539127129Connect your Slack account 

Solution: The field `type` was not being mapped for JDBC installations for the method `search`. Once adding `type` to the projection, it is returned to the user via MAPI-V2 and can then be used by the console to display the API type.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

