### PR TITLE
fix: API's categories indexation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Api.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Api.java
@@ -35,7 +35,7 @@ import lombok.With;
  */
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 @Getter
 @Setter
 @ToString

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Category.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Category.java
@@ -17,11 +17,17 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class Category {
 
     public enum AuditEvent implements Audit.AuditEvent {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.ApiMetadataDecodeContext;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
 import io.gravitee.apim.core.documentation.model.PrimaryOwnerApiTemplateData;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.search.Indexer;
@@ -28,10 +29,16 @@ import java.util.Date;
 public class ApiIndexerDomainService {
 
     private final ApiMetadataDecoderDomainService apiMetadataDecoderDomainService;
+    private final ApiCategoryQueryService apiCategoryQueryService;
     private final Indexer indexer;
 
-    public ApiIndexerDomainService(ApiMetadataDecoderDomainService apiMetadataDecoderDomainService, Indexer indexer) {
+    public ApiIndexerDomainService(
+        ApiMetadataDecoderDomainService apiMetadataDecoderDomainService,
+        ApiCategoryQueryService apiCategoryQueryService,
+        Indexer indexer
+    ) {
         this.apiMetadataDecoderDomainService = apiMetadataDecoderDomainService;
+        this.apiCategoryQueryService = apiCategoryQueryService;
         this.indexer = indexer;
     }
 
@@ -54,7 +61,8 @@ public class ApiIndexerDomainService {
                 )
                 .build()
         );
+        var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(apiToIndex);
 
-        indexer.index(context, new IndexableApi(apiToIndex, primaryOwner, metadata));
+        indexer.index(context, new IndexableApi(apiToIndex, primaryOwner, metadata, categoryKeys));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiCategoryQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiCategoryQueryService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.query_service;
+
+import io.gravitee.apim.core.api.model.Api;
+import java.util.Collection;
+
+public interface ApiCategoryQueryService {
+    /**
+     * Find all category keys for the given API.
+     * @param api The API for which to find the category keys.
+     * @return The category keys.
+     */
+    Collection<String> findApiCategoryKeys(Api api);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/model/Category.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/model/Category.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class Category {
+
+    private String id;
+
+    private String name;
+
+    private String key;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.search.Indexable;
 import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.util.Collection;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -37,6 +38,9 @@ public class IndexableApi implements Indexable {
 
     /** Decoded API metadata */
     private Map<String, String> decodedMetadata;
+
+    /** API categories' keys */
+    private Collection<String> categoryKeys;
 
     @Override
     public String getId() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiCategoryQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiCategoryQueryServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.api;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.CategoryRepository;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ApiCategoryQueryServiceImpl implements ApiCategoryQueryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public ApiCategoryQueryServiceImpl(@Lazy CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    @Override
+    public Collection<String> findApiCategoryKeys(Api api) {
+        try {
+            var categoriesIds = api.getCategories();
+            if (categoriesIds == null || categoriesIds.isEmpty()) {
+                return Collections.emptySet();
+            }
+
+            // Uncomment when https://gravitee.atlassian.net/browse/APIM-4437 is fixed
+            //            return categoryRepository
+            //                .findByEnvironmentIdAndIdIn(api.getEnvironmentId(), categoriesIds)
+            //                .stream()
+            //                .map(io.gravitee.repository.management.model.Category::getKey)
+            //                .collect(Collectors.toSet());
+
+            return categoryRepository
+                .findAllByEnvironment(api.getEnvironmentId())
+                .stream()
+                .filter(category -> categoriesIds.contains(category.getId()) || categoriesIds.contains(category.getKey()))
+                .map(io.gravitee.repository.management.model.Category::getKey)
+                .collect(Collectors.toSet());
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find Categories for the api: " + api.getId(), e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService.ApiMetadataDecodeContext;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.model.PrimaryOwnerApiTemplateData;
@@ -119,6 +120,9 @@ public class SearchEngineServiceImpl implements SearchEngineService {
 
     @Autowired
     private ApiMetadataDecoderDomainService apiMetadataDecoderDomainService;
+
+    @Autowired
+    private ApiCategoryQueryService apiCategoryQueryService;
 
     @Async("indexerThreadPoolTaskExecutor")
     @Override
@@ -221,8 +225,9 @@ public class SearchEngineServiceImpl implements SearchEngineService {
                         )
                         .build()
                 );
+                var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(api);
 
-                return new IndexableApi(api, primaryOwner, metadata);
+                return new IndexableApi(api, primaryOwner, metadata, categoryKeys);
             }
         } catch (final AbstractNotFoundException nfe) {
             // ignore not found exception because may be due to synchronization not yet processed by DBs

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -73,6 +73,7 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
         var api = indexableApi.getApi();
         var primaryOwner = indexableApi.getPrimaryOwner();
         var metadata = indexableApi.getDecodedMetadata();
+        var categories = indexableApi.getCategoryKeys();
 
         if (api.getDefinitionVersion() != null && api.getDefinitionVersion() != DefinitionVersion.V4) {
             throw new TechnicalDomainException("Unsupported definition version: " + api.getDefinitionVersion());
@@ -140,8 +141,8 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
         }
 
         // categories
-        if (api.getCategories() != null) {
-            for (String category : api.getCategories()) {
+        if (categories != null) {
+            for (String category : categories) {
                 doc.add(new StringField(FIELD_CATEGORIES, category, Field.Store.NO));
                 doc.add(new TextField(FIELD_CATEGORIES_SPLIT, category, Field.Store.NO));
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializer.java
@@ -206,7 +206,7 @@ public class SearchIndexInitializer implements Initializer {
                     );
                 return runApiIndexationAsync(executionContext, api, primaryOwner, indexable, executorService);
             } else {
-                indexable = apiConverter.toApiEntity(api, primaryOwner);
+                indexable = apiConverter.toApiEntity(executionContext, api, primaryOwner, null, false);
                 return runApiIndexationAsync(executionContext, api, primaryOwner, indexable, executorService);
             }
         } catch (Exception e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/ApiFixtures.java
@@ -15,11 +15,16 @@
  */
 package fixtures.repository;
 
+import fixtures.definition.ApiDefinitionFixtures;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.model.Api;
 import java.time.Instant;
+import lombok.SneakyThrows;
 
 public class ApiFixtures {
+
+    private static final GraviteeMapper GRAVITEE_MAPPER = new GraviteeMapper();
 
     private ApiFixtures() {}
 
@@ -36,5 +41,21 @@ public class ApiFixtures {
 
     public static Api anApi() {
         return BASE.build();
+    }
+
+    @SneakyThrows
+    public static Api aV2Api() {
+        return BASE
+            .definitionVersion(DefinitionVersion.V2)
+            .definition(GRAVITEE_MAPPER.writeValueAsString(ApiDefinitionFixtures.anApiV2()))
+            .build();
+    }
+
+    @SneakyThrows
+    public static Api aV4Api() {
+        return BASE
+            .definitionVersion(DefinitionVersion.V4)
+            .definition(GRAVITEE_MAPPER.writeValueAsString(ApiDefinitionFixtures.anApiV4()))
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCategoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCategoryQueryServiceInMemory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
+import io.gravitee.apim.core.category.model.Category;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ApiCategoryQueryServiceInMemory implements ApiCategoryQueryService, InMemoryAlternative<Category> {
+
+    final List<Category> storage;
+
+    public ApiCategoryQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    @Override
+    public Collection<String> findApiCategoryKeys(Api api) {
+        var categoriesIds = api.getCategories();
+        if (categoriesIds == null || categoriesIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return storage
+            .stream()
+            .filter(category -> categoriesIds.contains(category.getId()) || categoriesIds.contains(category.getKey()))
+            .map(Category::getKey)
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public void initWith(List<Category> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Category> storage() {
+        return storage;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -16,6 +16,7 @@
 package inmemory.spring;
 
 import inmemory.*;
+import io.gravitee.apim.infra.query_service.api.ApiCategoryQueryServiceImpl;
 import io.gravitee.apim.infra.query_service.audit.AuditEventQueryServiceImpl;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
@@ -247,5 +248,10 @@ public class InMemoryConfiguration {
     @Bean
     public IntegrationAgentInMemory integrationAgent() {
         return new IntegrationAgentInMemory();
+    }
+
+    @Bean
+    public ApiCategoryQueryServiceInMemory apiCategoryQueryService() {
+        return new ApiCategoryQueryServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainServiceTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.MembershipFixtures;
+import fixtures.core.model.MetadataFixtures;
+import inmemory.ApiCategoryQueryServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.core.search.Indexer;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiIndexerDomainServiceTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String API_ID = "api-id";
+    private static final String USER_ID = "user-id";
+    private static final PrimaryOwnerEntity PRIMARY_OWNER = new PrimaryOwnerEntity(
+        USER_ID,
+        "jane.doe@gravitee.io",
+        "Jane Doe",
+        PrimaryOwnerEntity.Type.USER
+    );
+
+    ApiCategoryQueryServiceInMemory apiCategoryQueryService = new ApiCategoryQueryServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    ApiIndexerDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        service =
+            new ApiIndexerDomainService(
+                new ApiMetadataDecoderDomainService(apiMetadataQueryService, new FreemarkerTemplateProcessor()),
+                new ApiPrimaryOwnerDomainService(
+                    null,
+                    new GroupQueryServiceInMemory(),
+                    null,
+                    membershipQueryService,
+                    roleQueryService,
+                    userCrudService
+                ),
+                apiCategoryQueryService,
+                null
+            );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION_ID);
+    }
+
+    @Nested
+    class ToIndexableApi {
+
+        @Test
+        void should_build_indexable_api_from_api_provided() {
+            Api apiToIndex = givenApi(ApiFixtures.aProxyApiV4());
+            var result = service.toIndexableApi(apiToIndex, PRIMARY_OWNER);
+
+            assertThat(result).extracting(IndexableApi::getApi).isSameAs(apiToIndex);
+        }
+
+        @Test
+        void should_build_indexable_api_with_decoded_metadata() {
+            Api apiToIndex = givenApi(ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build());
+            givenApiMetadata(
+                MetadataFixtures.anApiMetadata(API_ID, "api-name", "${api.name}", "my-value", "api-name", Metadata.MetadataFormat.STRING),
+                MetadataFixtures.anApiMetadata(
+                    API_ID,
+                    "support",
+                    "${(api.primaryOwner.email)!''}",
+                    "my-value",
+                    "email-support",
+                    Metadata.MetadataFormat.MAIL
+                )
+            );
+
+            var result = service.toIndexableApi(apiToIndex, PRIMARY_OWNER);
+
+            assertThat(result)
+                .extracting(IndexableApi::getDecodedMetadata)
+                .isEqualTo(Map.ofEntries(Map.entry("api-name", apiToIndex.getName()), Map.entry("support", PRIMARY_OWNER.email())));
+        }
+
+        @Test
+        void should_build_indexable_api_with_categories() {
+            Api apiToIndex = givenApi(
+                ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).categories(Set.of("category1", "category2")).build()
+            );
+            givenApiCategories(
+                Category.builder().id("category1").key("category-key-1").build(),
+                Category.builder().id("category2").key("category-key-2").build()
+            );
+
+            var result = service.toIndexableApi(apiToIndex, PRIMARY_OWNER);
+
+            assertThat(result).extracting(IndexableApi::getCategoryKeys).isEqualTo(Set.of("category-key-1", "category-key-2"));
+        }
+
+        @Test
+        void should_fetch_primary_owner_if_not_defined() {
+            Api apiToIndex = givenApi(
+                ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).categories(Set.of("category1", "category2")).build()
+            );
+            givenExistingUsers(
+                BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build()
+            );
+            givenExistingMembership(MembershipFixtures.anApiPrimaryOwnerUserMembership(API_ID, USER_ID, ORGANIZATION_ID));
+
+            var result = service.toIndexableApi(new Indexer.IndexationContext(ORGANIZATION_ID, ENVIRONMENT_ID), apiToIndex);
+
+            assertThat(result).extracting(IndexableApi::getPrimaryOwner).isEqualTo(PRIMARY_OWNER);
+        }
+
+        @Test
+        void should_build_indexable_api_without_primary_owner_when_fetching_fails() {
+            Api apiToIndex = givenApi(ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build());
+            givenApiMetadata(
+                MetadataFixtures.anApiMetadata(API_ID, "api-name", "${api.name}", "my-value", "api-name", Metadata.MetadataFormat.STRING),
+                MetadataFixtures.anApiMetadata(
+                    API_ID,
+                    "support",
+                    "${(api.primaryOwner.email)!''}",
+                    "my-value",
+                    "email-support",
+                    Metadata.MetadataFormat.MAIL
+                )
+            );
+
+            var result = service.toIndexableApi(new Indexer.IndexationContext(ORGANIZATION_ID, ENVIRONMENT_ID), apiToIndex);
+
+            assertThat(result)
+                .isEqualTo(
+                    new IndexableApi(
+                        apiToIndex,
+                        null,
+                        Map.ofEntries(Map.entry("api-name", apiToIndex.getName()), Map.entry("support", "")),
+                        Set.of()
+                    )
+                );
+        }
+    }
+
+    private Api givenApi(Api api) {
+        return api;
+    }
+
+    private void givenApiMetadata(ApiMetadata... metadata) {
+        apiMetadataQueryService.initWithApiMetadata(Arrays.asList(metadata));
+    }
+
+    private void givenApiCategories(Category... categories) {
+        apiCategoryQueryService.initWith(Arrays.asList(categories));
+    }
+
+    private void givenExistingUsers(BaseUserEntity... users) {
+        userCrudService.initWith(Arrays.asList(users));
+    }
+
+    private void givenExistingMembership(Membership... memberships) {
+        membershipQueryService.initWith(Arrays.asList(memberships));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.NewApiFixtures;
+import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -150,6 +151,7 @@ class CreateV4ApiUseCaseTest {
             auditService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditService),
@@ -239,7 +241,8 @@ class CreateV4ApiUseCaseTest {
                     new IndexableApi(
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
-                        Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io"))
+                        Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
+                        Collections.emptyList()
                     )
                 );
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
@@ -145,24 +145,25 @@ class CreateV4ApiUseCaseTest {
             roleQueryService,
             userCrudService
         );
-
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
         var createApiDomainService = new CreateApiDomainService(
             apiCrudService,
             auditService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditService),
-            new ApiPrimaryOwnerDomainService(
-                auditService,
-                groupQueryService,
-                membershipCrudService,
-                membershipQueryService,
-                roleQueryService,
-                userCrudService
-            ),
+            apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,
             parametersQueryService,
@@ -242,7 +243,7 @@ class CreateV4ApiUseCaseTest {
                         expectedApi,
                         new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                         Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                        Collections.emptyList()
+                        Collections.emptySet()
                     )
                 );
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.definition.ApiDefinitionFixtures;
 import fixtures.definition.FlowFixtures;
+import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiKeyCrudServiceInMemory;
 import inmemory.ApiKeyQueryServiceInMemory;
@@ -119,6 +120,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -246,6 +248,7 @@ class ImportCRDUseCaseTest {
             auditDomainService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditDomainService),
@@ -364,7 +367,8 @@ class ImportCRDUseCaseTest {
                         new IndexableApi(
                             expected,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
-                            Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io"))
+                            Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
+                            Collections.emptyList()
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.AuditInfoFixtures;
@@ -242,24 +241,26 @@ class ImportCRDUseCaseTest {
             roleQueryService,
             userCrudService
         );
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditDomainService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
 
         var createApiDomainService = new CreateApiDomainService(
             apiCrudService,
             auditDomainService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditDomainService),
-            new ApiPrimaryOwnerDomainService(
-                auditDomainService,
-                groupQueryService,
-                membershipCrudService,
-                membershipQueryService,
-                roleQueryService,
-                userCrudService
-            ),
+            apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,
             parametersQueryService,
@@ -368,7 +369,7 @@ class ImportCRDUseCaseTest {
                             expected,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
-                            Collections.emptyList()
+                            Collections.emptySet()
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DiscoverIntegrationAssetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DiscoverIntegrationAssetUseCaseTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.IntegrationAssetFixtures;
 import fixtures.core.model.IntegrationFixture;
+import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -155,6 +156,7 @@ class DiscoverIntegrationAssetUseCaseTest {
             auditDomainService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditDomainService),
@@ -249,7 +251,8 @@ class DiscoverIntegrationAssetUseCaseTest {
                         new IndexableApi(
                             expectedApi,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
-                            Map.of()
+                            Map.of(),
+                            Collections.emptyList()
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DiscoverIntegrationAssetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DiscoverIntegrationAssetUseCaseTest.java
@@ -150,24 +150,25 @@ class DiscoverIntegrationAssetUseCaseTest {
             roleQueryService,
             userCrudService
         );
-
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditDomainService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
         var createApiDomainService = new CreateApiDomainService(
             apiCrudService,
             auditDomainService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditDomainService),
-            new ApiPrimaryOwnerDomainService(
-                auditDomainService,
-                groupQueryService,
-                membershipCrudService,
-                membershipQueryService,
-                roleQueryService,
-                userCrudService
-            ),
+            apiPrimaryOwnerDomainService,
             new FlowCrudServiceInMemory(),
             notificationConfigCrudService,
             parametersQueryService,
@@ -252,7 +253,7 @@ class DiscoverIntegrationAssetUseCaseTest {
                             expectedApi,
                             new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
                             Map.of(),
-                            Collections.emptyList()
+                            Collections.emptySet()
                         )
                     );
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiCategoryQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiCategoryQueryServiceImplTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.CategoryRepository;
+import io.gravitee.repository.management.model.Category;
+import jakarta.validation.constraints.Null;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiCategoryQueryServiceImplTest {
+
+    private static final String CATEGORY_ID_2 = "category2";
+    private static final String CATEGORY_ID_1 = "category1";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final Api API = ApiFixtures
+        .aProxyApiV4()
+        .toBuilder()
+        .environmentId(ENVIRONMENT_ID)
+        .categories(Set.of(CATEGORY_ID_1, CATEGORY_ID_2))
+        .build();
+
+    @Mock
+    CategoryRepository categoryRepository;
+
+    ApiCategoryQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiCategoryQueryServiceImpl(categoryRepository);
+    }
+
+    @Nested
+    class FindApiCategoryKeys {
+
+        @Test
+        @SneakyThrows
+        void should_query_only_categories_of_given_api() {
+            // when
+            service.findApiCategoryKeys(API);
+
+            // then
+            verify(categoryRepository).findAllByEnvironment(ENVIRONMENT_ID);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_category_keys() {
+            // given
+            // Uncomment when https://gravitee.atlassian.net/browse/APIM-4437 is fixed
+            //            when(categoryRepository.findByEnvironmentIdAndIdIn(any(), any()))
+            //                .thenAnswer(invocation -> {
+            //                    Set<String> categoryIds = invocation.getArgument(1);
+            //
+            //                    return categoryIds
+            //                        .stream()
+            //                        .map(categoryId -> Category.builder().id(categoryId).key("key-" + categoryId).build())
+            //                        .collect(Collectors.toSet());
+            //                });
+
+            when(categoryRepository.findAllByEnvironment(ENVIRONMENT_ID))
+                .thenAnswer(invocation -> {
+                    return Set.of(
+                        Category.builder().id(CATEGORY_ID_1).key("key-" + CATEGORY_ID_1).build(),
+                        Category.builder().id(CATEGORY_ID_2).key("key-" + CATEGORY_ID_2).build()
+                    );
+                });
+
+            // when
+            var categories = service.findApiCategoryKeys(API);
+
+            // then
+            Assertions.assertThat(categories).containsExactlyInAnyOrder("key-" + CATEGORY_ID_1, "key-" + CATEGORY_ID_2);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @SneakyThrows
+        void should_return_empty_list_when_api_has_no_category_defined(Set<String> categoryIds) {
+            // when
+            var categories = service.findApiCategoryKeys(API.toBuilder().categories(categoryIds).build());
+
+            // then
+            Assertions.assertThat(categories).isEmpty();
+            verifyNoInteractions(categoryRepository);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_fail_to_fetch_categories() {
+            // given
+            when(categoryRepository.findAllByEnvironment(any())).thenThrow(new TechnicalException("error"));
+
+            Throwable throwable = catchThrowable(() -> service.findApiCategoryKeys(API));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessageContaining("An error occurs while trying to find Categories for the api: " + API.getId())
+                .hasCauseInstanceOf(TechnicalException.class)
+                .hasRootCauseMessage("error");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
@@ -153,6 +154,7 @@ public class V4ApiServiceCockpitTest {
             auditService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditService),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -149,23 +149,25 @@ public class V4ApiServiceCockpitTest {
             roleQueryService,
             userCrudService
         );
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
         var createApiDomainService = new CreateApiDomainService(
             apiCrudService,
             auditService,
             new ApiIndexerDomainService(
                 new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                apiPrimaryOwnerDomainService,
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
             new ApiMetadataDomainService(metadataCrudService, auditService),
-            new ApiPrimaryOwnerDomainService(
-                auditService,
-                groupQueryService,
-                membershipCrudService,
-                membershipQueryService,
-                roleQueryService,
-                userCrudService
-            ),
+            apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,
             parametersQueryService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SearchEngineServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
@@ -744,13 +745,8 @@ public class SearchEngineServiceTest {
         }
 
         @Bean
-        public ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService() {
-            return mock(ApiPrimaryOwnerDomainService.class);
-        }
-
-        @Bean
-        public ApiMetadataDecoderDomainService apiMetadataDecoderDomainService() {
-            return mock(ApiMetadataDecoderDomainService.class);
+        public ApiIndexerDomainService apiIndexerDomainService() {
+            return mock(ApiIndexerDomainService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -71,7 +71,7 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_transform_id_and_type_only_when_definition_version_and_name_are_null() {
         // Given
-        var indexable = new IndexableApi(Api.builder().id(API_ID).build(), PRIMARY_OWNER, Map.of());
+        var indexable = new IndexableApi(Api.builder().id(API_ID).build(), PRIMARY_OWNER, Map.of(), Set.of());
 
         // When
         var result = cut.transform(indexable);
@@ -88,9 +88,10 @@ public class IndexableApiDocumentTransformerTest {
     void should_transform_api_info() {
         // Given
         var indexable = new IndexableApi(
-            ApiFixtures.aProxyApiV4().toBuilder().labels(List.of("Label1, Label2")).categories(Set.of("Category1", "Category2")).build(),
+            ApiFixtures.aProxyApiV4().toBuilder().labels(List.of("Label1, Label2")).build(),
             PRIMARY_OWNER,
-            Map.of()
+            Map.of(),
+            Set.of("category1", "category2")
         );
 
         // When
@@ -131,11 +132,11 @@ public class IndexableApiDocumentTransformerTest {
             softly
                 .assertThat(result.getFields(FIELD_CATEGORIES))
                 .extracting(IndexableField::stringValue)
-                .contains("Category1", "Category2");
+                .contains("category1", "category2");
             softly
                 .assertThat(result.getFields(FIELD_CATEGORIES_SPLIT))
                 .extracting(IndexableField::stringValue)
-                .contains("Category1", "Category2");
+                .contains("category1", "category2");
 
             // tags
             softly.assertThat(result.getFields(FIELD_TAGS)).extracting(IndexableField::stringValue).contains("tag1");
@@ -149,7 +150,7 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_transform_primary_owner_info() {
         // Given
-        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of());
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of(), Set.of());
 
         // When
         var result = cut.transform(indexable);
@@ -166,7 +167,12 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_transform_api_metadata() {
         // Given
-        var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of("metadata1", "value1", "metadata2", "value2"));
+        var indexable = new IndexableApi(
+            ApiFixtures.aProxyApiV4(),
+            PRIMARY_OWNER,
+            Map.of("metadata1", "value1", "metadata2", "value2"),
+            Set.of()
+        );
 
         // When
         var result = cut.transform(indexable);
@@ -181,7 +187,7 @@ public class IndexableApiDocumentTransformerTest {
     @Test
     void should_throw_when_not_V4_api() {
         // Given
-        var indexable = new IndexableApi(ApiFixtures.aProxyApiV2(), PRIMARY_OWNER, Map.of());
+        var indexable = new IndexableApi(ApiFixtures.aProxyApiV2(), PRIMARY_OWNER, Map.of(), Set.of());
 
         // When
         var throwable = catchThrowable(() -> cut.transform(indexable));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/SearchIndexInitializerTest.java
@@ -254,7 +254,7 @@ public class SearchIndexInitializerTest {
                             new IndexableApi(invocation.getArgument(1), null, Collections.emptyMap(), Collections.emptyList())
                         );
                 } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {
-                    when(apiConverter.toApiEntity(same(api), any()))
+                    when(apiConverter.toApiEntity(any(), same(api), any(), eq(null), eq(false)))
                         .thenReturn(
                             ApiEntity.builder().id(api.getId()).referenceId(api.getEnvironmentId()).referenceType("ENVIRONMENT").build()
                         );


### PR DESCRIPTION
## Description

At startup, an initializer triggers an indexation for all Database APIs. Unfortunately, this initializer was not "adapting" API like the regular indexation happening when creating/updating API.

This PR brings a change to use the same adaptation logic for indexation for V4 API.
For V2, I only fixed something related to categories indexation.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fhonsfdald.chromatic.com)
<!-- Storybook placeholder end -->
