### PR TITLE
fix: bump policy-cache version octet-stream data cache issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <gravitee-policy-assign-metrics.version>3.0.2</gravitee-policy-assign-metrics.version>
         <gravitee-policy-basic-authentication.version>1.6.0</gravitee-policy-basic-authentication.version>
         <gravitee-policy-aws-lambda.version>1.1.2</gravitee-policy-aws-lambda.version>
-        <gravitee-policy-cache.version>2.0.3</gravitee-policy-cache.version>
+        <gravitee-policy-cache.version>2.0.4</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>2.0.2</gravitee-policy-callout-http.version>
         <gravitee-policy-circuit-breaker.version>1.1.5</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4074

## Description

encode and decode content while storing in cache to allow storing octet-stream data

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qrhkremftg.chromatic.com)
<!-- Storybook placeholder end -->
