### PR TITLE
fix: bump gravitee-node version HTTP/2 max header limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.2.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>4.8.3</gravitee-node.version>
+        <gravitee-node.version>4.8.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>2.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4468

## Description

bump gravitee-node version HTTP/2 max header limit

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ylwyghkwit.chromatic.com)
<!-- Storybook placeholder end -->
