### PR TITLE
Add missing produce & consume annotation on mAPI v1 resources

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionResource.java
@@ -84,6 +84,7 @@ public class ApiDefinitionResource extends AbstractResource {
     }
 
     @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Update the API with json patches",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
@@ -26,9 +26,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
@@ -52,6 +54,7 @@ public class PromotionResource extends AbstractResource {
 
     @POST
     @Path("/_process")
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Process an API promotion by accepting or rejecting it")
     @ApiResponse(
         responseCode = "200",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/ClientRegistrationProvidersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/ClientRegistrationProvidersResource.java
@@ -92,6 +92,8 @@ public class ClientRegistrationProvidersResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLIENT_REGISTRATION_PROVIDER, acls = RolePermissionAction.CREATE) })
     @Operation(
         summary = "Create a client registration provider",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/identity/IdentityProvidersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/identity/IdentityProvidersResource.java
@@ -96,6 +96,8 @@ public class IdentityProvidersResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ORGANIZATION_IDENTITY_PROVIDER, acls = RolePermissionAction.CREATE) })
     @Operation(
         summary = "Create an identity provider",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -252,6 +252,8 @@ public class CurrentUserResource extends AbstractResource {
     }
 
     @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Update the authenticated user")
     @ApiResponse(
         responseCode = "200",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CustomUserFieldsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CustomUserFieldsResource.java
@@ -77,6 +77,8 @@ public class CustomUserFieldsResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(io.gravitee.common.http.MediaType.APPLICATION_JSON)
+    @Produces(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @Permissions(@Permission(value = RolePermission.ORGANIZATION_CUSTOM_USER_FIELDS, acls = CREATE))
     @Operation(
         summary = "Create a Custom User Field",
@@ -98,6 +100,8 @@ public class CustomUserFieldsResource extends AbstractResource {
     }
 
     @PUT
+    @Consumes(io.gravitee.common.http.MediaType.APPLICATION_JSON)
+    @Produces(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @Path("{key}")
     @Permissions(@Permission(value = RolePermission.ORGANIZATION_CUSTOM_USER_FIELDS, acls = UPDATE))
     @Operation(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/NewsletterResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/NewsletterResource.java
@@ -55,6 +55,7 @@ public class NewsletterResource extends AbstractResource {
     private UserService userService;
 
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/_subscribe")
     @Operation(summary = "Subscribe to the newsletter the authenticated user")
     @ApiResponse(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/NotificationTemplatesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/NotificationTemplatesResource.java
@@ -82,6 +82,8 @@ public class NotificationTemplatesResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(io.gravitee.common.http.MediaType.APPLICATION_JSON)
+    @Produces(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Create a notification template",
         description = "User must have the NOTIFICATION_TEMPLATES[CREATE] permission to use this service"
@@ -131,6 +133,8 @@ public class NotificationTemplatesResource extends AbstractResource {
 
     @Path("{notificationTemplateId}")
     @PUT
+    @Consumes(io.gravitee.common.http.MediaType.APPLICATION_JSON)
+    @Produces(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Update an existing notification template",
         description = "User must have the NOTIFICATION_TEMPLATES[UPDATE] permission to use this service"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.rest.resource.organization;
 
 import static io.gravitee.common.http.MediaType.APPLICATION_JSON;
 
+import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
@@ -239,6 +240,7 @@ public class UserResource extends AbstractResource {
     }
 
     @PUT
+    @Consumes(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @Path("/roles")
     @Permissions(@Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.UPDATE))
     public Response updateUserRoles(@NotNull UserReferenceRoleEntity userReferenceRoles) {
@@ -253,6 +255,7 @@ public class UserResource extends AbstractResource {
     }
 
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/changePassword")
     @Operation(summary = "Change user password after a reset", description = "User registration must be enabled")
     @ApiResponse(
@@ -274,6 +277,7 @@ public class UserResource extends AbstractResource {
     }
 
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/_process")
     @Permissions(@Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.UPDATE))
     @Operation(summary = "Process a user registration by accepting or rejecting it")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserTokensResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserTokensResource.java
@@ -123,8 +123,7 @@ public class UserTokensResource extends AbstractResource {
         userService.findById(GraviteeContext.getExecutionContext(), userId);
 
         // Check that token exists and belongs to user
-        Token tokenToRevoke = tokenService.findByToken(tokenId);
-        if (!userId.equalsIgnoreCase(tokenToRevoke.getReferenceId())) {
+        if (!tokenService.tokenExistsForUser(tokenId, userId)) {
             throw new TokenNotFoundException(tokenId);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersRegistrationResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.rest.resource.organization;
 
 import static io.gravitee.common.http.MediaType.APPLICATION_JSON;
 
+import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.NewExternalUserEntity;
 import io.gravitee.rest.api.model.RegisterUserEntity;
@@ -60,6 +61,8 @@ public class UsersRegistrationResource extends AbstractResource {
      * Generate a token and send it in an email to allow a user to create an account.
      */
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Register a user", description = "User registration must be enabled")
     @ApiResponse(
         responseCode = "200",
@@ -77,6 +80,8 @@ public class UsersRegistrationResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Path("/finalize")
     @Operation(summary = "Finalize user registration", description = "User registration must be enabled")
     @ApiResponse(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UsersResource.java
@@ -20,6 +20,7 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.model.Pageable;
 import io.gravitee.rest.api.management.rest.model.wrapper.UserPageResult;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
@@ -81,6 +82,8 @@ public class UsersResource extends AbstractResource {
     }
 
     @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
     @Permissions(@Permission(value = RolePermission.ORGANIZATION_USERS, acls = CREATE))
     @Operation(summary = "Create a user", description = "User must have the ORGANIZATION_USERS[CREATE] permission to use this service")
     @ApiResponse(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/UserTokensResourceAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/UserTokensResourceAdminTest.java
@@ -151,14 +151,12 @@ public class UserTokensResourceAdminTest extends AbstractResourceTest {
 
     @Test
     public void shouldRevokeToken() {
-        Token existingToken = new Token();
-        existingToken.setReferenceId(USER_ID);
-        when(tokenService.findByToken(TOKEN_ID)).thenReturn(existingToken);
+        when(tokenService.tokenExistsForUser(TOKEN_ID, USER_ID)).thenReturn(true);
 
         final Response response = envTarget().path(TOKEN_ID).request().delete();
 
         assertThat(response.getStatus()).isEqualTo(204);
-        verify(tokenService, times(1)).findByToken(TOKEN_ID);
+        verify(tokenService, times(1)).tokenExistsForUser(TOKEN_ID, USER_ID);
         verify(userService, times(1)).findById(GraviteeContext.getExecutionContext(), USER_ID);
         verify(tokenService, times(1)).revoke(GraviteeContext.getExecutionContext(), TOKEN_ID);
     }
@@ -171,33 +169,31 @@ public class UserTokensResourceAdminTest extends AbstractResourceTest {
 
         assertThat(response.getStatus()).isEqualTo(404);
         verify(userService, times(1)).findById(GraviteeContext.getExecutionContext(), USER_ID);
-        verify(tokenService, never()).findByToken(TOKEN_ID);
+        verify(tokenService, never()).tokenExistsForUser(TOKEN_ID, USER_ID);
         verify(tokenService, never()).revoke(GraviteeContext.getExecutionContext(), TOKEN_ID);
     }
 
     @Test
     public void shouldNotRevokeTokenBecauseTokenDoesNotExist() {
-        when(tokenService.findByToken(TOKEN_ID)).thenThrow(new TokenNotFoundException(TOKEN_ID));
+        when(tokenService.tokenExistsForUser(TOKEN_ID, USER_ID)).thenReturn(false);
 
         final Response response = envTarget().path(TOKEN_ID).request().delete();
 
         assertThat(response.getStatus()).isEqualTo(404);
         verify(userService, times(1)).findById(GraviteeContext.getExecutionContext(), USER_ID);
-        verify(tokenService, times(1)).findByToken(TOKEN_ID);
+        verify(tokenService, times(1)).tokenExistsForUser(TOKEN_ID, USER_ID);
         verify(tokenService, never()).revoke(GraviteeContext.getExecutionContext(), TOKEN_ID);
     }
 
     @Test
     public void shouldNotRevokeTokenBecauseTokenDoesBelongToUser() {
-        Token existingToken = new Token();
-        existingToken.setReferenceId("another_user_id");
-        when(tokenService.findByToken(TOKEN_ID)).thenReturn(existingToken);
+        when(tokenService.tokenExistsForUser(TOKEN_ID, USER_ID)).thenReturn(false);
 
         final Response response = envTarget().path(TOKEN_ID).request().delete();
 
         assertThat(response.getStatus()).isEqualTo(404);
         verify(userService, times(1)).findById(GraviteeContext.getExecutionContext(), USER_ID);
-        verify(tokenService, times(1)).findByToken(TOKEN_ID);
+        verify(tokenService, times(1)).tokenExistsForUser(TOKEN_ID, USER_ID);
         verify(tokenService, never()).revoke(GraviteeContext.getExecutionContext(), TOKEN_ID);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/TokenService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/TokenService.java
@@ -28,6 +28,7 @@ import java.util.List;
 public interface TokenService {
     List<TokenEntity> findByUser(String userId);
     Token findByToken(String token);
+    boolean tokenExistsForUser(String tokenId, String userId);
     TokenEntity create(ExecutionContext executionContext, NewTokenEntity token, String userId);
     void revokeByUser(ExecutionContext executionContext, String userId);
     void revoke(ExecutionContext executionContext, String tokenId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
@@ -153,6 +153,18 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
         }
     }
 
+    @Override
+    public boolean tokenExistsForUser(String tokenId, String userId) {
+        try {
+            Optional<Token> byId = tokenRepository.findById(tokenId);
+            return byId.map(Token::getReferenceId).filter(ref -> ref.equals(userId)).isPresent();
+        } catch (TechnicalException ex) {
+            final String error = "An error occurs while trying to check if token exists";
+            LOGGER.error(error, ex);
+            throw new TechnicalManagementException(error, ex);
+        }
+    }
+
     private Token convert(
         final NewTokenEntity tokenEntity,
         final TokenReferenceType referenceType,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
@@ -110,6 +110,7 @@ public class TokenServiceTest {
         when(token.getCreatedAt()).thenReturn(new Date(1486771200000L));
         when(token.getExpiresAt()).thenReturn(new Date(1486772200000L));
         when(token.getLastUseAt()).thenReturn(new Date(1486773200000L));
+        when(token.getReferenceId()).thenReturn(USER_ID);
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(of(token));
 
         SecurityContextHolder.setContext(
@@ -312,5 +313,25 @@ public class TokenServiceTest {
             verify(tokenRepository, never()).update(any());
             throw e;
         }
+    }
+
+    @Test
+    public void should_return_token_does_not_exist() throws TechnicalException {
+        when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.empty());
+        boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
+        assertFalse(tokenExistsForUser);
+    }
+
+    @Test
+    public void should_return_token_does_not_exist_because_does_not_belong_to_user() throws TechnicalException {
+        when(token.getReferenceId()).thenReturn("another_user_id");
+        boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
+        assertFalse(tokenExistsForUser);
+    }
+
+    @Test
+    public void should_return_token_exists() throws TechnicalException {
+        boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
+        assertTrue(tokenExistsForUser);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4613

## Description

A small description of what you did in that PR.

## Additional context

 - add missing produce & consume annotation
 - use the right method to check if a token exists and belongs to a user. Before, we used a method that expects a token value with a tokenId. Now it uses a dedicated service.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-etfkfhpdxd.chromatic.com)
<!-- Storybook placeholder end -->
