### PR TITLE
fix(console): use the ApiV2Service to get API data on metadata page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.spec.ts
@@ -215,7 +215,7 @@ describe('GioApiMetadataListComponent', () => {
 
   function expectGetAPI() {
     httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`,
       method: 'GET',
     });
   }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-api-metadata-list/gio-api-metadata-list.component.ts
@@ -22,6 +22,7 @@ import { MetadataSaveServices } from '../../../../components/gio-metadata/gio-me
 import { ApiService } from '../../../../services-ngx/api.service';
 import { ApiMetadataV2Service } from '../../../../services-ngx/api-metadata-v2.service';
 import { Metadata } from '../../../../entities/metadata/metadata';
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 
 @Component({
   selector: 'gio-api-metadata-list',
@@ -38,6 +39,7 @@ export class GioApiMetadataListComponent implements OnInit, OnDestroy {
 
   constructor(
     private readonly apiService: ApiService,
+    private readonly apiV2Service: ApiV2Service,
     private readonly apiMetadataV2Service: ApiMetadataV2Service,
     private readonly activatedRoute: ActivatedRoute,
   ) {}
@@ -58,11 +60,11 @@ export class GioApiMetadataListComponent implements OnInit, OnDestroy {
       delete: (metadataKey) => this.apiService.deleteMetadata(this.activatedRoute.snapshot.params.apiId, metadataKey),
     };
     this.description = `Set metadata information on the API that can be easily accessed through Markdown templating`;
-    this.apiService
+    this.apiV2Service
       .get(this.activatedRoute.snapshot.params.apiId)
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((api) => {
-        this.readOnly = api.definition_context?.origin === 'kubernetes';
+        this.readOnly = api.definitionContext?.origin === 'KUBERNETES';
       });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4784

## Description

Old ApiService used to get API info generated mapping issue with v4/federated API. 
I changed it to new APIV2Service and it solved the problem

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kajclkpuyd.chromatic.com)
<!-- Storybook placeholder end -->
