### PR TITLE
fix: added missing ssl configuration missing from helm chart

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -287,7 +287,45 @@ data:
         {{- if .Values.gateway.ratelimit.redis.ssl }}
         ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
         hostnameVerificationAlgorithm: {{ .Values.gateway.ratelimit.redis.hostnameVerificationAlgorithm | default "NONE" }}
+        trustAll: {{.Values.gateway.ratelimit.redis.trustAll | default true }}
+        tlsProtocols: {{ .Values.gateway.ratelimit.redis.tlsProtocols | default "TLSv1.2" }}
+        {{- if .Values.gateway.ratelimit.redis.tlsCiphers }}
+        tlsCiphers: {{ .Values.gateway.ratelimit.redis.tlsCiphers | quote }}
         {{- end }}
+        alpn:  {{ .Values.gateway.ratelimit.redis.alpn | default false }}
+        openssl: {{ .Values.gateway.ratelimit.redis.openssl | default false }}
+        {{/* end of ssl block */}}
+        {{- end }}
+        {{- if .Values.gateway.ratelimit.redis.keystore }}
+        keystore:
+          type: {{ .Values.gateway.ratelimit.redis.keystore.type | default "pem" }}
+          path: {{ .Values.gateway.ratelimit.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
+          password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.keystore.password }}
+          {{- if .Values.gateway.ratelimit.redis.keystore.keyPassword }}
+          keyPassword: {{ .Values.gateway.ratelimit.redis.keystore.keyPassword | quote }}
+          {{- end }}
+          {{- if .Values.gateway.ratelimit.redis.keystore.alias }}
+          alias: {{ .Values.gateway.ratelimit.redis.keystore.alias }}
+          {{- end }}
+          {{/* guard clause for pem mTLS requirements */}}
+          {{- if and ( eq .Values.gateway.ratelimit.redis.keystore.type "pem" ) ( empty .Values.gateway.ratelimit.redis.keystore.certificates ) }}
+            {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
+          {{- end }}
+          certificates:
+            {{- range .Values.gateway.ratelimit.redis.keystore.certificates }}
+            - cert: {{ .cert }}
+              key: {{ .key }}
+            {{- end }}
+        {{- end}}
+        {{- if .Values.gateway.ratelimit.redis.truststore }}
+        truststore:
+          type: {{ .Values.gateway.ratelimit.redis.truststore.type | default "pem" }}
+          path: {{ .Values.gateway.ratelimit.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
+          password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.keystore.password }}
+          {{- if .Values.gateway.ratelimit.redis.truststore.alias }}
+          alias: {{ .Values.gateway.ratelimit.redis.keystore.alias }}
+          {{- end }}
+        {{- end }}        
         {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
         sentinel:
           master: {{ .Values.gateway.ratelimit.redis.sentinel.master }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1017,19 +1017,41 @@ gateway:
   # tenant:
   websocket: false
   ratelimit:
-    redis:
-#      host: redis
-#      port: 6379
-#      password:
-#      ssl: false
-#      hostnameVerificationAlgorithm: NONE
-#      sentinel:
-#        master: redis-master
-#        nodes:
-#          - host: sentinel1
-#            port: 26379
-#          - host: sentinel2
-#            port: 26379
+    # redis:
+    #   host: redis
+    #   port: 6379
+    #   password:
+    #   ssl: false
+    #   hostnameVerificationAlgorithm: NONE
+    #   trustAll: true # default value is true to keep backward compatibility but you should set it to false and configure a truststore for security concerns
+    #   tlsProtocols: # List of TLS protocols to allow comma separated i.e: TLSv1.2, TLSv1.3
+    #   tlsCiphers: # List of TLS ciphers to allow comma separated i.e: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+    #   alpn: false
+    #   openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+    #   # Keystore for redis mTLS (client certificate)
+    #   keystore:
+    #     type: pem # Supports jks, pem, pkcs12
+    #     path: ${gravitee.home}/security/redis-keystore.jks # A path is required if certificate's type is jks or pkcs12
+    #     password: secret
+    #     keyPassword:
+    #     alias:
+    #     certificates: # Certificates are required if keystore's type is pem
+    #       - cert: ${gravitee.home}/security/redis-mycompany.org.pem
+    #         key: ${gravitee.home}/security/redis-mycompany.org.key
+    #       - cert: ${gravitee.home}/security/redis-mycompany.com.pem
+    #         key: ${gravitee.home}/security/redis-mycompany.com.key
+    #   truststore:
+    #     type: pem # Supports jks, pem, pkcs12
+    #     path: ${gravitee.home}/security/redis-truststore.jks
+    #     password: secret
+    #     alias:      
+    #   sentinel:
+    #     master: redis-master
+    #     nodes:
+    #       - host: sentinel1
+    #         port: 26379
+    #       - host: sentinel2
+    #         port: 26379
   management:
     http:
       # url:


### PR DESCRIPTION
## Issue
No Issue open yet, will be updated with one by [adrien.lacombe@graviteesource.com](mailto:adrien.lacombe@graviteesource.com) in the near future.
## Description

The helm chart currently does not support propagating required SSL configurations for Redis to the gateway configmap and ultimately underlying deployed pods. This causes pods to enter a crash loop, as Gravitee is unable to locate required SSL configurations for Redis in the `gravitee.yml` config file and establishes invalid connections with the Redis Instance/Cluster.

## Evidence
### log
![k9s](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/6ea116a2-c69c-47e1-9814-7cef6867fcc6)
### gravitee.yml
![image (2)](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/e161f725-f10e-46b1-a58a-4002bab8e051)
### gateway-configmap.yaml
![image (1)](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/7405193b-4329-4a5a-abfa-d84ed4822f56)

## Additional context
This fix was tested and [adrien.lacombe@graviteesource.com](mailto:adrien.lacombe@graviteesource.com) was informed of the tested fix in a Graviteeio client environment.

## Steps to Reproduce
Simply enable SSL in the helm chart and point to the correct port, Gravitee pods will immediately enter a crashloop once the configmap is reloaded.
