### PR TITLE
feat: create plans while ingesting federated API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.spec.ts
@@ -31,7 +31,7 @@ describe('ApiFederatedMenuService', () => {
         { provide: ApiFederatedMenuService },
         {
           provide: GioTestingPermissionProvider,
-          useValue: ['api-member-r', 'api-audit-r'],
+          useValue: ['api-member-r', 'api-audit-r', 'api-plan-r'],
         },
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },
@@ -80,6 +80,21 @@ describe('ApiFederatedMenuService', () => {
               },
             ],
           },
+          {
+            displayName: 'Consumers',
+            header: {
+              subtitle: 'Manage how your API is consumed',
+              title: 'Consumers',
+            },
+            icon: 'cloud-consumers',
+            routerLink: '',
+            tabs: [
+              {
+                displayName: 'Plans',
+                routerLink: 'plans',
+              },
+            ],
+          },
         ],
         groupItems: [],
       });
@@ -108,6 +123,16 @@ describe('ApiFederatedMenuService', () => {
                 },
               },
             ],
+          },
+          {
+            displayName: 'Consumers',
+            header: {
+              subtitle: 'Manage how your API is consumed',
+              title: 'Consumers',
+            },
+            icon: 'cloud-consumers',
+            routerLink: '',
+            tabs: [],
           },
         ],
         groupItems: [],

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-federated-menu.service.ts
@@ -36,7 +36,7 @@ export class ApiFederatedMenuService implements ApiMenuService {
     subMenuItems: MenuItem[];
     groupItems: MenuGroupItem[];
   } {
-    const subMenuItems: MenuItem[] = [this.addConfigurationMenuEntry()];
+    const subMenuItems: MenuItem[] = [this.addConfigurationMenuEntry(), this.addConsumersMenuEntry()];
 
     return { subMenuItems, groupItems: [] };
   }
@@ -78,6 +78,28 @@ export class ApiFederatedMenuService implements ApiMenuService {
       header: {
         title: 'Configuration',
         subtitle: 'Manage general settings, user permissions, properties, and resources, and track changes to your API',
+      },
+      tabs: tabs,
+    };
+  }
+
+  private addConsumersMenuEntry(): MenuItem {
+    const tabs: MenuItem[] = [];
+
+    if (this.permissionService.hasAnyMatching(['api-plan-r'])) {
+      tabs.push({
+        displayName: 'Plans',
+        routerLink: 'plans',
+      });
+    }
+
+    return {
+      displayName: 'Consumers',
+      icon: 'cloud-consumers',
+      routerLink: '',
+      header: {
+        title: 'Consumers',
+        subtitle: 'Manage how your API is consumed',
       },
       tabs: tabs,
     };

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedPlan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/federation/FederatedPlan.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.federation;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Data
+public class FederatedPlan implements Serializable {
+
+    @JsonProperty(required = true)
+    private String id;
+
+    @JsonProperty(required = true)
+    private String providerId;
+
+    @JsonProperty(required = true)
+    private PlanSecurity security;
+
+    @Builder.Default
+    @JsonProperty(required = true)
+    private PlanMode mode = PlanMode.STANDARD;
+
+    @JsonProperty(required = true)
+    @Builder.Default
+    private PlanStatus status = PlanStatus.PUBLISHED;
+
+    @JsonIgnore
+    public final boolean isSubscribable() {
+        return (
+            (
+                this.getSecurity() != null &&
+                this.getSecurity().getType() != null &&
+                !"KEY_LESS".equalsIgnoreCase(this.getSecurity().getType())
+            ) ||
+            usePushMode()
+        );
+    }
+
+    @JsonIgnore
+    public final boolean usePushMode() {
+        return this.getMode() != null && this.getMode() == PlanMode.PUSH;
+    }
+
+    @JsonIgnore
+    public final boolean useStandardMode() {
+        return this.getMode() != null && this.getMode() == PlanMode.STANDARD;
+    }
+
+    @JsonIgnore
+    public final boolean isApiKey() {
+        return (
+            this.getSecurity() != null &&
+            ("API_KEY".equalsIgnoreCase(this.getSecurity().getType()) || "api-key".equalsIgnoreCase(this.getSecurity().getType()))
+        );
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/PlanFixtures.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/PlanFixtures.java
@@ -15,6 +15,7 @@
  */
 package fixtures.definition;
 
+import io.gravitee.definition.model.federation.FederatedPlan;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -55,5 +56,16 @@ public class PlanFixtures {
 
     public static io.gravitee.definition.model.Plan aKeylessV1() {
         return BASE_V2.get().id("keyless").name("Keyless").security("key-less").paths(Map.of("/", List.of())).build();
+    }
+
+    public static FederatedPlan aFederatedPlan() {
+        return FederatedPlan
+            .builder()
+            .id("my-plan")
+            .mode(PlanMode.STANDARD)
+            .providerId("provider-id")
+            .status(PlanStatus.PUBLISHED)
+            .security(PlanSecurity.builder().type("api-key").build())
+            .build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -107,7 +107,13 @@ public class Plan {
     private Date closedAt;
 
     /**
-     * The JSON payload of all policies to apply for this plan
+     * The JSON payload containing plan definition.
+     *
+     * <ul>
+     * <li>For V1, it contains all policies to apply for this plan</li>
+     * <li>For V2/V4, it null</li>
+     * <li>For FEDERATED, it contains the serialized definition</li>
+     * </ul>
      */
     private String definition;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
@@ -31,11 +31,9 @@ public record IntegrationApi(
     Map<String, String> connectionDetails,
     List<Plan> plans
 ) {
-    public record Plan(String id, String name, PlanType type) {}
+    public record Plan(String id, String name, String description, PlanType type) {}
     public enum PlanType {
         API_KEY,
-        OAUTH,
-        JWT,
     }
 
     public FederatedApi.FederatedApiBuilder toFederatedApiDefinitionBuilder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.sql.Date;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -63,6 +64,7 @@ public class CreatePlanDomainService {
     public PlanWithFlows create(Plan plan, List<Flow> flows, Api api, AuditInfo auditInfo) {
         return switch (api.getDefinitionVersion()) {
             case V4 -> createV4ApiPlan(plan, flows, api, auditInfo);
+            case FEDERATED -> createFederatedApiPlan(plan, auditInfo);
             default -> throw new IllegalStateException(api.getDefinitionVersion() + " is not supported");
         };
     }
@@ -107,6 +109,12 @@ public class CreatePlanDomainService {
         createAuditLog(createdPlan, auditInfo);
 
         return toPlanWithFlows(createdPlan, createdFlows);
+    }
+
+    private PlanWithFlows createFederatedApiPlan(Plan plan, AuditInfo auditInfo) {
+        var createdPlan = planCrudService.create(plan);
+        createAuditLog(createdPlan, auditInfo);
+        return toPlanWithFlows(plan, Collections.emptyList());
     }
 
     private void createAuditLog(Plan createdPlan, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
@@ -20,6 +20,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -90,6 +91,7 @@ public class Plan implements GenericPlanEntity {
 
     private io.gravitee.definition.model.v4.plan.Plan planDefinitionV4;
     private io.gravitee.definition.model.Plan planDefinitionV2;
+    private io.gravitee.definition.model.federation.FederatedPlan federatedPlanDefinition;
 
     @Override
     public io.gravitee.rest.api.model.v4.plan.PlanType getPlanType() {
@@ -101,7 +103,7 @@ public class Plan implements GenericPlanEntity {
         return switch (definitionVersion) {
             case V4 -> planDefinitionV4.getSecurity();
             case V1, V2 -> new PlanSecurity(planDefinitionV2.getSecurity(), planDefinitionV2.getSecurityDefinition());
-            case FEDERATED -> throw new IllegalStateException("FEDERATED type not supported");
+            case FEDERATED -> federatedPlanDefinition.getSecurity();
         };
     }
 
@@ -110,7 +112,7 @@ public class Plan implements GenericPlanEntity {
         return switch (definitionVersion) {
             case V4 -> planDefinitionV4.getStatus();
             case V1, V2 -> PlanStatus.valueOf(planDefinitionV2.getStatus());
-            case FEDERATED -> throw new IllegalStateException("FEDERATED type not supported");
+            case FEDERATED -> federatedPlanDefinition.getStatus();
         };
     }
 
@@ -118,6 +120,7 @@ public class Plan implements GenericPlanEntity {
         switch (definitionVersion) {
             case V4 -> planDefinitionV4.setStatus(planStatus);
             case V1, V2 -> planDefinitionV2.setStatus(planStatus.name());
+            case FEDERATED -> federatedPlanDefinition.setStatus(planStatus);
         }
         return this;
     }
@@ -127,7 +130,7 @@ public class Plan implements GenericPlanEntity {
         return switch (definitionVersion) {
             case V4 -> planDefinitionV4.getMode();
             case V1, V2 -> PlanMode.STANDARD;
-            case FEDERATED -> throw new IllegalStateException("FEDERATED type not supported");
+            case FEDERATED -> federatedPlanDefinition.getMode();
         };
     }
 
@@ -143,6 +146,7 @@ public class Plan implements GenericPlanEntity {
         switch (definitionVersion) {
             case V4 -> planDefinitionV4.setId(id);
             case V1, V2 -> planDefinitionV2.setId(id);
+            case FEDERATED -> federatedPlanDefinition.setId(id);
         }
         return this;
     }
@@ -156,6 +160,9 @@ public class Plan implements GenericPlanEntity {
         switch (definitionVersion) {
             case V4 -> planDefinitionV4.setTags(tags);
             case V1, V2 -> planDefinitionV2.setTags(tags);
+            case FEDERATED -> {
+                // do nothing
+            }
         }
         return this;
     }
@@ -198,6 +205,7 @@ public class Plan implements GenericPlanEntity {
             .updatedAt(TimeProvider.now())
             .planDefinitionV4(updated.planDefinitionV4)
             .planDefinitionV2(updated.planDefinitionV2)
+            .federatedPlanDefinition(updated.federatedPlanDefinition)
             .commentRequired(updated.commentRequired)
             .commentMessage(updated.commentMessage)
             .generalConditions(updated.generalConditions)
@@ -218,7 +226,7 @@ public class Plan implements GenericPlanEntity {
         return switch (definitionVersion) {
             case V4 -> toBuilder().planDefinitionV4(planDefinitionV4.toBuilder().build()).build();
             case V1, V2 -> toBuilder().planDefinitionV2(planDefinitionV2.toBuilder().build()).build();
-            case FEDERATED -> toBuilder().build();
+            case FEDERATED -> toBuilder().federatedPlanDefinition(federatedPlanDefinition.toBuilder().build()).build();
         };
     }
 
@@ -236,6 +244,14 @@ public class Plan implements GenericPlanEntity {
             this.planDefinitionV4 = planDefinitionV4;
             if (planDefinitionV4 != null) {
                 this.definitionVersion = DefinitionVersion.V4;
+            }
+            return self();
+        }
+
+        public B federatedPlanDefinition(io.gravitee.definition.model.federation.FederatedPlan federatedPlan) {
+            this.federatedPlanDefinition = federatedPlan;
+            if (federatedPlan != null) {
+                this.definitionVersion = DefinitionVersion.FEDERATED;
             }
             return self();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanWithFlows.java
@@ -54,7 +54,8 @@ public class PlanWithFlows extends Plan {
             plan.getCommentMessage(),
             plan.getGeneralConditions(),
             plan.getPlanDefinitionV4(),
-            plan.getPlanDefinitionV2()
+            plan.getPlanDefinitionV2(),
+            plan.getFederatedPlanDefinition()
         );
         this.flows = flows;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
@@ -17,8 +17,11 @@ package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.integration.model.IntegrationApi;
+import io.gravitee.integration.api.model.PlanSecurityType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -37,4 +40,9 @@ public interface IntegrationAdapter {
 
     @Mapping(source = "planSecurityType", target = "type")
     IntegrationApi.Plan map(io.gravitee.integration.api.model.Plan source);
+
+    @ValueMapping(source = "API_KEY", target = "API_KEY")
+    @ValueMapping(source = "JWT", target = MappingConstants.NULL)
+    @ValueMapping(source = "OAUTH", target = MappingConstants.NULL)
+    IntegrationApi.PlanType map(PlanSecurityType source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationApiFixtures.java
@@ -16,6 +16,7 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.integration.model.IntegrationApi;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 public class IntegrationApiFixtures {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
@@ -66,4 +66,14 @@ public class PlanFixtures {
     public static Plan aPushPlan() {
         return BASE.get().id("push").name("Push Plan").planDefinitionV4(fixtures.definition.PlanFixtures.aPushPlan()).build();
     }
+
+    public static Plan aFederatedPlan() {
+        return BASE
+            .get()
+            .id("federated")
+            .name("Federated Plan")
+            .federatedPlanDefinition(fixtures.definition.PlanFixtures.aFederatedPlan())
+            .validation(Plan.PlanValidationType.MANUAL)
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PlanCrudServiceInMemory.java
@@ -42,9 +42,6 @@ public class PlanCrudServiceInMemory implements PlanCrudService, InMemoryAlterna
 
     @Override
     public Plan create(Plan plan) {
-        if (storage.stream().anyMatch(p -> p.getId().equals(plan.getId()))) {
-            throw new IllegalStateException("Plan already exists");
-        }
         storage.add(plan);
         return plan;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -97,7 +98,7 @@ class IntegrationAgentImplTest {
                         "asset-description-1",
                         "asset-version-1",
                         Map.of("url", "https://example.com/1"),
-                        List.of(new IntegrationApi.Plan("plan-id-1", "Gold 1", IntegrationApi.PlanType.API_KEY))
+                        List.of(new IntegrationApi.Plan("plan-id-1", "Gold 1", "Gold description 1", IntegrationApi.PlanType.API_KEY))
                     ),
                     new IntegrationApi(
                         INTEGRATION_ID,
@@ -107,7 +108,7 @@ class IntegrationAgentImplTest {
                         "asset-description-2",
                         "asset-version-2",
                         Map.of("url", "https://example.com/2"),
-                        List.of(new IntegrationApi.Plan("plan-id-2", "Gold 2", IntegrationApi.PlanType.API_KEY))
+                        List.of(new IntegrationApi.Plan("plan-id-2", "Gold 2", "Gold description 2", IntegrationApi.PlanType.API_KEY))
                     )
                 );
         }
@@ -147,7 +148,17 @@ class IntegrationAgentImplTest {
             .version("asset-version-" + index)
             .description("asset-description-" + index)
             .connectionDetails(Map.of("url", "https://example.com/" + index))
-            .plans(List.of(Plan.builder().id("plan-id-" + index).name("Gold " + index).planSecurityType(PlanSecurityType.API_KEY).build()))
+            .plans(
+                List.of(
+                    Plan
+                        .builder()
+                        .id("plan-id-" + index)
+                        .name("Gold " + index)
+                        .description("Gold description " + index)
+                        .planSecurityType(PlanSecurityType.API_KEY)
+                        .build()
+                )
+            )
             .build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4193

## Description

Create plans when ingesting Federated API.

A new Plan definition is introduced, `FederatedPlan.` This allows us to save some data coming from the provider (for now, only the `providerId`)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wbdtxijwqm.chromatic.com)
<!-- Storybook placeholder end -->
