### PR TITLE
refactor: introduce OriginContext

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
         AnalyticsMapper.class,
         DateMapper.class,
         DefinitionContextMapper.class,
+        OriginContextMapper.class,
         EndpointMapper.class,
         EntrypointMapper.class,
         FlowMapper.class,
@@ -125,10 +126,12 @@ public interface ApiMapper {
         return result;
     }
 
+    @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "listeners", qualifiedByName = "fromListeners")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
     ApiV4 mapToV4(ApiEntity apiEntity, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
+    @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
     @Mapping(target = "analytics", source = "source.apiDefinitionV4.analytics")
     @Mapping(target = "deploymentState", source = "deploymentState")
@@ -141,6 +144,7 @@ public interface ApiMapper {
     @Mapping(target = "state", source = "source.lifecycleState")
     ApiV4 mapToV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
+    @Mapping(target = "definitionContext", source = "apiEntity.originContext")
     @Mapping(target = "links", expression = "java(computeApiLinks(apiEntity, uriInfo))")
     ApiV2 mapToV2(io.gravitee.rest.api.model.api.ApiEntity apiEntity, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/OriginContextMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/OriginContextMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.KubernetesOriginContext;
+import io.gravitee.rest.api.management.v2.rest.model.ManagementOriginContext;
+import io.gravitee.rest.api.model.context.KubernetesContext;
+import io.gravitee.rest.api.model.context.ManagementContext;
+import io.gravitee.rest.api.model.context.OriginContext;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface OriginContextMapper {
+    OriginContextMapper INSTANCE = Mappers.getMapper(OriginContextMapper.class);
+
+    default io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext map(OriginContext source) {
+        if (source == null) {
+            return null;
+        }
+
+        return switch (source.getOrigin()) {
+            case MANAGEMENT -> map((ManagementContext) source);
+            case KUBERNETES -> map((KubernetesContext) source);
+        };
+    }
+
+    default OriginContext map(io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext source) {
+        if (source == null || source.getOrigin() == null) {
+            return new ManagementContext();
+        }
+        return switch (source.getOrigin()) {
+            case MANAGEMENT -> map((ManagementOriginContext) source);
+            case KUBERNETES -> map((KubernetesOriginContext) source);
+        };
+    }
+
+    ManagementOriginContext map(ManagementContext source);
+    KubernetesOriginContext map(KubernetesContext source);
+    ManagementContext map(ManagementOriginContext source);
+    KubernetesContext map(KubernetesOriginContext source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2123,6 +2123,8 @@ components:
                               - 12559b64-0b2c-4004-9300-640b2ce0047b
                           items:
                               type: string
+                      originContext:
+                          $ref: "#/components/schemas/BaseOriginContext"
                       definitionContext:
                           $ref: "#/components/schemas/DefinitionContext"
                       workflowState:
@@ -2778,9 +2780,69 @@ components:
                 endpoint:
                     type: string
                     description: The endpoint of the DLQ.
-        DefinitionContext:
+        OriginContext:
+            oneOf:
+                - $ref: "#/components/schemas/ManagementOriginContext"
+                - $ref: "#/components/schemas/KubernetesOriginContext"
+            discriminator:
+                propertyName: origin
+                mapping:
+                    MANAGEMENT: ManagementOriginContext
+                    KUBERNETES: KubernetesOriginContext
+        BaseOriginContext:
             type: object
-            description: the context where the api definition was created
+            properties:
+                origin:
+                    type: string
+                    description: The origin of the API.
+                    example: MANAGEMENT
+                    enum:
+                        - MANAGEMENT
+                        - KUBERNETES
+            discriminator:
+                propertyName: origin
+                mapping:
+                    MANAGEMENT: ManagementOriginContext
+                    KUBERNETES: KubernetesOriginContext
+        ManagementOriginContext:
+            type: object
+            title: "ManagementOriginContext"
+            description: Indicates the API has been created by the Management API
+            allOf:
+                - $ref: "#/components/schemas/BaseOriginContext"
+        KubernetesOriginContext:
+            type: object
+            title: "KubernetesOriginContext"
+            description: Indicates the API has been created by the Gravitee Kubernetes Operator
+            allOf:
+                - $ref: "#/components/schemas/BaseOriginContext"
+                - properties:
+                      mode:
+                          type: string
+                          description: |-
+                              The mode of the API.
+                              fully_managed: Mode indicating the api is fully managed by the origin and so, only the origin should be able to manage the api.
+                          example: FULLY_MANAGED
+                          enum:
+                              - FULLY_MANAGED
+                      syncFrom:
+                          type: string
+                          description: |-
+                              syncFrom stands for where the Gateway should source the API definition from. 
+                              If the value is KUBERNETES, then the gateway will sync the definition by listening to changes
+                              issued on a kubernetes config map. If the value is MANAGEMENT, then the gateway will sync
+                              the definition using the same datastore as APIM. 
+                              Defining MANAGEMENT as source for sync is useful e.g. when a single operator should operate
+                              on gateways deployed on multiple kubernetes clusters.
+                          example: MANAGEMENT
+                          enum:
+                              - MANAGEMENT
+                              - KUBERNETES
+
+        DefinitionContext:
+            deprecated: true
+            type: object
+            description: the context where the api definition was created. Deprecated in favor of OriginContext.
             properties:
                 origin:
                     type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/DefinitionContextMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/DefinitionContextMapperTest.java
@@ -15,10 +15,11 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
-import static io.gravitee.definition.model.DefinitionContext.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.gravitee.rest.api.management.v2.rest.model.DefinitionContext;
+import io.gravitee.rest.api.model.context.KubernetesContext;
+import io.gravitee.rest.api.model.context.ManagementContext;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
@@ -28,12 +29,9 @@ public class DefinitionContextMapperTest {
 
     @Test
     void shouldMapDefinitionContextWithManagementOriginString() {
-        io.gravitee.definition.model.DefinitionContext definitionContext = new io.gravitee.definition.model.DefinitionContext(
-            ORIGIN_MANAGEMENT,
-            MODE_FULLY_MANAGED
-        );
+        var context = new ManagementContext();
 
-        io.gravitee.rest.api.management.v2.rest.model.DefinitionContext result = definitionContextMapper.map(definitionContext);
+        io.gravitee.rest.api.management.v2.rest.model.DefinitionContext result = definitionContextMapper.map(context);
 
         assertThat(result).isNotNull();
         assertThat(result.getOrigin()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.DefinitionContext.OriginEnum.MANAGEMENT);
@@ -42,16 +40,13 @@ public class DefinitionContextMapperTest {
 
     @Test
     void shouldMapDefinitionContextWithKubernetesOriginString() {
-        io.gravitee.definition.model.DefinitionContext definitionContext = new io.gravitee.definition.model.DefinitionContext(
-            ORIGIN_KUBERNETES,
-            MODE_API_DEFINITION_ONLY
-        );
+        var context = new KubernetesContext(KubernetesContext.Mode.FULLY_MANAGED);
 
-        io.gravitee.rest.api.management.v2.rest.model.DefinitionContext result = definitionContextMapper.map(definitionContext);
+        io.gravitee.rest.api.management.v2.rest.model.DefinitionContext result = definitionContextMapper.map(context);
 
         assertThat(result).isNotNull();
         assertThat(result.getOrigin()).isEqualTo(DefinitionContext.OriginEnum.KUBERNETES);
-        assertThat(result.getMode()).isEqualTo(DefinitionContext.ModeEnum.API_DEFINITION_ONLY);
+        assertThat(result.getMode()).isEqualTo(DefinitionContext.ModeEnum.FULLY_MANAGED);
     }
 
     @Test
@@ -61,24 +56,20 @@ public class DefinitionContextMapperTest {
         definitionContext.setOrigin(io.gravitee.rest.api.management.v2.rest.model.DefinitionContext.OriginEnum.MANAGEMENT);
         definitionContext.setMode(io.gravitee.rest.api.management.v2.rest.model.DefinitionContext.ModeEnum.FULLY_MANAGED);
 
-        io.gravitee.definition.model.DefinitionContext result = definitionContextMapper.map(definitionContext);
+        var result = definitionContextMapper.map(definitionContext);
 
-        assertThat(result).isNotNull();
-        assertThat(result.getOrigin()).isEqualTo(ORIGIN_MANAGEMENT);
-        assertThat(result.getMode()).isEqualTo(MODE_FULLY_MANAGED);
+        assertThat(result).isEqualTo(new ManagementContext());
     }
 
     @Test
     void shouldMapDefinitionContextWithKubernetesEnum() {
         io.gravitee.rest.api.management.v2.rest.model.DefinitionContext definitionContext =
             new io.gravitee.rest.api.management.v2.rest.model.DefinitionContext();
-        definitionContext.setOrigin(io.gravitee.rest.api.management.v2.rest.model.DefinitionContext.OriginEnum.MANAGEMENT);
+        definitionContext.setOrigin(DefinitionContext.OriginEnum.KUBERNETES);
         definitionContext.setMode(io.gravitee.rest.api.management.v2.rest.model.DefinitionContext.ModeEnum.FULLY_MANAGED);
 
-        io.gravitee.definition.model.DefinitionContext result = definitionContextMapper.map(definitionContext);
+        var result = definitionContextMapper.map(definitionContext);
 
-        assertThat(result).isNotNull();
-        assertThat(result.getOrigin()).isEqualTo(ORIGIN_MANAGEMENT);
-        assertThat(result.getMode()).isEqualTo(MODE_FULLY_MANAGED);
+        assertThat(result).isEqualTo(new KubernetesContext(KubernetesContext.Mode.FULLY_MANAGED));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
@@ -38,6 +38,9 @@ import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
+import io.gravitee.rest.api.model.context.KubernetesContext;
+import io.gravitee.rest.api.model.context.ManagementContext;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -284,5 +287,18 @@ public class ApiEntity implements GenericApiEntity {
             return DefinitionVersion.valueOfLabel(graviteeDefinitionVersion);
         }
         return null;
+    }
+
+    @Override
+    public OriginContext getOriginContext() {
+        if (definitionContext == null) {
+            return new ManagementContext();
+        } else if (definitionContext.isOriginKubernetes()) {
+            return new io.gravitee.rest.api.model.context.KubernetesContext(
+                KubernetesContext.Mode.valueOf(definitionContext.getMode().toUpperCase()),
+                definitionContext.getSyncFrom()
+            );
+        }
+        return new ManagementContext();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/AbstractContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/AbstractContext.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.context;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@EqualsAndHashCode
+@Getter
+public abstract class AbstractContext implements OriginContext {
+
+    private final Origin origin;
+
+    public AbstractContext(Origin origin) {
+        this.origin = origin;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/KubernetesContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/KubernetesContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.context;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * This context tells that the API has been created by the Kubernetes Operator.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class KubernetesContext extends AbstractContext {
+
+    private final Mode mode;
+    private final String syncFrom;
+
+    public KubernetesContext(Mode mode) {
+        this(mode, Origin.KUBERNETES.name());
+    }
+
+    public KubernetesContext(Mode mode, String syncFrom) {
+        super(Origin.KUBERNETES);
+        this.mode = mode;
+        this.syncFrom = syncFrom;
+    }
+
+    public enum Mode {
+        /** Mode indicating the api is fully managed by the origin and so, only the origin should be able to manage the api. */
+        FULLY_MANAGED,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/ManagementContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/ManagementContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.context;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * This context tells that the API has been created with the management API.
+ */
+@Builder
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString
+public class ManagementContext extends AbstractContext {
+
+    public ManagementContext() {
+        super(Origin.MANAGEMENT);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/OriginContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/context/OriginContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.context;
+
+/**
+ * Context explaining where an API comes from.
+ */
+public interface OriginContext {
+    Origin getOrigin();
+
+    default boolean isOriginManagement() {
+        return getOrigin() == Origin.MANAGEMENT;
+    }
+
+    default boolean isOriginKubernetes() {
+        return getOrigin() == Origin.KUBERNETES;
+    }
+
+    default boolean isManagement(String value) {
+        return Origin.MANAGEMENT.name().equalsIgnoreCase(value);
+    }
+
+    default boolean isKubernetes(String value) {
+        return Origin.KUBERNETES.name().equalsIgnoreCase(value);
+    }
+
+    enum Origin {
+        MANAGEMENT,
+        KUBERNETES,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -35,6 +35,8 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.context.ManagementContext;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
@@ -182,6 +184,10 @@ public class ApiEntity implements GenericApiEntity {
     @Schema(description = "the context where the api definition was created from")
     @Builder.Default
     private DefinitionContext definitionContext = new DefinitionContext();
+
+    /** Context explaining where the API comes from. */
+    @Builder.Default
+    private OriginContext originContext = new ManagementContext();
 
     @JsonIgnore
     @Builder.Default

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -181,10 +181,6 @@ public class ApiEntity implements GenericApiEntity {
     @Schema(description = "the free list of labels associated with this API", example = "json, read_only, awesome")
     private List<String> labels;
 
-    @Schema(description = "the context where the api definition was created from")
-    @Builder.Default
-    private DefinitionContext definitionContext = new DefinitionContext();
-
     /** Context explaining where the API comes from. */
     @Builder.Default
     private OriginContext originContext = new ManagementContext();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.search.Indexable;
 import java.util.Date;
 import java.util.List;
@@ -69,7 +70,7 @@ public interface GenericApiEntity extends Indexable {
 
     Set<String> getCategories();
 
-    DefinitionContext getDefinitionContext();
+    OriginContext getOriginContext();
 
     WorkflowState getWorkflowState();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -68,12 +68,6 @@ public class Api {
     private OriginContext originContext = new ManagementContext();
 
     /**
-     * the API definition context.
-     */
-    @Builder.Default
-    private DefinitionContext definitionContext = new DefinitionContext();
-
-    /**
      * The api definition version.
      */
     private DefinitionVersion definitionVersion;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -20,6 +20,8 @@ import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.rest.api.model.context.ManagementContext;
+import io.gravitee.rest.api.model.context.OriginContext;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
@@ -60,6 +62,10 @@ public class Api {
      * The api version.
      */
     private String version;
+
+    /** Context explaining where the API comes from. */
+    @Builder.Default
+    private OriginContext originContext = new ManagementContext();
 
     /**
      * the API definition context.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -42,6 +42,7 @@ public class ApiWithFlows extends Api {
             api.getName(),
             api.getDescription(),
             api.getVersion(),
+            api.getOriginContext(),
             api.getDefinitionContext(),
             api.getDefinitionVersion(),
             api.getApiDefinitionV4(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -43,7 +43,6 @@ public class ApiWithFlows extends Api {
             api.getDescription(),
             api.getVersion(),
             api.getOriginContext(),
-            api.getDefinitionContext(),
             api.getDefinitionVersion(),
             api.getApiDefinitionV4(),
             api.getApiDefinition(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCase.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.context.KubernetesContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
 import java.util.Map;
@@ -173,7 +174,12 @@ public class ImportCRDUseCase {
             var api = apiCrudService.update(
                 updated
                     .toBuilder()
-                    .definitionContext(input.crd().getDefinitionContext())
+                    .originContext(
+                        new KubernetesContext(
+                            KubernetesContext.Mode.valueOf(input.crd().getDefinitionContext().getMode().toUpperCase()),
+                            input.crd().getDefinitionContext().getSyncFrom()
+                        )
+                    )
                     .lifecycleState(Api.LifecycleState.valueOf(input.crd().getState()))
                     .build()
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import java.io.IOException;
 import java.util.stream.Stream;
+import org.mapstruct.DecoratedWith;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
@@ -33,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Mapper(uses = { PlanAdapter.class })
+@DecoratedWith(ApiAdapterDecorator.class)
 public interface ApiAdapter {
     Logger LOGGER = LoggerFactory.getLogger(ApiAdapter.class);
     ApiAdapter INSTANCE = Mappers.getMapper(ApiAdapter.class);
@@ -45,8 +47,6 @@ public interface ApiAdapter {
 
     Stream<Api> toCoreModelStream(Stream<io.gravitee.repository.management.model.Api> source);
 
-    @Mapping(target = "mode", source = "definitionContext.mode")
-    @Mapping(target = "origin", source = "definitionContext.origin")
     @Mapping(target = "definition", expression = "java(serializeApiDefinition(source))")
     io.gravitee.repository.management.model.Api toRepository(Api source);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -39,8 +39,6 @@ public interface ApiAdapter {
     Logger LOGGER = LoggerFactory.getLogger(ApiAdapter.class);
     ApiAdapter INSTANCE = Mappers.getMapper(ApiAdapter.class);
 
-    @Mapping(target = "definitionContext.mode", source = "mode")
-    @Mapping(target = "definitionContext.origin", source = "origin")
     @Mapping(target = "apiDefinitionV4", expression = "java(deserializeApiDefinitionV4(source))")
     @Mapping(target = "apiDefinition", expression = "java(deserializeApiDefinitionV2(source))")
     Api toCoreModel(io.gravitee.repository.management.model.Api source);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapterDecorator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapterDecorator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.context.KubernetesContext;
+import io.gravitee.rest.api.model.context.ManagementContext;
+import io.gravitee.rest.api.model.context.OriginContext;
+
+public abstract class ApiAdapterDecorator implements ApiAdapter {
+
+    private final ApiAdapter delegate;
+
+    public ApiAdapterDecorator(ApiAdapter delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Api toRepository(io.gravitee.apim.core.api.model.Api source) {
+        var api = delegate.toRepository(source);
+
+        switch (source.getOriginContext().getOrigin()) {
+            case MANAGEMENT -> {
+                api.setOrigin(OriginContext.Origin.MANAGEMENT.name().toLowerCase());
+            }
+            case KUBERNETES -> {
+                api.setOrigin(OriginContext.Origin.KUBERNETES.name().toLowerCase());
+                api.setMode(((KubernetesContext) source.getOriginContext()).getMode().name().toLowerCase());
+            }
+        }
+
+        return api;
+    }
+
+    @Override
+    public io.gravitee.apim.core.api.model.Api toCoreModel(Api source) {
+        var api = delegate.toCoreModel(source);
+
+        OriginContext.Origin origin;
+        try {
+            if (source.getOrigin() == null) {
+                origin = OriginContext.Origin.MANAGEMENT;
+            } else {
+                origin = OriginContext.Origin.valueOf(source.getOrigin().toUpperCase());
+            }
+        } catch (IllegalArgumentException e) {
+            origin = OriginContext.Origin.MANAGEMENT;
+        }
+
+        switch (origin) {
+            case MANAGEMENT -> {
+                api.setOriginContext(new ManagementContext());
+            }
+            case KUBERNETES -> {
+                api.setOriginContext(new KubernetesContext(KubernetesContext.Mode.valueOf(source.getMode().toUpperCase())));
+            }
+        }
+
+        return api;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -200,8 +200,8 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
                 });
         }
 
-        if (api.getDefinitionContext() != null && api.getDefinitionContext().getOrigin() != null) {
-            doc.add(new StringField(FIELD_ORIGIN, api.getDefinitionContext().getOrigin(), Field.Store.NO));
+        if (api.getOriginContext() != null && api.getOriginContext().getOrigin() != null) {
+            doc.add(new StringField(FIELD_ORIGIN, api.getOriginContext().getOrigin().name().toLowerCase(), Field.Store.NO));
         }
 
         return doc;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -173,8 +173,8 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
                 });
         }
 
-        if (api.getDefinitionContext() != null && api.getDefinitionContext().getOrigin() != null) {
-            doc.add(new StringField(FIELD_ORIGIN, api.getDefinitionContext().getOrigin(), Field.Store.NO));
+        if (api.getOriginContext() != null && api.getOriginContext().getOrigin() != null) {
+            doc.add(new StringField(FIELD_ORIGIN, api.getOriginContext().getOrigin().name().toLowerCase(), Field.Store.NO));
         }
 
         return doc;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiIdsCalculatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiIdsCalculatorServiceImpl.java
@@ -191,8 +191,8 @@ public class ApiIdsCalculatorServiceImpl implements ApiIdsCalculatorService {
 
     private boolean canRecalculateIds(ExportApiEntity api) {
         // If the definition is managed by kubernetes, do not try to recalculate ids because k8s is the source of truth.
-        final DefinitionContext definitionContext = api.getApiEntity().getDefinitionContext();
-        return !DefinitionContext.ORIGIN_KUBERNETES.equalsIgnoreCase(definitionContext != null ? definitionContext.getOrigin() : null);
+        var originContext = api.getApiEntity().getOriginContext();
+        return !originContext.isOriginKubernetes();
     }
 
     private ExportApiEntity generateEmptyIdsForPlansAndPages(ExportApiEntity toRecalculate) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -249,7 +249,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         repositoryApi.setUpdatedAt(repositoryApi.getCreatedAt());
 
         repositoryApi.setApiLifecycleState(ApiLifecycleState.CREATED);
-        if (apiEntity.getDefinitionContext().isOriginManagement()) {
+        if (apiEntity.getOriginContext().isOriginManagement()) {
             repositoryApi.setLifecycleState(LifecycleState.STOPPED);
         } else {
             repositoryApi.setLifecycleState(LifecycleState.valueOf(apiEntity.getState().name()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -394,7 +394,7 @@ public class ApiStateServiceImpl implements ApiStateService {
     public boolean isSynchronized(ExecutionContext executionContext, GenericApiEntity genericApiEntity) {
         try {
             // The state of the api is managed by kubernetes. There is no synchronization allowed from management.
-            if (genericApiEntity.getDefinitionContext().isOriginKubernetes()) {
+            if (genericApiEntity.getOriginContext().isOriginKubernetes()) {
                 return true;
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -21,7 +21,6 @@ import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.property.Property;
@@ -96,7 +95,6 @@ public class ApiMapper {
     public ApiEntity toEntity(final Api api, final PrimaryOwnerEntity primaryOwner) {
         ApiEntity apiEntity = new ApiEntity();
 
-        apiEntity.setDefinitionContext(new DefinitionContext(api.getOrigin(), api.getMode()));
         apiEntity.setId(api.getId());
         apiEntity.setCrossId(api.getCrossId());
         apiEntity.setName(api.getName());
@@ -360,11 +358,6 @@ public class ApiMapper {
         }
         if (apiEntity.getState() != null) {
             repoApi.setLifecycleState(LifecycleState.valueOf(apiEntity.getState().name()));
-        }
-
-        if (apiEntity.getDefinitionContext() != null) {
-            repoApi.setMode(apiEntity.getDefinitionContext().getMode());
-            repoApi.setOrigin(apiEntity.getDefinitionContext().getOrigin());
         }
 
         switch (apiEntity.getOriginContext().getOrigin()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/assertions/ApiAssert.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/assertions/ApiAssert.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.context.OriginContext;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.AbstractObjectAssert;
@@ -165,6 +166,14 @@ public class ApiAssert extends AbstractObjectAssert<ApiAssert, Api> {
         isNotNull();
         if (!actual.getDefinitionContext().equals(definitionContext)) {
             failWithMessage("Expected api definition context to be <%s> but was <%s>", definitionContext, actual.getDefinitionContext());
+        }
+        return this;
+    }
+
+    public ApiAssert hasOriginContext(OriginContext originContext) {
+        isNotNull();
+        if (!actual.getOriginContext().equals(originContext)) {
+            failWithMessage("Expected api origin context to be <%s> but was <%s>", originContext, actual.getOriginContext());
         }
         return this;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/assertions/ApiAssert.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/assertions/ApiAssert.java
@@ -162,14 +162,6 @@ public class ApiAssert extends AbstractObjectAssert<ApiAssert, Api> {
         return this;
     }
 
-    public ApiAssert hasDefinitionContext(DefinitionContext definitionContext) {
-        isNotNull();
-        if (!actual.getDefinitionContext().equals(definitionContext)) {
-            failWithMessage("Expected api definition context to be <%s> but was <%s>", definitionContext, actual.getDefinitionContext());
-        }
-        return this;
-    }
-
     public ApiAssert hasOriginContext(OriginContext originContext) {
         isNotNull();
         if (!actual.getOriginContext().equals(originContext)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.rest.api.model.context.ManagementContext;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
@@ -62,6 +63,7 @@ public class ApiFixtures {
             .categories(Set.of("category-1"))
             .labels(List.of("label-1"))
             .disableMembershipNotifications(true)
+            .originContext(new ManagementContext())
             .background("api-background");
 
     public static Api aProxyApiV4() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -67,7 +67,6 @@ class ApiAdapterTest {
                 soft.assertThat(api.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
-                soft.assertThat(api.getDefinitionContext()).isEqualTo(new DefinitionContext("management", "fully_managed"));
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
                 soft.assertThat(api.getApiDefinition()).isNull();
                 soft
@@ -145,7 +144,6 @@ class ApiAdapterTest {
                 soft.assertThat(api.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
-                soft.assertThat(api.getDefinitionContext()).isEqualTo(new DefinitionContext("management", "fully_managed"));
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
                 soft.assertThat(api.getApiDefinition()).isNull();
                 soft.assertThat(api.getApiDefinitionV4()).isNull();
@@ -178,7 +176,6 @@ class ApiAdapterTest {
                 soft.assertThat(api.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
-                soft.assertThat(api.getDefinitionContext()).isEqualTo(new DefinitionContext("management", "fully_managed"));
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V2);
                 soft.assertThat(api.getApiDefinitionV4()).isNull();
                 soft
@@ -214,7 +211,6 @@ class ApiAdapterTest {
                 soft.assertThat(api.getCrossId()).isEqualTo("cross-id");
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
-                soft.assertThat(api.getDefinitionContext()).isEqualTo(new DefinitionContext("management", "fully_managed"));
                 soft.assertThat(api.getDefinitionVersion()).isNull();
                 soft.assertThat(api.getApiDefinitionV4()).isNull();
                 soft.assertThat(api.getApiDefinition()).isNull();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -103,6 +103,12 @@ public class ApiCrudServiceImplTest {
     @Nested
     class Update {
 
+        @BeforeEach
+        @SneakyThrows
+        void setUp() {
+            when(apiRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        }
+
         @Test
         @SneakyThrows
         void should_update_an_existing_v4_api() {
@@ -131,7 +137,6 @@ public class ApiCrudServiceImplTest {
                         .apiLifecycleState(ApiLifecycleState.PUBLISHED)
                         .lifecycleState(LifecycleState.STARTED)
                         .visibility(Visibility.PUBLIC)
-                        .mode("fully_managed")
                         .origin("management")
                         .background("api-background")
                         .picture("api-picture")
@@ -155,8 +160,8 @@ public class ApiCrudServiceImplTest {
         @Test
         @SneakyThrows
         void should_update_an_existing_v2_api() {
-            var plan = ApiFixtures.aProxyApiV2();
-            service.update(plan);
+            var api = ApiFixtures.aProxyApiV2();
+            service.update(api);
 
             var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.Api.class);
             verify(apiRepository).update(captor.capture());
@@ -175,7 +180,6 @@ public class ApiCrudServiceImplTest {
                         .apiLifecycleState(ApiLifecycleState.PUBLISHED)
                         .lifecycleState(LifecycleState.STARTED)
                         .visibility(Visibility.PUBLIC)
-                        .mode("fully_managed")
                         .origin("management")
                         .background("api-background")
                         .picture("api-picture")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiDuplicateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiDuplicateServiceImplTest.java
@@ -276,7 +276,7 @@ public class ApiDuplicateServiceImplTest {
             .hasPictureUrl(sourceApi.getPictureUrl())
             .hasOnlyCategories(sourceApi.getCategories())
             .hasOnlyLabels(sourceApi.getLabels())
-            .hasDefinitionContext(sourceApi.getDefinitionContext())
+            .hasOriginContext(sourceApi.getOriginContext())
             .hasOnlyMetadataKeys(sourceApi.getMetadata().keySet())
             .hasDisableMembershipNotifications(sourceApi.isDisableMembershipNotifications())
             .hasBackground(sourceApi.getBackground())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiIdsCalculatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiIdsCalculatorServiceImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.rest.api.model.PageEntity;
+import io.gravitee.rest.api.model.context.KubernetesContext;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.ExportApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
@@ -386,11 +387,7 @@ class ApiIdsCalculatorServiceImplTest {
                 .filter(page -> page.getId() != null && !page.getId().isEmpty())
                 .collect(Collectors.toMap(PageEntity::getName, PageEntity::getId));
 
-            toRecalculate
-                .getApiEntity()
-                .setDefinitionContext(
-                    new DefinitionContext(DefinitionContext.ORIGIN_KUBERNETES, DefinitionContext.MODE_API_DEFINITION_ONLY)
-                );
+            toRecalculate.getApiEntity().setOriginContext(new KubernetesContext(KubernetesContext.Mode.FULLY_MANAGED));
             final ExecutionContext executionContext = new ExecutionContext("default", "default");
             final ExportApiEntity result = cut.recalculateApiDefinitionIds(executionContext, toRecalculate);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -101,6 +101,7 @@ import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
+import io.gravitee.rest.api.model.context.ManagementContext;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -1160,8 +1161,7 @@ public class ApiServiceImplTest {
         apiEntity.setType(ApiType.PROXY);
         apiEntity.setVisibility(Visibility.PUBLIC);
 
-        DefinitionContext context = new DefinitionContext();
-        apiEntity.setDefinitionContext(context);
+        apiEntity.setOriginContext(new ManagementContext());
         PrimaryOwnerEntity primaryOwnerEntity = new PrimaryOwnerEntity();
         primaryOwnerEntity.setId(USER_NAME);
         primaryOwnerEntity.setType("USER");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EventLatestRepository;
 import io.gravitee.rest.api.model.EventEntity;
 import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.context.ManagementContext;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.*;
@@ -187,7 +188,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setId("apiId");
         apiEntity.setName("Api name");
-        apiEntity.setDefinitionContext(new DefinitionContext());
+        apiEntity.setOriginContext(new ManagementContext());
 
         EventEntity eventEntity = new EventEntity();
         eventEntity.setType(EventType.PUBLISH_API);
@@ -338,7 +339,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setId("apiId");
         apiEntity.setName("Api name");
-        apiEntity.setDefinitionContext(new DefinitionContext());
+        apiEntity.setOriginContext(new ManagementContext());
 
         EventEntity eventEntity = new EventEntity();
         eventEntity.setType(EventType.PUBLISH_API);
@@ -389,7 +390,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         apiEntity.setId("apiId");
         apiEntity.setName("Api name");
         apiEntity.setDeployedAt(nowDate);
-        apiEntity.setDefinitionContext(new DefinitionContext());
+        apiEntity.setOriginContext(new ManagementContext());
 
         EventEntity eventEntity = new EventEntity();
         eventEntity.setType(EventType.PUBLISH_API);
@@ -450,7 +451,7 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
         apiEntity.setId("apiId");
         apiEntity.setName("Api name");
         apiEntity.setDeployedAt(nowDate);
-        apiEntity.setDefinitionContext(new DefinitionContext());
+        apiEntity.setOriginContext(new ManagementContext());
 
         EventEntity eventEntity = new EventEntity();
         eventEntity.setType(EventType.PUBLISH_API);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/assertions/ApiEntityAssert.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/assertions/ApiEntityAssert.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.List;
@@ -293,6 +294,14 @@ public class ApiEntityAssert extends AbstractObjectAssert<ApiEntityAssert, ApiEn
             failWithMessage(assertjErrorMessage, labels, actual.getLabels());
         }
 
+        return this;
+    }
+
+    public ApiEntityAssert hasOriginContext(OriginContext originContext) {
+        isNotNull();
+        if (!actual.getOriginContext().equals(originContext)) {
+            failWithMessage("Expected api origin context to be <%s> but was <%s>", originContext, actual.getOriginContext());
+        }
         return this;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/assertions/ApiEntityAssert.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/assertions/ApiEntityAssert.java
@@ -305,14 +305,6 @@ public class ApiEntityAssert extends AbstractObjectAssert<ApiEntityAssert, ApiEn
         return this;
     }
 
-    public ApiEntityAssert hasDefinitionContext(DefinitionContext definitionContext) {
-        isNotNull();
-        if (!actual.getDefinitionContext().equals(definitionContext)) {
-            failWithMessage("Expected api definition context to be <%s> but was <%s>", definitionContext, actual.getDefinitionContext());
-        }
-        return this;
-    }
-
     public ApiEntityAssert hasOnlyMetadataKeys(Set<String> metadataKeys) {
         isNotNull();
         var assertjErrorMessage = "Expecting api to have metadata:  <%s> but was: <%s>";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ApiModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/ApiModelFixtures.java
@@ -21,6 +21,7 @@ import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.rest.api.model.WorkflowState;
+import io.gravitee.rest.api.model.context.ManagementContext;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import java.util.Date;
@@ -32,12 +33,6 @@ import java.util.Set;
 public class ApiModelFixtures {
 
     private ApiModelFixtures() {}
-
-    private static final io.gravitee.definition.model.DefinitionContext.DefinitionContextBuilder BASE_MODEL_DEFINITION_CONTEXT =
-        io.gravitee.definition.model.DefinitionContext
-            .builder()
-            .origin(io.gravitee.definition.model.DefinitionContext.ORIGIN_MANAGEMENT)
-            .mode(io.gravitee.definition.model.DefinitionContext.MODE_FULLY_MANAGED);
 
     private static final io.gravitee.rest.api.model.api.ApiEntity.ApiEntityBuilder BASE_MODEL_API_V1 =
         io.gravitee.rest.api.model.api.ApiEntity
@@ -97,7 +92,7 @@ public class ApiModelFixtures {
         .pictureUrl("my-picture-url")
         .categories(Set.of("my-category1", "my-category2"))
         .labels(List.of("my-label1", "my-label2"))
-        .definitionContext(BASE_MODEL_DEFINITION_CONTEXT.build())
+        .originContext(new ManagementContext())
         .metadata(Map.of("key", "value"))
         .lifecycleState(io.gravitee.rest.api.model.api.ApiLifecycleState.CREATED)
         .workflowState(WorkflowState.REVIEW_OK)


### PR DESCRIPTION
## Description

Replace `DefinitionContext` by `OriginContext`.

With Federation, we must save the `integrationId` that created the new Federated API. It seems legit to add that in the "definitionContext". 
However, the name was unclear; with @remibaptistegio, we found this new name `OriginContext` to explain that this object will contain information related to the "origin" of the API.

This PR takes care of migrating the code to support this without changing any external interface:
- the repository stays the same
- the REST API keeps the current `definitionContext` to prevent breaking change

However, in the REST API v2, I've added the `originContext` in the API model.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ixnatbngwp.chromatic.com)
<!-- Storybook placeholder end -->
