### PR TITLE
fix(console): Filter possible endpoints by selected entrypoint capabilities

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/connectorVM.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/connectorVM.ts
@@ -1,4 +1,5 @@
 import { ConnectorPlugin, ListenerType, Qos } from '../../index';
+import { IconService } from '../../../../services-ngx/icon.service';
 
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
@@ -43,3 +44,15 @@ export const fromConnector: (iconService, connector: ConnectorPlugin) => Connect
   };
   return result;
 };
+
+export function mapAndFilterBySupportedQos(endpointPlugins: ConnectorPlugin[], requiredQoS: Qos[], iconService: IconService) {
+  const mapped = endpointPlugins.map((endpoint) => fromConnector(iconService, endpoint));
+
+  if (requiredQoS.length === 0) {
+    return mapped;
+  }
+
+  return mapped.filter((endpoint) => {
+    return endpoint.supportedQos !== undefined && endpoint.supportedQos.some((qos) => requiredQoS.includes(qos));
+  });
+}

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -864,6 +864,69 @@ describe('ApiCreationV4Component', () => {
       ]);
     });
 
+    describe('step3 with QoS selection', () => {
+      beforeEach(async () => {
+        await fillAndValidateStep1ApiDetails();
+        await fillAndValidateStep2Entrypoints0Architecture();
+        expectLicenseGetRequest({ tier: '', features: [], packs: [] });
+        const connectorPlugins: Partial<ConnectorPlugin>[] = [
+          {
+            id: 'http-get',
+            name: 'Send an HTTP GET request including the data directly in the request URL and process the response from the HTTP server.',
+            supportedApiType: 'MESSAGE',
+            supportedListenerType: 'HTTP',
+            supportedQos: ['AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'],
+          },
+        ];
+        await fillAndValidateStep2Entrypoints1List(connectorPlugins);
+        expectSchemaGetRequest(connectorPlugins);
+      });
+      it('cannot select rabbitmq for AT_LEAST_ONCE QoS option', async () => {
+        const step22EntrypointsConfigHarness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+        exceptEnvironmentGetRequest(fakeEnvironment());
+
+        expectApiGetPortalSettings();
+        await step22EntrypointsConfigHarness.fillPaths('/some-entrypoint');
+        await step22EntrypointsConfigHarness.selectQos('http-get', 'AT_LEAST_ONCE');
+        expect(await step22EntrypointsConfigHarness.hasValidationDisabled()).toBeFalsy();
+
+        await step22EntrypointsConfigHarness.clickValidate();
+        expectVerifyContextPathGetRequest();
+        const endpoints: Partial<ConnectorPlugin>[] = [
+          { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+          { id: 'rabbitmq', supportedApiType: 'MESSAGE', name: 'RabbitMq', supportedQos: ['NONE', 'AUTO'] },
+          { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+        ];
+        expectEndpointsGetRequest(endpoints);
+        const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
+        expect(step3Harness).toBeTruthy();
+        const list = await step3Harness.getEndpoints();
+        expect(await list.getListValues()).toEqual(['kafka', 'mock']);
+      });
+      it('can select rabbitmq for AUTO QoS option', async () => {
+        const step22EntrypointsConfigHarness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+        exceptEnvironmentGetRequest(fakeEnvironment());
+
+        expectApiGetPortalSettings();
+        await step22EntrypointsConfigHarness.fillPaths('/some-entrypoint');
+        await step22EntrypointsConfigHarness.selectQos('http-get', 'AUTO');
+        expect(await step22EntrypointsConfigHarness.hasValidationDisabled()).toBeFalsy();
+
+        await step22EntrypointsConfigHarness.clickValidate();
+        expectVerifyContextPathGetRequest();
+        const endpoints: Partial<ConnectorPlugin>[] = [
+          { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+          { id: 'rabbitmq', supportedApiType: 'MESSAGE', name: 'RabbitMq', supportedQos: ['NONE', 'AUTO'] },
+          { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+        ];
+        expectEndpointsGetRequest(endpoints);
+        const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
+        expect(step3Harness).toBeTruthy();
+        const list = await step3Harness.getEndpoints();
+        expect(await list.getListValues()).toEqual(['kafka', 'mock', 'rabbitmq']);
+      });
+    });
+
     it('should display only async endpoints in the list', async () => {
       await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
       await fillAndValidateStep2Entrypoints0Architecture('MESSAGE');
@@ -872,9 +935,9 @@ describe('ApiCreationV4Component', () => {
       const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
 
       expectEndpointsGetRequest([
-        { id: 'http-post', supportedApiType: 'PROXY', name: 'HTTP Post' },
-        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
-        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
+        { id: 'http-post', supportedApiType: 'PROXY', name: 'HTTP Post', supportedQos: ['NONE', 'AUTO'] },
+        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
       ]);
       expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
@@ -892,8 +955,8 @@ describe('ApiCreationV4Component', () => {
       expect(step3Harness).toBeTruthy();
 
       expectEndpointsGetRequest([
-        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
-        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
+        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
       ]);
       expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
@@ -929,8 +992,8 @@ describe('ApiCreationV4Component', () => {
       expect(step3Harness).toBeTruthy();
 
       expectEndpointsGetRequest([
-        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
-        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
+        { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+        { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
       ]);
       expectLicenseGetRequest({ tier: '', features: [], packs: [] });
 
@@ -1384,8 +1447,8 @@ describe('ApiCreationV4Component', () => {
 
         const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);
         expectEndpointsGetRequest([
-          { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
-          { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
+          { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
+          { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['NONE', 'AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE'] },
         ]);
 
         const list = await step3Harness.getEndpoints();
@@ -1567,8 +1630,8 @@ describe('ApiCreationV4Component', () => {
 
   async function fillAndValidateStep3Endpoints1List(
     endpoints: Partial<ConnectorPlugin>[] = [
-      { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka' },
-      { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' },
+      { id: 'kafka', supportedApiType: 'MESSAGE', name: 'Kafka', supportedQos: ['AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE', 'NONE'] },
+      { id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock', supportedQos: ['AUTO', 'AT_MOST_ONCE', 'AT_LEAST_ONCE', 'NONE'] },
     ],
   ) {
     const step3Harness = await harnessLoader.getHarness(Step3EndpointListHarness);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.ts
@@ -26,7 +26,7 @@ import { Step3Endpoints2ConfigComponent } from './step-3-endpoints-2-config.comp
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
-import { ConnectorVM, fromConnector } from '../../../../../entities/management-api-v2';
+import { ConnectorVM, mapAndFilterBySupportedQos } from '../../../../../entities/management-api-v2';
 import {
   GioConnectorDialogComponent,
   GioConnectorDialogData,
@@ -78,7 +78,8 @@ export class Step3Endpoints1ListComponent implements OnInit, OnDestroy {
       .listEndpointPluginsByApiType('MESSAGE')
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((endpointPlugins) => {
-        this.endpoints = endpointPlugins.map((endpoint) => fromConnector(this.iconService, endpoint));
+        const requiredQoS = this.stepService.payload.selectedEntrypoints.map((e) => e.selectedQos);
+        this.endpoints = mapAndFilterBySupportedQos(endpointPlugins, requiredQoS, this.iconService);
 
         this.changeDetectorRef.detectChanges();
       });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -23,7 +23,11 @@
           <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
         </ng-template>
         <ng-template matStepLabel>Endpoint Group Type</ng-template>
-        <api-endpoints-group-selection [endpointGroupTypeForm]="endpointGroupTypeForm" [apiType]="apiType"></api-endpoints-group-selection>
+        <api-endpoints-group-selection
+          [endpointGroupTypeForm]="endpointGroupTypeForm"
+          [apiType]="apiType"
+          [requiredQos]="requiredQos"
+        ></api-endpoints-group-selection>
         <div class="api-endpoint-group-create__footer">
           <ng-container *ngTemplateOutlet="exitButton"></ng-container>
           <button mat-raised-button type="button" color="primary" [disabled]="createForm.get('type').invalid" matStepperNext>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
@@ -125,6 +125,7 @@ const ENDPOINT_LIST = [
     icon: 'mock-icon',
     deployed: true,
     supportedApiType: 'MESSAGE',
+    supportedQos: ['AT_MOST_ONCE', 'NONE', 'AT_LEAST_ONCE', 'AUTO'],
   },
   {
     id: 'rabbitmq',
@@ -133,6 +134,7 @@ const ENDPOINT_LIST = [
     icon: 'rabbitmq-icon',
     deployed: true,
     supportedApiType: 'MESSAGE',
+    supportedQos: ['NONE', 'AUTO'],
   },
   {
     id: 'kafka',
@@ -141,6 +143,7 @@ const ENDPOINT_LIST = [
     icon: 'kafka-icon',
     deployed: true,
     supportedApiType: 'MESSAGE',
+    supportedQos: ['AT_MOST_ONCE', 'NONE', 'AT_LEAST_ONCE', 'AUTO'],
   },
 ];
 describe('ApiEndpointGroupCreateComponent', () => {
@@ -190,7 +193,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
   describe('V4 API - Message', () => {
     describe('Stepper', () => {
       beforeEach(async () => {
-        await initComponent(fakeApiV4({ id: API_ID }));
+        await initComponent(fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-get', qos: 'AUTO' }] }] }));
       });
 
       it('should go back to endpoint groups page on exit', async () => {
@@ -247,7 +250,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
 
     describe('When creating a Kafka endpoint group', () => {
       beforeEach(async () => {
-        await initComponent(fakeApiV4({ id: API_ID }));
+        await initComponent(fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-get', qos: 'AUTO' }] }] }));
         await fillOutAndValidateEndpointSelection();
         await fillOutAndValidateGeneralInformation();
         await harness.setConfigurationInputValue('bootstrapServers', 'a new server');
@@ -297,7 +300,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
 
     describe('When creating a Mock endpoint group', () => {
       beforeEach(async () => {
-        await initComponent(fakeApiV4({ id: API_ID }));
+        await initComponent(fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-get', qos: 'AUTO' }] }] }));
         await fillOutAndValidateEndpointSelection('mock');
         await fillOutAndValidateGeneralInformation();
 
@@ -331,6 +334,22 @@ describe('ApiEndpointGroupCreateComponent', () => {
           },
         });
       });
+    });
+  });
+
+  describe('When creating a RabbitMQ endpoint group', () => {
+    it('cannot create an endpoint group for AT_LEAST_ONCE QoS', async () => {
+      await initComponent(
+        fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-get', qos: 'AT_LEAST_ONCE' }] }] }),
+      );
+      expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(true);
+      expect(await harness.getEndpointGroupTypes()).toEqual(['kafka', 'mock']);
+    });
+
+    it('can create an endpoint group for AUTO QoS', async () => {
+      await initComponent(fakeApiV4({ id: API_ID, listeners: [{ type: 'HTTP', entrypoints: [{ type: 'http-get', qos: 'AUTO' }] }] }));
+      expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(true);
+      expect(await harness.getEndpointGroupTypes()).toEqual(['kafka', 'mock', 'rabbitmq']);
     });
   });
 
@@ -374,7 +393,12 @@ describe('ApiEndpointGroupCreateComponent', () => {
    * Expect requests
    */
   function expectApiGet(): void {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
+        method: 'GET',
+      })
+      .flush(api);
   }
 
   function expectConfigurationSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSchema): void {
@@ -385,18 +409,29 @@ describe('ApiEndpointGroupCreateComponent', () => {
 
   function expectSharedConfigurationSchemaGet(endpointId = 'kafka', schema: any = fakeKafkaSharedSchema): void {
     httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${endpointId}/shared-configuration-schema`, method: 'GET' })
+      .expectOne({
+        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${endpointId}/shared-configuration-schema`,
+        method: 'GET',
+      })
       .flush(schema);
   }
 
   function expectApiPut(updatedApi: ApiV4): void {
-    const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'PUT' });
+    const req = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
+      method: 'PUT',
+    });
     expect(req.request.body.endpointGroups).toEqual(updatedApi.endpointGroups);
     req.flush(updatedApi);
   }
 
   function expectEndpointListGet(): void {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' }).flush(ENDPOINT_LIST);
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`,
+        method: 'GET',
+      })
+      .flush(ENDPOINT_LIST);
   }
 
   /**

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
@@ -26,7 +26,7 @@ import { ApiEndpointGroupConfigurationComponent } from '../configuration/api-end
 import { ApiEndpointGroupGeneralComponent } from '../general/api-endpoint-group-general.component';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { isUnique } from '../../../../../shared/utils';
-import { ApiType, ApiV4, EndpointGroupV4, EndpointV4Default, UpdateApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiType, ApiV4, EndpointGroupV4, EndpointV4Default, Qos, UpdateApiV4 } from '../../../../../entities/management-api-v2';
 import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
@@ -63,6 +63,7 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
   public configurationSchema: GioJsonSchema;
   public sharedConfigurationSchema: GioJsonSchema;
   public apiType: ApiType;
+  public requiredQos: Qos[];
 
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
@@ -84,6 +85,7 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
           const apiV4 = api as ApiV4;
           this.generalForm.get('name').addValidators([isUnique(apiV4.endpointGroups.map((group) => group.name))]);
           this.apiType = apiV4.type;
+          this.requiredQos = apiV4.listeners.flatMap((listener) => listener.entrypoints).flatMap((entrypoint) => entrypoint.qos);
           if (this.apiType === 'PROXY') {
             this.endpointGroupTypeForm.get('endpointGroupType').setValue('http-proxy');
           }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.harness.ts
@@ -45,6 +45,10 @@ export class ApiEndpointGroupCreateHarness extends ComponentHarness {
     return this.getEndpointGroupRadio().then((radioGroup) => radioGroup.selectOptionById(type));
   }
 
+  async getEndpointGroupTypes(): Promise<string[]> {
+    return this.getEndpointGroupRadio().then((radioGroup) => radioGroup.getValues());
+  }
+
   async getSelectedEndpointGroupId(): Promise<string> {
     return this.getEndpointGroupRadio().then((radioGroup) => radioGroup.getValue());
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/selection/api-endpoint-group-selection.component.ts
@@ -19,7 +19,7 @@ import { of, Subject } from 'rxjs';
 import { FormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
-import { ApiType, ConnectorVM, fromConnector } from '../../../../../entities/management-api-v2';
+import { ApiType, ConnectorVM, mapAndFilterBySupportedQos, Qos } from '../../../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
 import { IconService } from '../../../../../services-ngx/icon.service';
 import {
@@ -41,6 +41,7 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
   public apiType: ApiType;
 
   public endpoints: ConnectorVM[];
+  @Input() requiredQos!: Qos[];
 
   constructor(
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
@@ -53,7 +54,7 @@ export class ApiEndpointGroupSelectionComponent implements OnInit {
       .listEndpointPluginsByApiType(this.apiType)
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((endpointPlugins) => {
-        this.endpoints = endpointPlugins.map((endpoint) => fromConnector(this.iconService, endpoint));
+        this.endpoints = mapAndFilterBySupportedQos(endpointPlugins, this.requiredQos, this.iconService);
       });
   }
 

--- a/gravitee-apim-console-webui/src/shared/components/gio-connector-list-option/gio-connector-radio-list.harness.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-connector-list-option/gio-connector-radio-list.harness.ts
@@ -24,4 +24,9 @@ export class GioConnectorRadioListHarness extends MatRadioGroupHarness {
   async getValue(): Promise<string> {
     return this.getCheckedValue();
   }
+
+  async getValues(): Promise<string[]> {
+    const radioButtons = await this.getRadioButtons();
+    return Promise.all(radioButtons.map((radioButton) => radioButton.getValue()));
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4201

## Description

Added filtering of selectable endpoints based on entry point QoS capabilities.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7236/console](https://pr.team-apim.gravitee.dev/7236/console)
      Portal: [https://pr.team-apim.gravitee.dev/7236/portal](https://pr.team-apim.gravitee.dev/7236/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7236/api/management](https://pr.team-apim.gravitee.dev/7236/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7236](https://pr.team-apim.gravitee.dev/7236)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7236](https://pr.gateway-v3.team-apim.gravitee.dev/7236)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjxvsguzcz.chromatic.com)
<!-- Storybook placeholder end -->
