### PR TITLE
ci: use the same cache for sonar jobs

### DIFF
--- a/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
+++ b/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
@@ -32,6 +32,7 @@ export class SonarCloudAnalysisJob {
       'gravitee-apim-rest-api',
       'Directory where the Sonarcloud analysis will be run',
     ),
+    new parameters.CustomEnumParameter('cache_type', ['backend', 'frontend'], 'backend', 'Type of cache to use'),
   ]);
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
@@ -54,11 +55,7 @@ export class SonarCloudAnalysisJob {
       new commands.Checkout(),
       new commands.workspace.Attach({ at: '.' }),
       new commands.cache.Restore({
-        keys: [
-          `${config.cache.prefix}-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}`,
-          `${config.cache.prefix}-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}`,
-          `${config.cache.prefix}-sonarcloud-analysis-<< parameters.working_directory >>`,
-        ],
+        keys: [`${config.cache.prefix}-sonarcloud-analysis-<< parameters.cache_type >>`],
       }),
       new reusable.ReusedCommand(orbs.keeper.commands['env-export'], {
         'secret-url': config.secrets.sonarToken,
@@ -72,7 +69,7 @@ export class SonarCloudAnalysisJob {
       new reusable.ReusedCommand(notifyOnFailureCmd),
       new commands.cache.Save({
         paths: ['/opt/sonar-scanner/.sonar/cache'],
-        key: `${config.cache.prefix}-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}`,
+        key: `${config.cache.prefix}-sonarcloud-analysis-<< parameters.cache_type >>`,
         when: 'always',
       }),
     ];

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -473,6 +473,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -485,9 +492,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -499,7 +504,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-webui-lint-test:
     parameters:
@@ -1056,6 +1061,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -1063,6 +1069,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -1070,6 +1077,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -1077,6 +1085,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -1084,6 +1093,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:
@@ -1113,6 +1123,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
@@ -1134,6 +1145,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-build-images:
           name: Build and push rest api and gateway images
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -354,6 +354,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -366,9 +373,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -380,7 +385,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:
@@ -458,6 +463,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -465,6 +471,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -472,6 +479,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -479,6 +487,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -486,6 +495,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -295,6 +295,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -307,9 +314,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -321,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:
@@ -363,6 +368,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -225,6 +225,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -237,9 +244,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -251,7 +256,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:
@@ -285,6 +290,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -440,6 +440,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -452,9 +459,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -466,7 +471,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-webui-lint-test:
     parameters:
@@ -702,6 +707,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -709,6 +715,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -716,6 +723,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -723,6 +731,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -730,6 +739,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:
@@ -759,6 +769,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
@@ -780,6 +791,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -473,6 +473,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -485,9 +492,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -499,7 +504,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-webui-lint-test:
     parameters:
@@ -1056,6 +1061,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -1063,6 +1069,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -1070,6 +1077,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -1077,6 +1085,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -1084,6 +1093,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:
@@ -1113,6 +1123,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
@@ -1134,6 +1145,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-build-images:
           name: Build and push rest api and gateway images
           context:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -440,6 +440,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -452,9 +459,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -466,7 +471,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-webui-lint-test:
     parameters:
@@ -702,6 +707,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -709,6 +715,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -716,6 +723,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -723,6 +731,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -730,6 +739,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:
@@ -759,6 +769,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
@@ -780,6 +791,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -440,6 +440,13 @@ jobs:
         type: string
         default: gravitee-apim-rest-api
         description: Directory where the Sonarcloud analysis will be run
+      cache_type:
+        type: enum
+        default: backend
+        description: Type of cache to use
+        enum:
+          - backend
+          - frontend
     docker:
       - image: sonarsource/sonar-scanner-cli:5.0.1
     resource_class: large
@@ -452,9 +459,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>
+            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -466,7 +471,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.working_directory >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-webui-lint-test:
     parameters:
@@ -867,6 +872,7 @@ workflows:
           requires:
             - Test definition
           working_directory: gravitee-apim-definition
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-gateway
           context:
@@ -874,6 +880,7 @@ workflows:
           requires:
             - Test gateway
           working_directory: gravitee-apim-gateway
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-rest-api
           context:
@@ -881,6 +888,7 @@ workflows:
           requires:
             - Test rest-api
           working_directory: gravitee-apim-rest-api
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-plugin
           context:
@@ -888,6 +896,7 @@ workflows:
           requires:
             - Test plugins
           working_directory: gravitee-apim-plugin
+          cache_type: backend
       - job-sonarcloud-analysis:
           name: Sonar - gravitee-apim-repository
           context:
@@ -895,6 +904,7 @@ workflows:
           requires:
             - Test repository
           working_directory: gravitee-apim-repository
+          cache_type: backend
       - job-webui-lint-test:
           name: Lint & test APIM Console
           context:
@@ -924,6 +934,7 @@ workflows:
           requires:
             - Lint & test APIM Console
           working_directory: gravitee-apim-console-webui
+          cache_type: frontend
       - job-webui-lint-test:
           name: Lint & test APIM Portal
           context:
@@ -945,6 +956,7 @@ workflows:
           requires:
             - Lint & test APIM Portal
           working_directory: gravitee-apim-portal-webui
+          cache_type: frontend
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -171,18 +171,21 @@ export class PullRequestsWorkflow {
           context: config.jobContext,
           requires: ['Test definition'],
           working_directory: 'gravitee-apim-definition',
+          cache_type: 'backend',
         }),
         new workflow.WorkflowJob(sonarCloudAnalysisJob, {
           name: 'Sonar - gravitee-apim-gateway',
           context: config.jobContext,
           requires: ['Test gateway'],
           working_directory: 'gravitee-apim-gateway',
+          cache_type: 'backend',
         }),
         new workflow.WorkflowJob(sonarCloudAnalysisJob, {
           name: 'Sonar - gravitee-apim-rest-api',
           context: config.jobContext,
           requires: ['Test rest-api'],
           working_directory: 'gravitee-apim-rest-api',
+          cache_type: 'backend',
         }),
 
         new workflow.WorkflowJob(sonarCloudAnalysisJob, {
@@ -190,12 +193,14 @@ export class PullRequestsWorkflow {
           context: config.jobContext,
           requires: ['Test plugins'],
           working_directory: 'gravitee-apim-plugin',
+          cache_type: 'backend',
         }),
         new workflow.WorkflowJob(sonarCloudAnalysisJob, {
           name: 'Sonar - gravitee-apim-repository',
           context: config.jobContext,
           requires: ['Test repository'],
           working_directory: 'gravitee-apim-repository',
+          cache_type: 'backend',
         }),
       );
 
@@ -245,6 +250,7 @@ export class PullRequestsWorkflow {
           context: config.jobContext,
           requires: ['Lint & test APIM Console'],
           working_directory: config.dockerImages.console.project,
+          cache_type: 'frontend',
         }),
       );
 
@@ -281,6 +287,7 @@ export class PullRequestsWorkflow {
           context: config.jobContext,
           requires: ['Lint & test APIM Portal'],
           working_directory: config.dockerImages.portal.project,
+          cache_type: 'frontend',
         }),
       );
 


### PR DESCRIPTION
## Issue

N/A

## Description

The cache for sonar jobs is only used for the analyzer plugins. So instead of having one cache per branch and per module, we can only use a cache for java analysis and one cache for typescript analysis.
By doing this, we hope it can reduce the amount of memory used to store the Sonar cache.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-judsfvvpbo.chromatic.com)
<!-- Storybook placeholder end -->
