### PR TITLE
chore: upgrade gravitee-bom to 8.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,11 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2
              in gravitee-apim-gateway-tests-sdk and gravitee-apim-integration-tests
              along with the grpc libs to create test clients and servers -->
-        <vertx.version>4.5.3</vertx.version>
+        <vertx.version>4.5.7</vertx.version>
         <protobuf-java.version>3.24.0</protobuf-java.version>
         <grpc-java.version>1.50.2</grpc-java.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>7.0.23</gravitee-bom.version>
+        <gravitee-bom.version>8.0.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.0.18</gravitee-cockpit-api.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.0.0-alpha.9</gravitee-integration-api.version>
-        <gravitee-node.version>5.12.4</gravitee-node.version>
+        <gravitee-node.version>5.14.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
@@ -84,7 +84,6 @@
         <angus-activation.version>2.0.0</angus-activation.version>
         <asm.version>9.2</asm.version>
         <batik-transcoder.version>1.17</batik-transcoder.version>
-        <bcpkix-jdk18on.version>1.77</bcpkix-jdk18on.version>
         <classgraph.version>4.8.138</classgraph.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
@@ -891,12 +890,6 @@
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>batik-transcoder</artifactId>
                 <version>${batik-transcoder.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bcpkix-jdk18on.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
 - gravitee-node to 5.14.2
 - remove bouncycastle from dependency mgt as it is now managed in the bom

## Issue

https://gravitee.atlassian.net/browse/ARCHI-345

## Description

Upgrade gravitee-bom to 8.x version (includes upgrade of vert.x to 4.5.7) and gravitee-node. Also removed bouncycastle from dep mgt as it is now managed in the bom.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-izbfdxmjkd.chromatic.com)
<!-- Storybook placeholder end -->
