### PR TITLE
feat(portal-next): add page-tree component

### DIFF
--- a/gravitee-apim-portal-webui-next/.storybook/preview-head.html
+++ b/gravitee-apim-portal-webui-next/.storybook/preview-head.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
+      rel="stylesheet" />
+  </head>
+</html>

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.html
@@ -17,35 +17,43 @@
 -->
 <mat-card class="api-details" appearance="outlined">
   <mat-card-content class="api-details__content">
-    <div class="api-details__header">
-      <app-api-picture [picture]="details._links?.picture" [name]="details.name" [version]="details.version" [size]="40" />
-      <div>
-        <div class="api-details__header-content-title">{{ details.name }}</div>
-        <div class="api-details__header-content-version">{{ details.version }}</div>
-      </div>
-      <button i18n="@@logInOrSignUpToSubscribe" mat-stroked-button disabled color="primary api-details__header-button">
-        Log in / Sign up to subscribe
-      </button>
-    </div>
-    @if (details.description) {
-      <app-banner class="api-details__banner">
-        <div class="api-details__banner-content">
-          <mat-icon svgIcon="light-bulb" aria-hidden="false" aria-label="Light-bulb icon"></mat-icon>
-          <p>{{ details.description }}</p>
+    @if (details$ | async; as details) {
+      <div class="api-details__header">
+        <app-api-picture [picture]="details._links?.picture" [name]="details.name" [version]="details.version" [size]="40" />
+        <div>
+          <div class="api-details__header-content-title">{{ details.name }}</div>
+          <div class="api-details__header-content-version">{{ details.version }}</div>
         </div>
-      </app-banner>
+        <button i18n="@@logInOrSignUpToSubscribe" mat-stroked-button disabled color="primary api-details__header-button">
+          Log in / Sign up to subscribe
+        </button>
+      </div>
+      @if (details.description) {
+        <app-banner class="api-details__banner">
+          <div class="api-details__banner-content">
+            <mat-icon svgIcon="light-bulb" aria-hidden="false" aria-label="Light-bulb icon"></mat-icon>
+            <p>{{ details.description }}</p>
+          </div>
+        </app-banner>
+      }
+      <mat-tab-group animationDuration="0ms">
+        <mat-tab label="Details">
+          <ng-template matTabContent>
+            <app-api-tab-details />
+          </ng-template>
+        </mat-tab>
+        @if (pages$ | async; as pages) {
+          <mat-tab label="Documentation" [disabled]="pages.length === 0">
+            <ng-template matTabContent>
+              <app-api-tab-documentation [pages]="pages" />
+            </ng-template>
+          </mat-tab>
+        } @else {
+          <mat-tab label="Documentation" disabled="true" />
+        }
+      </mat-tab-group>
+    } @else {
+      <div>TODO: Add skeleton here....</div>
     }
-    <mat-tab-group animationDuration="0ms">
-      <mat-tab label="Details">
-        <ng-template matTabContent>
-          <app-api-tab-details />
-        </ng-template>
-      </mat-tab>
-      <mat-tab label="Documentation">
-        <ng-template matTabContent>
-          <app-api-tab-documentation />
-        </ng-template>
-      </mat-tab>
-    </mat-tab-group>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.spec.ts
@@ -13,16 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTabHarness } from '@angular/material/tabs/testing';
 
 import { ApiDetailsComponent } from './api-details.component';
-import { AppTestingModule } from '../../testing/app-testing.module';
+import { fakeApi } from '../../entities/api/api.fixtures';
+import { fakePagesResponse } from '../../entities/page/page.fixtures';
+import { PagesResponse } from '../../entities/page/pages-response';
+import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
 
 describe('ApiDetailsComponent', () => {
   let component: ApiDetailsComponent;
   let fixture: ComponentFixture<ApiDetailsComponent>;
   let httpTestingController: HttpTestingController;
+  let harnessLoader: HarnessLoader;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -31,14 +38,32 @@ describe('ApiDetailsComponent', () => {
 
     fixture = TestBed.createComponent(ApiDetailsComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
+    component.apiId = 'api-id';
+    fixture.detectChanges();
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/api-id`).flush(fakeApi({ id: 'api-id' }));
+    fixture.detectChanges();
   });
 
   afterEach(() => {
+    httpTestingController.match('assets/images/lightbulb_24px.svg');
     httpTestingController.verify();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should disable Documentation tab when pages empty', async () => {
+    expectPageList(fakePagesResponse({ data: [] }));
+    const documentationTab = await harnessLoader.getHarness(MatTabHarness.with({ label: 'Documentation' }));
+    expect(await documentationTab.isDisabled()).toEqual(true);
   });
+
+  it('should have active Documentation tab if pages exist', async () => {
+    expectPageList(fakePagesResponse());
+    const documentationTab = await harnessLoader.getHarness(MatTabHarness.with({ label: 'Documentation' }));
+    expect(await documentationTab.isDisabled()).toEqual(false);
+  });
+
+  function expectPageList(pagesResponse: PagesResponse = fakePagesResponse()) {
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/api-id/pages?homepage=false&page=1&size=-1`).flush(pagesResponse);
+  }
 });

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AsyncPipe } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardActions, MatCardContent } from '@angular/material/card';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { DomSanitizer } from '@angular/platform-browser';
+import { map, Observable, of } from 'rxjs';
 
 import { ApiTabDetailsComponent } from './api-tab-details/api-tab-details.component';
 import { ApiTabDocumentationComponent } from './api-tab-documentation/api-tab-documentation.component';
@@ -26,7 +28,9 @@ import { ApiCardComponent } from '../../components/api-card/api-card.component';
 import { ApiPictureComponent } from '../../components/api-picture/api-picture.component';
 import { BannerComponent } from '../../components/banner/banner.component';
 import { Api } from '../../entities/api/api';
+import { Page } from '../../entities/page/page';
 import { ApiService } from '../../services/api.service';
+import { PageService } from '../../services/page.service';
 
 @Component({
   selector: 'app-api-details',
@@ -43,16 +47,19 @@ import { ApiService } from '../../services/api.service';
     MatIconModule,
     ApiTabDetailsComponent,
     ApiTabDocumentationComponent,
+    AsyncPipe,
   ],
   templateUrl: './api-details.component.html',
   styleUrl: './api-details.component.scss',
 })
 export class ApiDetailsComponent implements OnInit {
   @Input() apiId!: string;
-  details!: Api;
+  details$: Observable<Api> = of();
+  pages$: Observable<Page[]> = of([]);
 
   constructor(
     private apiService: ApiService,
+    private pageService: PageService,
     private domSanitizer: DomSanitizer,
     private matIconRegistry: MatIconRegistry,
   ) {
@@ -60,8 +67,8 @@ export class ApiDetailsComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.apiService.details(this.apiId).subscribe(apiDetails => {
-      this.details = apiDetails;
-    });
+    this.details$ = this.apiService.details(this.apiId);
+
+    this.pages$ = this.pageService.listByApiId(this.apiId).pipe(map(response => response.data ?? []));
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2024 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,4 +15,10 @@
     limitations under the License.
 
 -->
-<p>api-tab-documentation works!</p>
+<div class="api-tab-documentation__side-bar">
+  <app-page-tree [pages]="pageNodes" (openFile)="showPage($event)" />
+</div>
+
+<div class="api-tab-documentation__page-content">
+  {{ selectedPage }}
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.spec.ts
@@ -16,6 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ApiTabDocumentationComponent } from './api-tab-documentation.component';
+import { AppTestingModule } from '../../../testing/app-testing.module';
 
 describe('ApiTabDocumentationComponent', () => {
   let component: ApiTabDocumentationComponent;
@@ -23,7 +24,7 @@ describe('ApiTabDocumentationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApiTabDocumentationComponent],
+      imports: [ApiTabDocumentationComponent, AppTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiTabDocumentationComponent);

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-tab-documentation/api-tab-documentation.component.ts
@@ -13,13 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { Component, Input, OnInit } from '@angular/core';
+
+import { PageTreeComponent, PageTreeNode } from '../../../components/page-tree/page-tree.component';
+import { Page } from '../../../entities/page/page';
+import { PageService } from '../../../services/page.service';
 
 @Component({
   selector: 'app-api-tab-documentation',
   standalone: true,
-  imports: [],
+  imports: [PageTreeComponent, AsyncPipe],
   templateUrl: './api-tab-documentation.component.html',
   styleUrl: './api-tab-documentation.component.scss',
 })
-export class ApiTabDocumentationComponent {}
+export class ApiTabDocumentationComponent implements OnInit {
+  @Input()
+  pages: Page[] = [];
+  pageNodes: PageTreeNode[] = [];
+  selectedPage: string = '';
+
+  constructor(private pageService: PageService) {}
+
+  ngOnInit(): void {
+    this.pageNodes = this.pageService.mapToPageTreeNode(undefined, this.pages);
+  }
+
+  showPage(pageId: string) {
+    this.selectedPage = pageId;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -109,7 +109,6 @@ describe('CatalogComponent', () => {
       expect(allHarnesses.length).toEqual(2);
 
       const secondPageApi = await harnessLoader.getHarnessOrNull(ApiCardHarness.with({ selector: '[ng-reflect-id="second-page-api"]' }));
-      console.log(1, secondPageApi);
       expect(secondPageApi).toBeTruthy();
     });
 

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+  <!-- This is the tree node template for leaf nodes -->
+  <mat-tree-node
+    class="file-tree__node clickable"
+    *matTreeNodeDef="let node"
+    [ngClass]="{ active: node.id === activeFile }"
+    matTreeNodePadding
+    (click)="fileSelected(node.id)">
+    <div class="file-tree__node__container">
+      {{ node.name }}
+    </div>
+  </mat-tree-node>
+  <!-- This is the tree node template for expandable nodes -->
+  <mat-tree-node
+    class="file-tree__node"
+    *matTreeNodeDef="let node; when: hasChild"
+    [ngClass]="{ active: node.id === activeFile }"
+    matTreeNodePadding>
+    <div class="file-tree__node__container">
+      {{ node.name }}
+
+      <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'Toggle ' + node.name">
+        <mat-icon>
+          {{ treeControl.isExpanded(node) ? 'expand_less' : 'expand_more' }}
+        </mat-icon>
+      </button>
+    </div>
+  </mat-tree-node>
+</mat-tree>

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.scss
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@import '../../scss/theme/theme';
+
+:host {
+  --mat-tree-container-background-color: none;
+}
+
+.file-tree {
+  &__node {
+    border-radius: 28px;
+    font-weight: 600;
+    transition: 0.1s;
+
+    &:hover {
+      background-color: map.get($theme-accent, main);
+    }
+
+    &__container {
+      display: flex;
+      width: 100%;
+      align-items: center;
+      justify-content: space-between;
+      padding-left: 20px;
+    }
+  }
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.active {
+  background-color: map.get($theme-accent, main);
+}

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTreeHarness } from '@angular/material/tree/testing';
+
+import { PageTreeComponent } from './page-tree.component';
+
+describe('PageTreeComponent', () => {
+  let component: PageTreeComponent;
+  let fixture: ComponentFixture<PageTreeComponent>;
+  let harnessLoader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PageTreeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PageTreeComponent);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    component = fixture.componentInstance;
+    component.pages = [
+      {
+        id: 'parent',
+        name: 'Parent',
+        children: [
+          { id: 'child', name: 'Child' },
+          {
+            id: 'second-child',
+            name: 'Second Child',
+            children: [
+              {
+                id: 'grandchild',
+                name: 'Grandchild',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'lone-node',
+        name: 'Lone Node',
+      },
+    ];
+    fixture.detectChanges();
+  });
+
+  it('should be expanded by default', async () => {
+    const fileTree = await harnessLoader.getHarness(MatTreeHarness);
+    expect(await fileTree.getNodes().then(nodes => nodes[0].isExpanded())).toEqual(true);
+  });
+
+  it('should create a node for each page', async () => {
+    const fileTree = await harnessLoader.getHarness(MatTreeHarness);
+    expect(await fileTree.getNodes().then(nodes => nodes.length)).toEqual(5);
+  });
+
+  it('should select file when page has no children', async () => {
+    let emitted = '';
+    component.openFile.subscribe((event: string) => {
+      emitted = event;
+    });
+    const fileTree = await harnessLoader.getHarness(MatTreeHarness);
+    const clickableNode = await fileTree.getNodes().then(nodes => nodes[1].host());
+    await clickableNode.click();
+
+    expect(emitted).toEqual('child');
+  });
+
+  it('should not select file when a page has children', async () => {
+    let emitted = 'never-called';
+    component.openFile.subscribe((event: string) => {
+      emitted = event;
+    });
+    const fileTree = await harnessLoader.getHarness(MatTreeHarness);
+    const parentNode = await fileTree.getNodes().then(nodes => nodes[0].host());
+    await parentNode.click();
+
+    expect(emitted).toEqual('never-called');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FlatTreeControl } from '@angular/cdk/tree';
+import { NgClass } from '@angular/common';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTreeFlatDataSource, MatTreeFlattener, MatTreeModule } from '@angular/material/tree';
+import { isEmpty } from 'lodash';
+
+export interface PageTreeNode {
+  id: string;
+  name: string;
+  children?: PageTreeNode[];
+}
+
+/** Flat node with expandable and level information */
+interface FlatNode {
+  expandable: boolean;
+  name: string;
+  level: number;
+  id: string;
+}
+
+@Component({
+  selector: 'app-page-tree',
+  standalone: true,
+  imports: [MatTreeModule, MatButtonModule, MatIconModule, NgClass],
+  templateUrl: './page-tree.component.html',
+  styleUrl: './page-tree.component.scss',
+})
+export class PageTreeComponent implements OnInit {
+  @Input({ required: true })
+  pages!: PageTreeNode[];
+
+  @Output()
+  openFile = new EventEmitter<string>();
+  dataSource: MatTreeFlatDataSource<PageTreeNode, FlatNode>;
+  treeControl: FlatTreeControl<FlatNode>;
+  activeFile: string = '';
+
+  private readonly treeFlattener: MatTreeFlattener<PageTreeNode, FlatNode>;
+
+  constructor() {
+    this.treeFlattener = new MatTreeFlattener(
+      this._transformer,
+      node => node.level,
+      node => node.expandable,
+      node => node.children,
+    );
+    this.treeControl = new FlatTreeControl<FlatNode>(
+      node => node.level,
+      node => node.expandable,
+    );
+    this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
+  }
+
+  ngOnInit() {
+    this.dataSource.data = this.pages;
+    this.treeControl.expandAll();
+    if (!isEmpty(this.pages)) {
+      this.activeFile = this.getFirstAvailablePage(this.pages[0]).id;
+      this.openFile.emit(this.activeFile);
+    }
+  }
+
+  hasChild = (_: number, node: FlatNode) => node.expandable;
+
+  fileSelected(id: string) {
+    this.activeFile = id;
+    this.openFile.emit(id);
+  }
+
+  private _transformer = (node: PageTreeNode, level: number): FlatNode => ({
+    expandable: !!node.children && node.children.length > 0,
+    name: node.name,
+    level: level,
+    id: node.id,
+  });
+
+  private getFirstAvailablePage(node: PageTreeNode): PageTreeNode {
+    if (node?.children && node.children.length > 0) {
+      return this.getFirstAvailablePage(node.children[0]);
+    }
+    return node;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.component.ts
@@ -24,6 +24,7 @@ import { isEmpty } from 'lodash';
 export interface PageTreeNode {
   id: string;
   name: string;
+  order?: number;
   children?: PageTreeNode[];
 }
 

--- a/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.stories.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page-tree/page-tree.stories.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { action } from '@storybook/addon-actions';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { PageTreeComponent, PageTreeNode } from './page-tree.component';
+
+const PAGE_DATA: PageTreeNode[] = [
+  {
+    id: 'fruit',
+    name: 'Fruit',
+    children: [
+      { id: 'Apple', name: 'Apple' },
+      { id: 'Banana', name: 'Banana' },
+      { id: 'Fruit loops', name: 'Fruit loops' },
+    ],
+  },
+  {
+    id: 'Vegetables',
+    name: 'Vegetables',
+    children: [
+      {
+        id: 'Green',
+        name: 'Green',
+        children: [
+          { id: 'Broccoli', name: 'Broccoli' },
+          { id: 'Brussels sprouts', name: 'Brussels sprouts' },
+        ],
+      },
+      {
+        id: 'Orange',
+        name: 'Orange',
+        children: [
+          { id: 'Pumpkins', name: 'Pumpkins' },
+          { id: 'Carrots', name: 'Carrots' },
+        ],
+      },
+    ],
+  },
+];
+
+export default {
+  title: 'Components / Page Tree',
+  decorators: [
+    moduleMetadata({
+      imports: [PageTreeComponent],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(MatIconModule)],
+    }),
+  ],
+  render: () => ({}),
+} as Meta;
+
+export const PageTree: StoryObj = {
+  render: () => ({
+    template: `
+        <div style="width: 300px">
+          <app-page-tree [pages]="pages" (openFile)="onOpenFile($event)"/>
+        </div>
+        `,
+    styles: [``],
+    props: {
+      pages: PAGE_DATA,
+      onOpenFile: (id: string) => action('File selected')(id),
+    },
+  }),
+};
+
+const PAGE_DATA_LONG_NAMES: PageTreeNode[] = [
+  {
+    id: 'fruit',
+    name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+    children: [
+      { id: 'Apple', name: 'Apple' },
+      {
+        id: 'Banana',
+        name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+      },
+      { id: 'Fruit loops', name: 'Fruit loops' },
+    ],
+  },
+  {
+    id: 'Vegetables',
+    name: 'Vegetables',
+    children: [
+      {
+        id: 'Green',
+        name: 'Green',
+        children: [
+          {
+            id: 'Broccoli',
+            name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+          },
+          { id: 'Brussels sprouts', name: 'Brussels sprouts' },
+        ],
+      },
+      {
+        id: 'Orange',
+        name: 'Orange',
+        children: [
+          {
+            id: 'Pumpkins',
+            name: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+          },
+          { id: 'Carrots', name: 'Carrots' },
+        ],
+      },
+    ],
+  },
+];
+
+export const PageTreeWithLongNames: StoryObj = {
+  render: () => ({
+    template: `
+        <div style="width: 300px">
+          <app-page-tree [pages]="pages" (openFile)="onOpenFile($event)"/>
+        </div>
+        `,
+    styles: [``],
+    props: {
+      pages: PAGE_DATA_LONG_NAMES,
+      onOpenFile: (id: string) => action('File selected')(id),
+    },
+  }),
+};

--- a/gravitee-apim-portal-webui-next/src/entities/page/page-links.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page-links.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PageLinks {
+  self?: string;
+  content?: string;
+  parent?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/page/page-media.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page-media.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PageMedia {
+  /**
+   * the name of the media.
+   */
+  name: string;
+  /**
+   * link to download the media.
+   */
+  link: string;
+  /**
+   * type of the media.
+   */
+  type: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/page/page-metadata.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page-metadata.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface PageMetadata {
+  name?: string;
+  value?: string;
+  order?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/page/page-revision-id.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page-revision-id.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PageRevisionId {
+  pageId?: string;
+  revision?: number;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/page/page.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page.fixtures.ts
@@ -16,6 +16,7 @@
 import { isFunction } from 'rxjs/internal/util/isFunction';
 
 import { Page } from './page';
+import { PagesResponse } from './pages-response';
 
 export function fakePage(modifier?: Partial<Page> | ((baseApi: Page) => Page)): Page {
   const base: Page = {
@@ -26,6 +27,23 @@ export function fakePage(modifier?: Partial<Page> | ((baseApi: Page) => Page)): 
     content: 'markdown content',
     updated_at: new Date(1642675655553),
     _links: {},
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakePagesResponse(modifier?: Partial<PagesResponse> | ((baseApi: PagesResponse) => PagesResponse)): PagesResponse {
+  const base: PagesResponse = {
+    data: [fakePage()],
+    metadata: {},
+    links: {},
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-portal-webui-next/src/entities/page/page.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page.fixtures.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'rxjs/internal/util/isFunction';
+
+import { Page } from './page';
+
+export function fakePage(modifier?: Partial<Page> | ((baseApi: Page) => Page)): Page {
+  const base: Page = {
+    id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
+    name: '\uD83E\uDE90 Planets',
+    order: 0,
+    type: 'MARKDOWN',
+    content: 'markdown content',
+    updated_at: new Date(1642675655553),
+    _links: {},
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/page/page.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page.ts
@@ -31,7 +31,7 @@ export interface Page {
   /**
    * Type of documentation.
    */
-  type: TypeEnum;
+  type: PageTypeEnum;
   /**
    * Order of the documentation page in its folder.
    */
@@ -60,4 +60,4 @@ export interface Page {
   contentRevisionId?: PageRevisionId;
 }
 
-type TypeEnum = 'ASCIIDOC' | 'ASYNCAPI' | 'SWAGGER' | 'MARKDOWN' | 'FOLDER' | 'ROOT' | 'LINK';
+export type PageTypeEnum = 'ASCIIDOC' | 'ASYNCAPI' | 'SWAGGER' | 'MARKDOWN' | 'FOLDER' | 'ROOT' | 'LINK';

--- a/gravitee-apim-portal-webui-next/src/entities/page/page.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/page.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PageLinks } from './page-links';
+import { PageMedia } from './page-media';
+import { PageMetadata } from './page-metadata';
+import { PageRevisionId } from './page-revision-id';
+
+export interface Page {
+  /**
+   * Unique identifier of a page.
+   */
+  id: string;
+  /**
+   * Name of the page.
+   */
+  name: string;
+  /**
+   * Type of documentation.
+   */
+  type: TypeEnum;
+  /**
+   * Order of the documentation page in its folder.
+   */
+  order: number;
+  /**
+   * Parent page. MAY be null.
+   */
+  parent?: string;
+  /**
+   * Last update date and time.
+   */
+  updated_at?: Date;
+  /**
+   * list of media hash, attached to this page
+   */
+  media?: Array<PageMedia>;
+  /**
+   * Array of metadata about the page. This array is filled when the page has been fetched from a distant source (GitHub, GitLab, etc...).
+   */
+  metadata?: Array<PageMetadata>;
+  _links?: PageLinks;
+  /**
+   * Only returned with (*)/apis/{apiId}/pages/{pageId}* and (*)/pages/{pageId}*. Need *include* query param to contain \'content\'.  The content of the page.
+   */
+  content?: string;
+  contentRevisionId?: PageRevisionId;
+}
+
+type TypeEnum = 'ASCIIDOC' | 'ASYNCAPI' | 'SWAGGER' | 'MARKDOWN' | 'FOLDER' | 'ROOT' | 'LINK';

--- a/gravitee-apim-portal-webui-next/src/entities/page/pages-response.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/page/pages-response.ts
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-:host {
-  display: flex;
-}
+import { Page } from './page';
+import { Links } from '../pagination/links';
 
-.api-tab-documentation {
-  &__side-bar {
-    width: 324px;
-  }
+export interface PagesResponse {
+  /**
+   * List of pages.
+   */
+  data?: Page[];
+  /**
+   * Map of Map of Object
+   */
+  metadata?: { [key: string]: { [key: string]: object } };
+  links?: Links;
 }

--- a/gravitee-apim-portal-webui-next/src/index.html
+++ b/gravitee-apim-portal-webui-next/src/index.html
@@ -23,6 +23,9 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.png" />
+    <link
+      href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
+      rel="stylesheet" />
   </head>
   <body>
     <app-root></app-root>

--- a/gravitee-apim-portal-webui-next/src/services/page.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/page.service.spec.ts
@@ -13,18 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { PageService } from './page.service';
 import { PageTreeNode } from '../components/page-tree/page-tree.component';
-import { fakePage } from '../entities/page/page.fixtures';
+import { fakePage, fakePagesResponse } from '../entities/page/page.fixtures';
+import { PagesResponse } from '../entities/page/pages-response';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('PageService', () => {
   let service: PageService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
     service = TestBed.inject(PageService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   describe('mapToPageTreeNode', () => {
@@ -112,6 +123,33 @@ describe('PageService', () => {
       ];
 
       expect(treeNodes).toEqual(expectedTreeNodes);
+    });
+  });
+  describe('listByApiId', () => {
+    it('should return pages with default query parameters', done => {
+      const pagesResponse: PagesResponse = fakePagesResponse();
+
+      service.listByApiId('api-id').subscribe(response => {
+        expect(response).toMatchObject(pagesResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/api-id/pages?homepage=false&page=1&size=-1`);
+      expect(req.request.method).toEqual('GET');
+      req.flush(pagesResponse);
+    });
+
+    it('should return pages with custom query parameters', done => {
+      const pagesResponse: PagesResponse = fakePagesResponse();
+
+      service.listByApiId('api-id', true, 2, 1).subscribe(response => {
+        expect(response).toMatchObject(pagesResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/api-id/pages?homepage=true&page=2&size=1`);
+      expect(req.request.method).toEqual('GET');
+      req.flush(pagesResponse);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/page.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/page.service.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { PageService } from './page.service';
+import { PageTreeNode } from '../components/page-tree/page-tree.component';
+import { fakePage } from '../entities/page/page.fixtures';
+
+describe('PageService', () => {
+  let service: PageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PageService);
+  });
+
+  describe('mapToPageTreeNode', () => {
+    it('should map page list to list of page tree nodes', () => {
+      const treeNodes = service.mapToPageTreeNode(undefined, [
+        fakePage({ id: 'parent', name: 'Parent', parent: undefined }),
+        fakePage({ id: 'child-one', name: 'Child One', parent: 'parent' }),
+        fakePage({ id: 'child-two', name: 'Child Two', parent: 'parent' }),
+        fakePage({ id: 'grandchild', name: 'Grandchild', parent: 'child-two' }),
+        fakePage({ id: 'lone-page', name: 'Lone Page', parent: undefined }),
+      ]);
+
+      const expectedTreeNodes: PageTreeNode[] = [
+        {
+          id: 'parent',
+          name: 'Parent',
+          children: [
+            {
+              id: 'child-one',
+              name: 'Child One',
+              children: [],
+            },
+            {
+              id: 'child-two',
+              name: 'Child Two',
+              children: [{ id: 'grandchild', name: 'Grandchild', children: [] }],
+            },
+          ],
+        },
+        {
+          id: 'lone-page',
+          name: 'Lone Page',
+          children: [],
+        },
+      ];
+
+      expect(treeNodes).toEqual(expectedTreeNodes);
+    });
+
+    it('should map empty list', () => {
+      const treeNodes = service.mapToPageTreeNode(undefined, []);
+      expect(treeNodes).toEqual([]);
+    });
+
+    it('should map list with no root parent to empty list', () => {
+      const treeNodes = service.mapToPageTreeNode(undefined, [
+        fakePage({ id: 'child-one', name: 'Child One', parent: 'parent' }),
+        fakePage({ id: 'child-two', name: 'Child Two', parent: 'parent' }),
+        fakePage({ id: 'grandchild', name: 'Grandchild', parent: 'child-two' }),
+      ]);
+      expect(treeNodes).toEqual([]);
+    });
+
+    it('should sort page list to nodes', () => {
+      const treeNodes = service.mapToPageTreeNode(undefined, [
+        fakePage({ id: 'parent', name: 'Parent', parent: undefined, order: 99 }),
+        fakePage({ id: 'child-one', name: 'Child One', parent: 'parent', order: 1 }),
+        fakePage({ id: 'child-two', name: 'Child Two', parent: 'parent', order: 0 }),
+        fakePage({ id: 'grandchild', name: 'Grandchild', parent: 'child-two', order: 0 }),
+        fakePage({ id: 'lone-page', name: 'Lone Page', parent: undefined, order: 1 }),
+      ]);
+
+      const expectedTreeNodes: PageTreeNode[] = [
+        {
+          id: 'lone-page',
+          name: 'Lone Page',
+          children: [],
+        },
+        {
+          id: 'parent',
+          name: 'Parent',
+          children: [
+            {
+              id: 'child-two',
+              name: 'Child Two',
+              children: [{ id: 'grandchild', name: 'Grandchild', children: [] }],
+            },
+            {
+              id: 'child-one',
+              name: 'Child One',
+              children: [],
+            },
+          ],
+        },
+      ];
+
+      expect(treeNodes).toEqual(expectedTreeNodes);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/page.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/page.service.ts
@@ -13,16 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import { ConfigService } from './config.service';
 import { PageTreeNode } from '../components/page-tree/page-tree.component';
 import { Page } from '../entities/page/page';
+import { PagesResponse } from '../entities/page/pages-response';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PageService {
-  constructor() {}
+  constructor(
+    private readonly http: HttpClient,
+    private configService: ConfigService,
+  ) {}
+
+  listByApiId(apiId: string, homepage = false, page = 1, size = -1) {
+    return this.http.get<PagesResponse>(`${this.configService.baseURL}/apis/${apiId}/pages`, {
+      params: {
+        homepage,
+        page,
+        size,
+      },
+    });
+  }
 
   mapToPageTreeNode(root: string | undefined, pages: Page[]): PageTreeNode[] {
     return pages

--- a/gravitee-apim-portal-webui-next/src/services/page.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/page.service.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+
+import { PageTreeNode } from '../components/page-tree/page-tree.component';
+import { Page } from '../entities/page/page';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PageService {
+  constructor() {}
+
+  mapToPageTreeNode(root: string | undefined, pages: Page[]): PageTreeNode[] {
+    return pages
+      .filter(p => p.parent === root)
+      .sort((p1, p2) => p1.order - p2.order)
+      .map(p => ({
+        id: p.id,
+        name: p.name,
+        children: this.mapToPageTreeNode(p.id, pages),
+      }));
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -16,6 +16,7 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable, NgModule } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ConfigService } from '../services/config.service';
 
@@ -30,7 +31,7 @@ export class ConfigServiceStub {
 
 @NgModule({
   declarations: [],
-  imports: [CommonModule, HttpClientTestingModule],
+  imports: [CommonModule, HttpClientTestingModule, NoopAnimationsModule],
   providers: [
     {
       provide: ConfigService,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3926

## Description

Create a page tree to show documentation pages.


https://github.com/gravitee-io/gravitee-api-management/assets/42294616/77161741-3a26-4b9a-8e43-3d768b43e1d5

Page tree in api details documentation tab:


![Screenshot 2024-04-18 at 10 40 09](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/66d70a1a-af94-44ad-a11a-a0402548de75)


TODO: 
- [x]  -- Create mapping from list of documentation pages to PageNode
- [x]  -- Test + Storybook for long names 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-owutfcstqe.chromatic.com)
<!-- Storybook placeholder end -->
