### PR TITLE
fix(rest-api): change Error.details.invalidValue to any

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapper.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -56,7 +57,7 @@ public class ConstraintValidationExceptionMapper extends AbstractExceptionMapper
                     .message(constraintViolation.getMessage())
                     // getPropertyPath returns a location in the form of "methodName.methodParameter.fieldNameOfTheParameter.[...]". We are not interested by the method name and parameter, so we remove them.
                     .location(errorLocation.substring(StringUtils.ordinalIndexOf(errorLocation, ".", 2) + 1))
-                    .invalidValue(constraintViolation.getInvalidValue())
+                    .invalidValue(JsonNullable.of(constraintViolation.getInvalidValue()))
                     .build();
             })
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,7 +52,7 @@ public class ValidationExceptionMapper extends AbstractExceptionMapper<AbstractV
                 ErrorDetailsInner
                     .builder()
                     .message(exception.getDetailMessage())
-                    .invalidValue(entry.getKey())
+                    .invalidValue(JsonNullable.of(entry.getKey()))
                     .location(entry.getValue())
                     .build()
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -2946,7 +2946,6 @@ components:
                                 description: The json path of the field in error.
                                 example: updateApi.properties[0].key
                             invalidValue:
-                                type: object
                                 description: The invalid value.
 
         FlowV4:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ConstraintValidationExceptionMapperTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ErrorDetailsInner;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ConstraintValidationExceptionMapperTest {
+
+    private ConstraintValidationExceptionMapper cve;
+
+    @BeforeEach
+    void setUp() {
+        cve = new ConstraintValidationExceptionMapper();
+    }
+
+    @Test
+    void shouldMapExceptionToResponse() {
+        final ConstraintViolationException exception = new FakeValidationException(
+            "fake message",
+            Set.of(
+                ConstraintViolationImpl.forReturnValueValidation(
+                    "fake message",
+                    null,
+                    null,
+                    "Size must be between 1 and 2147483647",
+                    null,
+                    null,
+                    null,
+                    List.of(),
+                    PathImpl.createPathFromString("path1"),
+                    null,
+                    null,
+                    null
+                ),
+                ConstraintViolationImpl.forReturnValueValidation(
+                    "fake message",
+                    null,
+                    null,
+                    "This value is not allowed",
+                    null,
+                    null,
+                    null,
+                    "InvalidValue",
+                    PathImpl.createPathFromString("path2"),
+                    null,
+                    null,
+                    null
+                )
+            )
+        );
+
+        try (Response response = cve.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+            assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+            assertThat(response.getEntity())
+                .isInstanceOf(Error.class)
+                .satisfies(errorObject -> {
+                    Error error = ((Error) errorObject);
+                    assertThat(error.getHttpStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+                    assertThat(error.getMessage()).isEqualTo("Validation error");
+                    assertThat(error.getDetails())
+                        .hasSize(2)
+                        .satisfies(listErrorDetails -> {
+                            final ErrorDetailsInner firstDetail = listErrorDetails
+                                .stream()
+                                .filter(detail -> "path1".equals(detail.getLocation()))
+                                .findFirst()
+                                .get();
+                            assertThat(firstDetail.getInvalidValue()).isEqualTo(List.of());
+                            assertThat(firstDetail.getMessage()).isEqualTo("Size must be between 1 and 2147483647");
+                            assertThat(firstDetail.getLocation()).isEqualTo("path1");
+
+                            final ErrorDetailsInner secondDetail = listErrorDetails
+                                .stream()
+                                .filter(detail -> "path2".equals(detail.getLocation()))
+                                .findFirst()
+                                .get();
+                            assertThat(secondDetail.getInvalidValue()).isEqualTo("InvalidValue");
+                            assertThat(secondDetail.getMessage()).isEqualTo("This value is not allowed");
+                            assertThat(secondDetail.getLocation()).isEqualTo("path2");
+                        });
+                });
+        }
+    }
+
+    static class FakeValidationException extends ConstraintViolationException {
+
+        public FakeValidationException(String message, Set<? extends ConstraintViolation<?>> constraintViolations) {
+            super(message, constraintViolations);
+        }
+
+        public FakeValidationException(Set<? extends ConstraintViolation<?>> constraintViolations) {
+            super(constraintViolations);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4526

## Description

as it is the value, it can be an Object, String, Array, ...

Ex : 
```
{
    "httpStatus": 400,
    "message": "Validation error",
    "details": [
        {
            "message": "size must be between 1 and 2147483647",
            "location": "endpointGroups",
            "invalidValue": []
        }
    ]
}
```


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-onjoppwrcs.chromatic.com)
<!-- Storybook placeholder end -->
