### PR TITLE
fix(portal-next): add config for next in docker

### DIFF
--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -27,6 +27,7 @@ COPY ./dist /usr/share/nginx/html/
 COPY ./dist-next /usr/share/nginx/html/next
 
 COPY docker/config/config.json /usr/share/nginx/html/assets/config.json
+COPY docker/config/config-next.json /usr/share/nginx/html/next/browser/assets/config.json
 COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/conf.d/

--- a/gravitee-apim-portal-webui/docker/config/config-next.json
+++ b/gravitee-apim-portal-webui/docker/config/config-next.json
@@ -1,0 +1,3 @@
+{
+  "baseURL": "$PORTAL_API_URL"
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3921

## Description

Override config.json file in docker image
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7232/console](https://pr.team-apim.gravitee.dev/7232/console)
      Portal: [https://pr.team-apim.gravitee.dev/7232/portal](https://pr.team-apim.gravitee.dev/7232/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7232/api/management](https://pr.team-apim.gravitee.dev/7232/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7232](https://pr.team-apim.gravitee.dev/7232)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7232](https://pr.gateway-v3.team-apim.gravitee.dev/7232)

<!-- Environment placeholder end -->
