### PR TITLE
chore(portal-next): add i18n instructions to readme

### DIFF
--- a/gravitee-apim-portal-webui-next/README.md
+++ b/gravitee-apim-portal-webui-next/README.md
@@ -18,6 +18,36 @@ Run `yarn build` to build the project. The build artifacts will be stored in the
 
 Run `yarn test` to execute the unit tests via [Jest](https://jestjs.io/).
 
+## Translations
+
+You can add your own translations to this project. 
+
+1. Run `yarn extract` to extract the source language file. 
+   - You can specify the file extension with `yarn extract --format=<format>`. Find out more about [available formats](https://angular.io/guide/i18n-common-translation-files#extract-i18n---format-example).
+2. Rename the translation file in `src/locale` to add the locale: `messages.xlf --> messages.{locale}.xlf`
+3. Complete the file with the desired translations.
+4. In the `angular.json` file, add the new local to `i18n.locales`. Example:
+```json
+{ 
+  // ...
+  "i18n": {
+    "sourceLocale": "en-US",
+    "locales": {
+      "fr": {
+        "translation": "src/locale/messages.fr.xlf"
+      }
+    }
+  },
+  // ...
+}
+```
+5. Run `yarn build:i18n` to build all translations of your app.
+6. Serve the application from the `gravitee-apim-portal-webui/dist/next/browser`. 
+   - You use a simple HTTP server to test the build with `npx http-server gravitee-apim-portal-webui/dist/next/browser`.
+7. The translations will be available via `<host>/en-US/` and for each locale specified, example: `<host>/fr/`.
+
+Find out more about [@angular/localize](https://angular.io/guide/i18n-common-translation-files).
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.

--- a/gravitee-apim-portal-webui-next/README.md
+++ b/gravitee-apim-portal-webui-next/README.md
@@ -22,6 +22,8 @@ Run `yarn test` to execute the unit tests via [Jest](https://jestjs.io/).
 
 You can add your own translations to this project. 
 
+### Manually add your translations
+
 1. Run `yarn extract` to extract the source language file. 
    - You can specify the file extension with `yarn extract --format=<format>`. Find out more about [available formats](https://angular.io/guide/i18n-common-translation-files#extract-i18n---format-example).
 2. Rename the translation file in `src/locale` to add the locale: `messages.xlf --> messages.{locale}.xlf`
@@ -45,6 +47,15 @@ You can add your own translations to this project.
 6. Serve the application from the `gravitee-apim-portal-webui/dist/next/browser`. 
    - You use a simple HTTP server to test the build with `npx http-server gravitee-apim-portal-webui/dist/next/browser`.
 7. The translations will be available via `<host>/en-US/` and for each locale specified, example: `<host>/fr/`.
+
+### Use a script to merge your translations
+
+1. Run `yarn extract` to extract the source language file.
+  - You can specify the file extension with `yarn extract --format=<format>`. Find out more about [available formats](https://angular.io/guide/i18n-common-translation-files#extract-i18n---format-example).
+2. Rename the translation file in `src/locale` to add the locale: `messages.xlf --> messages.{locale}.xlf`
+3. Complete the file with the desired translations.
+4. Run `yarn merge:i18n` to update the `angular.json` with the locale configuration and build the project. 
+5. Serve the application from the `gravitee-apim-portal-webui/dist/next/browser`.
 
 Find out more about [@angular/localize](https://angular.io/guide/i18n-common-translation-files).
 

--- a/gravitee-apim-portal-webui-next/angular.json
+++ b/gravitee-apim-portal-webui-next/angular.json
@@ -11,7 +11,8 @@
         }
       },
       "i18n": {
-        "sourceLocale": "en-US"
+        "sourceLocale": "en-US",
+        "locales": {}
       },
       "root": "",
       "sourceRoot": "src",
@@ -28,7 +29,8 @@
             "inlineStyleLanguage": "scss",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
-            "scripts": []
+            "scripts": [],
+            "i18nMissingTranslation": "warning"
           },
           "configurations": {
             "production": {

--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "build:prod": "NODE_OPTIONS=--max_old_space_size=8192 ng build --configuration production",
+    "build:i18n": "yarn build:prod --localize",
     "watch": "ng build --watch --configuration development",
     "extract": "ng extract-i18n --output-path src/locale",
     "test": "jest",

--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -9,6 +9,7 @@
     "build:i18n": "yarn build:prod --localize",
     "watch": "ng build --watch --configuration development",
     "extract": "ng extract-i18n --output-path src/locale",
+    "merge:i18n": "sh ./scripts/update_angular_json.sh && yarn build:i18n",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --runInBand",

--- a/gravitee-apim-portal-webui-next/scripts/update_angular_json.sh
+++ b/gravitee-apim-portal-webui-next/scripts/update_angular_json.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2039
+LOCALE_REGEX='^\./src/locale/messages\.(.*)\.'
+LOCALES_JSON=""
+
+shopt -s nullglob
+TRANSLATIONS=(./src/locale/messages.*.*)
+
+[[ ${#TRANSLATIONS[@]} == 0 ]] && echo "ERROR: No translations with locales found in 'src/locale'" && exit 1
+
+for file in "${TRANSLATIONS[@]}"; do
+    if [[ $LOCALES_JSON != "" ]] # No longer the first file
+    then
+      LOCALES_JSON+="," # Add comma to separate multiple locales
+    fi
+    FORMATTED_NAME=$(echo "$file" | sed 's/\.\///g') # Replace './' with ''
+    echo "Adding translation: $FORMATTED_NAME"
+    [[ $file =~ $LOCALE_REGEX ]] # Get locale from regex group
+    LOCALES_JSON+="\"${BASH_REMATCH[1]}\": { \"translation\": \"${FORMATTED_NAME}\"}"
+done
+
+# Replace i18n locales value in 'angular.json'
+jq ".projects.\"gravitee-apim-portal-webui-next\".i18n.locales = {${LOCALES_JSON}}" angular.json > angular.json.tmp && cp angular.json.tmp angular.json && rm angular.json.tmp && echo "SUCCESS: Locale configuration has been updated" || echo "ERROR: Unable to update locale configuration"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4245

## Description

Add instructions to the README so that users can know how to add translations and how to access them. 
Add simple script for merging translations into app

This is the first of multiple iterations for industrializing the i18n. Next steps in the not-so-near future:
- Create a multi-stage docker image that integrates one or multiple translation files with a simple file input

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pwtpdsqszr.chromatic.com)
<!-- Storybook placeholder end -->
