### PR TITLE
APIM 3921 portal-next: UI touch-ups for single page of api list

### DIFF
--- a/gravitee-apim-portal-webui-next/.storybook/main.ts
+++ b/gravitee-apim-portal-webui-next/.storybook/main.ts
@@ -10,5 +10,6 @@ const config: StorybookConfig = {
   docs: {
     autodocs: 'tag',
   },
+  staticDirs: ['../src/assets'],
 };
 export default config;

--- a/gravitee-apim-portal-webui-next/.storybook/preview.ts
+++ b/gravitee-apim-portal-webui-next/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/angular';
+import '@angular/localize/init';
 
 const preview: Preview = {
   parameters: {

--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -40,6 +40,7 @@
     "@angular/platform-browser": "17.3.3",
     "@angular/platform-browser-dynamic": "17.3.3",
     "@angular/router": "17.3.3",
+    "jdenticon": "3.2.0",
     "rxjs": "7.8.0",
     "tslib": "2.3.0",
     "zone.js": "0.14.3"

--- a/gravitee-apim-portal-webui-next/src/app/app.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.scss
@@ -19,7 +19,7 @@
   min-height: 95vh;
   flex-flow: column;
   margin: auto;
-  gap: 60px;
+  gap: 40px;
 }
 
 .content {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -20,6 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatCardHarness } from '@angular/material/card/testing';
 
 import { CatalogComponent } from './catalog.component';
+import { ApiCardHarness } from '../../components/api-card/api-card.harness';
 import { fakeApi, fakeApisResponse } from '../../entities/api/api.fixtures';
 import { ApisResponse } from '../../entities/api/apis-response';
 import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
@@ -67,8 +68,13 @@ describe('CatalogComponent', () => {
         ],
       }),
     );
-    const debugApiCardElement = fixture.debugElement.nativeElement.querySelector('app-api-card');
-    expect(debugApiCardElement).toBeDefined();
+    const apiCard = await harnessLoader.getHarness(ApiCardHarness);
+    expect(apiCard).toBeDefined();
+    expect(await apiCard.getTitle()).toEqual('Test title');
+    expect(await apiCard.getDescription()).toEqual(
+      'Get real-time weather updates, forecasts, and historical data to enhance your applications with accurate weather information.',
+    );
+    expect(await apiCard.getVersion()).toEqual('v.1.2');
   });
 
   function expectApiList(apisResponse: ApisResponse = fakeApisResponse()) {

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
@@ -18,13 +18,7 @@
 <mat-card class="api-card" appearance="outlined">
   <mat-card-content>
     <div class="api-card__header">
-      <img
-        i18n-alt="@@apiCardPicture"
-        ngSrc="{{ picture }}"
-        height="40"
-        width="40"
-        alt="Api Card Picture"
-        class="api-card__header-picture" />
+      <app-api-picture [picture]="picture" [name]="title" [version]="version" [size]="40" />
       <div class="api-card__header-content">
         <div class="api-card__header-content-title">{{ title }}</div>
         <div class="api-card__header-content-version">{{ version }}</div>

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
@@ -16,17 +16,17 @@
 
 -->
 <mat-card class="api-card" appearance="outlined">
-  <mat-card-content>
+  <mat-card-content class="api-card__content">
     <div class="api-card__header">
       <app-api-picture [picture]="picture" [name]="title" [version]="version" [size]="40" />
-      <div class="api-card__header-content">
+      <div>
         <div class="api-card__header-content-title">{{ title }}</div>
         <div class="api-card__header-content-version">{{ version }}</div>
       </div>
     </div>
-    <div class="api-card__content">
-      <p class="api-card__description">{{ content }}</p>
-      <button class="api-card__content-button" i18n="@@apiCardButton" mat-stroked-button color="primary">Learn more</button>
-    </div>
+    <p class="api-card__description">{{ content }}</p>
   </mat-card-content>
+  <mat-card-actions class="api-card__actions">
+    <button i18n="@@apiCardButton" mat-stroked-button color="primary">Learn more</button>
+  </mat-card-actions>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+:host {
+  display: flex;
+  height: 25vh;
+  flex-flow: column;
+
+  --mdc-outlined-card-container-shape: 12px;
+}
+
 .api-card {
   display: flex;
-
-  --mdc-elevated-card-container-shape: 12px;
+  height: 100%;
+  flex-flow: column;
+  justify-content: space-between;
 
   &__header {
     display: flex;
@@ -26,13 +35,6 @@
 
   &__header-picture {
     border-radius: 50%;
-  }
-
-  &_header-content {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    gap: 4px;
   }
 
   &__header-content-title {
@@ -48,8 +50,8 @@
 
   &__content {
     display: flex;
+    flex: 1 1 100%;
     flex-direction: column;
-    gap: 32px;
   }
 
   &__description {
@@ -61,7 +63,7 @@
     text-overflow: ellipsis;
   }
 
-  &__content-button {
-    max-width: fit-content;
+  &__actions {
+    margin: 8px;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.harness.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiCardHarness extends ComponentHarness {
+  public static hostSelector = 'app-api-card';
+  protected locateTitle = this.locatorFor('.api-card__header-content-title');
+  protected locateVersion = this.locatorFor('.api-card__header-content-version');
+  protected locateDescription = this.locatorFor('.api-card__description');
+
+  public async getTitle(): Promise<string> {
+    const div = await this.locateTitle();
+    return await div.text();
+  }
+
+  public async getVersion(): Promise<string> {
+    const div = await this.locateVersion();
+    return await div.text();
+  }
+
+  public async getDescription(): Promise<string> {
+    const div = await this.locateDescription();
+    return await div.text();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.component.scss
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.round {
+  border-radius: 50%;
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.component.ts
@@ -14,25 +14,38 @@
  * limitations under the License.
  */
 import { Component, Input } from '@angular/core';
-import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
-
-import { ApiPictureComponent } from '../api-picture/api-picture.component';
+import { toSvg } from 'jdenticon';
 
 @Component({
-  selector: 'app-api-card',
+  selector: 'app-api-picture',
   standalone: true,
-  imports: [MatCardModule, MatButtonModule, ApiPictureComponent],
-  templateUrl: './api-card.component.html',
-  styleUrl: './api-card.component.scss',
+  imports: [],
+  template: `
+    <img
+      i18n-alt="@@apiPicture"
+      alt="API Picture"
+      class="round"
+      [src]="picture"
+      [height]="size"
+      [width]="size"
+      (error)="useGeneratedPicture()"
+      placeholder="assets/images/logo.png" />
+  `,
+  styleUrl: './api-picture.component.scss',
 })
-export class ApiCardComponent {
+export class ApiPictureComponent {
   @Input({ required: true })
-  title!: string;
+  name!: string;
   @Input({ required: true })
   version!: string;
   @Input()
-  picture: string | undefined;
+  picture: string | undefined = 'assets/images/logo.png';
   @Input()
-  content?: string;
+  size: number = 40;
+
+  useGeneratedPicture() {
+    const asSvg = toSvg(`${this.name} ${this.version}`, this.size, { backColor: '#FFF', padding: 0 });
+    const encodedToBase64 = window.btoa(asSvg);
+    this.picture = `data:image/svg+xml;base64,${encodedToBase64}`;
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.stories.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-picture/api-picture.stories.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { ApiPictureComponent } from './api-picture.component';
+
+export default {
+  title: 'API Picture',
+  decorators: [
+    moduleMetadata({
+      imports: [ApiPictureComponent],
+    }),
+  ],
+  render: () => ({}),
+} as Meta;
+
+export const ApiPicture: StoryObj = {
+  render: () => ({
+    template: `
+        <div>
+          <h3>Generated API Picture</h3>
+          <app-api-picture name="pic-does-not-exist" version="1.2" picture="pic-does-not-exist" size="100"></app-api-picture>
+          <br />
+          <br />
+          <h3>Found API Picture</h3>
+          <app-api-picture name="name" version="1.2" picture="images/logo.png" size="100"></app-api-picture>
+        </div>
+        `,
+    styles: [
+      `
+            .button-container {
+                display: flex;
+                flex-direction: row;
+                justify-content: space-around;
+                width: 500px;
+                margin-bottom: 16px;
+            }
+       `,
+    ],
+  }),
+};

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@import '../../scss/theme/theme';
+
 :host {
+  position: sticky;
+  z-index: 99;
+  top: 0;
   display: flex;
-  width: 100%;
   flex-flow: row;
   align-items: center;
+  padding: 18px 0;
+  backdrop-filter: blur(10px);
+  background-color: color-mix(in srgb, $background-color, transparent 20%);
   gap: 40px;
 }
 

--- a/gravitee-apim-portal-webui-next/src/styles.scss
+++ b/gravitee-apim-portal-webui-next/src/styles.scss
@@ -35,6 +35,7 @@ $light-theme: mat.define-light-theme(
 @include mat.all-component-themes($light-theme);
 
 body {
+  margin: 0;
   background-color: $background-color;
   color: $default-text-color;
   font-family: 'Golos UI', Roboto, 'Helvetica Neue', sans-serif;

--- a/gravitee-apim-portal-webui-next/yarn.lock
+++ b/gravitee-apim-portal-webui-next/yarn.lock
@@ -8298,6 +8298,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"canvas-renderer@npm:~2.2.0":
+  version: 2.2.1
+  resolution: "canvas-renderer@npm:2.2.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/436f2f516723cf2cac03dcb189907b282249cc33446c6bce7760fb3ebd22689b0a4a27b3a3ab077a2c8204bd597a5e923da505520735b00cd839a790e6bdda50
+  languageName: node
+  linkType: hard
+
 "case-sensitive-paths-webpack-plugin@npm:^2.4.0":
   version: 2.4.0
   resolution: "case-sensitive-paths-webpack-plugin@npm:2.4.0"
@@ -11443,6 +11452,7 @@ __metadata:
     eslint-plugin-import: "npm:2.29.1"
     eslint-plugin-prettier: "npm:5.1.3"
     eslint-plugin-storybook: "npm:0.8.0"
+    jdenticon: "npm:3.2.0"
     jest: "npm:29.7.0"
     jest-junit: "npm:16.0.0"
     jest-preset-angular: "npm:14.0.3"
@@ -12568,6 +12578,17 @@ __metadata:
   bin:
     jake: bin/cli.js
   checksum: 10c0/89326d01a8bc110d02d973729a66394c79a34b34461116f5c530a2a2dbc30265683fe6737928f75df9178e9d369ff1442f5753fb983d525e740eefdadc56a103
+  languageName: node
+  linkType: hard
+
+"jdenticon@npm:3.2.0":
+  version: 3.2.0
+  resolution: "jdenticon@npm:3.2.0"
+  dependencies:
+    canvas-renderer: "npm:~2.2.0"
+  bin:
+    jdenticon: bin/jdenticon.js
+  checksum: 10c0/441e1ecf4efae01b006825a5b4630958a445d0841e9f84c10957ca3185070c8a8373135ccd2c782935719849ec2865e301d1abde22ab0723150efc8204d239f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3921

## Description

API Picture component will show either the valid picture or a generated icon:
![Screenshot 2024-04-12 at 17 44 35](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1d64123c-15a1-4e32-9a50-95d08c2608d5)


Clean up styling so that the cards are consistent sizes regardless of description length.

![Screenshot 2024-04-12 at 18 20 43](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/0e197bed-34fc-41a8-ad9c-18344c91f91e)



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nxeemqvrtw.chromatic.com)
<!-- Storybook placeholder end -->
