### PR TITLE
Hide delete account button in external auth mode

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -68,6 +68,12 @@ export interface ConsoleSettingsAuthentication {
   localLogin?: {
     enabled?: boolean;
   };
+  externalAuth?: {
+    enabled?: boolean;
+  };
+  externalAuthAccountDeletion?: {
+    enabled?: boolean;
+  };
 }
 
 export interface ConsoleSettingsCors {

--- a/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
@@ -17,6 +17,7 @@ import { User } from '../../entities/user';
 import NotificationService from '../../services/notification.service';
 import TokenService from '../../services/token.service';
 import UserService from '../../services/user.service';
+import { Constants } from '../../entities/Constants';
 
 class UserController {
   private originalPicture: any;
@@ -33,7 +34,7 @@ class UserController {
     private NotificationService: NotificationService,
     private TokenService: TokenService,
     private $mdDialog: angular.material.IDialogService,
-    private Constants,
+    private Constants: Constants,
   ) {}
 
   $onInit() {
@@ -66,6 +67,13 @@ class UserController {
       this.NotificationService.show('User has been updated successfully');
       this.onSaved();
     });
+  }
+
+  displayDangerZone(): boolean {
+    return (
+      !this.Constants.org.settings.authentication.externalAuth.enabled ||
+      this.Constants.org.settings.authentication.externalAuthAccountDeletion.enabled
+    );
   }
 
   canDeleteMyAccount(): boolean {

--- a/gravitee-apim-console-webui/src/user/my-accout/user.html
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.html
@@ -148,7 +148,7 @@
     </div>
   </div>
 
-  <div class="gv-form gv-form-danger">
+  <div class="gv-form gv-form-danger" ng-if="$ctrl.displayDangerZone()">
     <h2>Danger Zone</h2>
     <div class="gv-form-content" layout="column">
       <div layout="row" layout-align="space-between center" ng-if="!$ctrl.canDeleteMyAccount()">

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -362,7 +362,10 @@ public enum Key {
     ALERT_ENGINE_ENABLED("alerts.alert-engine.enabled", "false", Set.of(SYSTEM)),
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
-    TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM));
+    TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
+
+    EXTERNAL_AUTH_ENABLED("auth.external.enabled", "false", Set.of(SYSTEM)),
+    EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED("auth.external.allowAccountDeletion", "true", Set.of(SYSTEM));
 
     String key;
     String defaultValue;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleAuthentication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleAuthentication.java
@@ -29,11 +29,33 @@ public class ConsoleAuthentication extends CommonAuthentication {
     @ParameterKey(Key.CONSOLE_AUTHENTICATION_LOCALLOGIN_ENABLED)
     private Enabled localLogin;
 
+    @ParameterKey(Key.EXTERNAL_AUTH_ENABLED)
+    private Enabled externalAuth;
+
+    @ParameterKey(Key.EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED)
+    private Enabled externalAuthAccountDeletion;
+
     public Enabled getLocalLogin() {
         return localLogin;
     }
 
     public void setLocalLogin(Enabled localLogin) {
         this.localLogin = localLogin;
+    }
+
+    public Enabled getExternalAuth() {
+        return externalAuth;
+    }
+
+    public void setExternalAuth(Enabled externalAuth) {
+        this.externalAuth = externalAuth;
+    }
+
+    public Enabled getExternalAuthAccountDeletion() {
+        return externalAuthAccountDeletion;
+    }
+
+    public void setExternalAuthAccountDeletion(Enabled externalAuthAccountDeletion) {
+        this.externalAuthAccountDeletion = externalAuthAccountDeletion;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -637,10 +637,11 @@ notifiers:
 # External Authentication
 #auth:
 #  external:
-#    enabled: true
+#    enabled: false
 #    algorithm: HS256
 #    verificationKey: ozhbx5HJCS41NzKrBSQ0vZU1WOmG0Uhm
 #    issuer: my-issuer
+#    allowAccountDeletion: true
 
 # Integration
 integration:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3930

## Description

Hide delete account button in external auth mode.

Change the default value of `auth.external.enabled` in the gravitee.yaml file to reflect the default value in the code.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pdkrrmsziz.chromatic.com)
<!-- Storybook placeholder end -->
