### PR TITLE
fix(portal): skip navigation when md page has no navigable elements

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.ts
@@ -65,7 +65,7 @@ export class GvPageMarkdownComponent implements OnInit, AfterViewInit {
     // Best effort to scroll to the anchor after markdown is rendered
     setTimeout(() => {
       const fragment = this.activatedRoute.snapshot.fragment;
-      if (fragment && this.pageElementsPosition && this.pageElementsPosition.map(e => e.id).includes(fragment)) {
+      if (fragment && this.pageElementsPosition?.map(e => e.id).includes(fragment)) {
         this.scrollService.scrollToAnchor(fragment);
       }
     }, 1000);
@@ -90,7 +90,7 @@ export class GvPageMarkdownComponent implements OnInit, AfterViewInit {
   @HostListener('window:scroll')
   onScroll() {
     this.processOffsets();
-    if (this.pageElementsPosition) {
+    if (this.pageElementsPosition && this.pageElementsPosition.length > 0) {
       let anchor: string;
       const currentYPosition = window.pageYOffset;
       for (let index = 0; index < this.pageElementsPosition.length && !anchor; index++) {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-4365

## Issue

https://gravitee.atlassian.net/browse/APIM-4365

## Description

When markdown documentation has no fragments to navigate (has only level 1 header or no headers at all) scroll event should not update page navigation.

## Additional context

Test steps:
1. Upload and publish MD file with either no header or only level 1 header (`#`) and long text requiring scrolling
2. Scroll this file in portal

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7144/console](https://pr.team-apim.gravitee.dev/7144/console)
      Portal: [https://pr.team-apim.gravitee.dev/7144/portal](https://pr.team-apim.gravitee.dev/7144/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7144/api/management](https://pr.team-apim.gravitee.dev/7144/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7144](https://pr.team-apim.gravitee.dev/7144)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7144](https://pr.gateway-v3.team-apim.gravitee.dev/7144)

<!-- Environment placeholder end -->
