### PR TITLE
chore: add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*]
+charset = utf-8
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_formatter_tags_enabled = true
+ij_smart_tabs = false
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 99
+ij_java_imports_layout = $*,|,*,javax.**,java.**,|
+ij_java_layout_static_imports_separately = true
+ij_java_names_count_to_use_import_on_demand = 99
+ij_java_packages_to_use_import_on_demand = java.awt.*,javax.swing.*
+ij_java_use_single_class_imports = true


### PR DESCRIPTION
## Description

This file only contains config for dealing with imports, as most of the formatting is handled by Prettier.

It is configured not to use `*` import. we can change that I don't remember who I spoke to who prefers that 🙈 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

