### PR TITLE
feat(helm): add support of integration controller

### DIFF
--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -490,6 +490,14 @@ data:
     gateway:
       unknown-expire-after: {{ .Values.api.gateway.unknownExpireAfter }}
 
+    # Integration controller
+    integration:
+      enabled: {{ .Values.api.integration.enabled }}
+      {{ if .Values.api.integration.enabled }}
+      controller:
+        ws:
+          port: {{ .Values.api.integration.port }}
+      {{- end}}
     # Alert Engine communication
     {{ if .Values.alerts.enabled }}
     alerts:
@@ -530,7 +538,9 @@ data:
     auth:
       external: {{- toYaml .Values.api.auth.external | nindent 8 -}}
     {{- end }}
-    {{- if .Values.api.logging.debug }}
+
+
+  {{- if .Values.api.logging.debug }}
   logback.xml: |
     <?xml version="1.0" encoding="UTF-8"?>
     <!--

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -133,6 +133,10 @@ spec:
           ports:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}
+            {{- if .Values.api.integration.enabled }}
+            - name: {{ printf "%s-%s" (.Values.api.name | trunc 8 | trimSuffix "-") "integration" }}
+              containerPort: {{ .Values.api.integration.port }}
+            {{- end }}
             {{- if .Values.api.http.services.core.http.enabled }}
             - name: {{ printf "%s-%s" (.Values.api.name | trunc 7 | trimSuffix "-") "techapi" }}
               containerPort: {{ .Values.api.http.services.core.http.port | default "18083" }}

--- a/helm/templates/api/api-ingress-integration-controller.yaml
+++ b/helm/templates/api/api-ingress-integration-controller.yaml
@@ -1,0 +1,60 @@
+{{- if and (.Values.api.enabled) (.Values.api.integration.enabled) -}}
+{{- if .Values.api.integration.ingress.enabled -}}
+{{- $serviceAPIName := include "gravitee.api.fullname" . -}}
+{{- $serviceAPIPort := .Values.api.integration.service.externalPort -}}
+{{- $ingressPath   := .Values.api.integration.ingress.path -}}
+{{- $ingressPathType   := .Values.api.integration.ingress.pathType -}}
+{{- $apiVersion := include "common.capabilities.ingress.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}-integration-controller
+  labels:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.api.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/component: "{{ .Values.api.name }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- if and .Values.common .Values.common.labels }}
+    {{- range $key, $value := .Values.common.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  annotations:
+    {{- if .Values.api.integration.ingress.annotations }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.integration.ingress.annotations "ingressClassName" .Values.api.integration.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if and .Values.common .Values.common.annotations }}
+    {{- range $key, $value := .Values.common.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if and (eq (include "common.ingress.supportsIngressClassname" .) "true") (.Values.api.integration.ingress.ingressClassName) (ne .Values.api.integration.ingress.ingressClassName "none") }}
+  ingressClassName: {{ .Values.api.integration.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+  {{- range $host := .Values.api.integration.ingress.hosts }}
+  - host: {{ $host | quote }}
+    http:
+      paths:
+      - pathType: {{ $ingressPathType }}
+        path: {{ $ingressPath }}
+        backend:
+          {{- if (eq $apiVersion "networking.k8s.io/v1") }}
+          service:
+            name: {{ $serviceAPIName }}
+            port:
+              number: {{ $serviceAPIPort }}
+          {{ else }}
+            serviceName: {{ $serviceAPIName }}
+            servicePort: {{ $serviceAPIPort }}
+          {{- end -}}
+  {{- end -}}
+  {{- if .Values.api.integration.ingress.tls }}
+  tls:
+{{ toYaml .Values.api.integration.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/api/api-service.yaml
+++ b/helm/templates/api/api-service.yaml
@@ -78,6 +78,12 @@ spec:
       {{- end }}
       name: {{ printf "%s-%s" (.Values.api.name | trunc 56 | trimSuffix "-") "bridge" }}
     {{- end }}
+    {{- if .Values.api.integration.enabled }}
+    - port: {{ .Values.api.integration.service.externalPort }}
+      targetPort: {{ .Values.api.integration.port }}
+      protocol: TCP
+      name: {{ printf "%s-%s" (.Values.api.name | trunc 56 | trimSuffix "-") "integration-controller" }}
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "gravitee.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/tests/api/configmap_test.yaml
+++ b/helm/tests/api/configmap_test.yaml
@@ -153,3 +153,18 @@ tests:
                     *   issuer: test\n
                     *   key: ozhbx5HJCS41NzKrBSQ0vZU1WOmG0Uhm"
 
+  - it: Configure Integration
+    template: api/api-configmap.yaml
+    set:
+      api:
+        integration:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: "integration:\n
+                    * enabled: true\n
+                    * \n
+                    * controller:\n
+                    *   ws:\n
+                    *     port: 8072"

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -88,6 +88,32 @@ tests:
           # There is a k8s limitation that port names must be 15 characters or less
           pattern: ^.{0,15}$
 
+  - it: Set containerPort for Integration Controller when enabled
+    template: api/api-deployment.yaml
+    set:
+      api:
+        integration:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - name: http
+              containerPort: 8083
+            - name: api-integration
+              containerPort: 8072
+            - name: api-techapi
+              containerPort: 18083
+      - matchRegex:
+          path: spec.template.spec.containers[0].ports[1].name
+          # There is a k8s limitation that port names must be 15 characters or less
+          pattern: ^.{0,15}$
+
+
   - it: Deploy with managed ServiceAccount
     template: api/api-deployment.yaml
     set:

--- a/helm/tests/api/ingress_integrationcontroller_test.yaml
+++ b/helm/tests/api/ingress_integrationcontroller_test.yaml
@@ -1,0 +1,131 @@
+suite: Test Management API - Integration Controller Ingress
+templates:
+  - "api/api-ingress-integration-controller.yaml"
+tests:
+  - it: Check integration ingress disabled by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Check integration disabled
+    set:
+      api:
+        integration:
+          enabled: false
+          ingress:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Check integration ingress disabled
+    set:
+      api:
+        integration:
+          enabled: true
+          ingress:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Check default integration ingress
+    set:
+      api:
+        integration:
+          enabled: true
+          ingress:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.rules[0].host
+          value: apim.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /integration-controller(/.*)?
+
+  - it: Check integration controller ingress with ingressClassName and kube < 1.18-0
+    set:
+      global:
+        kubeVersion: 1.15.0
+      api:
+        integration:
+          enabled: true
+          ingress:
+            enabled: true
+            ingressClassName: "nginx"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - isEmpty:
+          path: spec.ingressClassName
+
+  - it: Check integration controller ingress with ingressClassName and kube >= 1.18-0
+    set:
+      global:
+        kubeVersion: 1.18.0
+      api:
+        integration:
+          enabled: true
+          ingress:
+            enabled: true
+            ingressClassName: "ingress"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - equal:
+          path: spec.ingressClassName
+          value: ingress
+
+  - it: Check integration controller ingress with ingressClassName "none" and kube >= 1.18-0
+    set:
+      global:
+        kubeVersion: 1.18.0
+      api:
+          integration:
+            enabled: true
+            ingress:
+              enabled: true
+              ingressClassName: "none"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - isEmpty:
+          path: spec.ingressClassName
+
+  - it: Check Ingress pathType and path
+    set:
+      global:
+        kubeVersion: 1.18.0
+      api:
+          integration:
+            enabled: true
+            ingress:
+              enabled: true
+              pathType: Exact
+              path: /test-integration-controller
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Exact
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /test-integration-controller

--- a/helm/tests/api/service_integrationcontroller_test.yaml
+++ b/helm/tests/api/service_integrationcontroller_test.yaml
@@ -1,0 +1,55 @@
+suite: Test Management API - Integration Controller Service
+templates:
+  - "api/api-service.yaml"
+tests:
+  - it: Check default integration service
+    template: api/api-service.yaml
+    set:
+      api:
+        integration:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            port: 72
+            targetPort: 8072
+            protocol: TCP
+            name: api-integration-controller
+
+  - it: Check overridden integration service
+    template: api/api-service.yaml
+    set:
+      api:
+        integration:
+          enabled: true
+          service:
+            externalPort: 8888
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            port: 8888
+            targetPort: 8072
+            protocol: TCP
+            name: api-integration-controller
+      - isNull:
+          path: spec.externalTrafficPolicy

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,7 +89,7 @@ inMemoryAuth:
 jwtSecret: myJWT4Gr4v1t33_S3cr3t
 
 # Define extra inMemory users here or disable the default ones here
-# By default, admin user will be added. If you want to remove the default admin turn the followong boolean to false. 
+# By default, admin user will be added. If you want to remove the default admin turn the followong boolean to false.
 adminAccountEnable: true
 # Default password "admin", use bcrypt ($2a$ version) to generate a new one
 adminPasswordBcrypt: $2a$10$Ihk05VSds5rUSgMdsMVi9OKMIx2yUvMz7y9VP3rJmQeizZLrhLMyq
@@ -258,7 +258,7 @@ jdbc:
   # the version of the gravitee-repository-jdbc (only required for apim versions < 3.5.0)
 #  repositoryVersion: 3.3.0
   username:
-  password: 
+  password:
   liquibase: true
   schema: public
   pool:
@@ -406,24 +406,25 @@ ratelimit:
 # Support for Gravitee.io Cockpit (cockpit.gravitee.io)
 cockpit:
   enabled: false
-  keystore: 
+  keystore:
     value: "base64 encoded value of the keystore provided by Cockpit (required)"
     password:
       #value: "keystores password provided by Cockpit"
-      #valueFrom: 
+      #valueFrom:
         #secretKeyRef:
         #configMapKeyRef:
-  #truststore: 
+  #truststore:
     #value: base64 encoded value of the truststore provided by Cockpit (optional)
     #password:
       #value: "truststore password provided by Cockpit"
-      #valueFrom: 
+      #valueFrom:
         #secretKeyRef:
         #configMapKeyRef:
   url: https://cockpit.gravitee.io
   controller: https://cockpit-controller.gravitee.io
   ssl:
     verifyHostname: true
+
 
 api:
   enabled: true
@@ -641,7 +642,7 @@ api:
 #          annotations:
 #            kubernetes.io/ingress.class: nginx
 #            nginx.ingress.kubernetes.io/rewrite-target: /_$1
-        service: 
+        service:
 #       If you choose to enable this service, you'll need to expose the technical api
 #       on an accessible host outside of the pod: api.http.services.core.http.host
           enabled: false
@@ -720,7 +721,7 @@ api:
       # Used to create an Ingress record.
       hosts:
         - apim.example.com
-      annotations: 
+      annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_set_header if-match \"\";\n"
         # kubernetes.io/tls-acme: "true"
@@ -771,6 +772,28 @@ api:
   #      algorithm: HS256
   #      verificationKey: ozhbx5HJCS41NzKrBSQ0vZU1WOmG0Uhm # verificationKey or the JWKS URL
   #      issuer: MY_ISSUER
+
+  integration:
+    enabled: false
+    port: 8072
+    ingress:
+      enabled: false
+      ingressClassName: ""
+      path: /integration-controller(/.*)?
+      pathType: Prefix
+      hosts:
+        - apim.example.com
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/proxy-read-timeout: 3600                                                                                                                                              │
+        nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
+        nginx.ingress.kubernetes.io/rewrite-target: /$1
+#      tls:
+#        - hosts:
+#            - apim.example.com
+#          secretName: api-custom-cert
+    service:
+      externalPort: 72
 
 gateway:
   enabled: true
@@ -1006,13 +1029,13 @@ gateway:
 #            port: 26379
 #          - host: sentinel2
 #            port: 26379
-  management: 
+  management:
     http:
-      # url: 
+      # url:
       # keepAlive: true
       # idleTimeout: 30000
       # connectTimeout: 10000
-      # username: 
+      # username:
       # password:
       # proxy:
       #   host: proxy.com
@@ -1060,7 +1083,7 @@ gateway:
         annotations: {}
 #            kubernetes.io/ingress.class: nginx
 #            nginx.ingress.kubernetes.io/rewrite-target: /_$1
-      service: 
+      service:
 #       If you choose to enable this service, you'll need to expose the technical api
 #       on an accessible host outside of the pod: api.http.services.core.http.host
         enabled: false
@@ -1333,7 +1356,7 @@ portal:
     enabled: false
     minAvailable: ""
     maxUnavailable: "50%"
-       
+
   podAnnotations: {}
     # iam.amazonaws.com/role: es-cluster
 
@@ -1486,7 +1509,7 @@ ui:
         maxUnavailable: 1
     topologySpreadConstraints: []
     # revisionHistoryLimit: 10
-    
+
     livenessProbe:
       enabled: true
       httpGet:
@@ -1520,7 +1543,7 @@ ui:
     maxUnavailable: "50%"
 
   podAnnotations: {}
-    # iam.amazonaws.com/role: es-cluster 
+    # iam.amazonaws.com/role: es-cluster
 
   # How long to wait for APIM Console pods to stop gracefully
   terminationGracePeriod: 30


### PR DESCRIPTION
## Description

To support Federation feature, there is a new component in APIM that listens for WebSocket connection (powered by https://github.com/gravitee-io/gravitee-exchange)
The Helm chart has been updated to expose the component through a service and ingress


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

