### PR TITLE
feat: import oas

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationApi.java
@@ -29,11 +29,21 @@ public record IntegrationApi(
     String description,
     String version,
     Map<String, String> connectionDetails,
-    List<Plan> plans
+    List<Plan> plans,
+    List<Page> pages
 ) {
     public record Plan(String id, String name, String description, PlanType type) {}
     public enum PlanType {
         API_KEY,
+    }
+
+    public record Page(PageType pageType, String content) {}
+    public enum PageType {
+        ASCIIDOC,
+        ASYNCAPI,
+        MARKDOWN,
+        MARKDOWN_TEMPLATE,
+        SWAGGER,
     }
 
     public FederatedApi.FederatedApiBuilder toFederatedApiDefinitionBuilder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationAdapter.java
@@ -45,4 +45,6 @@ public interface IntegrationAdapter {
     @ValueMapping(source = "JWT", target = MappingConstants.NULL)
     @ValueMapping(source = "OAUTH", target = MappingConstants.NULL)
     IntegrationApi.PlanType map(PlanSecurityType source);
+
+    IntegrationApi.Page map(io.gravitee.integration.api.model.Page source);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -596,7 +596,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     private String getContextPath(GenericApiEntity genericApiEntity) {
-        if (genericApiEntity.getDefinitionVersion() != DefinitionVersion.FEDERATED) {
+        if (genericApiEntity.getDefinitionVersion() == DefinitionVersion.FEDERATED) {
             return null;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationApiFixtures.java
@@ -16,7 +16,6 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.integration.model.IntegrationApi;
-import java.util.Collections;
 import java.util.function.Supplier;
 
 public class IntegrationApiFixtures {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
@@ -37,6 +37,8 @@ import io.gravitee.integration.api.command.subscribe.SubscribeCommand;
 import io.gravitee.integration.api.command.subscribe.SubscribeCommandPayload;
 import io.gravitee.integration.api.command.subscribe.SubscribeReply;
 import io.gravitee.integration.api.command.subscribe.SubscribeReplyPayload;
+import io.gravitee.integration.api.model.Page;
+import io.gravitee.integration.api.model.PageType;
 import io.gravitee.integration.api.model.Plan;
 import io.gravitee.integration.api.model.PlanSecurityType;
 import io.gravitee.integration.api.model.Subscription;
@@ -107,7 +109,8 @@ class IntegrationAgentImplTest {
                         "asset-description-1",
                         "asset-version-1",
                         Map.of("url", "https://example.com/1"),
-                        List.of(new IntegrationApi.Plan("plan-id-1", "Gold 1", "Gold description 1", IntegrationApi.PlanType.API_KEY))
+                        List.of(new IntegrationApi.Plan("plan-id-1", "Gold 1", "Gold description 1", IntegrationApi.PlanType.API_KEY)),
+                        List.of(new IntegrationApi.Page(IntegrationApi.PageType.SWAGGER, "swaggerDoc"))
                     ),
                     new IntegrationApi(
                         INTEGRATION_ID,
@@ -117,7 +120,8 @@ class IntegrationAgentImplTest {
                         "asset-description-2",
                         "asset-version-2",
                         Map.of("url", "https://example.com/2"),
-                        List.of(new IntegrationApi.Plan("plan-id-2", "Gold 2", "Gold description 2", IntegrationApi.PlanType.API_KEY))
+                        List.of(new IntegrationApi.Plan("plan-id-2", "Gold 2", "Gold description 2", IntegrationApi.PlanType.API_KEY)),
+                        List.of(new IntegrationApi.Page(IntegrationApi.PageType.SWAGGER, "swaggerDoc"))
                     )
                 );
         }
@@ -253,6 +257,7 @@ class IntegrationAgentImplTest {
                         .build()
                 )
             )
+            .pages(List.of(new Page(PageType.SWAGGER, "swaggerDoc")))
             .build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4191

## Description

PR that enables importing OpanApi doc from the AWS API gateway during the API ingestion process. 
According to Acceptance Criteria, documentation parameters are set as follows:
- enable try-it-out (**true**)
- homepage (**true**)
- OpenAPI documentation viewer: (**Swagger-UI**)
- Use entrypoints of the API as server urls (**false**)
- Use context-path of the API (**false**)
- Allow "Try it!" for anonymous users (**false**)
- Show the URL to download the content (**false**)
- Display the operationId in the operations list (**false**)
- Published (**true**)
- Public (**false**)

The name given for oas definition is : [apiname]-oas.yaml

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mippmjypag.chromatic.com)
<!-- Storybook placeholder end -->
