### PR TITLE
feat: optimize wiremock instantiation in test sdk

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tls/MutualTLSIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tls/MutualTLSIntegrationTest.java
@@ -62,6 +62,11 @@ public class MutualTLSIntegrationTest {
         }
 
         @Override
+        public void configurePlaceHolderVariables(Map<String, String> variables) {
+            variables.put("WIREMOCK_PORT", "" + wiremock.port());
+        }
+
+        @Override
         @SneakyThrows
         protected void configureGateway(GatewayConfigurationBuilder config) {
             /*

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tls/TlsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tls/TlsIntegrationTest.java
@@ -63,6 +63,11 @@ public class TlsIntegrationTest {
         }
 
         @Override
+        public void configurePlaceHolderVariables(Map<String, String> variables) {
+            variables.put("WIREMOCK_PORT", "" + wiremock.port());
+        }
+
+        @Override
         protected void configureGateway(GatewayConfigurationBuilder config) {
             config.httpSecured(true).set("http.ssl.sni", true).configureTcpGateway(this.tcpPort());
         }

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/tcp/api-multi-domain.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/tcp/api-multi-domain.json
@@ -31,7 +31,7 @@
           "configuration": {
             "target": {
               "host": "localhost",
-              "port": 8080
+              "port": ${WIREMOCK_PORT}
             }
           },
           "sharedConfiguration": {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4597

## Description

This PR refactors the way Wiremock is instantiated by the test SDK. Instead of starting/stopping a Wiremock server for each test, it is now started once for the whole test class. This should be a bit less CPU consuming and allow injecting the Wiremock port into the API definition using the new placeholder replacement mechanism.
