### PR TITLE
Build Portal-next in CI and add it in portal docker image

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -36,6 +36,9 @@ const dockerImages = {
   portal: {
     project: 'gravitee-apim-portal-webui',
     image: 'apim-portal-ui',
+    next: {
+      project: 'gravitee-apim-portal-webui-next',
+    },
   },
 };
 

--- a/.circleci/ci/src/jobs/frontend/index.ts
+++ b/.circleci/ci/src/jobs/frontend/index.ts
@@ -15,6 +15,7 @@
  */
 export * from './job-chromatic-console';
 export * from './job-storybook-console';
+export * from './job-portal-webui-next-build';
 export * from './job-webui-build';
 export * from './job-webui-lint-test';
 export * from './job-webui-publish-artifactory';

--- a/.circleci/ci/src/jobs/frontend/job-portal-webui-next-build.ts
+++ b/.circleci/ci/src/jobs/frontend/job-portal-webui-next-build.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { commands, Config, Job, reusable } from '@circleci/circleci-config-sdk';
+import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
+import { NodeLtsExecutor } from '../../executors';
+import { InstallYarnCommand, NotifyOnFailureCommand, WebuiInstallCommand } from '../../commands';
+import { CircleCIEnvironment } from '../../pipelines';
+import { computeApimVersion } from '../../utils';
+import { config } from '../../config';
+
+export class PortalWebuiNextBuildJob {
+  private static jobName = 'job-portal-webui-next-build';
+
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
+    const installYarnCmd = InstallYarnCommand.get();
+    dynamicConfig.addReusableCommand(installYarnCmd);
+
+    const webUiInstallCommand = WebuiInstallCommand.get();
+    dynamicConfig.addReusableCommand(webUiInstallCommand);
+
+    const notifyOnFailureCommand = NotifyOnFailureCommand.get(dynamicConfig);
+    dynamicConfig.addReusableCommand(notifyOnFailureCommand);
+
+    const apimVersion = computeApimVersion(environment);
+
+    const steps: Command[] = [
+      new commands.Checkout(),
+      new commands.workspace.Attach({ at: '.' }),
+      new reusable.ReusedCommand(installYarnCmd),
+      new reusable.ReusedCommand(webUiInstallCommand, { 'apim-ui-project': `${config.dockerImages.portal.next.project}` }),
+      new commands.Run({
+        name: 'Update Build version',
+        command: `sed -i 's/"version": ".*"/"version": "${apimVersion}"/' ${config.dockerImages.portal.next.project}/build.json`,
+      }),
+      new commands.Run({
+        name: 'Build',
+        command: 'yarn build:prod',
+        environment: {
+          NODE_OPTIONS: '--max_old_space_size=4086',
+        },
+        working_directory: `${config.dockerImages.portal.next.project}`,
+      }),
+      new reusable.ReusedCommand(notifyOnFailureCommand),
+      new commands.workspace.Persist({
+        root: '.',
+        paths: [`${config.dockerImages.portal.project}/dist-next`], // Using the current Portal project because PortalNext output path is in the dist folder of the current Portal
+      }),
+    ];
+
+    return new Job(PortalWebuiNextBuildJob.jobName, NodeLtsExecutor.create(), steps);
+  }
+}

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-alpha.1\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -619,6 +644,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0-alpha.1 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -626,7 +657,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -607,6 +632,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -614,7 +645,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -619,6 +644,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -626,7 +657,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -619,6 +644,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -626,7 +657,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -258,6 +258,31 @@ jobs:
           docker-image-name: apim-gateway
           version: 4.1.x-latest
       - cmd-docker-azure-logout
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -370,11 +395,17 @@ workflows:
           name: Build APIM Console and publish image
           apim-ui-project: gravitee-apim-console-webui
           docker-image-name: apim-management-ui
-      - job-webui-build:
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
           context:
             - cicd-orchestrator
           requires:
             - Setup
+      - job-webui-build:
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           name: Build APIM Portal and publish image
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -210,6 +210,31 @@ jobs:
             -t graviteeio.azurecr.io/apim-gateway:apim-1234-branch-name-latest \
             gateway-docker-context
       - cmd-docker-azure-logout
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -322,11 +347,17 @@ workflows:
           name: Build APIM Console and publish image
           apim-ui-project: gravitee-apim-console-webui
           docker-image-name: apim-management-ui
-      - job-webui-build:
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
           context:
             - cicd-orchestrator
           requires:
             - Setup
+      - job-webui-build:
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           name: Build APIM Portal and publish image
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -258,6 +258,31 @@ jobs:
           docker-image-name: apim-gateway
           version: master-latest
       - cmd-docker-azure-logout
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -370,11 +395,17 @@ workflows:
           name: Build APIM Console and publish image
           apim-ui-project: gravitee-apim-console-webui
           docker-image-name: apim-management-ui
-      - job-webui-build:
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
           context:
             - cicd-orchestrator
           requires:
             - Setup
+      - job-webui-build:
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           name: Build APIM Portal and publish image
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -658,6 +658,31 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-build-images:
     docker:
       - image: cimg/openjdk:17.0.8
@@ -1125,15 +1150,26 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -179,6 +179,31 @@ jobs:
           path: << parameters.apim-ui-project >>/coverage/lcov.info
       - store_test_results:
           path: << parameters.apim-ui-project >>/coverage/junit.xml
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -264,15 +289,26 @@ workflows:
   pull_requests:
     jobs:
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:
@@ -286,6 +322,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Lint & test APIM Portal
+            - Lint & test APIM Portal Next
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -625,6 +625,31 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -761,15 +786,26 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:
@@ -791,6 +827,7 @@ workflows:
             - Lint & test APIM Console
             - Build APIM Console and publish image
             - Lint & test APIM Portal
+            - Lint & test APIM Portal Next
             - Build APIM Portal and publish image
 orbs:
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -658,6 +658,31 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-build-images:
     docker:
       - image: cimg/openjdk:17.0.8
@@ -1125,15 +1150,26 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -625,6 +625,31 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -761,15 +786,26 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:
@@ -791,6 +827,7 @@ workflows:
             - Lint & test APIM Console
             - Build APIM Console and publish image
             - Lint & test APIM Portal
+            - Lint & test APIM Portal Next
             - Build APIM Portal and publish image
 orbs:
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -625,6 +625,31 @@ jobs:
 
             gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
       - cmd-notify-on-failure
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-validate-workflow-status:
     docker:
       - image: cimg/base:stable
@@ -934,15 +959,26 @@ workflows:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
       - job-webui-lint-test:
+          name: Lint & test APIM Portal Next
+          context:
+            - cicd-orchestrator
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
             - cicd-orchestrator
           apim-ui-project: gravitee-apim-portal-webui
           resource_class: large
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
       - job-webui-build:
           name: Build APIM Portal and publish image
           context:
             - cicd-orchestrator
+          requires:
+            - Build APIM Portal Next
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
       - job-sonarcloud-analysis:
@@ -964,6 +1000,7 @@ workflows:
             - Lint & test APIM Console
             - Build APIM Console and publish image
             - Lint & test APIM Portal
+            - Lint & test APIM Portal Next
             - Build APIM Portal and publish image
       - job-build-images:
           name: Build and push rest api and gateway images

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-alpha.1\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -392,6 +417,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0-alpha.1 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -399,7 +430,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -392,6 +417,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -399,7 +430,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -225,6 +225,31 @@ jobs:
                 }
               ]
             }
+  job-portal-webui-next-build:
+    docker:
+      - image: cimg/node:20.11.1
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - cmd-install-yarn
+      - cmd-webui-install:
+          apim-ui-project: gravitee-apim-portal-webui-next
+      - run:
+          name: Update Build version
+          command: "sed -i 's/\"version\": \".*\"/\"version\": \"4.2.0-SNAPSHOT\"/' gravitee-apim-portal-webui-next/build.json"
+      - run:
+          name: Build
+          command: yarn build:prod
+          environment:
+            NODE_OPTIONS: --max_old_space_size=4086
+          working_directory: gravitee-apim-portal-webui-next
+      - cmd-notify-on-failure
+      - persist_to_workspace:
+          root: .
+          paths:
+            - gravitee-apim-portal-webui/dist-next
   job-webui-build:
     parameters:
       apim-ui-project:
@@ -392,6 +417,12 @@ workflows:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🚀 Starting APIM 4.2.0 release!
+      - job-portal-webui-next-build:
+          name: Build APIM Portal Next
+          context:
+            - cicd-orchestrator
+          requires:
+            - Setup
       - job-webui-build:
           context:
             - cicd-orchestrator
@@ -399,7 +430,7 @@ workflows:
           apim-ui-project: gravitee-apim-portal-webui
           docker-image-name: apim-portal-ui
           requires:
-            - Setup
+            - Build APIM Portal Next
       - job-webui-publish-artifactory:
           context:
             - cicd-orchestrator

--- a/gravitee-apim-portal-webui-next/angular.json
+++ b/gravitee-apim-portal-webui-next/angular.json
@@ -21,7 +21,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "../gravitee-apim-portal-webui/dist/next",
+            "outputPath": "../gravitee-apim-portal-webui/dist-next",
             "index": "src/index.html",
             "browser": "src/main.ts",
             "polyfills": ["zone.js"],

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { CompanyTitleComponent } from './company-title.component';
 
@@ -24,6 +25,7 @@ describe('CompanyTitleComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CompanyTitleComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CompanyTitleComponent);

--- a/gravitee-apim-portal-webui-next/src/components/footer/footer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/footer/footer.component.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { FooterComponent } from './footer.component';
 
@@ -24,6 +25,7 @@ describe('FooterComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [FooterComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FooterComponent);

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { NavBarComponent } from './nav-bar.component';
 
@@ -24,6 +25,7 @@ describe('NavBarComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavBarComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavBarComponent);

--- a/gravitee-apim-portal-webui/.gitignore
+++ b/gravitee-apim-portal-webui/.gitignore
@@ -1,3 +1,6 @@
+# Compiled output for portal-next
+/dist-next
+
 .pnp.*
 .yarn/*
 !.yarn/patches

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -17,11 +17,14 @@
 FROM graviteeio/nginx-noconfd:1.25.1
 LABEL maintainer="contact@graviteesource.com"
 
+EXPOSE 8080
+
 ENV ALLOWED_FRAME_ANCESTOR_URLS "'self'"
 ENV PORTAL_BASE_HREF "/"
 ENV PORTAL_API_URL "http://localhost:8083/portal"
 
 COPY ./dist /usr/share/nginx/html/
+COPY ./dist-next /usr/share/nginx/html/next
 
 COPY docker/config/config.json /usr/share/nginx/html/assets/config.json
 COPY docker/config/default.conf /etc/nginx/conf.d/default.conf

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -21,6 +21,16 @@ server {
     gzip_http_version 1.1;
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
+    location /next {
+        rewrite ^ /next/ last;
+    }
+
+    location /next/ {
+        alias /usr/share/nginx/html/next/browser/;
+        sub_filter '<base href="/"' '<base href="${PORTAL_BASE_HREF}next/"';
+        sub_filter_once on;
+    }
+
     location / {
         try_files $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4246

## Description

To Include portal next into the same docker image as current portal, we need to modify the nginx configuration.
This PR also adds a new circleci job to build portal-next.
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7193/console](https://pr.team-apim.gravitee.dev/7193/console)
      Portal: [https://pr.team-apim.gravitee.dev/7193/portal](https://pr.team-apim.gravitee.dev/7193/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7193/api/management](https://pr.team-apim.gravitee.dev/7193/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7193](https://pr.team-apim.gravitee.dev/7193)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7193](https://pr.gateway-v3.team-apim.gravitee.dev/7193)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-epgwdyweco.chromatic.com)
<!-- Storybook placeholder end -->
