### PR TITLE
Console: Application creation migration

### DIFF
--- a/gravitee-apim-console-webui/src/components/dialog/apiKeyMode/api-key-mode-choice-dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/components/dialog/apiKeyMode/api-key-mode-choice-dialog.controller.ts
@@ -15,7 +15,7 @@
  */
 import * as angular from 'angular';
 
-import { ApiKeyMode } from '../../../entities/application/application';
+import { ApiKeyMode } from '../../../entities/application/Application';
 
 export default class ApiKeyModeChoiceDialogController {
   constructor(private $mdDialog: angular.material.IDialogService) {}

--- a/gravitee-apim-console-webui/src/entities/application-type/ApplicationType.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/application-type/ApplicationType.fixture.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApplicationType } from './ApplicationType';
+
+export function fakeApplicationTypes(): ApplicationType[] {
+  const base: ApplicationType[] = [
+    {
+      id: 'simple',
+      name: 'Simple',
+      description: 'A hands-free application. Using this type, you will be able to define the client_id by your own.',
+      requires_redirect_uris: false,
+      allowed_grant_types: [],
+      default_grant_types: [],
+      mandatory_grant_types: [],
+    },
+    {
+      id: 'browser',
+      name: 'SPA',
+      description: 'Angular, React, Ember, ...',
+      requires_redirect_uris: true,
+      allowed_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+        {
+          type: 'implicit',
+          name: 'Implicit',
+          response_types: ['token', 'id_token'],
+        },
+      ],
+      default_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+      ],
+      mandatory_grant_types: [],
+    },
+    {
+      id: 'web',
+      name: 'Web',
+      description: 'Java, .Net, ...',
+      requires_redirect_uris: true,
+      allowed_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+        {
+          type: 'refresh_token',
+          name: 'Refresh Token',
+          response_types: [],
+        },
+        {
+          type: 'implicit',
+          name: 'Implicit (Hybrid)',
+          response_types: ['token', 'id_token'],
+        },
+      ],
+      default_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+      ],
+      mandatory_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+      ],
+    },
+    {
+      id: 'native',
+      name: 'Native',
+      description: 'iOS, Android, ...',
+      requires_redirect_uris: true,
+      allowed_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+        {
+          type: 'refresh_token',
+          name: 'Refresh Token',
+          response_types: [],
+        },
+        {
+          type: 'password',
+          name: 'Resource Owner Password',
+          response_types: [],
+        },
+        {
+          type: 'implicit',
+          name: 'Implicit (Hybrid)',
+          response_types: ['token', 'id_token'],
+        },
+      ],
+      default_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+      ],
+      mandatory_grant_types: [
+        {
+          type: 'authorization_code',
+          name: 'Authorization Code',
+          response_types: ['code'],
+        },
+      ],
+    },
+    {
+      id: 'backend_to_backend',
+      name: 'Backend to backend',
+      description: 'Machine to machine',
+      requires_redirect_uris: false,
+      allowed_grant_types: [
+        {
+          type: 'client_credentials',
+          name: 'Client Credentials',
+          response_types: [],
+        },
+      ],
+      default_grant_types: [
+        {
+          type: 'client_credentials',
+          name: 'Client Credentials',
+          response_types: [],
+        },
+      ],
+      mandatory_grant_types: [
+        {
+          type: 'client_credentials',
+          name: 'Client Credentials',
+          response_types: [],
+        },
+      ],
+    },
+  ];
+
+  return base;
+}

--- a/gravitee-apim-console-webui/src/entities/application-type/ApplicationType.ts
+++ b/gravitee-apim-console-webui/src/entities/application-type/ApplicationType.ts
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-import { DeprecatedApplicationType } from '../entities/application-type/DeprecatedApplicationType';
-
-class ApplicationTypesService {
-  constructor(
-    private $http: ng.IHttpService,
-    private Constants,
-  ) {}
-
-  getEnabledApplicationTypes(): ng.IHttpPromise<Array<DeprecatedApplicationType>> {
-    return this.$http.get(`${this.Constants.env.baseURL}/configuration/applications/types`);
-  }
+export interface ApplicationType {
+  id: string;
+  name: string;
+  description?: string;
+  configuration?: unknown;
+  default_grant_types: Array<ApplicationTypeGrantType>;
+  requires_redirect_uris: boolean;
+  allowed_grant_types: Array<ApplicationTypeGrantType>;
+  mandatory_grant_types: Array<ApplicationTypeGrantType>;
 }
-ApplicationTypesService.$inject = ['$http', 'Constants'];
 
-export default ApplicationTypesService;
+export interface ApplicationTypeGrantType {
+  type: string;
+  name: string;
+  response_types: Array<string>;
+}

--- a/gravitee-apim-console-webui/src/entities/application-type/DeprecatedApplicationType.ts
+++ b/gravitee-apim-console-webui/src/entities/application-type/DeprecatedApplicationType.ts
@@ -16,17 +16,18 @@
 
 import { indexOf } from 'lodash';
 
-export class ApplicationType {
+export class DeprecatedApplicationType {
   public name: string;
   public id: string;
   public description: string;
-  public icon: string;
-  public oauth?: any;
   public configuration: any;
   public default_grant_types: Array<any>;
   public requires_redirect_uris: boolean;
   public allowed_grant_types: Array<any>;
   public mandatory_grant_types: Array<any>;
+
+  public icon?: string;
+  public oauth?: any;
 
   constructor({ name, id, description, requires_redirect_uris, allowed_grant_types, default_grant_types, mandatory_grant_types }) {
     this.id = id;

--- a/gravitee-apim-console-webui/src/entities/application/Application.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/application/Application.fixture.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiKeyMode, Application, ApplicationType } from './application';
+import { ApiKeyMode, Application, ApplicationType } from './Application';
 
 export function fakeApplication(attributes?: Partial<Application>): Application {
   const base: Application = {

--- a/gravitee-apim-console-webui/src/entities/application/Application.ts
+++ b/gravitee-apim-console-webui/src/entities/application/Application.ts
@@ -42,6 +42,7 @@ export interface Application {
 export interface ApplicationSettings {
   app?: {
     client_id?: string;
+    type?: string;
   };
   oauth?: {
     client_id?: string;

--- a/gravitee-apim-console-webui/src/entities/application/CreateApplication.ts
+++ b/gravitee-apim-console-webui/src/entities/application/CreateApplication.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApplicationSettings } from './Application';
+
+export interface CreateApplication {
+  name: string;
+  description?: string;
+  domain?: string;
+  type?: string;
+  settings?: ApplicationSettings;
+}

--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Api, ApiPlan } from '../api';
-import { Application } from '../application/application';
+import { Application } from '../application/Application';
 import { User } from '../user/user';
 
 export type SubscriptionStatus = 'PENDING' | 'REJECTED' | 'ACCEPTED' | 'CLOSED' | 'PAUSED' | 'RESUMED';

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -42,7 +42,7 @@ import {
   PlanV4,
 } from '../../../../entities/management-api-v2';
 import { fakeApplication } from '../../../../entities/application/Application.fixture';
-import { Application } from '../../../../entities/application/application';
+import { Application } from '../../../../entities/application/Application';
 
 type ComponentInitData = {
   hasLogs: boolean;

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -46,7 +46,7 @@ import {
   Plan,
   VerifySubscription,
 } from '../../../../../../entities/management-api-v2';
-import { ApiKeyMode, Application } from '../../../../../../entities/application/application';
+import { ApiKeyMode, Application } from '../../../../../../entities/application/Application';
 import { PagedResult } from '../../../../../../entities/pagedResult';
 import { fakeApplication } from '../../../../../../entities/application/Application.fixture';
 import { SubscriptionService } from '../../../../../../services-ngx/subscription.service';

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -24,7 +24,7 @@ import { has } from 'lodash';
 
 import { CreateSubscription, Entrypoint, Plan } from '../../../../../../entities/management-api-v2';
 import { ApplicationService } from '../../../../../../services-ngx/application.service';
-import { ApiKeyMode, Application } from '../../../../../../entities/application/application';
+import { ApiKeyMode, Application } from '../../../../../../entities/application/Application';
 import { PagedResult } from '../../../../../../entities/pagedResult';
 import { Constants } from '../../../../../../entities/Constants';
 import { ConnectorPluginsV2Service } from '../../../../../../services-ngx/connector-plugins-v2.service';

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.spec.ts
@@ -46,7 +46,7 @@ import {
   VerifySubscription,
 } from '../../../../entities/management-api-v2';
 import { PagedResult } from '../../../../entities/pagedResult';
-import { Application } from '../../../../entities/application/application';
+import { Application } from '../../../../entities/application/Application';
 import { fakeApplication } from '../../../../entities/application/Application.fixture';
 import { ApiPortalSubscriptionCreationDialogHarness } from '../components/dialogs/creation/api-portal-subscription-creation-dialog.harness';
 import { PlanSecurityType } from '../../../../entities/plan';

--- a/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/application-navigation/application-navigation.component.ts
@@ -23,7 +23,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { cleanRouterLink, getPathFromRoot } from '../../../util/router-link.util';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
-import { Application } from '../../../entities/application/application';
+import { Application } from '../../../entities/application/Application';
 import { ApplicationService } from '../../../services-ngx/application.service';
 
 export interface MenuItem {

--- a/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
@@ -24,7 +24,10 @@ import { ApplicationSubscriptionComponent } from './details/subscriptions/applic
 import { ApplicationAnalyticsComponent } from './details/analytics/application-analytics.component';
 import { ApplicationLogsComponent } from './details/logs/application-logs.component';
 import { ApplicationLogComponent } from './details/logs/application-log.component';
-import { ApplicationCreationComponent } from './creation/steps/application-creation.component';
+import {
+  ApplicationCreationComponent as ApplicationCreationAjsComponent,
+  ApplicationCreationComponent,
+} from './creation/steps/application-creation.component';
 import { ApplicationSubscribeComponent } from './details/subscribe/application-subscribe.component';
 import { ApplicationGeneralMembersComponent } from './details/user-group-access/members/application-general-members.component';
 import { ApplicationGeneralGroupsComponent } from './details/user-group-access/groups/application-general-groups.component';
@@ -52,6 +55,19 @@ const applicationRoutes: Routes = [
   },
   {
     path: 'create',
+    component: ApplicationCreationAjsComponent,
+    canActivate: [PermissionGuard.checkRouteDataPermissions],
+    data: {
+      permissions: {
+        anyOf: ['environment-application-c'],
+      },
+      docs: {
+        page: 'management-create-application',
+      },
+    },
+  },
+  {
+    path: 'create-ng',
     component: ApplicationCreationComponent,
     canActivate: [PermissionGuard.checkRouteDataPermissions],
     data: {

--- a/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
@@ -52,7 +52,7 @@ const applicationRoutes: Routes = [
     },
   },
   {
-    path: 'create',
+    path: 'create-old',
     component: ApplicationCreationAjsComponent,
     canActivate: [PermissionGuard.checkRouteDataPermissions],
     data: {
@@ -65,7 +65,7 @@ const applicationRoutes: Routes = [
     },
   },
   {
-    path: 'create-ng',
+    path: 'create',
     component: ApplicationCreationComponent,
     canActivate: [PermissionGuard.checkRouteDataPermissions],
     data: {

--- a/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications-routing.module.ts
@@ -24,10 +24,7 @@ import { ApplicationSubscriptionComponent } from './details/subscriptions/applic
 import { ApplicationAnalyticsComponent } from './details/analytics/application-analytics.component';
 import { ApplicationLogsComponent } from './details/logs/application-logs.component';
 import { ApplicationLogComponent } from './details/logs/application-log.component';
-import {
-  ApplicationCreationComponent as ApplicationCreationAjsComponent,
-  ApplicationCreationComponent,
-} from './creation/steps/application-creation.component';
+import { ApplicationCreationComponent as ApplicationCreationAjsComponent } from './creation/steps/application-creation.component';
 import { ApplicationSubscribeComponent } from './details/subscribe/application-subscribe.component';
 import { ApplicationGeneralMembersComponent } from './details/user-group-access/members/application-general-members.component';
 import { ApplicationGeneralGroupsComponent } from './details/user-group-access/groups/application-general-groups.component';
@@ -35,6 +32,7 @@ import { ApplicationGeneralTransferOwnershipComponent } from './details/user-gro
 import { ApplicationGeneralComponent } from './details/general/application-general.component';
 import { ApplicationNotificationComponent } from './details/notification/application-notification.component';
 import { ApplicationSubscriptionListComponent } from './details/subscriptions/list/application-subscription-list.component';
+import { ApplicationCreationComponent } from './creation-ng/application-creation.component';
 
 import { PermissionGuard } from '../../shared/components/gio-permission/gio-permission.guard';
 

--- a/gravitee-apim-console-webui/src/management/application/components/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/components/api-key/api-keys.controller.ts
@@ -18,7 +18,7 @@ import { Observable } from 'rxjs';
 
 import NotificationService from '../../../../services/notification.service';
 import ApplicationService from '../../../../services/application.service';
-import { ApiKeyMode } from '../../../../entities/application/application';
+import { ApiKeyMode } from '../../../../entities/application/Application';
 
 class ApiKeysController {
   private subscription: any;

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
@@ -16,17 +16,23 @@
 
 -->
 
-<mat-card>
-  <mat-card-header>
-    <div class="application-creation__header">
-      <div class="application-creation__header__titles">
-        <mat-card-title>Hello applicationCreation !</mat-card-title>
-        <mat-card-subtitle>Add a description here</mat-card-subtitle>
-      </div>
-    </div>
-  </mat-card-header>
-  <mat-card-content>
-    Put your card content here ! 👀
-  </mat-card-content>
-</mat-card>
+<form [formGroup]="applicationFormGroup" (ngSubmit)="onSubmit()" gioFormFocusInvalid>
+  <mat-card>
+    <mat-card-header class="header">
+      <mat-card-title>Application creation</mat-card-title>
+      <mat-card-subtitle
+        >An application is required to subscribe to API's plan. It is the intermediate link between a user (you) and an API managed by
+        someone else.</mat-card-subtitle
+      >
+    </mat-card-header>
 
+    <mat-card-content class="content">
+      <application-creation-form
+        [applicationTypes]="applicationTypes$ | async"
+        [applicationFormGroup]="applicationFormGroup"
+      ></application-creation-form>
+    </mat-card-content>
+  </mat-card>
+
+  <gio-save-bar [creationMode]="true" [form]="applicationFormGroup"></gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
@@ -1,0 +1,32 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card>
+  <mat-card-header>
+    <div class="application-creation__header">
+      <div class="application-creation__header__titles">
+        <mat-card-title>Hello applicationCreation !</mat-card-title>
+        <mat-card-subtitle>Add a description here</mat-card-subtitle>
+      </div>
+    </div>
+  </mat-card-header>
+  <mat-card-content>
+    Put your card content here ! 👀
+  </mat-card-content>
+</mat-card>
+

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.html
@@ -27,10 +27,12 @@
     </mat-card-header>
 
     <mat-card-content class="content">
-      <application-creation-form
-        [applicationTypes]="applicationTypes$ | async"
-        [applicationFormGroup]="applicationFormGroup"
-      ></application-creation-form>
+      @if (applicationTypes$ | async; as applicationTypes) {
+        <application-creation-form
+          [applicationTypes]="applicationTypes"
+          [applicationFormGroup]="applicationFormGroup"
+        ></application-creation-form>
+      }
     </mat-card-content>
   </mat-card>
 

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.scss
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.application-creation {
+  &__header {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.scss
@@ -13,12 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.application-creation {
-  &__header {
+
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.header {
+  margin-bottom: 24px;
+}
+
+.content {
+  &__form {
     display: flex;
-    width: 100%;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 20px;
+    flex-direction: column;
+
+    &__securityTitle {
+      margin-top: 24px;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
@@ -28,7 +28,6 @@ import { fakeApplicationTypes } from '../../../entities/application-type/Applica
 import { ApplicationType } from '../../../entities/application-type/ApplicationType';
 
 describe('ApplicationCreationComponent', () => {
-  let component: ApplicationCreationComponent;
   let fixture: ComponentFixture<ApplicationCreationComponent>;
   let loader: HarnessLoader;
   let applicationCreationForm: ApplicationCreationFormHarness;
@@ -40,7 +39,6 @@ describe('ApplicationCreationComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApplicationCreationComponent);
-    component = fixture.componentInstance;
     loader = TestbedHarnessEnvironment.loader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.autoDetectChanges();
@@ -61,15 +59,20 @@ describe('ApplicationCreationComponent', () => {
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       await saveBar.clickSubmit();
 
-      expect(component.applicationPayload).toEqual({
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications`,
+      });
+      expect(req.request.body).toEqual({
         name: 'name',
         description: 'description',
         domain: 'domain',
-        type: 'SIMPLE',
-        appType: 'appType',
-        appClientId: 'appClientId',
-        oauthGrantTypes: null,
-        oauthRedirectUris: [],
+        settings: {
+          app: {
+            client_id: 'appClientId',
+            type: 'appType',
+          },
+        },
       });
     });
 
@@ -82,15 +85,21 @@ describe('ApplicationCreationComponent', () => {
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       await saveBar.clickSubmit();
 
-      expect(component.applicationPayload).toEqual({
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications`,
+      });
+      expect(req.request.body).toEqual({
         name: 'name',
         description: 'description',
         domain: 'domain',
-        type: 'WEB',
-        appType: null,
-        appClientId: null,
-        oauthGrantTypes: ['authorization_code', 'refresh_token'],
-        oauthRedirectUris: ['redirectUri'],
+        settings: {
+          oauth: {
+            application_type: 'WEB',
+            grant_types: ['authorization_code', 'refresh_token'],
+            redirect_uris: ['redirectUri'],
+          },
+        },
       });
     });
 
@@ -103,15 +112,21 @@ describe('ApplicationCreationComponent', () => {
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       await saveBar.clickSubmit();
 
-      expect(component.applicationPayload).toEqual({
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications`,
+      });
+      expect(req.request.body).toEqual({
         name: 'name',
         description: 'description',
         domain: 'domain',
-        type: 'BACKEND_TO_BACKEND',
-        appType: null,
-        appClientId: null,
-        oauthGrantTypes: ['client_credentials'],
-        oauthRedirectUris: [],
+        settings: {
+          oauth: {
+            application_type: 'BACKEND_TO_BACKEND',
+            grant_types: ['client_credentials'],
+            redirect_uris: [],
+          },
+        },
       });
     });
   });
@@ -131,15 +146,20 @@ describe('ApplicationCreationComponent', () => {
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       await saveBar.clickSubmit();
 
-      expect(component.applicationPayload).toEqual({
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications`,
+      });
+      expect(req.request.body).toEqual({
         name: 'name',
         description: 'description',
         domain: 'domain',
-        type: 'SIMPLE',
-        appType: 'appType',
-        appClientId: 'appClientId',
-        oauthGrantTypes: null,
-        oauthRedirectUris: [],
+        settings: {
+          app: {
+            client_id: 'appClientId',
+            type: 'appType',
+          },
+        },
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApplicationCreationComponent } from './application-creation.component';
+import { ApplicationCreationHarness } from './application-creation.harness';
+
+describe('ApplicationCreationComponent', () => {
+  let component: ApplicationCreationComponent;
+  let fixture: ComponentFixture<ApplicationCreationComponent>;
+  let componentHarness: ApplicationCreationHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationCreationComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationCreationComponent);
+    component = fixture.componentInstance;
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationCreationHarness);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.spec.ts
@@ -15,28 +15,107 @@
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { ApplicationCreationComponent } from './application-creation.component';
-import { ApplicationCreationHarness } from './application-creation.harness';
+import { ApplicationCreationFormHarness } from './components/application-creation-form.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { fakeApplicationTypes } from '../../../entities/application-type/ApplicationType.fixture';
 
 describe('ApplicationCreationComponent', () => {
   let component: ApplicationCreationComponent;
   let fixture: ComponentFixture<ApplicationCreationComponent>;
-  let componentHarness: ApplicationCreationHarness;
+  let loader: HarnessLoader;
+  let applicationCreationForm: ApplicationCreationFormHarness;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApplicationCreationComponent]
-    })
-    .compileComponents();
+      imports: [NoopAnimationsModule, ApplicationCreationComponent, GioTestingModule],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(ApplicationCreationComponent);
     component = fixture.componentInstance;
-    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationCreationHarness);
-    fixture.detectChanges();
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.autoDetectChanges();
+    applicationCreationForm = await loader.getHarness(ApplicationCreationFormHarness);
+
+    expectGetEnabledApplicationTypes();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should create application type=simple', async () => {
+    await applicationCreationForm.setGeneralInformation('name', 'description', 'domain');
+    await applicationCreationForm.setApplicationType('SIMPLE');
+
+    await applicationCreationForm.setSimpleApplicationType('appType', 'appClientId');
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    await saveBar.clickSubmit();
+
+    expect(component.applicationPayload).toEqual({
+      name: 'name',
+      description: 'description',
+      domain: 'domain',
+      type: 'SIMPLE',
+      appType: 'appType',
+      appClientId: 'appClientId',
+      oauthGrantTypes: null,
+      oauthRedirectUris: [],
+    });
   });
+
+  it('should create application type=web', async () => {
+    await applicationCreationForm.setGeneralInformation('name', 'description', 'domain');
+    await applicationCreationForm.setApplicationType('WEB');
+
+    await applicationCreationForm.setOAuthApplicationType(['Refresh Token'], ['redirectUri']);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    await saveBar.clickSubmit();
+
+    expect(component.applicationPayload).toEqual({
+      name: 'name',
+      description: 'description',
+      domain: 'domain',
+      type: 'WEB',
+      appType: null,
+      appClientId: null,
+      oauthGrantTypes: ['authorization_code', 'refresh_token'],
+      oauthRedirectUris: ['redirectUri'],
+    });
+  });
+
+  it('should create application type=BACKEND_TO_BACKEND', async () => {
+    await applicationCreationForm.setGeneralInformation('name', 'description', 'domain');
+    await applicationCreationForm.setApplicationType('BACKEND_TO_BACKEND');
+
+    expect(await applicationCreationForm.getOauthRedirectUrisInput()).toEqual(null);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    await saveBar.clickSubmit();
+
+    expect(component.applicationPayload).toEqual({
+      name: 'name',
+      description: 'description',
+      domain: 'domain',
+      type: 'BACKEND_TO_BACKEND',
+      appType: null,
+      appClientId: null,
+      oauthGrantTypes: ['client_credentials'],
+      oauthRedirectUris: [],
+    });
+  });
+
+  function expectGetEnabledApplicationTypes() {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `${CONSTANTS_TESTING.env.baseURL}/configuration/applications/types`,
+    });
+    req.flush(fakeApplicationTypes());
+  }
 });

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
@@ -87,6 +88,12 @@ export class ApplicationCreationComponent implements OnInit {
         };
       }),
     ),
+    tap((types) => {
+      // If there is only one type available, select it by default
+      if (types.length === 1) {
+        this.applicationFormGroup.get('type').setValue(types[0].id.toUpperCase());
+      }
+    }),
   );
 
   public applicationPayload: unknown;

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+
+
+@Component({
+  selector: 'application-creation',
+  templateUrl: './application-creation.component.html',
+  styleUrls: ['./application-creation.component.scss'],
+  imports: [CommonModule, MatCardModule],
+  standalone: true,
+})
+export class ApplicationCreationComponent {}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.component.ts
@@ -14,15 +14,87 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
+import { map } from 'rxjs/operators';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
+import { ApplicationCreationFormComponent, ApplicationForm } from './components/application-creation-form.component';
+
+import { ApplicationTypesService } from '../../../services-ngx/application-types.service';
+
+const TYPES_INFOS = {
+  SIMPLE: {
+    title: 'Simple',
+    subtitle: 'A hands-free application. Using this type, you will be able to define the client_id by your own',
+    icon: 'gio:hand',
+  },
+  BROWSER: {
+    title: 'SPA',
+    subtitle: 'Angular, React, Ember, ...',
+    icon: 'gio:laptop',
+  },
+  WEB: {
+    title: 'Web',
+    subtitle: 'Java, .Net, ...',
+    icon: 'gio:language',
+  },
+  NATIVE: {
+    title: 'Native',
+    subtitle: 'iOS, Android, ...',
+    icon: 'gio:tablet-device',
+  },
+  BACKEND_TO_BACKEND: {
+    title: 'Backend to backend',
+    subtitle: 'Machine to machine',
+    icon: 'gio:share-2',
+  },
+};
 
 @Component({
   selector: 'application-creation',
-  templateUrl: './application-creation.component.html',
-  styleUrls: ['./application-creation.component.scss'],
-  imports: [CommonModule, MatCardModule],
+  imports: [CommonModule, ReactiveFormsModule, MatCardModule, ApplicationCreationFormComponent, GioSaveBarModule],
   standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrls: ['./application-creation.component.scss'],
+  templateUrl: './application-creation.component.html',
 })
-export class ApplicationCreationComponent {}
+export class ApplicationCreationComponent implements OnInit {
+  public applicationFormGroup = new FormGroup<ApplicationForm>({
+    name: new FormControl(undefined, Validators.required),
+    description: new FormControl(),
+    domain: new FormControl(),
+    type: new FormControl(undefined, Validators.required),
+
+    appType: new FormControl(),
+    appClientId: new FormControl(),
+
+    oauthGrantTypes: new FormControl(),
+    oauthRedirectUris: new FormControl([]),
+  });
+
+  public applicationTypes$ = this.applicationTypesService.getEnabledApplicationTypes().pipe(
+    map((types) =>
+      types.map((type) => {
+        const typeInfo = TYPES_INFOS[type.id.toUpperCase()];
+        return {
+          ...type,
+          id: type.id.toUpperCase(),
+          title: typeInfo.title,
+          subtitle: typeInfo.subtitle,
+          icon: typeInfo.icon,
+        };
+      }),
+    ),
+  );
+
+  public applicationPayload: unknown;
+  constructor(private readonly applicationTypesService: ApplicationTypesService) {}
+  ngOnInit() {}
+
+  onSubmit() {
+    // TODO: save application
+    this.applicationPayload = this.applicationFormGroup.value;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.harness.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.harness.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApplicationCreationHarness extends ComponentHarness {
+  static readonly hostSelector = 'application-creation';
+}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.stories.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.stories.ts
@@ -13,12 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Meta, StoryObj } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { of } from 'rxjs';
 
 import { ApplicationCreationComponent } from './application-creation.component';
 
+import { fakeApplicationTypes } from '../../../entities/application-type/ApplicationType.fixture';
+import { ApplicationTypesService } from '../../../services-ngx/application-types.service';
+
 export default {
-  title: 'ApplicationCreationComponent story',
+  title: 'Application / Creation page',
   component: ApplicationCreationComponent,
   argTypes: {},
   render: (args) => ({
@@ -29,7 +33,33 @@ export default {
     `,
     props: args,
   }),
+  decorators: [
+    moduleMetadata({
+      providers: [
+        {
+          provide: ApplicationTypesService,
+          useValue: {
+            getEnabledApplicationTypes: () => of(fakeApplicationTypes()),
+          },
+        },
+      ],
+    }),
+  ],
 } as Meta;
 
 export const Default: StoryObj = {};
 Default.args = {};
+
+export const WithOnlySimpleType: StoryObj = {};
+WithOnlySimpleType.decorators = [
+  moduleMetadata({
+    providers: [
+      {
+        provide: ApplicationTypesService,
+        useValue: {
+          getEnabledApplicationTypes: () => of([fakeApplicationTypes()[0]]),
+        },
+      },
+    ],
+  }),
+];

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.stories.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/application-creation.stories.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, StoryObj } from '@storybook/angular';
+
+import { ApplicationCreationComponent } from './application-creation.component';
+
+export default {
+  title: 'ApplicationCreationComponent story',
+  component: ApplicationCreationComponent,
+  argTypes: {},
+  render: (args) => ({
+    template: `
+      <div style="width: 800px">
+        <application-creation></application-creation>
+      </div>
+    `,
+    props: args,
+  }),
+} as Meta;
+
+export const Default: StoryObj = {};
+Default.args = {};

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.html
@@ -1,0 +1,105 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (applicationTypes && applicationFormGroup) {
+  <div class="form" [formGroup]="applicationFormGroup">
+    <mat-form-field>
+      <input
+        id="name"
+        type="text"
+        matInput
+        formControlName="name"
+        maxlength="512"
+        required
+        data-testid="application_creation_v4_name_input"
+      />
+      <mat-label>Name</mat-label>
+      <mat-error *ngIf="applicationFormGroup.controls.name.errors?.required">Application name is required</mat-error>
+    </mat-form-field>
+
+    <mat-form-field>
+      <textarea
+        id="description"
+        matInput
+        #input
+        maxlength="40000"
+        formControlName="description"
+        rows="4"
+        data-testid="application_creation_v4_description_input"
+      ></textarea>
+      <mat-label>Description</mat-label>
+      <mat-hint>Provide a description of your application, what it does, ...</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field>
+      <input id="domain" type="text" matInput formControlName="domain" maxlength="512" data-testid="application_creation_v4_domain_input" />
+      <mat-label>Domain</mat-label>
+    </mat-form-field>
+
+    <h3 class="form__securityTitle">Security</h3>
+    <gio-form-card-group formControlName="type">
+      @for (type of applicationTypes; track type.id) {
+        <gio-form-card [value]="type.id">
+          <gio-form-card-content [icon]="type.icon">
+            <gio-form-card-content-title>{{ type.title }}</gio-form-card-content-title>
+            <gio-form-card-content-subtitle>{{ type.subtitle }}</gio-form-card-content-subtitle>
+          </gio-form-card-content>
+        </gio-form-card>
+      }
+    </gio-form-card-group>
+
+    @if (applicationType$ | async; as applicationType) {
+      @if (applicationType.isOauth) {
+        <mat-form-field>
+          <mat-label>Allowed grant types</mat-label>
+          <mat-select formControlName="oauthGrantTypes" multiple>
+            @for (grantType of applicationType.allowedGrantTypesVM; track grantType.value) {
+              <mat-option [value]="grantType.value" [disabled]="grantType.disabled"
+                >{{ grantType.label }}
+                @if (grantType.disabled) {
+                  - <i>(Mandatory)</i>
+                }
+              </mat-option>
+            }
+          </mat-select>
+          <mat-hint>Grant types allowed for the client. Please set only grant types you need for security reasons</mat-hint>
+        </mat-form-field>
+
+        <mat-form-field *ngIf="applicationType.requiresRedirectUris">
+          <mat-label>Redirect URIs</mat-label>
+          <gio-form-tags-input formControlName="oauthRedirectUris" placeholder="Enter a redirect URI"> </gio-form-tags-input>
+          <mat-hint align="start">URIs where the authorization server will send OAuth responses</mat-hint>
+        </mat-form-field>
+      } @else {
+        <mat-form-field>
+          <input id="appType" type="text" matInput formControlName="appType" maxlength="64" />
+          <mat-label>Type</mat-label>
+          <mat-hint>Type of the application (mobile, web, ...)</mat-hint>
+        </mat-form-field>
+
+        <mat-form-field>
+          <input id="appClientId" type="text" matInput formControlName="appClientId" maxlength="300" />
+          <mat-label>Client ID</mat-label>
+          <mat-hint
+            >The <code>client_id</code> of the application. This field is required to subscribe to certain type of API Plan (OAuth2,
+            JWT)</mat-hint
+          >
+        </mat-form-field>
+      }
+    }
+  </div>
+}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.html
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.html
@@ -51,16 +51,22 @@
     </mat-form-field>
 
     <h3 class="form__securityTitle">Security</h3>
-    <gio-form-card-group formControlName="type">
-      @for (type of applicationTypes; track type.id) {
-        <gio-form-card [value]="type.id">
-          <gio-form-card-content [icon]="type.icon">
-            <gio-form-card-content-title>{{ type.title }}</gio-form-card-content-title>
-            <gio-form-card-content-subtitle>{{ type.subtitle }}</gio-form-card-content-subtitle>
-          </gio-form-card-content>
-        </gio-form-card>
-      }
-    </gio-form-card-group>
+    @if (applicationTypes.length === 0) {
+      <gio-banner-warning>No application type available, please check Client Registration configuration.</gio-banner-warning>
+    }
+
+    @if (applicationTypes.length > 1) {
+      <gio-form-card-group formControlName="type">
+        @for (type of applicationTypes; track type.id) {
+          <gio-form-card [value]="type.id">
+            <gio-form-card-content [icon]="type.icon">
+              <gio-form-card-content-title>{{ type.title }}</gio-form-card-content-title>
+              <gio-form-card-content-subtitle>{{ type.subtitle }}</gio-form-card-content-subtitle>
+            </gio-form-card-content>
+          </gio-form-card>
+        }
+      </gio-form-card-group>
+    }
 
     @if (applicationType$ | async; as applicationType) {
       @if (applicationType.isOauth) {

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentHarness } from '@angular/cdk/testing';
 
-export class ApplicationCreationHarness extends ComponentHarness {
-  static readonly hostSelector = 'application-creation';
+.form {
+  display: flex;
+  flex-direction: column;
+
+  &__securityTitle {
+    margin-top: 24px;
+  }
 }

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
@@ -83,8 +83,6 @@ export class ApplicationCreationFormComponent implements OnInit {
     }
   >;
 
-  constructor() {}
-
   ngOnInit() {
     this.applicationType$ = this.applicationFormGroup.get('type').valueChanges.pipe(
       startWith(this.applicationFormGroup.get('type').value),

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
@@ -19,9 +19,9 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { MatRadioModule } from '@angular/material/radio';
-import { map, share, tap } from 'rxjs/operators';
+import { filter, map, share, startWith, tap } from 'rxjs/operators';
 import { MatSelectModule } from '@angular/material/select';
 import { Observable } from 'rxjs';
 
@@ -60,6 +60,7 @@ export type ApplicationCreationFormApplicationType = ApplicationType & {
     GioFormCardGroupModule,
     GioIconsModule,
     GioFormTagsInputModule,
+    GioBannerModule,
   ],
   standalone: true,
   styleUrls: ['./application-creation-form.component.scss'],
@@ -86,6 +87,8 @@ export class ApplicationCreationFormComponent implements OnInit {
 
   ngOnInit() {
     this.applicationType$ = this.applicationFormGroup.get('type').valueChanges.pipe(
+      startWith(this.applicationFormGroup.get('type').value),
+      filter((typeSelected) => !!typeSelected),
       map((typeSelected) => {
         const applicationType = this.applicationTypes.find(
           (applicationType) => applicationType.id.toUpperCase() === typeSelected.toUpperCase(),

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.component.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject, DestroyRef, Input } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { GioFormTagsInputModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatRadioModule } from '@angular/material/radio';
+import { map, share, tap } from 'rxjs/operators';
+import { MatSelectModule } from '@angular/material/select';
+import { Observable } from 'rxjs';
+
+import { GioFormCardGroupModule } from '../../../../shared/components/gio-form-card-group/gio-form-card-group.module';
+import { ApplicationType } from '../../../../entities/application-type/ApplicationType';
+
+export type ApplicationForm = {
+  name: FormControl<string>;
+  description: FormControl<string>;
+  domain: FormControl<string>;
+  type: FormControl<string>;
+
+  appType: FormControl<string>;
+  appClientId: FormControl<string>;
+
+  oauthGrantTypes: FormControl<string[]>;
+  oauthRedirectUris: FormControl<string[]>;
+};
+
+export type ApplicationCreationFormApplicationType = ApplicationType & {
+  title: string;
+  subtitle: string;
+  icon: string;
+};
+
+@Component({
+  selector: 'application-creation-form',
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonToggleModule,
+    MatRadioModule,
+    MatSelectModule,
+    GioFormCardGroupModule,
+    GioIconsModule,
+    GioFormTagsInputModule,
+  ],
+  standalone: true,
+  styleUrls: ['./application-creation-form.component.scss'],
+  templateUrl: './application-creation-form.component.html',
+})
+export class ApplicationCreationFormComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
+  @Input({ required: true })
+  public applicationTypes: ApplicationCreationFormApplicationType[];
+
+  @Input({ required: true })
+  public applicationFormGroup: FormGroup<ApplicationForm>;
+
+  public applicationType$?: Observable<
+    ApplicationType & {
+      isOauth: boolean;
+      requiresRedirectUris: boolean;
+      allowedGrantTypesVM: { value: string; label: string; disabled: boolean }[];
+    }
+  >;
+
+  constructor() {}
+
+  ngOnInit() {
+    this.applicationType$ = this.applicationFormGroup.get('type').valueChanges.pipe(
+      map((typeSelected) => {
+        const applicationType = this.applicationTypes.find(
+          (applicationType) => applicationType.id.toUpperCase() === typeSelected.toUpperCase(),
+        );
+        return {
+          ...applicationType,
+          isOauth: applicationType.id.toUpperCase() !== 'SIMPLE',
+          requiresRedirectUris: applicationType.requires_redirect_uris,
+          allowedGrantTypesVM: applicationType.allowed_grant_types.map((grantType) => ({
+            value: grantType.type,
+            label: grantType.name,
+            disabled: applicationType.mandatory_grant_types.some((mandatoryGrantType) => mandatoryGrantType.type === grantType.type),
+          })),
+        };
+      }),
+      tap((applicationType) => {
+        if (applicationType.isOauth) {
+          this.applicationFormGroup.get('oauthGrantTypes')?.setValidators(Validators.required);
+
+          const defaultGrantType = applicationType?.default_grant_types?.map((grantType) => grantType.type) ?? [];
+          this.applicationFormGroup.get('oauthGrantTypes')?.setValue(defaultGrantType);
+          return;
+        }
+        this.applicationFormGroup.get('oauthGrantTypes')?.clearValidators();
+        this.applicationFormGroup.get('oauthGrantTypes')?.reset();
+      }),
+      share(),
+    );
+  }
+}

--- a/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation-ng/components/application-creation-form.harness.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+import { GioFormCardGroupHarness } from '../../../../shared/components/gio-form-card-group/gio-form-card-group.harness';
+
+export class ApplicationCreationFormHarness extends ComponentHarness {
+  static readonly hostSelector = 'application-creation-form';
+
+  private getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  private getDescriptionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+  private getDomainInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="domain"]' }));
+
+  private getTypeInput = this.locatorFor(GioFormCardGroupHarness.with({ selector: '[formControlName="type"]' }));
+
+  // Simple type
+  private getAppTypeInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="appType"]' }));
+  private getAppClientIdInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="appClientId"]' }));
+
+  // OAuth type
+  private getOauthGrantTypesInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="oauthGrantTypes"]' }));
+  public getOauthRedirectUrisInput = this.locatorForOptional(
+    GioFormTagsInputHarness.with({ selector: '[formControlName="oauthRedirectUris"]' }),
+  );
+
+  public async setGeneralInformation(name: string, description: string, domain: string) {
+    await this.getNameInput().then(async (input) => await input.setValue(name));
+    await this.getDescriptionInput().then(async (input) => await input.setValue(description));
+    await this.getDomainInput().then(async (input) => await input.setValue(domain));
+  }
+
+  public async setApplicationType(type: string) {
+    await this.getTypeInput().then(async (input) => await input.select(type));
+  }
+
+  public async setSimpleApplicationType(appType: string, appClientId: string) {
+    await this.getAppTypeInput().then(async (input) => await input.setValue(appType));
+    await this.getAppClientIdInput().then(async (input) => await input.setValue(appClientId));
+  }
+
+  public async setOAuthApplicationType(grantTypes: string[], redirectUris?: string[]) {
+    const oauthGrantTypesInput = await this.getOauthGrantTypesInput();
+
+    await parallel(() => grantTypes.map(async (grantType) => await oauthGrantTypesInput.clickOptions({ text: grantType })));
+
+    if (redirectUris) {
+      const redirectUrisInput = await this.getOauthRedirectUrisInput();
+      await parallel(() => redirectUris.map(async (redirectUri) => await redirectUrisInput.addTag(redirectUri)));
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step2.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation-step2.controller.ts
@@ -15,17 +15,17 @@
  */
 import ApplicationCreationController from './application-creation.controller';
 
-import { ApplicationType } from '../../../../entities/application';
+import { DeprecatedApplicationType } from '../../../../entities/application-type/DeprecatedApplicationType';
 
 class ApplicationCreationStep2Controller {
-  private selectedType: ApplicationType;
+  private selectedType: DeprecatedApplicationType;
   private parent: ApplicationCreationController;
 
   $onInit() {
     this.selectedType = this.parent.enabledApplicationTypes[0];
   }
 
-  selectType(applicationType: ApplicationType) {
+  selectType(applicationType: DeprecatedApplicationType) {
     this.selectedType = applicationType;
     if (this.selectedType.isOauth()) {
       this.parent.application.settings = {

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.component.ts
@@ -43,7 +43,7 @@ export class ApplicationCreationComponent extends UpgradeComponent {
   }
 
   override ngOnInit() {
-    combineLatest([this.applicationTypeService.getEnabledApplicationTypes(), this.groupService.list()])
+    combineLatest([this.applicationTypeService.deprecatedGetEnabledApplicationTypes(), this.groupService.list()])
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe({
         next: ([applicationTypes, groupList]) => {

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
@@ -16,7 +16,7 @@
 import { ActivatedRoute, Router } from '@angular/router';
 import { find, findIndex, groupBy, join, keys, map, remove, uniqBy } from 'lodash';
 
-import { ApplicationType } from '../../../../entities/application';
+import { DeprecatedApplicationType } from '../../../../entities/application-type/DeprecatedApplicationType';
 import { ApiService } from '../../../../services/api.service';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
@@ -25,7 +25,7 @@ import { PlanSecurityType } from '../../../../entities/plan';
 
 class ApplicationCreationController {
   application: any;
-  enabledApplicationTypes: ApplicationType[];
+  enabledApplicationTypes: DeprecatedApplicationType[];
   private activatedRoute: ActivatedRoute;
 
   private steps: any[];

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.html
@@ -125,12 +125,14 @@
           <div class="details-card__header__right-coll__media coll-oauth">
             <mat-form-field class="oauth">
               <mat-label>Client ID</mat-label>
-              <input formControlName="client_id" matInput type="text" maxlength="50" readonly />
+              <input #clientIdInput formControlName="client_id" matInput type="text" maxlength="50" readonly />
+              <gio-clipboard-copy-icon matIconSuffix [contentToCopy]="clientIdInput.value"></gio-clipboard-copy-icon>
             </mat-form-field>
 
             <mat-form-field class="oauth">
               <mat-label>Client Secret</mat-label>
-              <input formControlName="client_secret" matInput type="text" readonly />
+              <input #clientSecretInput formControlName="client_secret" matInput type="text" readonly />
+              <gio-clipboard-copy-icon matIconSuffix [contentToCopy]="clientSecretInput.value"></gio-clipboard-copy-icon>
             </mat-form-field>
           </div>
           <div class="details-card__header__info-inputs__second-row">

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.spec.ts
@@ -29,7 +29,7 @@ import { ApplicationGeneralModule } from './application-general.module';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { fakeApplication, fakeApplicationType } from '../../../../entities/application/Application.fixture';
-import { Application, ApplicationType } from '../../../../entities/application/application';
+import { Application, ApplicationType } from '../../../../entities/application/Application';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 describe('ApplicationGeneralInfoComponent', () => {

--- a/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/general/application-general.component.ts
@@ -24,7 +24,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApplicationService } from '../../../../services-ngx/application.service';
-import { Application, ApplicationType } from '../../../../entities/application/application';
+import { Application, ApplicationType } from '../../../../entities/application/Application';
 
 @Component({
   selector: 'application-general',

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -21,7 +21,7 @@ import { filter, find, forEach, groupBy, includes, join, map, merge, noop } from
 import { ApiService } from '../../../../services/api.service';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
-import { ApiKeyMode } from '../../../../entities/application/application';
+import { ApiKeyMode } from '../../../../entities/application/Application';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
 import { Constants } from '../../../../entities/Constants';
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ajs.ts
@@ -19,7 +19,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
-import { ApiKeyMode } from '../../../../entities/application/application';
+import { ApiKeyMode } from '../../../../entities/application/Application';
 
 const ApplicationSubscriptionComponentAjs: ng.IComponentOptions = {
   bindings: {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.spec.ts
@@ -29,7 +29,7 @@ import { ApplicationGeneralUserGroupModule } from '../application-general-user-g
 import { fakeApplication } from '../../../../../entities/application/Application.fixture';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
 import { fakeGroup, Group } from '../../../../../entities/management-api-v2';
-import { Application } from '../../../../../entities/application/application';
+import { Application } from '../../../../../entities/application/Application';
 
 describe('ApplicationGeneralGroupsComponent', () => {
   let fixture: ComponentFixture<ApplicationGeneralGroupsComponent>;

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/groups/application-general-groups.component.ts
@@ -23,7 +23,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 
 import { GroupService } from '../../../../../services-ngx/group.service';
 import { ApplicationService } from '../../../../../services-ngx/application.service';
-import { Application } from '../../../../../entities/application/application';
+import { Application } from '../../../../../entities/application/Application';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 
 @Component({

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.spec.ts
@@ -36,7 +36,7 @@ import { RoleService } from '../../../../../services-ngx/role.service';
 import { fakeGroup, fakeGroupsResponse, Member } from '../../../../../entities/management-api-v2';
 import { fakeMembers } from '../../../../../entities/members/Members.fixture';
 import { fakeApplication } from '../../../../../entities/application/Application.fixture';
-import { Application } from '../../../../../entities/application/application';
+import { Application } from '../../../../../entities/application/Application';
 import { fakeSearchableUser } from '../../../../../entities/user/searchableUser.fixture';
 import { GioUsersSelectorHarness } from '../../../../../shared/components/gio-users-selector/gio-users-selector.harness';
 import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/members/application-general-members.component.ts
@@ -36,7 +36,7 @@ import { ApplicationService } from '../../../../../services-ngx/application.serv
 import { GroupData } from '../../../../api/user-group-access/members/api-general-members.component';
 import { GroupV2Service } from '../../../../../services-ngx/group-v2.service';
 import { Member } from '../../../../../entities/members/members';
-import { Application } from '../../../../../entities/application/application';
+import { Application } from '../../../../../entities/application/Application';
 import { ApplicationMembersService } from '../../../../../services-ngx/application-members.service';
 
 class MemberDataSource {

--- a/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/user-group-access/transfer-ownership/application-general-transfer-ownership.component.ts
@@ -30,7 +30,7 @@ import { Group } from '../../../../../entities/group/group';
 import { Role } from '../../../../../entities/role/role';
 import { Member } from '../../../../../entities/members/members';
 import { Constants } from '../../../../../entities/Constants';
-import { ApplicationTransferOwnership } from '../../../../../entities/application/application';
+import { ApplicationTransferOwnership } from '../../../../../entities/application/Application';
 
 @Component({
   selector: 'application-general-transfer-ownership',

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
@@ -30,7 +30,7 @@ import { ApplicationsModule } from '../applications.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { fakePagedResult } from '../../../entities/pagedResult';
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
-import { Application } from '../../../entities/application/application';
+import { Application } from '../../../entities/application/Application';
 import { fakeApplication } from '../../../entities/application/Application.fixture';
 import { GioTestingRoleProvider } from '../../../shared/components/gio-role/gio-role.service';
 

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.ts
@@ -24,7 +24,7 @@ import { PagedResult } from '../../../entities/pagedResult';
 import { GioTableWrapperFilters, Sort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { ApplicationService } from '../../../services-ngx/application.service';
-import { Application } from '../../../entities/application/application';
+import { Application } from '../../../entities/application/Application';
 import { GioRoleService } from '../../../shared/components/gio-role/gio-role.service';
 import { toOrder, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 

--- a/gravitee-apim-console-webui/src/services-ngx/application-members.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application-members.service.ts
@@ -19,7 +19,7 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
 import { Member } from '../entities/members/members';
-import { ApplicationTransferOwnership } from '../entities/application/application';
+import { ApplicationTransferOwnership } from '../entities/application/Application';
 
 @Injectable({
   providedIn: 'root',

--- a/gravitee-apim-console-webui/src/services-ngx/application-types.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application-types.service.ts
@@ -19,7 +19,8 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { Constants } from '../entities/Constants';
-import { ApplicationType } from '../entities/application';
+import { DeprecatedApplicationType } from '../entities/application-type/DeprecatedApplicationType';
+import { ApplicationType } from '../entities/application-type/ApplicationType';
 
 @Injectable({
   providedIn: 'root',
@@ -30,9 +31,13 @@ export class ApplicationTypesService {
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
-  getEnabledApplicationTypes(): Observable<ApplicationType[]> {
+  deprecatedGetEnabledApplicationTypes(): Observable<DeprecatedApplicationType[]> {
     return this.http
       .get<any[]>(`${this.constants.env.baseURL}/configuration/applications/types`)
-      .pipe(map((response) => response.map((applicationType) => new ApplicationType(applicationType))));
+      .pipe(map((response) => response.map((applicationType) => new DeprecatedApplicationType(applicationType))));
+  }
+
+  getEnabledApplicationTypes(): Observable<ApplicationType[]> {
+    return this.http.get<ApplicationType[]>(`${this.constants.env.baseURL}/configuration/applications/types`);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
@@ -352,4 +352,33 @@ describe('ApplicationService', () => {
         .flush(subscriptions);
     });
   });
+
+  describe('create', () => {
+    it('should call the API', (done) => {
+      const mockApplication = {
+        name: 'my-app',
+        description: 'my-app-description',
+        domain: 'my-app-domain',
+        settings: {
+          oauth: {
+            application_type: 'WEB',
+            grant_types: ['authorization_code', 'refresh_token'],
+            redirect_uris: ['redirectUri'],
+          },
+        },
+      };
+
+      applicationService.create(mockApplication).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications`,
+      });
+
+      expect(req.request.body).toEqual(mockApplication);
+      req.flush({});
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -25,6 +25,7 @@ import { SubscribedApi } from '../entities/application/SubscribedApi';
 import { ApplicationSubscription } from '../entities/subscription/subscription';
 import { ApplicationLog } from '../entities/application/ApplicationLog';
 import { MembershipListItem } from '../entities/role/membershipListItem';
+import { CreateApplication } from '../entities/application/CreateApplication';
 
 @Injectable({
   providedIn: 'root',
@@ -197,5 +198,9 @@ export class ApplicationService {
 
   delete(applicationId: string): Observable<Application> {
     return this.http.delete<Application>(`${this.constants.env.baseURL}/applications/${applicationId}/`);
+  }
+
+  create(application: CreateApplication): Observable<Application> {
+    return this.http.post<Application>(`${this.constants.env.baseURL}/applications`, application);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -20,7 +20,7 @@ import { filter, shareReplay, switchMap, tap } from 'rxjs/operators';
 
 import { Constants } from '../entities/Constants';
 import { PagedResult } from '../entities/pagedResult';
-import { Application, ApplicationType } from '../entities/application/application';
+import { Application, ApplicationType } from '../entities/application/Application';
 import { SubscribedApi } from '../entities/application/SubscribedApi';
 import { ApplicationSubscription } from '../entities/subscription/subscription';
 import { ApplicationLog } from '../entities/application/ApplicationLog';

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -22,7 +22,7 @@ import { ApplicationExcludeFilter } from './application.service';
 import { Constants } from '../entities/Constants';
 import { PagedResult } from '../entities/pagedResult';
 import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
-import { ApiKeyMode } from '../entities/application/application';
+import { ApiKeyMode } from '../entities/application/Application';
 
 export class LogsQuery {
   from: number;

--- a/gravitee-apim-console-webui/src/services/application.service.ts
+++ b/gravitee-apim-console-webui/src/services/application.service.ts
@@ -19,7 +19,7 @@ import { IHttpResponse } from 'angular';
 import { clone, forEach, startsWith } from 'lodash';
 
 import { PagedResult } from '../entities/pagedResult';
-import { ApiKeyMode } from '../entities/application/application';
+import { ApiKeyMode } from '../entities/application/Application';
 
 export class LogsQuery {
   from: number;

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-content/gio-form-card-content.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-content/gio-form-card-content.component.scss
@@ -1,0 +1,27 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+
+  &__icon {
+    width: 32px;
+    height: 32px;
+    margin-bottom: 8px;
+  }
+
+  &__title {
+    @include mat.typography-level($typography, subtitle-1);
+
+    margin-bottom: 8px;
+  }
+
+  &__subtitle {
+    @include mat.typography-level($typography, body-2);
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-content/gio-form-card-content.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-content/gio-form-card-content.component.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'gio-form-card-content',
+  template: `<div class="content">
+    <mat-icon class="content__icon" [svgIcon]="icon" *ngIf="icon"></mat-icon>
+    <div class="content__title">
+      <ng-content select="gio-form-card-content-title"></ng-content>
+    </div>
+    <div class="content__subtitle">
+      <ng-content select="gio-form-card-content-subtitle"></ng-content>
+    </div>
+  </div>`,
+  styleUrls: ['./gio-form-card-content.component.scss'],
+})
+export class GioFormCardContentComponent {
+  @Input()
+  public icon: string | undefined;
+}
+
+@Component({
+  selector: 'gio-form-card-content-title',
+  template: `<ng-content></ng-content>`,
+})
+export class GioFormCardContentTitleComponent {}
+
+@Component({
+  selector: 'gio-form-card-content-subtitle',
+  template: `<ng-content></ng-content>`,
+})
+export class GioFormCardContentSubtitleComponent {}

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.component.html
@@ -15,6 +15,4 @@
     limitations under the License.
 
 -->
-<div class="form-card-group">
-  <ng-content select="gio-form-card"></ng-content>
-</div>
+<ng-content select="gio-form-card"></ng-content>

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.component.scss
@@ -13,18 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-@use 'sass:map';
-@use '@angular/material' as mat;
-@use '@gravitee/ui-particles-angular' as gio;
-
-$typography: map.get(gio.$mat-theme, typography);
-$foreground: map.get(gio.$mat-theme, foreground);
-
-.form-card-group {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: space-evenly;
+:host {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.module.ts
@@ -18,13 +18,31 @@ import { NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { GioFormCardComponent } from './gio-form-card.component';
 import { GioFormCardGroupComponent } from './gio-form-card-group.component';
+import {
+  GioFormCardContentComponent,
+  GioFormCardContentSubtitleComponent,
+  GioFormCardContentTitleComponent,
+} from './gio-form-card-content/gio-form-card-content.component';
 
 @NgModule({
-  imports: [CommonModule, MatCardModule, MatIconModule, MatRippleModule],
-  declarations: [GioFormCardGroupComponent, GioFormCardComponent],
-  exports: [GioFormCardGroupComponent, GioFormCardComponent],
+  imports: [CommonModule, MatCardModule, MatIconModule, MatRippleModule, GioIconsModule],
+  declarations: [
+    GioFormCardGroupComponent,
+    GioFormCardComponent,
+    GioFormCardContentSubtitleComponent,
+    GioFormCardContentTitleComponent,
+    GioFormCardContentComponent,
+  ],
+  exports: [
+    GioFormCardGroupComponent,
+    GioFormCardComponent,
+    GioFormCardContentSubtitleComponent,
+    GioFormCardContentTitleComponent,
+    GioFormCardContentComponent,
+  ],
 })
 export class GioFormCardGroupModule {}

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card-group.stories.ts
@@ -41,11 +41,11 @@ export const Simple: StoryObj = {
       <gio-form-card value="B">Hello</gio-form-card>
       <gio-form-card value="C">Hello</gio-form-card>
       <gio-form-card value="D">Hello</gio-form-card>
-      <gio-form-card value="E">Hello</gio-form-card>
+        <gio-form-card [lock]="true" value="E">Hello locked</gio-form-card>
     </gio-form-card-group>
     `,
     props: {
-      selected: 'A',
+      selected: 'E',
       onSelect: (e) => action('On select')(e),
     },
   }),
@@ -66,7 +66,7 @@ export const ReactiveForms: StoryObj = {
         <gio-form-card value="B">Hello</gio-form-card>
         <gio-form-card value="C">Hello</gio-form-card>
         <gio-form-card value="D">Hello</gio-form-card>
-        <gio-form-card value="E">Hello</gio-form-card>
+        <gio-form-card [lock]="true" value="E">Hello locked</gio-form-card>
       </gio-form-card-group>
       `,
       props: {
@@ -76,7 +76,7 @@ export const ReactiveForms: StoryObj = {
   },
 };
 
-export const ReactiveFormsGroupDisable: StoryObj = {
+export const Disable: StoryObj = {
   render: () => {
     const selectControl = new FormControl({ value: 'A', disabled: true });
 
@@ -91,7 +91,54 @@ export const ReactiveFormsGroupDisable: StoryObj = {
         <gio-form-card value="B">B card</gio-form-card>
         <gio-form-card value="C">C card</gio-form-card>
         <gio-form-card value="D">D card</gio-form-card>
-        <gio-form-card value="E">E card</gio-form-card>
+        <gio-form-card value="E" [lock]="true" value="E">E card</gio-form-card>
+      </gio-form-card-group>
+      `,
+      props: {
+        selectControl,
+      },
+    };
+  },
+};
+
+export const WithContent: StoryObj = {
+  render: () => {
+    const selectControl = new FormControl({ value: 'A', disabled: false });
+
+    selectControl.valueChanges.subscribe((value) => {
+      action('On select')(value);
+    });
+
+    return {
+      template: `
+      <gio-form-card-group [formControl]="selectControl">
+        <gio-form-card value="fox">
+            <gio-form-card-content icon="gio:gitlab">
+                <gio-form-card-content-title>Fox</gio-form-card-content-title>
+                <gio-form-card-content-subtitle>This is a fox icon</gio-form-card-content-subtitle>
+            </gio-form-card-content>
+        </gio-form-card>
+
+        <gio-form-card value="cat" [lock]="true" value="E">
+          <gio-form-card-content icon="gio:github">
+            <gio-form-card-content-title>Cat</gio-form-card-content-title>
+            <gio-form-card-content-subtitle>Lorem ipsum dolor sit amet, consectetur adipiscing elit</gio-form-card-content-subtitle>
+          </gio-form-card-content>
+        </gio-form-card>
+
+        <gio-form-card value="dog">
+          <gio-form-card-content icon="gio:cpu">
+            <gio-form-card-content-title>Dog</gio-form-card-content-title>
+            <gio-form-card-content-subtitle>This is not a dog icon</gio-form-card-content-subtitle>
+          </gio-form-card-content>
+        </gio-form-card>
+
+        <gio-form-card value="no-title">
+          <gio-form-card-content icon="gio:off-rounded">
+            <gio-form-card-content-subtitle>Only subtitle</gio-form-card-content-subtitle>
+          </gio-form-card-content>
+        </gio-form-card>
+
       </gio-form-card-group>
       `,
       props: {

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card.component.scss
@@ -21,66 +21,67 @@ $foreground: map.get(gio.$mat-theme, foreground);
 $accent: map.get(gio.$mat-theme, accent);
 
 :host {
+  flex: 1 0 0%;
   display: flex;
 }
 
 .card {
-  @include mat.elevation(1);
   flex: 1 1 auto;
   margin: 6px;
   cursor: pointer;
   min-height: 40px;
   min-width: 64px;
+  border: 1px solid var(--mdc-outlined-text-field-outline-color);
+  border-radius: 4px;
+
+  &:hover:not(.disabled, .selected) {
+    border-color: var(--mdc-outlined-text-field-hover-outline-color);
+    & .selection-icon {
+      color: var(--mdc-outlined-text-field-hover-outline-color);
+    }
+  }
 
   & > .selection-icon,
   & > .lock-icon {
-    opacity: 0;
+    color: var(--mdc-outlined-text-field-outline-color);
     cursor: pointer;
-    color: mat.get-color-from-palette($accent);
-    background: #fff;
     position: absolute;
-    right: 4px;
-    top: 4px;
+    right: 8px;
+    top: 8px;
     border-radius: 100%;
     height: 24px;
     width: 24px;
 
     &__disabled {
-      color: mat.get-color-from-palette($foreground, disabled);
       cursor: auto;
+      color: mat.get-color-from-palette($foreground, disabled);
     }
   }
 
-  & > .lock-icon {
-    opacity: 1;
-  }
-
   &.selected {
-    border: 1px solid mat.get-color-from-palette($accent);
+    border: 2px solid mat.get-color-from-palette($accent);
+    color: mat.get-color-from-palette($accent);
     margin: 5px;
 
-    & > .selection-icon {
-      opacity: 1;
+    & > .selection-icon,
+    .lock-icon {
+      color: mat.get-color-from-palette($accent);
     }
   }
 
   &.disabled {
     color: mat.get-color-from-palette($foreground, disabled);
-    border: 1px solid mat.get-color-from-palette($foreground, disabled);
+    border-color: mat.get-color-from-palette($foreground, disabled);
     cursor: auto;
-  }
+    opacity: 0.4;
 
-  &:hover:not(.disabled) {
-    @include mat.elevation-transition();
-    @include mat.elevation(3);
-
-    & > .selection-icon {
-      opacity: 1;
+    & > .selection-icon,
+    .lock-icon {
+      color: mat.get-color-from-palette($foreground, disabled);
     }
   }
 
   &__content {
-    margin-bottom: 0;
-    padding-top: 16px;
+    padding: 16px;
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-card-group/gio-form-card.component.ts
@@ -18,15 +18,16 @@ import { ChangeDetectorRef, Component, Input } from '@angular/core';
 @Component({
   selector: 'gio-form-card',
   template: `
-    <mat-card matRipple [matRippleDisabled]="disabled" class="card" [class.selected]="selected" [class.disabled]="disabled">
+    <div matRipple [matRippleDisabled]="disabled" class="card" [class.selected]="selected" [class.disabled]="disabled">
       <span *ngIf="!lock" class="selection-icon" [class.selection-icon__disabled]="disabled">
-        <mat-icon>check_circle</mat-icon>
+        <mat-icon>{{ selected ? 'radio_button_checked' : 'radio_button_unchecked' }}</mat-icon>
       </span>
+
       <span *ngIf="lock" class="lock-icon">
         <mat-icon svgIcon="gio:lock"></mat-icon>
       </span>
-      <mat-card-content class="card__content"><ng-content></ng-content></mat-card-content>
-    </mat-card>
+      <div class="card__content"><ng-content></ng-content></div>
+    </div>
   `,
   host: {
     '[class.disabled]': 'disabled',

--- a/gravitee-apim-console-webui/src/user/support/new-ticket/new-ticket.component.spec.ts
+++ b/gravitee-apim-console-webui/src/user/support/new-ticket/new-ticket.component.spec.ts
@@ -30,7 +30,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { TicketsModule } from '../tickets.module';
 import { Api, ApisResponse, fakeApiV2, fakeApiV4 } from '../../../entities/management-api-v2';
 import { fakePagedResult, PagedResult } from '../../../entities/pagedResult';
-import { Application } from '../../../entities/application/application';
+import { Application } from '../../../entities/application/Application';
 import { fakeApplication } from '../../../entities/application/Application.fixture';
 
 describe('NewTicketComponent', () => {

--- a/gravitee-apim-console-webui/src/user/support/new-ticket/new-ticket.component.ts
+++ b/gravitee-apim-console-webui/src/user/support/new-ticket/new-ticket.component.ts
@@ -22,7 +22,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { Api } from '../../../entities/management-api-v2';
 import { ApplicationService } from '../../../services-ngx/application.service';
-import { Application } from '../../../entities/application/application';
+import { Application } from '../../../entities/application/Application';
 import { NewTicket } from '../../../entities/ticket/newTicket';
 import { TicketService } from '../../../services-ngx/ticket.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2242
https://gravitee.atlassian.net/browse/APIM-4180

## Description

Migrate Application Creation page to simpler one.

Avantage :
- Easier to migrate
- Avoids 🤯  use case. Like the shared api key mode on the 2nd accepted subscription, change application "mode" (but in this case nothing is created or accepted, as the application does not yet exist.)


 TODO next PR: 
- Move `gio-form-card-group` to ui-particles and use it to replace "Gio Button Toggle (group)"
- Delete old creation page (wait a little)

## Additional context
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/79dc09f3-2d1c-4313-88a2-55583c46129f)
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/18836c3f-79c1-4390-a366-bf11a0c6311f)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7191/console](https://pr.team-apim.gravitee.dev/7191/console)
      Portal: [https://pr.team-apim.gravitee.dev/7191/portal](https://pr.team-apim.gravitee.dev/7191/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7191/api/management](https://pr.team-apim.gravitee.dev/7191/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7191](https://pr.team-apim.gravitee.dev/7191)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7191](https://pr.gateway-v3.team-apim.gravitee.dev/7191)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gzrzssivuj.chromatic.com)
<!-- Storybook placeholder end -->
