### PR TITLE
fix(console): use total searched elements to properly calculate total pages

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -99,7 +99,7 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
                 results.add(reference);
             }
 
-            return new SearchResult(results, results.size());
+            return new SearchResult(results, topDocs.totalHits.value);
         } catch (IOException ioe) {
             logger.error("An error occurs while getting documents from search result", ioe);
             throw new TechnicalException("An error occurs while getting documents from search result", ioe);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4771

## Description

use total searched elements to properly calculate total pages

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7349/console](https://pr.team-apim.gravitee.dev/7349/console)
      Portal: [https://pr.team-apim.gravitee.dev/7349/portal](https://pr.team-apim.gravitee.dev/7349/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7349/api/management](https://pr.team-apim.gravitee.dev/7349/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7349](https://pr.team-apim.gravitee.dev/7349)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7349](https://pr.gateway-v3.team-apim.gravitee.dev/7349)

<!-- Environment placeholder end -->
