### PR TITLE
APIM-4805: User can search APIs within a category

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -120,10 +120,14 @@ public class ApisResource extends AbstractResource<Api, String> {
     @Path("_search")
     @Produces(MediaType.APPLICATION_JSON)
     @RequirePortalAuth
-    public Response searchApis(@QueryParam("q") String query, @BeanParam PaginationParam paginationParam) {
+    public Response searchApis(
+        @QueryParam("q") String query,
+        @QueryParam("category") String category,
+        @BeanParam PaginationParam paginationParam
+    ) {
         try {
             final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-            Collection<String> apisList = filteringService.searchApis(executionContext, getAuthenticatedUserOrNull(), query);
+            Collection<String> apisList = filteringService.searchApis(executionContext, getAuthenticatedUserOrNull(), query, category);
             return createListResponse(executionContext, new ArrayList<>(apisList), paginationParam);
         } catch (TechnicalException e) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -316,7 +316,9 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldSearchApis() throws TechnicalException {
-        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+        doReturn(new HashSet<>(List.of("3")))
+            .when(filteringService)
+            .searchApis(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
 
         final Response response = target("/_search").queryParam("q", "3").request().post(Entity.json(null));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -327,8 +329,24 @@ public class ApisResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    public void shouldSearchApisWithCategory() throws TechnicalException {
+        doReturn(new HashSet<>(List.of("3")))
+            .when(filteringService)
+            .searchApis(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
+
+        final Response response = target("/_search").queryParam("q", "3").queryParam("category", "12345").request().post(Entity.json(null));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+        assertEquals(1, apiResponse.getData().size());
+        assertTrue(getmaxLabelsListSize(apiResponse) > 0);
+    }
+
+    @Test
     public void shouldSearchApisWithEmptyQ() throws TechnicalException {
-        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+        doReturn(new HashSet<>(List.of("3")))
+            .when(filteringService)
+            .searchApis(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
 
         final Response response = target("/_search").queryParam("q", "").request().post(Entity.json(null));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -340,7 +358,9 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldSearchApisWithNoQParameter() throws TechnicalException {
-        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+        doReturn(new HashSet<>(List.of("3")))
+            .when(filteringService)
+            .searchApis(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
 
         final Response response = target("/_search").request().post(Entity.json(null));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -361,7 +381,9 @@ public class ApisResourceTest extends AbstractResourceTest {
         )
             .thenReturn(false);
 
-        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+        doReturn(new HashSet<>(List.of("3")))
+            .when(filteringService)
+            .searchApis(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
         final Response response = target("/_search").queryParam("q", "3").request().post(Entity.json(null));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/filtering/FilteringService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/filtering/FilteringService.java
@@ -43,7 +43,13 @@ public interface FilteringService {
         final ApiQuery apiQuery
     );
 
-    Collection<String> searchApis(ExecutionContext executionContext, final String userId, final String query) throws TechnicalException;
+    default Collection<String> searchApis(ExecutionContext executionContext, final String userId, final String query)
+        throws TechnicalException {
+        return searchApis(executionContext, userId, query, null);
+    }
+
+    Collection<String> searchApis(ExecutionContext executionContext, final String userId, final String query, final String category)
+        throws TechnicalException;
 
     Set<CategoryEntity> listCategories(
         ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -165,8 +165,12 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
     }
 
     @Override
-    public Collection<String> searchApis(ExecutionContext executionContext, String userId, String query) throws TechnicalException {
-        Set<String> apis = apiAuthorizationService.findAccessibleApiIdsForUser(executionContext, userId);
+    public Collection<String> searchApis(ExecutionContext executionContext, String userId, String query, String category)
+        throws TechnicalException {
+        var apiQuery = new ApiQuery();
+        apiQuery.setCategory(category);
+
+        Set<String> apis = apiAuthorizationService.findAccessibleApiIdsForUser(executionContext, userId, apiQuery);
 
         Map<String, Object> filters = new HashMap<>();
         filters.put("api", apis);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiAuthorizationService.java
@@ -71,6 +71,8 @@ public interface ApiAuthorizationService {
     );
 
     Set<String> findApiIdsByUserId(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly);
+
     Set<String> findIdsByEnvironment(final String environmentId);
+
     List<ApiCriteria> computeApiCriteriaForUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -164,7 +164,6 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
             }
             apiQuery.setIds(targetIds);
         }
-
         List<ApiCriteria> apiCriteriaList = computeApiCriteriaForUser(executionContext, userId, apiQuery, manageOnly);
 
         if (apiCriteriaList.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TopApiEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -370,7 +371,7 @@ public class FilteringServiceTest {
 
         doReturn(Set.of("api-#1", "api-#2", "api-#3"))
             .when(apiAuthorizationService)
-            .findAccessibleApiIdsForUser(eq(GraviteeContext.getExecutionContext()), eq("user-#1"));
+            .findAccessibleApiIdsForUser(eq(GraviteeContext.getExecutionContext()), eq("user-#1"), nullable(ApiQuery.class));
         doReturn(Set.of("api-#3"))
             .when(apiSearchService)
             .searchIds(
@@ -381,6 +382,31 @@ public class FilteringServiceTest {
             );
 
         Collection<String> searchItems = filteringService.searchApis(GraviteeContext.getExecutionContext(), "user-#1", aQuery);
+
+        assertThat(searchItems).singleElement().isEqualTo("api-#3");
+    }
+
+    @Test
+    public void shouldSearchApisWithCategory() throws TechnicalException {
+        String aQuery = "a Query";
+        String category = "category-key";
+
+        var apiQuery = new ApiQuery();
+        apiQuery.setCategory(category);
+
+        doReturn(Set.of("api-#1", "api-#2", "api-#3"))
+            .when(apiAuthorizationService)
+            .findAccessibleApiIdsForUser(eq(GraviteeContext.getExecutionContext()), eq("user-#1"), eq(apiQuery));
+        doReturn(Set.of("api-#3"))
+            .when(apiSearchService)
+            .searchIds(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(aQuery),
+                eq(Map.of("api", Set.of("api-#1", "api-#2", "api-#3"))),
+                isNull()
+            );
+
+        Collection<String> searchItems = filteringService.searchApis(GraviteeContext.getExecutionContext(), "user-#1", aQuery, category);
 
         assertThat(searchItems).singleElement().isEqualTo("api-#3");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -581,6 +580,103 @@ public class ApiAuthorizationServiceImplTest {
 
         assertThat(result).hasSize(2);
         verify(subscriptionService).search(any(), argThat(argument -> argument.getExcludedApis().contains(apiId)));
+    }
+
+    @Test
+    public void shouldAddCategoryCriteriaWhenCategoryIsNotBlank() {
+        String apiId = "apiId";
+        String applicationId = "applicationId";
+        ApiQuery apiQuery = new ApiQuery();
+        apiQuery.setIds(Set.of(apiId));
+        String categoryKey = "category-Key";
+        apiQuery.setCategory(categoryKey);
+
+        var categoryEntity = new CategoryEntity();
+        categoryEntity.setKey(categoryKey);
+
+        Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId("USER_ROLE_ID");
+        userRole.setPermissions(userPermissions);
+        userRole.setScope(RoleScope.API);
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId("PO_ROLE_ID");
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        when(categoryService.findById(categoryKey, GraviteeContext.getExecutionContext().getEnvironmentId())).thenReturn(categoryEntity);
+
+        when(roleService.findByScope(RoleScope.API, GraviteeContext.getCurrentOrganization())).thenReturn(List.of(poRole, userRole));
+
+        when(applicationService.findUserApplicationsIds(GraviteeContext.getExecutionContext(), USER_NAME, ApplicationStatus.ACTIVE))
+            .thenReturn(Set.of(applicationId));
+
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("subscriptionId");
+        subscriptionEntity.setApi("anotherApi");
+        when(subscriptionService.search(any(), any())).thenReturn(List.of(subscriptionEntity));
+
+        List<ApiCriteria> result = apiAuthorizationService.computeApiCriteriaForUser(
+            GraviteeContext.getExecutionContext(),
+            USER_NAME,
+            apiQuery,
+            false
+        );
+
+        verify(subscriptionService).search(any(), argThat(argument -> argument.getExcludedApis().contains(apiId)));
+        assertThat(result).hasSize(2);
+        result
+            .stream()
+            .filter(i -> i.getCategory() != null)
+            .filter(i -> i.getIds().contains(categoryKey))
+            .forEach(i -> assertThat(i.getCategory()).isEqualTo(categoryKey));
+    }
+
+    @Test
+    public void shouldAddCategoryCriteriaWhenCategoryIsBlank() {
+        String apiId = "apiId";
+        String applicationId = "applicationId";
+        ApiQuery apiQuery = new ApiQuery();
+        apiQuery.setIds(Set.of(apiId));
+        String categoryKey = "";
+        apiQuery.setCategory(categoryKey);
+
+        var categoryEntity = new CategoryEntity();
+        categoryEntity.setKey(categoryKey);
+
+        Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId("USER_ROLE_ID");
+        userRole.setPermissions(userPermissions);
+        userRole.setScope(RoleScope.API);
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId("PO_ROLE_ID");
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        when(roleService.findByScope(RoleScope.API, GraviteeContext.getCurrentOrganization())).thenReturn(List.of(poRole, userRole));
+
+        when(applicationService.findUserApplicationsIds(GraviteeContext.getExecutionContext(), USER_NAME, ApplicationStatus.ACTIVE))
+            .thenReturn(Set.of(applicationId));
+
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("subscriptionId");
+        subscriptionEntity.setApi("anotherApi");
+        when(subscriptionService.search(any(), any())).thenReturn(List.of(subscriptionEntity));
+
+        List<ApiCriteria> result = apiAuthorizationService.computeApiCriteriaForUser(
+            GraviteeContext.getExecutionContext(),
+            USER_NAME,
+            apiQuery,
+            false
+        );
+
+        verify(subscriptionService).search(any(), argThat(argument -> argument.getExcludedApis().contains(apiId)));
+        assertThat(result).hasSize(2);
+        var nonNullCategoryResult = result.stream().filter(i -> i.getCategory() != null).count();
+        assertThat(nonNullCategoryResult).isZero();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4805

## Description

Added possibility to search by category id, or category key.
Before my changes: the endpoint only allows keyword search and cannot be given a category context.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7422/console](https://pr.team-apim.gravitee.dev/7422/console)
      Portal: [https://pr.team-apim.gravitee.dev/7422/portal](https://pr.team-apim.gravitee.dev/7422/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7422/api/management](https://pr.team-apim.gravitee.dev/7422/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7422](https://pr.team-apim.gravitee.dev/7422)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7422](https://pr.gateway-v3.team-apim.gravitee.dev/7422)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hqqbhscyhm.chromatic.com)
<!-- Storybook placeholder end -->
