### PR TITLE
feat(portal-next): user can login with email + password

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.spec.ts
@@ -16,10 +16,10 @@
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
 import { CompanyTitleHarness } from '../components/company-title/company-title.harness';
+import { AppTestingModule } from '../testing/app-testing.module';
 
 describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -27,8 +27,7 @@ describe('AppComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [provideRouter([])],
+      imports: [AppComponent, AppTestingModule],
     }).compileComponents();
     fixture = TestBed.createComponent(AppComponent);
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);

--- a/gravitee-apim-portal-webui-next/src/app/app.config.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.config.ts
@@ -17,14 +17,15 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { APP_INITIALIZER, ApplicationConfig } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withComponentInputBinding, withRouterConfig } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, switchMap } from 'rxjs';
 
 import { routes } from './app.routes';
 import { httpRequestInterceptor } from '../interceptors/http-request.interceptor';
 import { ConfigService } from '../services/config.service';
+import { CurrentUserService } from '../services/current-user.service';
 
-function initConfig(configService: ConfigService): () => Observable<string> {
-  return configService.initBaseURL();
+function initApp(configService: ConfigService, currentUserService: CurrentUserService): () => Observable<unknown> {
+  return () => configService.initBaseURL().pipe(switchMap(_ => currentUserService.loadUser()));
 }
 
 export const appConfig: ApplicationConfig = {
@@ -34,8 +35,8 @@ export const appConfig: ApplicationConfig = {
     provideAnimations(),
     {
       provide: APP_INITIALIZER,
-      useFactory: initConfig,
-      deps: [ConfigService],
+      useFactory: initApp,
+      deps: [ConfigService, CurrentUserService],
       multi: true,
     },
   ],

--- a/gravitee-apim-portal-webui-next/src/app/app.config.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.config.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { APP_INITIALIZER, ApplicationConfig } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, withComponentInputBinding, withRouterConfig } from '@angular/router';
 import { Observable } from 'rxjs';
 
 import { routes } from './app.routes';
+import { httpRequestInterceptor } from '../interceptors/http-request.interceptor';
 import { ConfigService } from '../services/config.service';
 
 function initConfig(configService: ConfigService): () => Observable<string> {
@@ -29,7 +30,7 @@ function initConfig(configService: ConfigService): () => Observable<string> {
 export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(routes, withComponentInputBinding(), withRouterConfig({ paramsInheritanceStrategy: 'always' })),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([httpRequestInterceptor])),
     provideAnimations(),
     {
       provide: APP_INITIALIZER,

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { ApiDetailsComponent } from './api-details/api-details.component';
 import { ApiTabDetailsComponent } from './api-details/api-tab-details/api-tab-details.component';
 import { ApiTabDocumentationComponent } from './api-details/api-tab-documentation/api-tab-documentation.component';
 import { CatalogComponent } from './catalog/catalog.component';
+import { LogInComponent } from './log-in/log-in.component';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { apiResolver } from '../resolvers/api.resolver';
 import { pagesResolver } from '../resolvers/pages.resolver';
@@ -54,7 +55,7 @@ export const routes: Routes = [
       },
     ],
   },
-
+  { path: 'log-in', component: LogInComponent },
   { path: '404', component: NotFoundComponent },
   {
     path: '**',

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -21,6 +21,7 @@ import { ApiTabDocumentationComponent } from './api-details/api-tab-documentatio
 import { CatalogComponent } from './catalog/catalog.component';
 import { LogInComponent } from './log-in/log-in.component';
 import { NotFoundComponent } from './not-found/not-found.component';
+import { anonymousGuard } from '../guards/anonymous.guard';
 import { apiResolver } from '../resolvers/api.resolver';
 import { pagesResolver } from '../resolvers/pages.resolver';
 
@@ -55,7 +56,7 @@ export const routes: Routes = [
       },
     ],
   },
-  { path: 'log-in', component: LogInComponent },
+  { path: 'log-in', component: LogInComponent, canActivate: [anonymousGuard] },
   { path: '404', component: NotFoundComponent },
   {
     path: '**',

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -1,0 +1,53 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="logInForm" (ngSubmit)="logIn()">
+  <mat-card appearance="outlined" class="log-in">
+    <mat-card-header>
+      <mat-card-title i18n="@@logInTitle">Log in</mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="log-in__form">
+      <mat-form-field class="log-in__form__input">
+        <mat-label i18n="@@logInUsername">Username</mat-label>
+        <input matInput formControlName="username" appearance="outlined" />
+        @if (logInForm.controls['username'].hasError('required')) {
+          <mat-error i18n="@@logInUsernameErrorRequired">Username is required</mat-error>
+        }
+      </mat-form-field>
+      <mat-form-field class="log-in__form__input">
+        <mat-label i18n="@@logInPassword">Password</mat-label>
+        <input type="password" matInput formControlName="password" />
+        @if (logInForm.controls['password'].hasError('required')) {
+          <mat-error i18n="@@logInPasswordErrorRequired">Password is required</mat-error>
+        }
+      </mat-form-field>
+    </mat-card-content>
+    <mat-card-footer>
+      <mat-card-actions>
+        <button
+          [disabled]="logInForm.invalid"
+          type="submit"
+          mat-flat-button
+          color="primary"
+          i18n="@@logInAction"
+          class="log-in__form__submit">
+          Log in
+        </button>
+      </mat-card-actions>
+    </mat-card-footer>
+  </mat-card>
+</form>

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.scss
@@ -1,35 +1,35 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-button {
-  --mdc-outlined-button-container-shape: 100px;
-  --mdc-filled-button-container-shape: 100px;
-  --mdc-outlined-button-label-text-tracking: 0.1px;
-  --mdc-filled-button-label-text-tracking: 0.1px;
-  --mat-outlined-button-horizontal-padding: 24px;
-  --mat-filled-button-horizontal-padding: 24px;
-  --mat-protected-button-horizontal-padding: 24px;
+:host {
+  display: flex;
+  justify-content: center;
 }
 
-mat-card {
-  --mdc-elevated-card-container-elevation: 0;
-  --mdc-elevated-card-container-shape: 12px;
-  --mdc-outlined-card-container-shape: 12px;
-}
+.log-in {
+  display: flex;
+  width: 500px;
+  flex-flow: column;
+  gap: 32px;
 
-mat-form-field {
-  --mdc-filled-text-field-container-color: var(--mdc-outlined-card-container-color);
+  &__form {
+    display: flex;
+    flex-flow: column;
+
+    &__submit {
+      width: 100%;
+    }
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { LogInComponent } from './log-in.component';
+import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
+
+describe('LogInComponent', () => {
+  let fixture: ComponentFixture<LogInComponent>;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LogInComponent, AppTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogInComponent);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should allow submit if username and password are valid', async () => {
+    const submitButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Log in' }));
+
+    const username = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="username"]' }));
+    await username.setValue('john@doe.com');
+
+    expect(await submitButton.isDisabled()).toEqual(true);
+
+    const password = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    await password.setValue('password');
+
+    expect(await submitButton.isDisabled()).toEqual(false);
+  });
+
+  it('should not validate form with missing username', async () => {
+    const submitButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Log in' }));
+
+    const password = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    await password.setValue('password');
+
+    expect(await submitButton.isDisabled()).toEqual(true);
+  });
+  it('should not validate form with missing password', async () => {
+    const submitButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Log in' }));
+
+    const username = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="username"]' }));
+    await username.setValue('john@doe.com');
+
+    expect(await submitButton.isDisabled()).toEqual(true);
+  });
+
+  it('should login and fetch current user on submit', async () => {
+    const submitButton = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Log in' }));
+    const username = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="username"]' }));
+    await username.setValue('john@doe.com');
+    const password = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    await password.setValue('password');
+
+    expect(await submitButton.isDisabled()).toEqual(false);
+    await submitButton.click();
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/auth/login`).flush({});
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/user`).flush({});
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { Router } from '@angular/router';
+import { switchMap, tap } from 'rxjs';
+
+import { AuthService } from '../../services/auth.service';
+import { CurrentUserService } from '../../services/current-user.service';
+
+@Component({
+  selector: 'app-log-in',
+  standalone: true,
+  imports: [MatCardModule, MatFormField, MatInput, MatButton, MatLabel, ReactiveFormsModule, MatError],
+  templateUrl: './log-in.component.html',
+  styleUrl: './log-in.component.scss',
+})
+export class LogInComponent {
+  logInForm: FormGroup<{ username: FormControl; password: FormControl }> = new FormGroup({
+    username: new FormControl('', [Validators.required]),
+    password: new FormControl('', [Validators.required]),
+  });
+
+  private destroyRef = inject(DestroyRef);
+  constructor(
+    private authService: AuthService,
+    private currentUserService: CurrentUserService,
+    private router: Router,
+  ) {}
+
+  logIn() {
+    this.authService
+      .login(this.logInForm.value.username, this.logInForm.value.password)
+      .pipe(
+        switchMap(_ => this.currentUserService.loadUser()),
+        tap(_ => this.router.navigate([''])),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: err => console.log(err), // TODO: Handle error
+      });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -20,6 +20,10 @@
   <app-nav-bar-button i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
 </div>
 <div class="actions">
-  <app-nav-bar-button i18n="@@logIn" [path]="['log-in']">Log in</app-nav-bar-button>
-  <button i18n="@@signUp" mat-flat-button color="primary">Sign up</button>
+  @if (currentUser()) {
+    <div>{{ currentUser()?.display_name }}'s avatar goes here</div>
+  } @else {
+    <app-nav-bar-button i18n="@@logIn" [path]="['log-in']">Log in</app-nav-bar-button>
+    <button i18n="@@signUp" mat-flat-button color="primary">Sign up</button>
+  }
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -20,6 +20,6 @@
   <app-nav-bar-button i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
 </div>
 <div class="actions">
-  <app-nav-bar-button i18n="@@logIn" [path]="['login']">Log in</app-nav-bar-button>
+  <app-nav-bar-button i18n="@@logIn" [path]="['log-in']">Log in</app-nav-bar-button>
   <button i18n="@@signUp" mat-flat-button color="primary">Sign up</button>
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
@@ -13,27 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { NavBarComponent } from './nav-bar.component';
+import { fakeUser } from '../../entities/user/user.fixtures';
+import { CurrentUserService } from '../../services/current-user.service';
+import { AppTestingModule } from '../../testing/app-testing.module';
 
 describe('NavBarComponent', () => {
-  let component: NavBarComponent;
   let fixture: ComponentFixture<NavBarComponent>;
+  let harnessLoader: HarnessLoader;
+  let currentUserService: CurrentUserService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NavBarComponent],
-      providers: [provideRouter([])],
+      imports: [NavBarComponent, AppTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavBarComponent);
-    component = fixture.componentInstance;
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    currentUserService = TestBed.inject(CurrentUserService);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should show login button if user not connected', async () => {
+    let logInButton = await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ text: 'Log in' }));
+    expect(logInButton).toBeTruthy();
+    currentUserService.user.set(fakeUser());
+    logInButton = await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ text: 'Log in' }));
+    expect(logInButton).toBeFalsy();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { RouterLink } from '@angular/router';
 
 import { NavBarButtonComponent } from './nav-bar-button/nav-bar-button.component';
+import { CurrentUserService } from '../../services/current-user.service';
 import { CompanyTitleComponent } from '../company-title/company-title.component';
 
 @Component({
@@ -27,4 +28,6 @@ import { CompanyTitleComponent } from '../company-title/company-title.component'
   templateUrl: './nav-bar.component.html',
   styleUrl: './nav-bar.component.scss',
 })
-export class NavBarComponent {}
+export class NavBarComponent {
+  currentUser = inject(CurrentUserService).user;
+}

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
@@ -17,6 +17,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageSwaggerComponent } from './page-swagger.component';
 import { fakePage } from '../../../entities/page/page.fixtures';
+import { AppTestingModule } from '../../../testing/app-testing.module';
 
 describe('PageSwaggerComponent', () => {
   let component: PageSwaggerComponent;
@@ -24,7 +25,7 @@ describe('PageSwaggerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PageSwaggerComponent],
+      imports: [PageSwaggerComponent, AppTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PageSwaggerComponent);

--- a/gravitee-apim-portal-webui-next/src/entities/user/user.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/user.fixtures.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'rxjs/internal/util/isFunction';
+
+import { User } from './user';
+
+export function fakeUser(modifier?: Partial<User> | ((baseApi: User) => User)): User {
+  const base: User = {
+    id: '8d4ce9b8-0efe-4d8b-8ce9-b80efe1d8bf1',
+    email: 'gaetan.maisse@graviteesource.com',
+    first_name: 'Hello',
+    last_name: 'World',
+    config: {},
+    reference: 'user-reference',
+    permissions: {
+      USER: [],
+      APPLICATION: [],
+    },
+    customFields: {},
+    display_name: 'admin',
+    editable_profile: false,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/guards/anonymous.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/anonymous.guard.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, CanActivateFn, Router } from '@angular/router';
+
+import { anonymousGuard } from './anonymous.guard';
+import { fakeUser } from '../entities/user/user.fixtures';
+import { CurrentUserService } from '../services/current-user.service';
+import { AppTestingModule } from '../testing/app-testing.module';
+
+describe('anonymousGuard', () => {
+  let currentUserService: CurrentUserService;
+  let activatedRoute: ActivatedRoute;
+  let router: Router;
+  const executeGuard: CanActivateFn = (...guardParameters) => TestBed.runInInjectionContext(() => anonymousGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    currentUserService = TestBed.inject(CurrentUserService);
+    activatedRoute = TestBed.inject(ActivatedRoute);
+    router = TestBed.inject(Router);
+  });
+
+  it('should allow anonymous user', () => {
+    currentUserService.user.set(null);
+    jest.spyOn(router, 'navigate');
+
+    expect(executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot })).toBeTruthy();
+    expect(router.navigate).toBeCalledTimes(0);
+  });
+
+  it('should not allow authenticated user', () => {
+    currentUserService.user.set(fakeUser());
+    jest.spyOn(router, 'navigate');
+
+    expect(executeGuard(activatedRoute.snapshot, { url: '', root: activatedRoute.snapshot })).toBeTruthy();
+    expect(router.navigate).toBeCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledWith(['']);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/guards/anonymous.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/anonymous.guard.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { CurrentUserService } from '../services/current-user.service';
+
+export const anonymousGuard: CanActivateFn = (_route, _state) =>
+  !inject(CurrentUserService).isAuthenticated() || inject(Router).navigate(['']);

--- a/gravitee-apim-portal-webui-next/src/interceptors/http-request.interceptor.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/interceptors/http-request.interceptor.spec.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpInterceptorFn } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+
+import { httpRequestInterceptor } from './http-request.interceptor';
+
+describe('httpRequestInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) => TestBed.runInInjectionContext(() => httpRequestInterceptor(req, next));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/interceptors/http-request.interceptor.ts
+++ b/gravitee-apim-portal-webui-next/src/interceptors/http-request.interceptor.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpInterceptorFn } from '@angular/common/http';
+
+export const httpRequestInterceptor: HttpInterceptorFn = (req, next) => {
+  req = req.clone({
+    withCredentials: true,
+  });
+  return next(req);
+};

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    service = TestBed.inject(AuthService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  it('should call log in endpoint', done => {
+    const token = { token: 'token', token_type: 'BEARER' };
+    service.login('username', 'password').subscribe(resp => {
+      expect(resp).toEqual(token);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/auth/login`);
+
+    expect(req.request.headers.get('Authorization')).toEqual('Basic dXNlcm5hbWU6cGFzc3dvcmQ=');
+    req.flush(token);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/auth.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/auth.service.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { ConfigService } from './config.service';
+
+interface Token {
+  token_type: string;
+  token: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthService {
+  constructor(
+    private http: HttpClient,
+    private configuration: ConfigService,
+  ) {}
+
+  login(username: string, password: string) {
+    return this.http.post<Token>(
+      `${this.configuration.baseURL}/auth/login`,
+      {},
+      {
+        headers: {
+          Authorization: `Basic ${btoa(username + ':' + password)}`,
+        },
+      },
+    );
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
@@ -42,12 +42,10 @@ describe('ConfigService', () => {
         environmentId: 'DEFAULT',
       };
 
-      service
-        .initBaseURL()()
-        .subscribe(baseUrl => {
-          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
-          done();
-        });
+      service.initBaseURL().subscribe(baseUrl => {
+        expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+        done();
+      });
 
       httpTestingController.expectOne('./assets/config.json').flush(configJson);
       httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap').flush(configBootstrap);
@@ -63,12 +61,10 @@ describe('ConfigService', () => {
         environmentId: 'DEFAULT',
       };
 
-      service
-        .initBaseURL()()
-        .subscribe(baseUrl => {
-          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
-          done();
-        });
+      service.initBaseURL().subscribe(baseUrl => {
+        expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+        done();
+      });
 
       httpTestingController.expectOne('./assets/config.json').flush(configJson);
       httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap?environmentId=DEFAULT').flush(configBootstrap);
@@ -85,12 +81,10 @@ describe('ConfigService', () => {
         environmentId: 'DEFAULT',
       };
 
-      service
-        .initBaseURL()()
-        .subscribe(baseUrl => {
-          expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
-          done();
-        });
+      service.initBaseURL().subscribe(baseUrl => {
+        expect(baseUrl).toEqual('http://localhost:8083/portal/environments/DEFAULT');
+        done();
+      });
 
       httpTestingController.expectOne('./assets/config.json').flush(configJson);
       httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap?environmentId=DEFAULT').flush(configBootstrap);

--- a/gravitee-apim-portal-webui-next/src/services/config.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.ts
@@ -41,21 +41,20 @@ export class ConfigService {
     this._baseURL = baseURL;
   }
 
-  public initBaseURL(): () => Observable<string> {
-    return () =>
-      this.httpClient.get<Config>('./assets/config.json').pipe(
-        switchMap(configJson => {
-          const baseURL = this._sanitizeBaseURLs(configJson);
-          const enforcedEnvironmentId = this._getEnforcedEnvironmentId(configJson);
-          const bootstrapUrl = `${baseURL}/ui/bootstrap${enforcedEnvironmentId ? `?environmentId=${enforcedEnvironmentId}` : ''}`;
+  public initBaseURL(): Observable<string> {
+    return this.httpClient.get<Config>('./assets/config.json').pipe(
+      switchMap(configJson => {
+        const baseURL = this._sanitizeBaseURLs(configJson);
+        const enforcedEnvironmentId = this._getEnforcedEnvironmentId(configJson);
+        const bootstrapUrl = `${baseURL}/ui/bootstrap${enforcedEnvironmentId ? `?environmentId=${enforcedEnvironmentId}` : ''}`;
 
-          return this.httpClient.get<Config>(bootstrapUrl);
-        }),
-        map((bootstrapConfig: Config) => {
-          this.baseURL = `${bootstrapConfig.baseURL}/environments/${bootstrapConfig.environmentId}`;
-          return this.baseURL;
-        }),
-      );
+        return this.httpClient.get<Config>(bootstrapUrl);
+      }),
+      map((bootstrapConfig: Config) => {
+        this.baseURL = `${bootstrapConfig.baseURL}/environments/${bootstrapConfig.environmentId}`;
+        return this.baseURL;
+      }),
+    );
   }
 
   private _sanitizeBaseURLs(config: Config): string {

--- a/gravitee-apim-portal-webui-next/src/services/current-user.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/current-user.service.spec.ts
@@ -42,4 +42,15 @@ describe('CurrentUserService', () => {
 
     httpTestingController.expectOne(`${TESTING_BASE_URL}/user`).flush(user);
   });
+
+  it('should reset user on error', done => {
+    service.user.set(fakeUser());
+
+    service.loadUser().subscribe(() => {
+      expect(service.user()).toEqual(null);
+      done();
+    });
+
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/user`).flush('', { status: 401, statusText: 'Unauthorized' });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/current-user.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/current-user.service.spec.ts
@@ -13,19 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { CurrentUserService } from './current-user.service';
+import { fakeUser } from '../entities/user/user.fixtures';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('CurrentUserService', () => {
   let service: CurrentUserService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
     service = TestBed.inject(CurrentUserService);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('should load user', done => {
+    expect(service.user()).toEqual(null);
+    const user = fakeUser();
+    service.loadUser().subscribe(() => {
+      expect(service.user()).toEqual(user);
+      done();
+    });
+
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/user`).flush(user);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/current-user.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/current-user.service.ts
@@ -13,19 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Injectable, signal, WritableSignal } from '@angular/core';
+import { Observable, tap } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { User } from '../entities/user/user';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CurrentUserService {
-  private _details: string | null = null;
+  public user: WritableSignal<User | null> = signal(null);
 
-  public get details(): string | null {
-    return this._details;
-  }
+  constructor(
+    private http: HttpClient,
+    private configuration: ConfigService,
+  ) {}
 
   public isAuthenticated(): boolean {
-    return this.details !== null;
+    return this.user() !== null;
+  }
+
+  public loadUser(): Observable<unknown> {
+    return this.http.get<User>(`${this.configuration.baseURL}/user`).pipe(
+      tap(resp => {
+        this.user.set(resp);
+      }),
+    );
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/current-user.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/current-user.service.ts
@@ -15,7 +15,8 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Injectable, signal, WritableSignal } from '@angular/core';
-import { Observable, tap } from 'rxjs';
+import { catchError, Observable, tap } from 'rxjs';
+import { of } from 'rxjs/internal/observable/of';
 
 import { ConfigService } from './config.service';
 import { User } from '../entities/user/user';
@@ -39,6 +40,10 @@ export class CurrentUserService {
     return this.http.get<User>(`${this.configuration.baseURL}/user`).pipe(
       tap(resp => {
         this.user.set(resp);
+      }),
+      catchError(_ => {
+        this.user.set(null);
+        return of({});
       }),
     );
   }

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -17,7 +17,7 @@ import { CommonModule } from '@angular/common';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Injectable, NgModule } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs/internal/observable/of';
 
 import { ConfigService } from '../services/config.service';
@@ -35,9 +35,17 @@ export class ConfigServiceStub {
   }
 }
 
+/**
+ * To avoid error during unit tests that navigation happens outside the ngZone
+ */
+@NgModule()
+export class TestRouterModule {
+  constructor(_router: Router) {}
+}
+
 @NgModule({
   declarations: [],
-  imports: [CommonModule, HttpClientTestingModule, NoopAnimationsModule],
+  imports: [CommonModule, HttpClientTestingModule, NoopAnimationsModule, TestRouterModule],
   providers: [
     {
       provide: ConfigService,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4230

## Description

Create log in view + authenticate

https://github.com/gravitee-io/gravitee-api-management/assets/42294616/a22709b4-b765-4d60-933e-64e30b366676



TODO:
- [x] Handle authentication
- [x] See that token is sent to back for api list
- [x] Load user automatically at start

Next PRs:
- handle error when user provides incorrect login info (waiting for designs)
- add avatar after login
- user can logout

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bawfkjzlru.chromatic.com)
<!-- Storybook placeholder end -->
