### PR TITLE
APIM 3921: Add Api service to portal-next

### DIFF
--- a/gravitee-apim-portal-webui-next/angular.json
+++ b/gravitee-apim-portal-webui-next/angular.json
@@ -46,7 +46,13 @@
                   "maximumError": "4kb"
                 }
               ],
-              "outputHashing": "all"
+              "outputHashing": "all",
+              "fileReplacements": [
+                {
+                  "replace": "src/assets/config.json",
+                  "with": "src/assets/config.prod.json"
+                }
+              ]
             },
             "development": {
               "optimization": false,
@@ -59,7 +65,9 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "port": 4101
+            "port": 4101,
+            "proxyConfig": "src/proxy.conf.mjs",
+            "buildTarget": "gravitee-apim-portal-webui-next:build"
           },
           "configurations": {
             "production": {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -32,7 +32,9 @@
     </mat-card-content>
   </mat-card>
 } @else {
-  @for (api of apis; track api.id) {
-    <app-api-card [title]="api.title" [version]="api.version" [content]="api.content" />
-  }
+  <div class="api-list__container">
+    @for (api of apis; track api.id) {
+      <app-api-card [title]="api.title" [version]="api.version" [content]="api.content" [picture]="api.picture" />
+    }
+  </div>
 }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
@@ -22,3 +22,9 @@
 .welcome-banner-content {
   padding: 0 16px;
 }
+
+.api-list__container {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -13,39 +13,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+
+import { Component, OnInit } from '@angular/core';
 import { MatCard, MatCardContent } from '@angular/material/card';
 
 import { ApiCardComponent } from '../../components/api-card/api-card.component';
 import { BannerComponent } from '../../components/banner/banner.component';
+import { ApiService } from '../../services/api.service';
 
 export interface ApiVM {
+  id: string;
   title: string;
   version: string;
   content: string;
-  id: number;
+  picture?: string;
 }
 
 @Component({
   selector: 'app-catalog',
   standalone: true,
-  imports: [BannerComponent, MatCard, MatCardContent, ApiCardComponent, CommonModule],
+  imports: [BannerComponent, MatCard, MatCardContent, ApiCardComponent],
   templateUrl: './catalog.component.html',
   styleUrl: './catalog.component.scss',
 })
-export class CatalogComponent {
-  apis: ApiVM[] = [
-    {
-      title: 'Test tile',
-      version: 'v.1.2',
-      content:
-        'Get real-time weather updates, forecasts, and historical data to enhance your applications with accurate weather information.',
-      id: 1,
-    },
-  ];
+export class CatalogComponent implements OnInit {
+  apis: ApiVM[] = [];
 
   // TODO: Get banner title + subtitle from configuration
   bannerTitle: string = 'Welcome to Gravitee Developer Portal!';
   bannerSubtitle: string = 'Discover powerful APIs to supercharge your projects.';
+
+  constructor(private apiService: ApiService) {}
+
+  ngOnInit(): void {
+    this.apiService.list().subscribe(resp => {
+      if (resp.data) {
+        this.apis = resp.data.map(api => ({
+          id: api.id,
+          content: api.description,
+          version: api.version,
+          title: api.name,
+          picture: api._links?.picture,
+        }));
+      }
+    });
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/assets/config.json
+++ b/gravitee-apim-portal-webui-next/src/assets/config.json
@@ -1,0 +1,3 @@
+{
+  "baseURL": "/portal"
+}

--- a/gravitee-apim-portal-webui-next/src/assets/config.prod.json
+++ b/gravitee-apim-portal-webui-next/src/assets/config.prod.json
@@ -1,0 +1,3 @@
+{
+  "baseURL": "http://localhost:8083/portal"
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
@@ -20,7 +20,7 @@
     <div class="api-card__header">
       <img
         i18n-alt="@@apiCardPicture"
-        ngSrc="assets/images/logo.png"
+        ngSrc="{{ picture }}"
         height="40"
         width="40"
         alt="Api Card Picture"

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
@@ -15,7 +15,6 @@
  */
 .api-card {
   display: flex;
-  width: calc(33.33% - 20px);
 
   --mdc-elevated-card-container-shape: 12px;
 

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.spec.ts
@@ -26,7 +26,7 @@ describe('CardComponent', () => {
     version: 'v.1',
     content:
       'Get real-time weather updates, forecasts, and historical data to enhance your applications with accurate weather information.',
-    id: 1,
+    id: '1',
   };
   beforeEach(async () => {
     await TestBed.configureTestingModule({

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.ts
@@ -27,9 +27,11 @@ import { MatCardModule } from '@angular/material/card';
 })
 export class ApiCardComponent {
   @Input({ required: true })
-  title: string;
+  title!: string;
   @Input({ required: true })
-  version: string;
+  version!: string;
   @Input()
-  content: string;
+  picture: string | undefined = 'assets/images/logo.png';
+  @Input()
+  content?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/entities/api/api-links.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api-links.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ApiLinks {
+  self?: string;
+  links?: string;
+  metrics?: string;
+  pages?: string;
+  picture?: string;
+  background?: string;
+  plans?: string;
+  ratings?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api/api.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.fixtures.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'rxjs/internal/util/isFunction';
+
+import { Api } from './api';
+import { ApisResponse } from './apis-response';
+
+export function fakeApi(modifier?: Partial<Api> | ((baseApi: Api) => Api)): Api {
+  const base: Api = {
+    id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
+    name: '\uD83E\uDE90 Planets',
+    version: '1.0',
+    description: 'The whole universe in your hand.',
+    _public: true,
+    running: true,
+    entrypoints: ['https://api.company.com/planets'],
+    listener_type: 'HTTP',
+    labels: [],
+    owner: {
+      id: '8d4ce9b8-0efe-4d8b-8ce9-b80efe1d8bf1',
+      email: 'gaetan.maisse@graviteesource.com',
+      first_name: 'Hello',
+      last_name: 'World',
+      config: {},
+      reference: 'user-reference',
+      permissions: {
+        USER: [],
+        APPLICATION: [],
+      },
+      customFields: {},
+      display_name: 'admin',
+      editable_profile: false,
+    },
+    created_at: new Date(1630437434407),
+    updated_at: new Date(1642675655553),
+    categories: ['my-category'],
+    _links: {
+      picture:
+        'https://master-apim-api.cloud.gravitee.io/management/organizations/DEFAULT/environments/DEFAULT/apis/aee23b1e-34b1-4551-a23b-1e34b165516a/picture?hash=1642675655553',
+    },
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeApisResponse(modifier?: Partial<ApisResponse> | ((baseApi: ApisResponse) => ApisResponse)): ApisResponse {
+  const base: ApisResponse = {
+    data: [fakeApi()],
+    metadata: {},
+    links: {},
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api/api.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiLinks } from './api-links';
+import { ListenerType } from './listener-type';
+import { User } from '../user/user';
+
+/**
+ * Describes an API.
+ */
+export interface Api {
+  /**
+   * Unique identifier of an API.
+   */
+  id: string;
+  /**
+   * Name of the API.
+   */
+  name: string;
+  /**
+   * Version of the API.
+   */
+  version: string;
+  /**
+   * Description of the API.
+   */
+  description: string;
+  /**
+   * Whether or not the API is public.
+   */
+  _public?: boolean;
+  /**
+   * Whether or not the API is running.
+   */
+  running?: boolean;
+  /**
+   * List of all the available endpoints to call the API.
+   */
+  entrypoints?: Array<string>;
+  listener_type?: ListenerType;
+  /**
+   * List of labels linked to this API.
+   */
+  labels?: Array<string>;
+  owner: User;
+  /**
+   * create date and time.
+   */
+  created_at?: Date;
+  /**
+   * Last update date and time.
+   */
+  updated_at?: Date;
+  /**
+   * List of categories this API belongs to.
+   */
+  categories?: Array<string>;
+  _links?: ApiLinks;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api/apis-response.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/apis-response.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Api } from './api';
+import { Links } from '../pagination/links';
+
+export interface ApisResponse {
+  /**
+   * List of API.
+   */
+  data?: Array<Api>;
+  /**
+   * Map of Map of Object
+   */
+  metadata?: { [key: string]: { [key: string]: object } };
+  links?: Links;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/api/listener-type.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/listener-type.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Listener of the API entrypoints.
+ */
+export type ListenerType = 'HTTP' | 'TCP' | 'SUBSCRIPTION';
+
+export const ListenerType = {
+  HTTP: 'HTTP' as ListenerType,
+  TCP: 'TCP' as ListenerType,
+  SUBSCRIPTION: 'SUBSCRIPTION' as ListenerType,
+};

--- a/gravitee-apim-portal-webui-next/src/entities/pagination/links.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/pagination/links.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Links {
+  self?: string;
+  first?: string;
+  last?: string;
+  prev?: string;
+  next?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/user/user.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/user.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface UserPermissions {
+  APPLICATION?: Array<string>;
+  USER?: Array<string>;
+}
+
+export interface UserConfig {
+  /**
+   * The URL of the Gravitee management UI
+   */
+  management_url?: string;
+}
+
+export interface UserLinks {
+  self?: string;
+  avatar?: string;
+  notifications?: string;
+}
+
+export interface User {
+  /**
+   * Unique identifier of a user.
+   */
+  id?: string;
+  /**
+   * Unique reference if user comes from external source. Use for search only.
+   */
+  reference?: string;
+  first_name?: string;
+  last_name?: string;
+  display_name?: string;
+  email?: string;
+  /**
+   * True if the user can edit the MyAccount information
+   */
+  editable_profile?: boolean;
+  permissions?: UserPermissions;
+  /**
+   * Values for CustomUserFields
+   */
+  customFields?: { [key: string]: object };
+  config?: UserConfig;
+  _links?: UserLinks;
+}

--- a/gravitee-apim-portal-webui-next/src/proxy.conf.mjs
+++ b/gravitee-apim-portal-webui-next/src/proxy.conf.mjs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const env = process.env.BACKEND_ENV;
+const target = `${env ? `https://${env}` : 'http://localhost:8083'}`
+export default [
+  {
+    context: ['/portal/ui/bootstrap'],
+    target,
+    secure: false,
+    changeOrigin: true,
+    onProxyRes: function(proxyRes, req, res) {
+      // Replace bootstrap full baseURL to use proxy configured bellow (/portal)
+      // This allows to bypass cors security with cloud env
+      var body = new Buffer('');
+      proxyRes.on('data', function(data) {
+        body = Buffer.concat([body, data]);
+      });
+      proxyRes.on('end', function() {
+        body = body.toString();
+        res.end(body.replace(`${target}/`, ""));
+      });
+    },
+    // selfHandleResponse: true,
+    logLevel: 'debug'
+  },
+  {
+    context: ['/portal'],
+    target,
+    secure: false,
+    changeOrigin: true,
+    onProxyReq: function (proxyReq, req, res) {
+      proxyReq.setHeader('origin', target.replace("-api", "-portal"));
+    },
+    logLevel: 'debug',
+  }
+]

--- a/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiService } from './api.service';
+import { fakeApisResponse } from '../entities/api/api.fixtures';
+import { ApisResponse } from '../entities/api/apis-response';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('ApiService', () => {
+  let service: ApiService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ApiService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list', () => {
+    it('should return apis response with default page and size', done => {
+      const apisResponse: ApisResponse = fakeApisResponse();
+
+      service.list().subscribe(response => {
+        expect(response).toMatchObject(apisResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis?page=1&size=9`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(apisResponse);
+    });
+
+    it('should return apis response with specified page and size', done => {
+      const apisResponse: ApisResponse = fakeApisResponse();
+
+      service.list(2, 99).subscribe(response => {
+        expect(response).toMatchObject(apisResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis?page=2&size=99`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(apisResponse);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/api.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { ApisResponse } from '../entities/api/apis-response';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiService {
+  constructor(
+    private readonly http: HttpClient,
+    private configService: ConfigService,
+  ) {}
+
+  list(page = 1, size = 9): Observable<ApisResponse> {
+    return this.http.get<ApisResponse>(`${this.configService.baseURL}/apis`, {
+      params: {
+        page,
+        size,
+      },
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClientTestingModule, HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from './config.service';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ConfigService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  describe('initBaseURL', () => {
+    it('should call base url without enforced env id', done => {
+      const configJson = {
+        baseURL: 'http://localhost:8083/portal',
+      };
+
+      const configBootstrap = {
+        ...configJson,
+        environmentId: 'DEFAULT',
+      };
+
+      service
+        .initBaseURL()()
+        .subscribe(baseUrl => {
+          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+          done();
+        });
+
+      httpTestingController.expectOne('./assets/config.json').flush(configJson);
+      httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap').flush(configBootstrap);
+    });
+
+    it('should call base url with enforced env id in baseURL', done => {
+      const configJson = {
+        baseURL: 'http://localhost:8083/portal/environments/DEFAULT',
+      };
+
+      const configBootstrap = {
+        baseURL: 'http://localhost:8083/portal',
+        environmentId: 'DEFAULT',
+      };
+
+      service
+        .initBaseURL()()
+        .subscribe(baseUrl => {
+          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+          done();
+        });
+
+      httpTestingController.expectOne('./assets/config.json').flush(configJson);
+      httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap?environmentId=DEFAULT').flush(configBootstrap);
+    });
+
+    it('should call base url with enforced env id in environmentId', done => {
+      const configJson = {
+        baseURL: 'http://localhost:8083/portal',
+        environmentId: 'DEFAULT',
+      };
+
+      const configBootstrap = {
+        baseURL: 'http://localhost:8083/portal',
+        environmentId: 'DEFAULT',
+      };
+
+      service
+        .initBaseURL()()
+        .subscribe(baseUrl => {
+          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+          done();
+        });
+
+      httpTestingController.expectOne('./assets/config.json').flush(configJson);
+      httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap?environmentId=DEFAULT').flush(configBootstrap);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/config.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map, Observable, switchMap } from 'rxjs';
+
+/**
+ * Object used in `config.json` file and `/ui/bootstrap` response
+ */
+interface Config {
+  baseURL: string;
+  environmentId: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ConfigService {
+  private _baseURL: string = '';
+
+  constructor(private httpClient: HttpClient) {}
+
+  public get baseURL(): string {
+    return this._baseURL;
+  }
+
+  private set baseURL(baseURL: string) {
+    this._baseURL = baseURL;
+  }
+
+  public initBaseURL(): () => Observable<string> {
+    return () =>
+      this.httpClient.get<Config>('./assets/config.json').pipe(
+        switchMap(configJson => {
+          const baseURL = this._sanitizeBaseURLs(configJson);
+          const enforcedEnvironmentId = this._getEnforcedEnvironmentId(configJson);
+          const bootstrapUrl = `${baseURL}/ui/bootstrap${enforcedEnvironmentId ? `?environmentId=${enforcedEnvironmentId}` : ''}`;
+
+          return this.httpClient.get<Config>(bootstrapUrl);
+        }),
+        map((bootstrapConfig: Config) => {
+          this.baseURL = `${bootstrapConfig.baseURL}/environments/${bootstrapConfig.environmentId}`;
+          return this.baseURL;
+        }),
+      );
+  }
+
+  private _sanitizeBaseURLs(config: Config): string {
+    let baseURL = config.baseURL;
+    if (config.baseURL.endsWith('/')) {
+      baseURL = config.baseURL.slice(0, -1);
+    }
+    const envIndex = baseURL.indexOf('/environments');
+    if (envIndex >= 0) {
+      baseURL = baseURL.substring(0, envIndex);
+    }
+    return baseURL;
+  }
+
+  private _getEnforcedEnvironmentId(config: Config): string | undefined {
+    if (config.environmentId) {
+      return config.environmentId;
+    }
+    const baseURL = config.baseURL;
+    const envIndex = baseURL.indexOf('/environments/');
+    if (envIndex >= 0) {
+      const subPathWithEnv = baseURL.substring(envIndex, baseURL.length);
+      const splitArr = subPathWithEnv.split('/');
+      if (splitArr.length >= 3) {
+        return splitArr[2];
+      }
+    }
+    return '';
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -13,27 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { provideHttpClient } from '@angular/common/http';
-import { APP_INITIALIZER, ApplicationConfig } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { Observable } from 'rxjs';
+import { CommonModule } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { Injectable, NgModule } from '@angular/core';
 
-import { routes } from './app.routes';
 import { ConfigService } from '../services/config.service';
 
-function initConfig(configService: ConfigService): () => Observable<string> {
-  return configService.initBaseURL();
+export const TESTING_BASE_URL = 'http://localhost:8083/portal/environments/DEFAULT';
+
+@Injectable()
+export class ConfigServiceStub {
+  get baseURL(): string {
+    return TESTING_BASE_URL;
+  }
 }
 
-export const appConfig: ApplicationConfig = {
+@NgModule({
+  declarations: [],
+  imports: [CommonModule, HttpClientTestingModule],
   providers: [
-    provideRouter(routes),
-    provideHttpClient(),
     {
-      provide: APP_INITIALIZER,
-      useFactory: initConfig,
-      deps: [ConfigService],
-      multi: true,
+      provide: ConfigService,
+      useClass: ConfigServiceStub,
     },
   ],
-};
+})
+export class AppTestingModule {}

--- a/gravitee-apim-portal-webui-next/tsconfig.json
+++ b/gravitee-apim-portal-webui-next/tsconfig.json
@@ -18,7 +18,6 @@
     "target": "ES2022",
     "module": "ES2022",
     "useDefineForClassFields": false,
-    "strictPropertyInitialization": false,
     "lib": ["ES2022", "dom"],
     "types": ["@angular/localize"]
   },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3921

## Description

- create config service as a store
- initialize api service + tests
- integrate service into the catalog component

With public + published APIs returned:

![Screenshot 2024-04-11 at 17 35 47](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/2ea2f4a8-fa56-4bd3-a3d8-a7d9bbcc0adf)


With no apis that are public + published:

![Screenshot 2024-04-10 at 09 45 11](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/77994bf4-9e5d-4c9d-8a4b-39841e660d32)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fsrwjzjcxc.chromatic.com)
<!-- Storybook placeholder end -->
