### PR TITLE
feat: update Integration Agent Status when agents connect/disconnect

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.html
@@ -72,7 +72,7 @@
           </div>
         </div>
       </mat-card>
-      <gio-banner-error>
+      <gio-banner-error *ngIf="integration.agentStatus === 'DISCONNECTED'">
         Check your agent status and ensure connectivity with the provider to start importing your APIs in Gravitee.
       </gio-banner-error>
     </div>

--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.spec.ts
@@ -88,16 +88,21 @@ describe('IntegrationOverviewComponent', () => {
     expectIntegrationGetRequest(fakeIntegration({ id: integrationId, agentStatus: 'DISCONNECTED' }));
 
     const errorBadge: TestElement = await componentHarness.getErrorBadge();
-
     expect(errorBadge).toBeTruthy();
+
+    const errorBanner = await componentHarness.getErrorBanner().then((e) => e.text());
+    expect(errorBanner).toEqual(
+      'Check your agent status and ensure connectivity with the provider to start importing your APIs in Gravitee.',
+    );
   });
 
   it('should display success badge', async (): Promise<void> => {
     expectIntegrationGetRequest(fakeIntegration({ id: integrationId, agentStatus: 'CONNECTED' }));
 
     const successBadge: TestElement = await componentHarness.getSuccessBadge();
-
     expect(successBadge).toBeTruthy();
+
+    expect(await componentHarness.getErrorBanner()).toBeNull();
   });
 
   describe('discover', () => {

--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.harness.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.harness.ts
@@ -24,9 +24,14 @@ export class IntegrationOverviewHarness extends ComponentHarness {
   private discoverButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorForOptional(
     MatButtonHarness.with({ selector: '[data-testid=discover-button]' }),
   );
+  private errorBannerLocator = this.locatorForOptional('gio-banner-error');
 
   public getErrorBadge = async (): Promise<TestElement> => {
     return this.badgeErrorLocator();
+  };
+
+  public getErrorBanner = async (): Promise<TestElement> => {
+    return this.errorBannerLocator();
   };
 
   public getSuccessBadge = async (): Promise<TestElement> => {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Integration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Integration.java
@@ -48,6 +48,7 @@ public class Integration {
     private AgentStatus agentStatus;
 
     public enum AgentStatus {
+        CONNECTED,
         DISCONNECTED,
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IntegrationMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IntegrationMongo.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class IntegrationMongo extends Auditable {
 
     public enum AgentStatus {
+        CONNECTED,
         DISCONNECTED,
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.integration.controller.command;
 
 import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.exchange.api.command.Reply;
@@ -28,12 +29,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IntegrationControllerCommandHandlerFactory implements ControllerCommandHandlersFactory {
 
-    private final IntegrationCrudService integrationCrudService;
+    private final UpdateAgentStatusUseCase updateAgentStatusUseCase;
 
     @Override
     public List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> buildCommandHandlers(
         final ControllerCommandContext controllerCommandContext
     ) {
-        return List.of(new HelloCommandHandler(integrationCrudService));
+        return List.of(new HelloCommandHandler(updateAgentStatusUseCase));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/listener/ControllerEventListener.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/listener/ControllerEventListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.listener;
+
+import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase;
+import io.gravitee.exchange.api.controller.listeners.TargetListener;
+
+/**
+ * This listener will be notified by ExchangeController when events occur.
+ */
+public class ControllerEventListener implements TargetListener {
+
+    private final UpdateAgentStatusUseCase updateAgentStatusUseCase;
+
+    public ControllerEventListener(UpdateAgentStatusUseCase updateAgentStatusUseCase) {
+        this.updateAgentStatusUseCase = updateAgentStatusUseCase;
+    }
+
+    /**
+     * This method is called when the primary channel is evicted for a given target ID.
+     *
+     * <p>
+     *     When it happens, it means that there is no Agent for that integration. Therefore, we can update the Agent Status.
+     * </p>
+     * @param targetId the ID of the target
+     */
+    @Override
+    public void onPrimaryChannelEvicted(String targetId) {
+        updateAgentStatusUseCase.execute(new UpdateAgentStatusUseCase.Input(targetId, Integration.AgentStatus.DISCONNECTED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
 import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
@@ -66,9 +67,9 @@ public class IntegrationControllerConfiguration {
 
     @Bean("integrationControllerCommandHandlerFactory")
     public IntegrationControllerCommandHandlerFactory integrationControllerCommandHandlerFactory(
-        final IntegrationCrudService integrationCrudService
+        final UpdateAgentStatusUseCase updateAgentStatusUseCase
     ) {
-        return new IntegrationControllerCommandHandlerFactory(integrationCrudService);
+        return new IntegrationControllerCommandHandlerFactory(updateAgentStatusUseCase);
     }
 
     @Bean("integrationExchangeController")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
@@ -30,6 +30,7 @@ import io.gravitee.exchange.controller.websocket.WebSocketExchangeController;
 import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
 import io.gravitee.integration.api.websocket.command.IntegrationExchangeSerDe;
 import io.gravitee.integration.controller.command.IntegrationControllerCommandHandlerFactory;
+import io.gravitee.integration.controller.listener.ControllerEventListener;
 import io.gravitee.integration.controller.websocket.auth.IntegrationWebsocketControllerAuthentication;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.certificate.KeyStoreLoaderFactoryRegistry;
@@ -72,6 +73,11 @@ public class IntegrationControllerConfiguration {
         return new IntegrationControllerCommandHandlerFactory(updateAgentStatusUseCase);
     }
 
+    @Bean("integrationControllerEventListener")
+    ControllerEventListener controllerEventListener(UpdateAgentStatusUseCase updateAgentStatusUseCase) {
+        return new ControllerEventListener(updateAgentStatusUseCase);
+    }
+
     @Bean("integrationExchangeController")
     public ExchangeController integrationExchangeController(
         final @Lazy ClusterManager clusterManager,
@@ -86,7 +92,8 @@ public class IntegrationControllerConfiguration {
         final @Qualifier(
             "integrationControllerCommandHandlerFactory"
         ) ControllerCommandHandlersFactory integrationControllerCommandHandlerFactory,
-        final @Qualifier("integrationExchangeSerDe") ExchangeSerDe integrationExchangeSerDe
+        final @Qualifier("integrationExchangeSerDe") ExchangeSerDe integrationExchangeSerDe,
+        final @Qualifier("integrationControllerEventListener") ControllerEventListener eventListener
     ) {
         return new WebSocketExchangeController(
             identifyConfiguration,
@@ -98,7 +105,8 @@ public class IntegrationControllerConfiguration {
             integrationWebsocketControllerAuthentication,
             integrationControllerCommandHandlerFactory,
             integrationExchangeSerDe
-        );
+        )
+            .addListener(eventListener);
     }
 
     public ObjectMapper objectMapper() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3195,6 +3195,7 @@ components:
                     description: Agent connection status
                     example: DISCONNECTED
                     enum:
+                        - CONNECTED
                         - DISCONNECTED
 
         IntegrationIngestionResponse:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/Integration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/Integration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.integration.model;
 
+import io.gravitee.common.utils.TimeProvider;
 import java.time.ZonedDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -44,6 +45,15 @@ public class Integration {
     AgentStatus agentStatus;
 
     public enum AgentStatus {
+        CONNECTED,
         DISCONNECTED,
+    }
+
+    public Integration agentConnected() {
+        return this.toBuilder().agentStatus(AgentStatus.CONNECTED).updatedAt(TimeProvider.now()).build();
+    }
+
+    public Integration agentDisconnected() {
+        return this.toBuilder().agentStatus(AgentStatus.DISCONNECTED).updatedAt(TimeProvider.now()).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCase.java
@@ -53,7 +53,11 @@ public class UpdateAgentStatusUseCase {
             .orElse(new Output(false, String.format("Integration [id=%s] not found", input.integrationId)));
     }
 
-    public record Input(String integrationId, String provider, Integration.AgentStatus agentStatus) {}
+    public record Input(String integrationId, String provider, Integration.AgentStatus agentStatus) {
+        public Input(String integrationId, Integration.AgentStatus agentStatus) {
+            this(integrationId, null, agentStatus);
+        }
+    }
 
     public record Output(boolean success, String message) {
         public Output(boolean success) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.integration.model.Integration;
+
+@UseCase
+public class UpdateAgentStatusUseCase {
+
+    private final IntegrationCrudService integrationCrudService;
+
+    public UpdateAgentStatusUseCase(IntegrationCrudService integrationCrudService) {
+        this.integrationCrudService = integrationCrudService;
+    }
+
+    public Output execute(Input input) {
+        return integrationCrudService
+            .findById(input.integrationId)
+            .map(integration -> {
+                if (input.agentStatus == Integration.AgentStatus.CONNECTED && !integration.getProvider().equals(input.provider)) {
+                    return new Output(
+                        false,
+                        String.format(
+                            "Integration [id=%s] does not match. Expected provider [provider=%s]",
+                            integration.getId(),
+                            integration.getProvider()
+                        )
+                    );
+                }
+                integrationCrudService.update(
+                    switch (input.agentStatus) {
+                        case CONNECTED -> integration.agentConnected();
+                        case DISCONNECTED -> integration.agentDisconnected();
+                    }
+                );
+                return new Output(true);
+            })
+            .orElse(new Output(false, String.format("Integration [id=%s] not found", input.integrationId)));
+    }
+
+    public record Input(String integrationId, String provider, Integration.AgentStatus agentStatus) {}
+
+    public record Output(boolean success, String message) {
+        public Output(boolean success) {
+            this(success, null);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationFixture.java
@@ -16,9 +16,8 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.integration.model.Integration;
-import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.function.Supplier;
 
 public class IntegrationFixture {
@@ -34,8 +33,8 @@ public class IntegrationFixture {
             .provider("test-provider")
             .environmentId("my-env")
             .agentStatus(Integration.AgentStatus.DISCONNECTED)
-            .createdAt(ZonedDateTime.parse("2020-02-03T20:22:02.00Z").withZoneSameLocal(ZoneId.systemDefault()))
-            .updatedAt(ZonedDateTime.parse("2020-02-03T20:22:02.00Z").withZoneSameLocal(ZoneId.systemDefault()));
+            .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()));
 
     public static Integration anIntegration() {
         return BASE.get().build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/UpdateAgentStatusUseCaseTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.IntegrationFixture;
+import inmemory.IntegrationCrudServiceInMemory;
+import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase.Input;
+import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase.Output;
+import io.gravitee.common.utils.TimeProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Arrays;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UpdateAgentStatusUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String INTEGRATION_ID = "my-integration-id";
+    private static final String PROVIDER = "aws-api-gateway";
+    private static final Integration INTEGRATION = IntegrationFixture
+        .anIntegration()
+        .toBuilder()
+        .id(INTEGRATION_ID)
+        .provider(PROVIDER)
+        .build();
+
+    IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
+
+    UpdateAgentStatusUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        useCase = new UpdateAgentStatusUseCase(integrationCrudService);
+    }
+
+    @Nested
+    class AgentConnected {
+
+        @Test
+        void should_fail_when_integration_does_not_exist() {
+            // When
+            var result = useCase.execute(new Input("unknown", PROVIDER, Integration.AgentStatus.CONNECTED));
+
+            // Then
+            assertThat(result).extracting(Output::success, Output::message).containsExactly(false, "Integration [id=unknown] not found");
+        }
+
+        @Test
+        void should_fail_when_integration_does_not_match_with_agent_connected() {
+            // Given
+            givenExistingIntegration(INTEGRATION);
+
+            // When
+            var result = useCase.execute(new Input(INTEGRATION_ID, "other", Integration.AgentStatus.CONNECTED));
+
+            // Then
+            assertThat(result)
+                .extracting(Output::success, Output::message)
+                .containsExactly(false, "Integration [id=my-integration-id] does not match. Expected provider [provider=aws-api-gateway]");
+        }
+
+        @Test
+        void should_update_agent_status() {
+            // Given
+            givenExistingIntegration(INTEGRATION);
+
+            var result = useCase.execute(new Input(INTEGRATION_ID, PROVIDER, Integration.AgentStatus.CONNECTED));
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft
+                    .assertThat(integrationCrudService.storage())
+                    .contains(
+                        INTEGRATION
+                            .toBuilder()
+                            .agentStatus(Integration.AgentStatus.CONNECTED)
+                            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+                soft.assertThat(result).extracting(Output::success).isEqualTo(true);
+            });
+        }
+    }
+
+    @Nested
+    class AgentDisconnected {
+
+        @Test
+        void should_fail_when_integration_does_not_exist() {
+            // When
+            var result = useCase.execute(new Input("unknown", PROVIDER, Integration.AgentStatus.DISCONNECTED));
+
+            // Then
+            assertThat(result).extracting(Output::success, Output::message).containsExactly(false, "Integration [id=unknown] not found");
+        }
+
+        @Test
+        void should_not_check_provider_input() {
+            // Given
+            givenExistingIntegration(INTEGRATION.toBuilder().agentStatus(Integration.AgentStatus.CONNECTED).build());
+
+            var result = useCase.execute(new Input(INTEGRATION_ID, "unknown", Integration.AgentStatus.DISCONNECTED));
+
+            assertThat(result).extracting(Output::success).isEqualTo(true);
+        }
+
+        @Test
+        void should_update_agent_status() {
+            // Given
+            givenExistingIntegration(INTEGRATION.toBuilder().agentStatus(Integration.AgentStatus.CONNECTED).build());
+
+            var result = useCase.execute(new Input(INTEGRATION_ID, PROVIDER, Integration.AgentStatus.DISCONNECTED));
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft
+                    .assertThat(integrationCrudService.storage())
+                    .contains(
+                        INTEGRATION
+                            .toBuilder()
+                            .agentStatus(Integration.AgentStatus.DISCONNECTED)
+                            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                            .build()
+                    );
+                soft.assertThat(result).extracting(Output::success).isEqualTo(true);
+            });
+        }
+    }
+
+    private void givenExistingIntegration(Integration... integration) {
+        integrationCrudService.initWith(Arrays.asList(integration));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-cockpit-api.version>3.0.6</gravitee-cockpit-api.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
-        <gravitee-exchange.version>1.2.1</gravitee-exchange.version>
+        <gravitee-exchange.version>1.4.0</gravitee-exchange.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>


### PR DESCRIPTION
## Description

The status changes to `CONNECTED` during the processing of the `HelloCommand` once the payload has been validated.
The status moves to `DISCONNECTED` when the last agent is disconnected. In that case, the ExchangeController detects the eviction of the PrimaryChannel and notifies listeners.


![image](https://github.com/gravitee-io/gravitee-api-management/assets/4171593/aecc3d3c-8eb4-4f0f-af27-dc3cd71f6107)

## Additional context

Require https://github.com/gravitee-io/gravitee-exchange/pull/36
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jdmcvkmgmt.chromatic.com)
<!-- Storybook placeholder end -->
