### PR TITLE
fix(analytics): improve performance of getting applications for non admin users in analytics

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.rest.api.model.permissions.RolePermission.*;
@@ -144,11 +145,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
         if (isAdmin()) {
             return applicationService.findIdsByUser(executionContext, null);
         }
-        return applicationService
-            .findIdsByUser(executionContext, getAuthenticatedUser())
-            .stream()
-            .filter(appId -> permissionService.hasPermission(executionContext, APPLICATION_ANALYTICS, appId, READ))
-            .collect(Collectors.toSet());
+        return applicationService.findIdsByUserAndPermission(executionContext, getAuthenticatedUser(), null, APPLICATION_ANALYTICS, READ);
     }
 
     private Analytics executeStats(AnalyticsParam analyticsParam, String extraFilter) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
@@ -107,16 +108,16 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
 
     @Test
     public void should_return_analytics_when_user_not_admin_and_application_analytics() {
-        when(applicationService.findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME)).thenReturn(Set.of("app-1"));
         when(
-            permissionService.hasPermission(
+            applicationService.findIdsByUserAndPermission(
                 GraviteeContext.getExecutionContext(),
+                USER_NAME,
+                null,
                 RolePermission.APPLICATION_ANALYTICS,
-                "app-1",
                 RolePermissionAction.READ
             )
         )
-            .thenReturn(true);
+            .thenReturn(Set.of("app-1"));
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4191

## Description

The problem is that we fetch permissions for every app separately and each permission check does a few db queries.
Instead fetch all permissions at once for all apps to improve the performance.
 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

