### PR TITLE
fix(console): use timestamp parameter in goToLog controller method in…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-log.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-log.component.ajs.ts
@@ -146,6 +146,7 @@ class ApiAnalyticsLogControllerAjs {
       relativeTo: this.activatedRoute,
       queryParams: {
         ...this.backStateParams,
+        timestamp: this.activatedRoute.snapshot.queryParams.timestamp,
       },
     });
     this.ApiService.getLog(this.activatedRoute.snapshot.params.apiId, logId, this.activatedRoute.snapshot.queryParams.timestamp).then(


### PR DESCRIPTION
… log analytics

## Issue

https://gravitee.atlassian.net/browse/APIM-4408

## Description

Added timestamp parameter in router navigation on goToLog action used to navigate to next/previous logs.

## Additional context



<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7129/console](https://pr.team-apim.gravitee.dev/7129/console)
      Portal: [https://pr.team-apim.gravitee.dev/7129/portal](https://pr.team-apim.gravitee.dev/7129/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7129/api/management](https://pr.team-apim.gravitee.dev/7129/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7129](https://pr.team-apim.gravitee.dev/7129)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7129](https://pr.gateway-v3.team-apim.gravitee.dev/7129)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tggbhbfulf.chromatic.com)
<!-- Storybook placeholder end -->
