### PR TITLE
Apim 3945 refactor services, repo + resources to handle theme type

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Theme;
+import io.gravitee.repository.management.model.ThemeType;
 import java.util.Set;
 
 /**
@@ -24,5 +25,5 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ThemeRepository extends CrudRepository<Theme, String> {
-    Set<Theme> findByReferenceIdAndReferenceType(String referenceId, String referenceType) throws TechnicalException;
+    Set<Theme> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcThemeRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -73,15 +74,20 @@ public class JdbcThemeRepository extends JdbcAbstractCrudRepository<Theme, Strin
     }
 
     @Override
-    public Set<Theme> findByReferenceIdAndReferenceType(String referenceId, String referenceType) throws TechnicalException {
+    public Set<Theme> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type)
+        throws TechnicalException {
         LOGGER.debug("JdbcThemeRepository.findByReference({})", referenceType);
         try {
             return new HashSet(
                 jdbcTemplate.query(
-                    getOrm().getSelectAllSql() + " where reference_id = ? and reference_type = ?",
+                    getOrm().getSelectAllSql() +
+                    " where reference_id = ? and reference_type = ? and " +
+                    escapeReservedWord("type") +
+                    " = ?",
                     getOrm().getRowMapper(),
                     referenceId,
-                    referenceType
+                    referenceType,
+                    type.name()
                 )
             );
         } catch (final Exception ex) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoThemeRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ThemeRepository;
 import io.gravitee.repository.management.model.Theme;
+import io.gravitee.repository.management.model.ThemeType;
 import io.gravitee.repository.mongodb.management.internal.ThemeMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
@@ -94,12 +95,13 @@ public class MongoThemeRepository implements ThemeRepository {
             themeMongo.setOptionalLogo(theme.getOptionalLogo());
             themeMongo.setBackgroundImage(theme.getBackgroundImage());
             themeMongo.setFavicon(theme.getFavicon());
+            themeMongo.setType(theme.getType().name());
 
             ThemeMongo themeMongoUpdated = internalThemeRepo.save(themeMongo);
             return mapper.map(themeMongoUpdated);
         } catch (Exception e) {
-            LOGGER.error("An error occured when updating theme", e);
-            throw new TechnicalException("An error occured when updating theme");
+            LOGGER.error("An error occurred when updating theme", e);
+            throw new TechnicalException("An error occurred when updating theme");
         }
     }
 
@@ -120,8 +122,9 @@ public class MongoThemeRepository implements ThemeRepository {
     }
 
     @Override
-    public Set<Theme> findByReferenceIdAndReferenceType(String referenceId, String referenceType) {
-        final Set<ThemeMongo> themes = internalThemeRepo.findByReferenceIdAndReferenceType(referenceId, referenceType);
+    public Set<Theme> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type)
+        throws TechnicalException {
+        final Set<ThemeMongo> themes = internalThemeRepo.findByReferenceIdAndReferenceTypeAndType(referenceId, referenceType, type);
         return themes.stream().map(themeMongo -> mapper.map(themeMongo)).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ThemeMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ThemeMongoRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.mongodb.management.internal;
 
+import io.gravitee.repository.management.model.ThemeType;
 import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
 import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -26,5 +27,5 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface ThemeMongoRepository extends MongoRepository<ThemeMongo, String> {
-    Set<ThemeMongo> findByReferenceIdAndReferenceType(String referenceId, String referenceType);
+    Set<ThemeMongo> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/themes/ThemeTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/themes/ThemeTypeUpgrader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.themes;
+
+import com.mongodb.client.model.Filters;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.plan.PlanDefinitionVersionUpgrader;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+/**
+ * Adds default value PORTAL to Themes if a type has not been denoted.
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class ThemeTypeUpgrader extends MongoUpgrader {
+
+    public static final int THEME_TYPE_UPGRADER_ORDER = PlanDefinitionVersionUpgrader.PLAN_DEFINITION_VERSION_UPGRADER_ORDER + 1;
+
+    @Override
+    public boolean upgrade() {
+        var themeTypeNullQuery = new Document("type", null);
+
+        template
+            .getCollection("themes")
+            .find(themeTypeNullQuery)
+            .forEach(theme -> {
+                theme.append("type", "PORTAL");
+                template.getCollection("themes").replaceOne(Filters.eq("_id", theme.getString("_id")), theme);
+            });
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return THEME_TYPE_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ThemeRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ThemeRepositoryTest.java
@@ -52,8 +52,8 @@ public class ThemeRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
-    public void shouldFindByReference() throws Exception {
-        final Set<Theme> themes = themeRepository.findByReferenceIdAndReferenceType("DEFAULT", "ENVIRONMENT");
+    public void shouldFindByReferenceAndType() throws Exception {
+        final Set<Theme> themes = themeRepository.findByReferenceIdAndReferenceTypeAndType("DEFAULT", "ENVIRONMENT", ThemeType.PORTAL);
         assertNotNull(themes);
         assertEquals(2, themes.size());
         final Theme darkTheme = themes.stream().filter(theme -> "dark".equals(theme.getId())).findAny().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
@@ -18,12 +18,14 @@ package io.gravitee.rest.api.management.rest.resource;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.NewThemeEntity;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.ThemeService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ThemeTypeNotSupportedException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -54,7 +56,10 @@ public class ThemesResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.CREATE) })
     public ThemeEntity createTheme(@Valid @NotNull final NewThemeEntity theme) {
-        return themeService.create(GraviteeContext.getExecutionContext(), theme);
+        if (!ThemeType.PORTAL.equals(theme.getType())) {
+            throw new ThemeTypeNotSupportedException(null, theme.getType());
+        }
+        return themeService.createPortalTheme(GraviteeContext.getExecutionContext(), theme);
     }
 
     @Path("/current")
@@ -62,7 +67,7 @@ public class ThemesResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.READ) })
     public ThemeEntity getCurrentTheme() {
-        return themeService.findOrCreateDefault(GraviteeContext.getExecutionContext());
+        return themeService.findOrCreateDefaultPortalTheme(GraviteeContext.getExecutionContext());
     }
 
     @Path("{themeId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemeResourceTest.java
@@ -72,6 +72,10 @@ public class ThemeResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldDeleteTheme() {
+        ThemeEntity theme = new ThemeEntity();
+        theme.setId(THEME_ID);
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(theme);
         final Response response = envTarget(THEME_ID).request().delete();
 
         assertEquals(NO_CONTENT_204, response.getStatus());
@@ -80,6 +84,11 @@ public class ThemeResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldUpdateTheme() {
+        ThemeEntity oldTheme = new ThemeEntity();
+        oldTheme.setId(THEME_ID);
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(oldTheme);
+
         UpdateThemeEntity updateTheme = new UpdateThemeEntity();
         updateTheme.setId(THEME_ID);
         updateTheme.setName("my-theme");
@@ -88,15 +97,55 @@ public class ThemeResourceTest extends AbstractResourceTest {
         ThemeEntity theme = new ThemeEntity();
         theme.setId(THEME_ID);
 
-        when(themeService.update(GraviteeContext.getExecutionContext(), updateTheme)).thenReturn(theme);
+        when(themeService.updatePortalTheme(GraviteeContext.getExecutionContext(), updateTheme)).thenReturn(theme);
 
         final Response response = envTarget(THEME_ID).request().put(json(updateTheme));
 
         assertEquals(OK_200, response.getStatus());
-        verify(themeService).update(eq(GraviteeContext.getExecutionContext()), eq(updateTheme));
+        verify(themeService).updatePortalTheme(eq(GraviteeContext.getExecutionContext()), eq(updateTheme));
 
         final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
         assertNotNull(responseTheme);
         assertEquals(theme, responseTheme);
+    }
+
+    @Test
+    public void shouldNotFindPortalNextThemeById() {
+        var theme = io.gravitee.rest.api.model.theme.portalnext.ThemeEntity.builder().id(THEME_ID).build();
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(theme);
+        final Response response = envTarget(THEME_ID).request().get();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotDeletePortalNextTheme() {
+        var theme = io.gravitee.rest.api.model.theme.portalnext.ThemeEntity.builder().id(THEME_ID).build();
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(theme);
+        final Response response = envTarget(THEME_ID).request().delete();
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotUpdatePortalNextTheme() {
+        var oldTheme = io.gravitee.rest.api.model.theme.portalnext.ThemeEntity.builder().id(THEME_ID).build();
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(oldTheme);
+        UpdateThemeEntity updateTheme = new UpdateThemeEntity();
+        updateTheme.setId(THEME_ID);
+        updateTheme.setName("my-theme");
+        updateTheme.setDefinition(new ThemeDefinition());
+
+        ThemeEntity theme = new ThemeEntity();
+        theme.setId(THEME_ID);
+
+        when(themeService.updatePortalTheme(GraviteeContext.getExecutionContext(), updateTheme)).thenReturn(theme);
+
+        final Response response = envTarget(THEME_ID).request().put(json(updateTheme));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemesResourceTest.java
@@ -54,12 +54,12 @@ public class ThemesResourceTest extends AbstractResourceTest {
         createdTheme.setId(THEME_ID);
         createdTheme.setName("my-theme");
 
-        when(themeService.create(eq(GraviteeContext.getExecutionContext()), eq(newTheme))).thenReturn(createdTheme);
+        when(themeService.createPortalTheme(eq(GraviteeContext.getExecutionContext()), eq(newTheme))).thenReturn(createdTheme);
 
         final Response response = envTarget().request().post(json(newTheme));
 
         assertEquals(OK_200, response.getStatus());
-        verify(themeService).create(eq(GraviteeContext.getExecutionContext()), eq(newTheme));
+        verify(themeService).createPortalTheme(eq(GraviteeContext.getExecutionContext()), eq(newTheme));
 
         final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
         assertNotNull(responseTheme);
@@ -72,7 +72,7 @@ public class ThemesResourceTest extends AbstractResourceTest {
         activeTheme.setId(THEME_ID);
         activeTheme.setName("my-theme");
 
-        when(themeService.findOrCreateDefault(eq(GraviteeContext.getExecutionContext()))).thenReturn(activeTheme);
+        when(themeService.findOrCreateDefaultPortalTheme(eq(GraviteeContext.getExecutionContext()))).thenReturn(activeTheme);
 
         final Response response = envTarget("/current").request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/ThemeType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/ThemeType.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.theme.portal;
+package io.gravitee.rest.api.model.theme;
 
 public enum ThemeType {
     PORTAL,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portal/ThemeEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portal/ThemeEntity.java
@@ -17,16 +17,23 @@ package io.gravitee.rest.api.model.theme.portal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.theme.GenericThemeEntity;
+import io.gravitee.rest.api.model.theme.ThemeType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ThemeEntity implements GenericThemeEntity {
 
     private String id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeDefinition.java
@@ -13,18 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.theme;
+package io.gravitee.rest.api.model.theme.portalnext;
 
-import java.util.Date;
+import io.gravitee.rest.api.model.theme.portal.ThemeComponentDefinition;
+import java.util.List;
+import lombok.Data;
 
-public interface GenericThemeEntity {
-    String getId();
-    String getName();
-    ThemeType getType();
-    Date getCreatedAt();
-    Date getUpdatedAt();
-    boolean isEnabled();
-    String getLogo();
-    String getOptionalLogo();
-    String getFavicon();
+@Data
+public class ThemeDefinition {
+
+    private String primary;
+    private String secondary;
+    private String tertiary;
+    private String error;
+    private String background;
+    private Banner banner;
+
+    @Data
+    public static class Banner {
+
+        private String background;
+        private String text;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeEntity.java
@@ -13,34 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.theme.portal;
+package io.gravitee.rest.api.model.theme.portalnext;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.theme.GenericThemeEntity;
 import io.gravitee.rest.api.model.theme.ThemeType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Data;
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * @author Guillaume CUSNIEUX (azize at graviteesource.com)
+ * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Data
-public class NewThemeEntity {
+@Setter
+@Getter
+@Builder
+public class ThemeEntity implements GenericThemeEntity {
+
+    private String id;
 
     @NotNull
-    @Size(min = 1, max = 64)
+    @Size(min = 1)
     private String name;
+
+    @Builder.Default
+    private ThemeType type = ThemeType.PORTAL_NEXT;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    @JsonProperty("updated_at")
+    private Date updatedAt;
 
     private boolean enabled;
 
-    private ThemeType type = ThemeType.PORTAL;
-
-    private Object definition;
+    private ThemeDefinition definition;
 
     private String logo;
-
-    private String backgroundImage;
 
     private String optionalLogo;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ThemeMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ThemeMapper.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
-import io.gravitee.rest.api.model.theme.portal.ThemeType;
 import io.gravitee.rest.api.portal.rest.model.ThemeLinks;
 import io.gravitee.rest.api.portal.rest.model.ThemeResponse;
 import org.springframework.stereotype.Component;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
@@ -19,6 +19,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.PictureEntity;
 import io.gravitee.rest.api.model.UrlPictureEntity;
+import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.portal.rest.mapper.ThemeMapper;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
@@ -44,7 +45,7 @@ public class ThemeResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getPortalTheme() {
-        ThemeEntity theme = themeService.findEnabled(GraviteeContext.getExecutionContext());
+        ThemeEntity theme = themeService.findEnabledPortalTheme(GraviteeContext.getExecutionContext());
         String themeURL = PortalApiLinkHelper.themeURL(uriInfo.getBaseUriBuilder(), theme.getId());
         return Response.ok(themeMapper.convert(theme, themeURL)).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.portal.rest.model.ThemeResponse;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -49,7 +50,7 @@ public class ThemeResourceTest extends AbstractResourceTest {
         ThemeEntity themeEntity = new ThemeEntity();
         themeEntity.setId(THEME_ID);
 
-        when(themeService.findEnabled(GraviteeContext.getExecutionContext())).thenReturn(themeEntity);
+        when(themeService.findEnabledPortalTheme(GraviteeContext.getExecutionContext())).thenReturn(themeEntity);
         when(themeMapper.convert(any(), any())).thenCallRealMethod();
 
         final Response response = target().request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ThemeService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ThemeService.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.service;
 
 import io.gravitee.rest.api.model.PictureEntity;
+import io.gravitee.rest.api.model.theme.GenericThemeEntity;
+import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.NewThemeEntity;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.model.theme.portal.UpdateThemeEntity;
@@ -27,17 +29,19 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ThemeService {
-    Set<ThemeEntity> findAll(final ExecutionContext executionContext);
-    ThemeEntity findById(final ExecutionContext executionContext, String themeId);
-    ThemeEntity create(final ExecutionContext executionContext, NewThemeEntity theme);
-    ThemeEntity update(final ExecutionContext executionContext, UpdateThemeEntity theme);
+    Set<GenericThemeEntity> findAllByType(final ExecutionContext executionContext, ThemeType type);
+    GenericThemeEntity findById(final ExecutionContext executionContext, String themeId);
     void delete(final ExecutionContext executionContext, String themeId);
-    ThemeEntity findEnabled(final ExecutionContext executionContext);
-    ThemeEntity findOrCreateDefault(ExecutionContext executionContext);
-    ThemeEntity resetToDefaultTheme(final ExecutionContext executionContext, String themeId);
+    GenericThemeEntity resetToDefaultTheme(final ExecutionContext executionContext, String themeId);
     PictureEntity getLogo(final ExecutionContext executionContext, String themeId);
     PictureEntity getOptionalLogo(final ExecutionContext executionContext, String themeId);
     PictureEntity getBackgroundImage(final ExecutionContext executionContext, String themeId);
-    void updateDefaultTheme(final ExecutionContext executionContext);
     PictureEntity getFavicon(final ExecutionContext executionContext, String themeId);
+
+    // PORTAL THEME
+    ThemeEntity findOrCreateDefaultPortalTheme(ExecutionContext executionContext);
+    ThemeEntity findEnabledPortalTheme(final ExecutionContext executionContext);
+    void updateDefaultPortalTheme(final ExecutionContext executionContext);
+    ThemeEntity createPortalTheme(final ExecutionContext executionContext, NewThemeEntity theme);
+    ThemeEntity updatePortalTheme(final ExecutionContext executionContext, UpdateThemeEntity theme);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.theme.ThemeType;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@AllArgsConstructor
+public class ThemeTypeNotSupportedException extends AbstractManagementException {
+
+    private final String id;
+    private final ThemeType type;
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return format("%s theme is currently not supported", type.name());
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "themeType.notAllowed";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("id", id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultThemeInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultThemeInitializer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade.initializer;
 
+import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.service.ThemeService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ public class DefaultThemeInitializer extends EnvironmentInitializer {
 
     @Override
     public void initializeEnvironment(ExecutionContext executionContext) {
-        themeService.updateDefaultTheme(executionContext);
+        themeService.updateDefaultPortalTheme(executionContext);
     }
 
     @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3945

## Description

The goal is to continue the migration to handling different theme types and have no regression on current functionality.

- Create theme entity for portal next
- Adjust services to handle portal specific themes + generic theme entity
- Update Resources: MAPI `/themes` + `/theme` should be EXCLUSIVELY portal themes. PAPI `/theme` should return only current portal theme (for now).

Next PR:
- Add CRUD endpoints to MAPI-v2 that handle PORTAL + PORTAL_NEXT theme types
- Add endpoint `/theme/next` to PAPI that returns the PORTAL_NEXT theme

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vqqmbnrdil.chromatic.com)
<!-- Storybook placeholder end -->
