### PR TITLE
fix(console): disable api quality check for federated api

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/api.fixture.ts
@@ -15,7 +15,7 @@
  */
 import { isFunction } from 'lodash';
 
-import { BaseApi, ApiV2, ApiV4, ApiV1, ManagementContext, GenericApi } from '.';
+import { BaseApi, ApiV2, ApiV4, ApiV1, ManagementContext, GenericApi, ApiFederated } from '.';
 
 export function fakeBaseApi(modifier?: Partial<BaseApi> | ((baseApi: BaseApi) => BaseApi)): BaseApi {
   const base: BaseApi = {
@@ -500,6 +500,28 @@ export function fakeProxyTcpApiV4(modifier?: Partial<ApiV4> | ((baseApi: ApiV4) 
         enabled: true,
       },
     ],
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeApiFederated(modifier?: Partial<ApiFederated> | ((baseApi: ApiFederated) => ApiFederated)): ApiFederated {
+  const base: ApiFederated = {
+    apiVersion: '1.0.0',
+    id: 'myId',
+    name: 'myName',
+    definitionVersion: 'FEDERATED',
+    originContext: {
+      origin: 'MANAGEMENT',
+      integrationId: 'integration-id',
+    },
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-quality/api-general-info-quality.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-quality/api-general-info-quality.harness.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiGeneralInfoQualityHarness extends ComponentHarness {
+  static hostSelector = 'api-general-info-quality';
+}

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -161,7 +161,7 @@
   </mat-card>
 
   <api-general-info-quality
-    *ngIf="isQualityEnabled && apiId && api.definitionVersion !== 'V4'"
+    *ngIf="isQualityEnabled && isQualitySupported && apiId"
     class="api-quality"
     [apiId]="apiId"
   ></api-general-info-quality>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -85,6 +85,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
   public canDisplayV4EmulationEngineToggle = false;
 
   public isQualityEnabled = false;
+  public isQualitySupported = false;
 
   public isReadOnly = false;
   public isKubernetesOrigin = false;
@@ -217,6 +218,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
           });
 
           this.initialApiDetailsFormValue = this.parentForm.getRawValue();
+          this.isQualitySupported = this.api.definitionVersion === 'V2' || this.api.definitionVersion === 'V1';
         }),
         takeUntil(this.unsubscribe$),
       )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4778

## Description

Currently quality check is not supported for Federated API so each time user tries to display API info it throws internal exception. This PR disables quality check for federated APIs as this feature will come in following releases. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ljriuiqhtl.chromatic.com)
<!-- Storybook placeholder end -->
