### PR TITLE
fix(jdbc): change datatype

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_22/schema-idp.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_0_22/schema-idp.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.0.22-idp
+      author: GraviteeSource Team
+      changes:
+        # ######################### #
+        # Identity Provider changes #
+        # ######################### #
+        - modifyDataType:
+            columnName: group_mappings
+            newDataType: clob
+            tableName: ${gravitee_prefix}identity_providers
+        - modifyDataType:
+            columnName: role_mappings
+            newDataType: clob
+            tableName: ${gravitee_prefix}identity_providers

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -161,3 +161,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_0_3/schema.yml
   - include:
       - file: liquibase/changelogs/v4_0_20/schema-dashboards.yml
+  - include:
+      - file: liquibase/changelogs/v4_0_22/schema-idp.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4512

## Description

Groups and roles mappings are stringify json arrays. `nvarchar(4000)` can be not enough for some users.
