### PR TITLE
feat: add new option for RedisClient to manage hostname verification …

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -266,6 +266,7 @@ ratelimit:
 #          port: 26379
 #    # SSL settings
 #    ssl: false
+#    hostnameVerificationAlgorithm: NONE # default value is NONE. Support NONE, HTTPS and LDAPS
 #    trustAll: true # default value is true to keep backward compatibility but you should set it to false and configure a truststore for security concerns
 #    tlsProtocols: # List of TLS protocols to allow comma separated i.e: TLSv1.2, TLSv1.3
 #    tlsCiphers: # List of TLS ciphers to allow comma separated i.e: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
@@ -81,6 +81,10 @@ All the specific configurations are located under the `ratelimit.redis` attribut
 |true
 |Default value is true for backward compatibility but keep in mind that this is not a good practice and you should set to false and configure a truststore
 
+|hostnameVerificationAlgorithm
+|NONE
+|Default value is NONE for backward compatibility, supports `NONE`, `HTTPS`, `LDAPS`
+
 |tlsProtocols
 |See https://vertx.io/docs/vertx-core/java/#_configuring_tls_protocol_versions[Vert.x doc]
 |List of TLS protocols to allow comma separated.
@@ -197,6 +201,7 @@ ratelimit:
     password: 'redis-password'
     # SSL settings
     ssl: true
+    hostnameVerificationAlgorithm: HTTPS
     trustAll: false
     tlsProtocols: TLSv1.2, TLSv1.3
     tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
@@ -127,6 +127,17 @@ public class RedisConnectionFactory {
             options.getNetClientOptions().setSsl(true);
             options.getNetClientOptions().setTrustAll(trustAll);
 
+            String hostnameVerificationAlgorithm = readPropertyValue(
+                propertyPrefix + "hostnameVerificationAlgorithm",
+                String.class,
+                "NONE"
+            );
+            if ("NONE".equals(hostnameVerificationAlgorithm)) {
+                options.getNetClientOptions().setHostnameVerificationAlgorithm("");
+            } else {
+                options.getNetClientOptions().setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+            }
+
             // TLS Protocols
             options
                 .getNetClientOptions()

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
@@ -107,6 +107,7 @@ public class RedisConnectionFactoryTest {
         sentinelEndpoints.add("rediss://sent2:26379");
 
         assertThat(options).isNotNull();
+        assertThat(options.getNetClientOptions().getHostnameVerificationAlgorithm()).isEqualTo("");
         assertThat(options.getEndpoints()).containsAll(sentinelEndpoints);
     }
 
@@ -130,6 +131,7 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.hostnameVerificationAlgorithm", "HTTPS");
         environment.setProperty(PROPERTY_PREFIX + ".redis.trustAll", "false");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.type", "pem");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[0].cert", keystoreCertPath);
@@ -148,6 +150,7 @@ public class RedisConnectionFactoryTest {
         pemTrustOptions.addCertPath(truststorePath);
 
         assertThat(options).isNotNull();
+        assertThat(options.getNetClientOptions().getHostnameVerificationAlgorithm()).isEqualTo("HTTPS");
         assertThat(options.getNetClientOptions().getPemKeyCertOptions()).usingRecursiveComparison().isEqualTo(pemKeyCertOptions);
         assertThat(options.getNetClientOptions().getPemTrustOptions()).usingRecursiveComparison().isEqualTo(pemTrustOptions);
     }

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -235,7 +235,7 @@ data:
         {{- end }}
       {{- end }}
     {{- end }}
-    
+
     ratelimit:
       type: {{ .Values.ratelimit.type | default "mongodb" }}
       {{- if or (eq .Values.ratelimit.type "mongodb") (kindIs "invalid" .Values.ratelimit.type) }}
@@ -286,6 +286,7 @@ data:
         {{- end }}
         {{- if .Values.gateway.ratelimit.redis.ssl }}
         ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
+        hostnameVerificationAlgorithm: {{ .Values.gateway.ratelimit.redis.hostnameVerificationAlgorithm | default "NONE" }}
         {{- end }}
         {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
         sentinel:
@@ -300,17 +301,17 @@ data:
 
     # Sharding tags configuration
     # Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.
-    tags: {{ .Values.gateway.sharding_tags }}  
+    tags: {{ .Values.gateway.sharding_tags }}
 
     # Multi-tenant configuration
     # Allow only a single-value
-    tenant: {{ .Values.gateway.tenant }}  
+    tenant: {{ .Values.gateway.tenant }}
 
     {{- if .Values.gateway.system}}
     system:
 {{ toYaml .Values.gateway.system | indent 6 }}
     {{- end }}
-    
+
     # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
     # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
     reporters:
@@ -366,7 +367,7 @@ data:
       {{- range $key, $value := .Values.gateway.reporters }}
       {{- if ne $key "elasticsearch"}}
       {{ $key }}:
-{{ toYaml $value | indent 8 }}      
+{{ toYaml $value | indent 8 }}
       {{- end }}
       {{- end }}
 
@@ -469,17 +470,17 @@ data:
     handlers:
 {{ toYaml .Values.gateway.handlers | indent 6 }}
     {{- end }}
-    
+
     {{- if .Values.gateway.policy }}
-    policy: 
-{{ toYaml .Values.gateway.policy | indent 6 }}   
+    policy:
+{{ toYaml .Values.gateway.policy | indent 6 }}
     {{ else }}
     policy:
       api-key:
         header: {{ .Values.gateway.apiKey.header }}
         param: {{ .Values.gateway.apiKey.param }}
     {{- end }}
-    
+
     # Alert Engine communication
     {{- if .Values.alerts.enabled }}
     alerts:

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -37,7 +37,30 @@ tests:
                      *  host: redis\n
                      *  port: 6379\n
                      *  password: mypassword\n
-                     *  ssl: true\n"
+                     *  ssl: true\n
+                     *  hostnameVerificationAlgorithm: NONE"
+  - it: Set host and port with password, ssl enabled and hostname verification algorithm to HTTPS
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: redis
+      gateway:
+        ratelimit:
+          redis:
+            host: redis
+            port: 6379
+            password: mypassword
+            ssl: true
+            hostnameVerificationAlgorithm: HTTPS
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * redis:\n
+                     *  host: redis\n
+                     *  port: 6379\n
+                     *  password: mypassword\n
+                     *  ssl: true\n
+                     *  hostnameVerificationAlgorithm: HTTPS"
   - it: Set configuration with sentinels
     template: gateway/gateway-configmap.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1022,6 +1022,7 @@ gateway:
 #      port: 6379
 #      password:
 #      ssl: false
+#      hostnameVerificationAlgorithm: NONE
 #      sentinel:
 #        master: redis-master
 #        nodes:


### PR DESCRIPTION
…algorithm

- to avoid BC, default value is set to NONE
- this change is needed before updating the BOM to 8.x

## Issue

https://gravitee.atlassian.net/browse/ARCHI-345

## Description

Add a new option for RedisClient to manage hostname verification algorithm and set a default value to NONE (which result in an empty string in Vert.x ClientOptions) to avoid any BC.
This change is needed before upgrading the BOM to 8.x which comes with Vert.x 4.5.7 (https://github.com/vert-x3/wiki/wiki/4.5.4-Deprecations-and-breaking-changes#breaking-change-in-the-tls-configuration-of-tcp-client).

