### PR TITLE
fix(portal-next): substitute PORTAL_API_URL in config.json

### DIFF
--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -32,8 +32,9 @@ COPY docker/config/default.conf /etc/nginx/conf.d/default.conf
 
 RUN chown -R 101:0 /usr/share/nginx/ /etc/nginx/conf.d/
 
+COPY docker/config/portal-next-run.sh /portal-next-run.sh
 
-CMD ["sh", "/run.sh"]
+CMD ["/bin/sh", "-c", "sh /portal-next-run.sh; sh /run.sh"]
 
 USER nginx
 

--- a/gravitee-apim-portal-webui/docker/config/portal-next-run.sh
+++ b/gravitee-apim-portal-webui/docker/config/portal-next-run.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright (C) 2015-2022 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# generate configs
+if [ -f "/usr/share/nginx/html/next/browser/assets/config.json" ]; then
+    envsubst < /usr/share/nginx/html/next/browser/assets/config.json > /usr/share/nginx/html/next/browser/assets/config.json.tmp
+    mv /usr/share/nginx/html/next/browser/assets/config.json.tmp /usr/share/nginx/html/next/browser/assets/config.json
+fi


### PR DESCRIPTION
## Issue

N/A

## Description

substitute PORTAL_API_URL in config.json
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7245/console](https://pr.team-apim.gravitee.dev/7245/console)
      Portal: [https://pr.team-apim.gravitee.dev/7245/portal](https://pr.team-apim.gravitee.dev/7245/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7245/api/management](https://pr.team-apim.gravitee.dev/7245/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7245](https://pr.team-apim.gravitee.dev/7245)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7245](https://pr.gateway-v3.team-apim.gravitee.dev/7245)

<!-- Environment placeholder end -->
