### PR TITLE
feat(console): hide action buttons for federated API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -118,7 +118,7 @@
         </div>
       </div>
     </mat-card-content>
-    <mat-card-actions class="details-card__actions">
+    <mat-card-actions class="details-card__actions" *ngIf="api.definitionVersion !== 'FEDERATED'">
       <button
         *gioPermission="{ anyOf: ['api-definition-r'] }"
         mat-button

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -775,6 +775,22 @@ describe('ApiGeneralInfoComponent', () => {
       const apiQualityInfo = await loader.getHarnessOrNull(ApiGeneralInfoQualityHarness);
       expect(apiQualityInfo).toBeNull();
     });
+
+    it('should not display api action buttons', async () => {
+      fixture.componentInstance.isQualityEnabled = true;
+      const api = fakeApiFederated({
+        id: API_ID,
+      });
+      expectApiGetRequest(api);
+      expectCategoriesGetRequest();
+
+      await Promise.all(
+        [/Import/, /Export/, /Duplicate/, /Promote/].map(async (btnText) => {
+          const button = await loader.getHarnessOrNull(MatButtonHarness.with({ text: btnText }));
+          expect(button).toBeNull();
+        }),
+      );
+    });
   });
 
   function expectApiGetRequest(api: Api) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4790

## Description

Task is about hiding some actions available for other types of APIs from overview tab. 

<img width="1144" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/155629548/f1147d05-e929-4945-914e-f1923a16f42b">

So it could look like this: 
<img width="1095" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/155629548/56f7e5d9-aecf-4910-9156-8490e96192fb">

This way user will not be able to perform any actions that are currently not supported for Federated API

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xudlpmnrlg.chromatic.com)
<!-- Storybook placeholder end -->
