### PR TITLE
fix: bump entrypoint-webhook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,7 @@
         <gravitee-entrypoint-http-get.version>1.0.3</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.0.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>4.0.2</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>2.0.4</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>2.1.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.3.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.1.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4660

## Description

Add the possibility to not interrupt consumption.

Not applying on 4.0.x because this version mentions DLQ which is not available in 4.0.x
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-efjzfczyrf.chromatic.com)
<!-- Storybook placeholder end -->
