### PR TITLE
feat: expose endpoint to delete ingested APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1204,6 +1204,21 @@ paths:
                     $ref: "#/components/responses/IngestedApisResponse"
                 default:
                     $ref: "#/components/responses/Error"
+        delete:
+            tags:
+                - Integrations
+            summary: Delete ingested APIs associated to integration
+            description: |-
+                Delete APIs that were ingested from 3rd party provider using this integration. 
+
+                To delete APIs user must have ENVIRONMENT_API[DELETE] permission.
+                Only unpublished APIs will deleted. APIs that are published will be omitted!
+            operationId: deleteIngestedApis
+            responses:
+                "200":
+                    description: APIs deleted
+                default:
+                    $ref: "#/components/responses/Error"
 
     # API Subscriptions
     /environments/{envId}/apis/{apiId}/subscribers:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
@@ -22,4 +22,5 @@ public interface ApiCrudService {
     boolean existsById(String id);
     Api create(Api api);
     Api update(Api api);
+    void delete(String id);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiIndexerDomainService.java
@@ -53,6 +53,10 @@ public class ApiIndexerDomainService {
         indexer.index(context, toIndexableApi(apiToIndex, primaryOwner));
     }
 
+    public void delete(Indexer.IndexationContext context, Api apiToDelete) {
+        indexer.delete(context, toIndexableApi(context, apiToDelete));
+    }
+
     /**
      * Build an {@link IndexableApi} from an {@link Api}.
      * @param context The indexation context.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCase.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.documentation.domain_service.DeleteApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.query_service.PageQueryService;
+import io.gravitee.apim.core.membership.domain_service.DeleteMembershipDomainService;
+import io.gravitee.apim.core.plan.domain_service.DeletePlanDomainService;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.apim.core.search.Indexer;
+import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.domain_service.DeleteSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import io.gravitee.common.utils.TimeProvider;
+import java.util.Collections;
+import lombok.Builder;
+
+@UseCase
+public class DeleteIngestedApisUseCase {
+
+    ApiQueryService apiQueryService;
+    PlanQueryService planQueryService;
+    SubscriptionQueryService subscriptionQueryService;
+    CloseSubscriptionDomainService closeSubscriptionDomainService;
+    DeleteSubscriptionDomainService deleteSubscriptionDomainService;
+    DeletePlanDomainService deletePlanDomainService;
+    PageQueryService pageQueryService;
+    DeleteApiDocumentationDomainService deleteApiDocumentationDomainService;
+    AuditDomainService auditDomainService;
+    ApiMetadataDomainService apiMetadataDomainService;
+    DeleteMembershipDomainService deleteMembershipDomainService;
+    ApiCrudService apiCrudService;
+    ApiIndexerDomainService apiIndexerDomainService;
+
+    public DeleteIngestedApisUseCase(
+        ApiQueryService apiQueryService,
+        PlanQueryService planQueryService,
+        SubscriptionQueryService subscriptionQueryService,
+        CloseSubscriptionDomainService closeSubscriptionDomainService,
+        DeleteSubscriptionDomainService deleteSubscriptionDomainService,
+        DeletePlanDomainService deletePlanDomainService,
+        PageQueryService pageQueryService,
+        DeleteApiDocumentationDomainService deleteApiDocumentationDomainService,
+        AuditDomainService auditDomainService,
+        ApiMetadataDomainService apiMetadataDomainService,
+        DeleteMembershipDomainService deleteMembershipDomainService,
+        ApiCrudService apiCrudService,
+        ApiIndexerDomainService apiIndexerDomainService
+    ) {
+        this.apiQueryService = apiQueryService;
+        this.planQueryService = planQueryService;
+        this.subscriptionQueryService = subscriptionQueryService;
+        this.closeSubscriptionDomainService = closeSubscriptionDomainService;
+        this.deleteSubscriptionDomainService = deleteSubscriptionDomainService;
+        this.deletePlanDomainService = deletePlanDomainService;
+        this.pageQueryService = pageQueryService;
+        this.deleteApiDocumentationDomainService = deleteApiDocumentationDomainService;
+        this.auditDomainService = auditDomainService;
+        this.apiMetadataDomainService = apiMetadataDomainService;
+        this.deleteMembershipDomainService = deleteMembershipDomainService;
+        this.apiCrudService = apiCrudService;
+        this.apiIndexerDomainService = apiIndexerDomainService;
+    }
+
+    public void execute(Input input) {
+        var apisToDelete = apiQueryService
+            .search(
+                ApiSearchCriteria.builder().integrationId(input.integrationId).build(),
+                null,
+                ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build()
+            )
+            .filter(api -> !api.getApiLifecycleState().equals(Api.ApiLifecycleState.PUBLISHED))
+            .toList();
+
+        apisToDelete.forEach(api -> delete(api, input.auditInfo));
+    }
+
+    @Builder
+    public record Input(String integrationId, AuditInfo auditInfo) {}
+
+    private void delete(Api api, AuditInfo auditInfo) {
+        var apiId = api.getId();
+
+        planQueryService
+            .findAllByApiId(apiId)
+            .forEach(plan -> {
+                //Close active Subscriptions
+                subscriptionQueryService
+                    .findActiveSubscriptionsByPlan(plan.getId())
+                    .forEach(activeSubscription -> closeSubscriptionDomainService.closeSubscription(activeSubscription.getId(), auditInfo));
+
+                //Delete all subscriptions
+                subscriptionQueryService
+                    .findSubscriptionsByPlan(plan.getId())
+                    .forEach(subscription -> deleteSubscriptionDomainService.delete(subscription, auditInfo));
+
+                //Delete plans
+                deletePlanDomainService.delete(plan, auditInfo);
+            });
+
+        //Delete pages
+        pageQueryService.searchByApiId(apiId).forEach(page -> deleteApiDocumentationDomainService.delete(api, page.getId(), auditInfo));
+
+        //Delete API Index
+        apiIndexerDomainService.delete(new Indexer.IndexationContext(auditInfo.organizationId(), auditInfo.environmentId()), api);
+
+        //Delete membership
+        deleteMembershipDomainService.deleteApiMemberships(apiId, auditInfo);
+
+        //Delete metadata
+        apiMetadataDomainService.deleteApiMetadata(apiId, auditInfo);
+
+        //Delete API
+        apiCrudService.delete(api.getId());
+
+        //Audit
+        createAuditLog(auditInfo, api);
+    }
+
+    private void createAuditLog(AuditInfo auditInfo, Api api) {
+        auditDomainService.createApiAuditLog(
+            ApiAuditLogEntity
+                .builder()
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .apiId(api.getId())
+                .event(ApiAuditEvent.API_DELETED)
+                .actor(auditInfo.actor())
+                .oldValue(api)
+                .createdAt(TimeProvider.now())
+                .properties(Collections.emptyMap())
+                .build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/DeleteMembershipDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/DeleteMembershipDomainService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.common.utils.TimeProvider;
+import java.util.Collections;
+
+@DomainService
+public class DeleteMembershipDomainService {
+
+    MembershipQueryService membershipQueryService;
+    MembershipCrudService membershipCrudService;
+    AuditDomainService auditDomainService;
+
+    public DeleteMembershipDomainService(
+        MembershipQueryService membershipQueryService,
+        MembershipCrudService membershipCrudService,
+        AuditDomainService auditDomainService
+    ) {
+        this.membershipQueryService = membershipQueryService;
+        this.membershipCrudService = membershipCrudService;
+        this.auditDomainService = auditDomainService;
+    }
+
+    public void deleteApiMemberships(String apiId, AuditInfo auditInfo) {
+        var memberships = membershipQueryService.findByReference(Membership.ReferenceType.API, apiId);
+        memberships.forEach(membership -> {
+            membershipCrudService.delete(membership.getId());
+            createAuditLog(auditInfo, membership, apiId);
+        });
+    }
+
+    private void createAuditLog(AuditInfo auditInfo, Membership membership, String apiId) {
+        auditDomainService.createApiAuditLog(
+            ApiAuditLogEntity
+                .builder()
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .apiId(apiId)
+                .event(MembershipAuditEvent.MEMBERSHIP_DELETED)
+                .actor(auditInfo.actor())
+                .oldValue(membership)
+                .createdAt(TimeProvider.now())
+                .properties(Collections.emptyMap())
+                .build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/MembershipQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/MembershipQueryService.java
@@ -22,6 +22,7 @@ import java.util.List;
 public interface MembershipQueryService {
     Collection<Membership> findByReferenceAndRoleId(Membership.ReferenceType referenceType, String referenceId, String roleId);
     Collection<Membership> findByReferencesAndRoleId(Membership.ReferenceType referenceType, List<String> referenceIds, String roleId);
+    Collection<Membership> findByReference(Membership.ReferenceType referenceType, String referenceId);
 
     Collection<Membership> findGroupsThatUserBelongsTo(String userId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/crud_service/MetadataCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/metadata/crud_service/MetadataCrudService.java
@@ -23,4 +23,5 @@ public interface MetadataCrudService {
     Metadata create(Metadata metadata);
     Optional<Metadata> findById(MetadataId id);
     Metadata update(Metadata metadata);
+    void delete(MetadataId metadataId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/crud_service/SubscriptionCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/crud_service/SubscriptionCrudService.java
@@ -21,4 +21,6 @@ public interface SubscriptionCrudService {
     SubscriptionEntity get(String subscriptionId);
 
     SubscriptionEntity update(SubscriptionEntity subscriptionEntity);
+
+    void delete(String subscriptionId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/DeleteSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/DeleteSubscriptionDomainService.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.common.utils.TimeProvider;
+import java.util.Collections;
+
+@DomainService
+public class DeleteSubscriptionDomainService {
+
+    SubscriptionCrudService subscriptionCrudService;
+    AuditDomainService auditService;
+
+    public DeleteSubscriptionDomainService(SubscriptionCrudService subscriptionCrudService, AuditDomainService auditService) {
+        this.subscriptionCrudService = subscriptionCrudService;
+        this.auditService = auditService;
+    }
+
+    public void delete(SubscriptionEntity subscriptionEntity, AuditInfo auditInfo) {
+        subscriptionCrudService.delete(subscriptionEntity.getId());
+        createAuditLog(subscriptionEntity, auditInfo);
+    }
+
+    private void createAuditLog(SubscriptionEntity subscriptionEntity, AuditInfo auditInfo) {
+        auditService.createApiAuditLog(
+            ApiAuditLogEntity
+                .builder()
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .apiId(subscriptionEntity.getApiId())
+                .event(SubscriptionAuditEvent.SUBSCRIPTION_DELETED)
+                .actor(auditInfo.actor())
+                .oldValue(subscriptionEntity)
+                .createdAt(TimeProvider.now())
+                .properties(Collections.emptyMap())
+                .build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionQueryService.java
@@ -21,6 +21,8 @@ import java.util.List;
 public interface SubscriptionQueryService {
     List<SubscriptionEntity> findExpiredSubscriptions();
 
+    List<SubscriptionEntity> findSubscriptionsByPlan(String planId);
+
     List<SubscriptionEntity> findActiveSubscriptionsByPlan(String planId);
 
     List<SubscriptionEntity> findActiveByApplicationIdAndApiId(String applicationId, String apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
@@ -77,4 +77,13 @@ public class ApiCrudServiceImpl implements ApiCrudService {
             throw new TechnicalDomainException("An error occurs while trying to update the api: " + api.getId(), e);
         }
     }
+
+    @Override
+    public void delete(String id) {
+        try {
+            apiRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to delete the api: " + id, e);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/membership/MembershipCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/membership/MembershipCrudServiceImpl.java
@@ -42,4 +42,13 @@ public class MembershipCrudServiceImpl implements MembershipCrudService {
             throw new TechnicalDomainException("An error occurs while trying to create the membership: " + membership.getId(), e);
         }
     }
+
+    @Override
+    public void delete(String id) {
+        try {
+            membershipRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to delete the membership: " + id, e);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImpl.java
@@ -91,4 +91,16 @@ public class MetadataCrudServiceImpl implements MetadataCrudService {
             );
         }
     }
+
+    @Override
+    public void delete(MetadataId id) {
+        try {
+            metadataRepository.delete(id.getKey(), id.getReferenceId(), MetadataReferenceType.valueOf(id.getReferenceType().name()));
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurs while trying to delete the metadata with key: %s", id.getKey()),
+                e
+            );
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/subscription/SubscriptionCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/subscription/SubscriptionCrudServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.crud_service.subscription;
 
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
@@ -56,6 +57,18 @@ public class SubscriptionCrudServiceImpl implements SubscriptionCrudService {
         } catch (TechnicalException e) {
             throw new TechnicalManagementException(
                 "An error occurs while trying to update the subscription: " + subscriptionEntity.getId(),
+                e
+            );
+        }
+    }
+
+    @Override
+    public void delete(String subscriptionId) {
+        try {
+            subscriptionRepository.delete(subscriptionId);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurs while trying to delete the subscription with id: %s", subscriptionId),
                 e
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiMetadataDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiMetadataDomainServiceLegacyWrapper.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.infra.domain_service.api;
 
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
@@ -41,9 +42,10 @@ public class ApiMetadataDomainServiceLegacyWrapper extends ApiMetadataDomainServ
     public ApiMetadataDomainServiceLegacyWrapper(
         ApiMetadataService metadataService,
         AuditDomainService auditDomainService,
-        MetadataCrudService metadataCrudService
+        MetadataCrudService metadataCrudService,
+        ApiMetadataQueryService apiMetadataQueryService
     ) {
-        super(metadataCrudService, auditDomainService);
+        super(metadataCrudService, apiMetadataQueryService, auditDomainService);
         this.metadataService = metadataService;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/membership/MembershipQueryServiceImpl.java
@@ -68,6 +68,11 @@ public class MembershipQueryServiceImpl implements MembershipQueryService {
     }
 
     @Override
+    public Collection<Membership> findByReference(Membership.ReferenceType referenceType, String referenceId) {
+        return findByReferenceAndRoleId(referenceType, referenceId, null);
+    }
+
+    @Override
     public Collection<Membership> findGroupsThatUserBelongsTo(String memberId) {
         try {
             return membershipRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImpl.java
@@ -56,6 +56,17 @@ public class SubscriptionQueryServiceImpl implements SubscriptionQueryService {
     }
 
     @Override
+    public List<SubscriptionEntity> findSubscriptionsByPlan(String planId) {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(List.of(planId)).build();
+
+        try {
+            return subscriptionRepository.search(criteria).stream().map(subscriptionAdapter::toEntity).toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find plan's subscription", e);
+        }
+    }
+
+    @Override
     public List<SubscriptionEntity> findActiveSubscriptionsByPlan(String planId) {
         SubscriptionCriteria criteria = SubscriptionCriteria
             .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PageFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PageFixture.java
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.membership.crud_service;
+package fixtures.core.model;
 
-import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.documentation.model.Page;
+import java.util.function.Supplier;
 
-public interface MembershipCrudService {
-    Membership create(Membership membership);
-    void delete(String id);
+public class PageFixture {
+
+    private PageFixture() {}
+
+    public static final Supplier<Page.PageBuilder> BASE = () ->
+        Page
+            .builder()
+            .id("page-id")
+            .name("page-name")
+            .type(Page.Type.SWAGGER)
+            .content("someSwaggerPageContent")
+            .referenceId("my-api")
+            .referenceType(Page.ReferenceType.API);
+
+    public static Page aPage() {
+        return BASE.get().build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
@@ -56,6 +56,11 @@ public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternati
     }
 
     @Override
+    public void delete(String id) {
+        storage.removeIf(api -> id.equals(api.getId()));
+    }
+
+    @Override
     public void initWith(List<Api> items) {
         storage.clear();
         storage.addAll(items);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipCrudServiceInMemory.java
@@ -32,6 +32,11 @@ public class MembershipCrudServiceInMemory implements MembershipCrudService, InM
     }
 
     @Override
+    public void delete(String id) {
+        storage.removeIf(s -> s.getId().equals(id));
+    }
+
+    @Override
     public void initWith(List<Membership> items) {
         storage.addAll(items);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipQueryServiceInMemory.java
@@ -63,6 +63,14 @@ public class MembershipQueryServiceInMemory implements MembershipQueryService, I
     }
 
     @Override
+    public Collection<Membership> findByReference(Membership.ReferenceType referenceType, String referenceId) {
+        return storage
+            .stream()
+            .filter(membership -> membership.getReferenceType().equals(referenceType) && membership.getReferenceId().equals(referenceId))
+            .toList();
+    }
+
+    @Override
     public Collection<Membership> findGroupsThatUserBelongsTo(String userId) {
         return storage.stream().filter(membership -> membership.isGroupUser() && membership.getMemberId().equals(userId)).toList();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MetadataCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MetadataCrudServiceInMemory.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import org.springframework.stereotype.Service;
 
 public class MetadataCrudServiceInMemory implements MetadataCrudService, InMemoryAlternative<Metadata> {
 
@@ -63,6 +62,15 @@ public class MetadataCrudServiceInMemory implements MetadataCrudService, InMemor
         }
 
         throw new IllegalStateException("Metadata not found");
+    }
+
+    @Override
+    public void delete(MetadataId metadataId) {
+        storage.removeIf(m ->
+            m.getReferenceId().equals(metadataId.getReferenceId()) &&
+            m.getReferenceType().equals(metadataId.getReferenceType()) &&
+            m.getKey().equals(metadataId.getKey())
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageCrudServiceInMemory.java
@@ -60,7 +60,6 @@ public class PageCrudServiceInMemory implements InMemoryAlternative<Page>, PageC
 
     @Override
     public void initWith(List<Page> items) {
-        this.reset();
         this.pages.addAll(items);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PageQueryServiceInMemory.java
@@ -25,7 +25,15 @@ import java.util.Optional;
 
 public class PageQueryServiceInMemory implements InMemoryAlternative<Page>, PageQueryService {
 
-    List<Page> pages = new ArrayList<>();
+    List<Page> pages;
+
+    public PageQueryServiceInMemory() {
+        this.pages = new ArrayList<>();
+    }
+
+    public PageQueryServiceInMemory(PageCrudServiceInMemory pageCrudServiceInMemory) {
+        pages = pageCrudServiceInMemory.pages;
+    }
 
     @Override
     public List<Page> searchByApiId(String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionCrudServiceInMemory.java
@@ -48,6 +48,11 @@ public class SubscriptionCrudServiceInMemory implements SubscriptionCrudService,
     }
 
     @Override
+    public void delete(String subscriptionId) {
+        storage.removeIf(subscription -> subscriptionId.equals(subscription.getId()));
+    }
+
+    @Override
     public void initWith(List<SubscriptionEntity> items) {
         storage.clear();
         storage.addAll(items);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
@@ -46,6 +46,11 @@ public class SubscriptionQueryServiceInMemory implements SubscriptionQueryServic
     }
 
     @Override
+    public List<SubscriptionEntity> findSubscriptionsByPlan(String planId) {
+        return storage.stream().filter(subscription -> subscription.getPlanId().equals(planId)).toList();
+    }
+
+    @Override
     public List<SubscriptionEntity> findActiveSubscriptionsByPlan(String planId) {
         return storage
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateApiMetadataUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateApiMetadataUseCaseTest.java
@@ -91,7 +91,11 @@ public class CreateApiMetadataUseCaseTest {
             ),
             apiMetadataDecoderDomainService
         );
-        var apiMetadataDomainService = new ApiMetadataDomainService(metadataCrudServiceInMemory, auditDomainService);
+        var apiMetadataDomainService = new ApiMetadataDomainService(
+            metadataCrudServiceInMemory,
+            apiMetadataQueryService,
+            auditDomainService
+        );
         createApiMetadataUseCase = new CreateApiMetadataUseCase(validateApiMetadataDomainService, apiMetadataDomainService, apiCrudService);
 
         apiCrudService.initWith(List.of(API));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
@@ -112,6 +112,7 @@ class CreateV4ApiUseCaseTest {
     NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
     ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
     MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
@@ -162,7 +163,7 @@ class CreateV4ApiUseCaseTest {
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
-            new ApiMetadataDomainService(metadataCrudService, auditService),
+            new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditService),
             apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -144,6 +144,7 @@ class ImportApiDefinitionUseCaseTest {
     GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
     IndexerInMemory indexer = new IndexerInMemory();
     MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryServiceInMemory = new ApiMetadataQueryServiceInMemory(metadataCrudService);
     MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
     PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
@@ -192,6 +193,11 @@ class ImportApiDefinitionUseCaseTest {
             roleQueryService,
             userCrudService
         );
+        var apiMetadataDomainService = new ApiMetadataDomainService(
+            metadataCrudService,
+            apiMetadataQueryServiceInMemory,
+            auditDomainService
+        );
         var createApiDomainService = new CreateApiDomainService(
             apiCrudService,
             auditDomainService,
@@ -201,14 +207,13 @@ class ImportApiDefinitionUseCaseTest {
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
-            new ApiMetadataDomainService(metadataCrudService, auditDomainService),
+            apiMetadataDomainService,
             apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,
             parametersQueryService,
             workflowCrudService
         );
-        var apiMetadataDomainService = new ApiMetadataDomainService(metadataCrudService, auditDomainService);
 
         var planValidatorService = new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService);
         var flowValidationDomainService = new FlowValidationDomainService(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportCRDUseCaseTest.java
@@ -162,6 +162,7 @@ class ImportCRDUseCaseTest {
     MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
     MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
@@ -261,7 +262,7 @@ class ImportCRDUseCaseTest {
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
-            new ApiMetadataDomainService(metadataCrudService, auditDomainService),
+            new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditDomainService),
             apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/DeleteIngestedApisUseCaseTest.java
@@ -1,0 +1,483 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.ApplicationModelFixtures;
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.MembershipFixtures;
+import fixtures.core.model.MetadataFixtures;
+import fixtures.core.model.PageFixture;
+import fixtures.core.model.PlanFixtures;
+import fixtures.core.model.SubscriptionFixtures;
+import inmemory.ApiCategoryQueryServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiKeyCrudServiceInMemory;
+import inmemory.ApiKeyQueryServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.IndexerInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
+import inmemory.PageQueryServiceInMemory;
+import inmemory.PageRevisionCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import inmemory.TriggerNotificationDomainServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
+import io.gravitee.apim.core.documentation.domain_service.DeleteApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.UpdateApiDocumentationDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.DeleteMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.plan.domain_service.DeletePlanDomainService;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.domain_service.DeleteSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class DeleteIngestedApisUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String INTEGRATION_ID = "integration-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String USER_ID = "user-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String MY_API = "my-api";
+
+    PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+    PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory(planCrudService);
+    SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
+    SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory(subscriptionCrudService);
+    ApplicationCrudServiceInMemory applicationService = new ApplicationCrudServiceInMemory();
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
+    PageQueryServiceInMemory pageQueryService = new PageQueryServiceInMemory(pageCrudService);
+    PageRevisionCrudServiceInMemory pageRevisionCrudServiceInMemory = new PageRevisionCrudServiceInMemory();
+    IndexerInMemory indexer = new IndexerInMemory();
+    TriggerNotificationDomainServiceInMemory triggerNotificationDomainServiceInMemory = new TriggerNotificationDomainServiceInMemory();
+    ApiKeyCrudServiceInMemory apiKeyCrudServiceInMemory = new ApiKeyCrudServiceInMemory();
+    ApiKeyQueryServiceInMemory apiKeyQueryServiceInMemory = new ApiKeyQueryServiceInMemory(apiKeyCrudServiceInMemory);
+    ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+    ApiQueryServiceInMemory apiQueryServiceInMemory = new ApiQueryServiceInMemory(apiCrudServiceInMemory);
+    MetadataCrudServiceInMemory metadataCrudServiceInMemory = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryServiceInMemory = new ApiMetadataQueryServiceInMemory(metadataCrudServiceInMemory);
+    MembershipCrudServiceInMemory membershipCrudServiceInMemory = new MembershipCrudServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryServiceInMemory = new MembershipQueryServiceInMemory(membershipCrudServiceInMemory);
+    RoleQueryServiceInMemory roleQueryServiceInMemory = new RoleQueryServiceInMemory();
+    GroupQueryServiceInMemory groupQueryServiceInMemory = new GroupQueryServiceInMemory();
+    ApiCategoryQueryServiceInMemory apiCategoryQueryServiceInMemory = new ApiCategoryQueryServiceInMemory();
+
+    private DeleteIngestedApisUseCase useCase;
+
+    @BeforeEach
+    public void setUp() {
+        var auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var revokeApiKeyDomainService = new RevokeApiKeyDomainService(
+            apiKeyCrudServiceInMemory,
+            apiKeyQueryServiceInMemory,
+            subscriptionCrudService,
+            auditDomainService,
+            triggerNotificationDomainServiceInMemory
+        );
+        var rejectSubscriptionDomainService = new RejectSubscriptionDomainService(
+            subscriptionCrudService,
+            planCrudService,
+            auditDomainService,
+            triggerNotificationDomainServiceInMemory,
+            userCrudService
+        );
+        var closeSubscriptionDomainService = new CloseSubscriptionDomainService(
+            subscriptionCrudService,
+            applicationService,
+            auditDomainService,
+            triggerNotificationDomainServiceInMemory,
+            rejectSubscriptionDomainService,
+            revokeApiKeyDomainService
+        );
+        var deleteSubscriptionDomainService = new DeleteSubscriptionDomainService(subscriptionCrudService, auditDomainService);
+        var deletePlanDomainService = new DeletePlanDomainService(planCrudService, subscriptionQueryService, auditDomainService);
+        var updateApiDocumentationService = new UpdateApiDocumentationDomainService(
+            pageCrudService,
+            pageRevisionCrudServiceInMemory,
+            auditDomainService,
+            indexer
+        );
+        var deleteApiDocumentationDomainService = new DeleteApiDocumentationDomainService(
+            pageCrudService,
+            pageQueryService,
+            auditDomainService,
+            updateApiDocumentationService,
+            planQueryService,
+            indexer
+        );
+        var apiMetadataDomainService = new ApiMetadataDomainService(
+            metadataCrudServiceInMemory,
+            apiMetadataQueryServiceInMemory,
+            auditDomainService
+        );
+        var deleteMembershipDomainService = new DeleteMembershipDomainService(
+            membershipQueryServiceInMemory,
+            membershipCrudServiceInMemory,
+            auditDomainService
+        );
+        var templateProcessor = new FreemarkerTemplateProcessor();
+        var apiMetadataDecoderDomainService = new ApiMetadataDecoderDomainService(apiMetadataQueryServiceInMemory, templateProcessor);
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditDomainService,
+            groupQueryServiceInMemory,
+            membershipCrudServiceInMemory,
+            membershipQueryServiceInMemory,
+            roleQueryServiceInMemory,
+            userCrudService
+        );
+        var apiIndexerDomainService = new ApiIndexerDomainService(
+            apiMetadataDecoderDomainService,
+            apiPrimaryOwnerDomainService,
+            apiCategoryQueryServiceInMemory,
+            indexer
+        );
+
+        useCase =
+            new DeleteIngestedApisUseCase(
+                apiQueryServiceInMemory,
+                planQueryService,
+                subscriptionQueryService,
+                closeSubscriptionDomainService,
+                deleteSubscriptionDomainService,
+                deletePlanDomainService,
+                pageQueryService,
+                deleteApiDocumentationDomainService,
+                auditDomainService,
+                apiMetadataDomainService,
+                deleteMembershipDomainService,
+                apiCrudServiceInMemory,
+                apiIndexerDomainService
+            );
+        initializePrimaryOwnerData();
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(
+                planCrudService,
+                planQueryService,
+                subscriptionCrudService,
+                subscriptionQueryService,
+                applicationService,
+                auditCrudService,
+                userCrudService,
+                pageCrudService,
+                pageQueryService,
+                pageRevisionCrudServiceInMemory,
+                indexer,
+                apiKeyCrudServiceInMemory,
+                apiKeyQueryServiceInMemory,
+                apiCrudServiceInMemory,
+                apiQueryServiceInMemory,
+                metadataCrudServiceInMemory,
+                apiMetadataQueryServiceInMemory,
+                membershipCrudServiceInMemory,
+                membershipQueryServiceInMemory,
+                roleQueryServiceInMemory,
+                groupQueryServiceInMemory,
+                apiCategoryQueryServiceInMemory
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Api.ApiLifecycleState.class, mode = EnumSource.Mode.EXCLUDE, names = { "PUBLISHED" })
+    public void should_delete_all_apis_except_published_one(Api.ApiLifecycleState apiLifecycleState) {
+        //given
+        apiCrudServiceInMemory.initWith(List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(apiLifecycleState).build()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(apiCrudServiceInMemory.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void should_not_delete_published_api() {
+        //given
+        apiCrudServiceInMemory.initWith(List.of(ApiFixtures.aFederatedApi()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(apiCrudServiceInMemory.storage())
+            .hasSize(1)
+            .extracting(Api::getApiLifecycleState)
+            .containsExactly(Api.ApiLifecycleState.PUBLISHED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SubscriptionEntity.Status.class, mode = EnumSource.Mode.INCLUDE, names = { "ACCEPTED", "PAUSED" })
+    public void should_close_active_subscriptions(SubscriptionEntity.Status subscriptionStatus) {
+        var activeSubscription = SubscriptionFixtures
+            .aSubscription()
+            .toBuilder()
+            .apiId(MY_API)
+            .planId("federated")
+            .status(subscriptionStatus)
+            .build();
+        subscriptionCrudService.initWith(List.of(activeSubscription));
+
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        planCrudService.initWith(List.of(PlanFixtures.aFederatedPlan()));
+        applicationService.initWith(List.of(ApplicationModelFixtures.anApplicationEntity().toBuilder().id("application-id").build()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch", "createdAt")
+            .contains(
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(MY_API)
+                    .user(USER_ID)
+                    .event(SubscriptionAuditEvent.SUBSCRIPTION_CLOSED.name())
+                    .properties(Map.of("APPLICATION", "application-id"))
+                    .build()
+            );
+    }
+
+    @Test
+    public void should_delete_all_subscriptions() {
+        var allSubscriptions = Stream
+            .of(SubscriptionEntity.Status.values())
+            .map(value -> SubscriptionFixtures.aSubscription().toBuilder().planId("federated").status(value).build())
+            .toList();
+        subscriptionCrudService.initWith(allSubscriptions);
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        planCrudService.initWith(List.of(PlanFixtures.aFederatedPlan()));
+        applicationService.initWith(List.of(ApplicationModelFixtures.anApplicationEntity().toBuilder().id("application-id").build()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        useCase.execute(input);
+
+        assertThat(subscriptionCrudService.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void should_delete_plans() {
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        planCrudService.initWith(List.of(PlanFixtures.aFederatedPlan()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(planCrudService.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void should_delete_pages() {
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        pageCrudService.initWith(List.of(PageFixture.aPage()));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(pageCrudService.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void should_create_audit_log() {
+        //given
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+            .contains(
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(MY_API)
+                    .user(USER_ID)
+                    .event(ApiAuditEvent.API_DELETED.name())
+                    .properties(Map.of())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_delete_membership() {
+        //given
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        membershipCrudServiceInMemory.initWith(List.of(MembershipFixtures.anApiMembership(MY_API)));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(membershipCrudServiceInMemory.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_delete_api_metadata() {
+        //given
+        apiCrudServiceInMemory.initWith(
+            List.of(ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build())
+        );
+        metadataCrudServiceInMemory.initWith(List.of(MetadataFixtures.anApiMetadata(MY_API)));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        //when
+        useCase.execute(input);
+
+        //then
+        assertThat(metadataCrudServiceInMemory.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_delete_api_index() {
+        var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
+        var apiToDelete = ApiFixtures.aFederatedApi().toBuilder().apiLifecycleState(Api.ApiLifecycleState.UNPUBLISHED).build();
+        var apiToIndex = new IndexableApi(apiToDelete, primaryOwner, null, null);
+        indexer.initWith(List.of(apiToIndex));
+        apiCrudServiceInMemory.initWith(List.of(apiToDelete));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+        var input = DeleteIngestedApisUseCase.Input.builder().integrationId(INTEGRATION_ID).auditInfo(auditInfo).build();
+
+        useCase.execute(input);
+
+        assertThat(indexer.storage()).isNotNull().isEmpty();
+    }
+
+    private void initializePrimaryOwnerData() {
+        roleQueryServiceInMemory.initWith(
+            List.of(
+                Role
+                    .builder()
+                    .id("role-id")
+                    .scope(Role.Scope.API)
+                    .referenceType(Role.ReferenceType.ORGANIZATION)
+                    .referenceId(ORGANIZATION_ID)
+                    .name("PRIMARY_OWNER")
+                    .build()
+            )
+        );
+        membershipCrudServiceInMemory.initWith(
+            List.of(
+                Membership
+                    .builder()
+                    .id("member-id")
+                    .memberId("my-member-id")
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API)
+                    .referenceId(MY_API)
+                    .roleId("role-id")
+                    .build()
+            )
+        );
+        userCrudService.initWith(List.of(BaseUserEntity.builder().id("my-member-id").email("one_valid@email.com").build()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
@@ -134,6 +134,7 @@ class IngestIntegrationApisUseCaseTest {
     IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
     MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
     MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryServiceInMemory = new ApiMetadataQueryServiceInMemory(metadataCrudService);
     NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
     ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
@@ -192,7 +193,7 @@ class IngestIntegrationApisUseCaseTest {
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
-            new ApiMetadataDomainService(metadataCrudService, auditDomainService),
+            new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryServiceInMemory, auditDomainService),
             apiPrimaryOwnerDomainService,
             new FlowCrudServiceInMemory(),
             notificationConfigCrudService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/DeleteMembershipDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/DeleteMembershipDomainServiceTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.MembershipFixtures;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeleteMembershipDomainServiceTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String API_ID = "my-api";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    MembershipCrudServiceInMemory membershipCrudServiceInMemory = new MembershipCrudServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryServiceInMemory = new MembershipQueryServiceInMemory(membershipCrudServiceInMemory);
+    AuditCrudServiceInMemory auditCrudServiceInMemory = new AuditCrudServiceInMemory();
+    UserCrudServiceInMemory userCrudServiceInMemory = new UserCrudServiceInMemory();
+
+    DeleteMembershipDomainService service;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        var auditDomainService = new AuditDomainService(auditCrudServiceInMemory, userCrudServiceInMemory, new JacksonJsonDiffProcessor());
+
+        service = new DeleteMembershipDomainService(membershipQueryServiceInMemory, membershipCrudServiceInMemory, auditDomainService);
+
+        membershipCrudServiceInMemory.initWith(List.of(MembershipFixtures.anApiMembership(API_ID)));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(membershipCrudServiceInMemory, membershipQueryServiceInMemory, auditCrudServiceInMemory, userCrudServiceInMemory)
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_delete_ApiMemberships_membership() {
+        service.deleteApiMemberships(API_ID, AUDIT_INFO);
+
+        assertThat(membershipCrudServiceInMemory.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_create_audit_log() {
+        service.deleteApiMemberships(API_ID, AUDIT_INFO);
+
+        assertThat(auditCrudServiceInMemory.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+            .contains(
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(API_ID)
+                    .user(USER_ID)
+                    .properties(Map.of())
+                    .event(MembershipAuditEvent.MEMBERSHIP_DELETED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/DeleteSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/DeleteSubscriptionDomainServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.SubscriptionFixtures;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.SubscriptionCrudServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class DeleteSubscriptionDomainServiceTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String USER_ID = "user-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String MY_API = "api-id";
+
+    SubscriptionCrudServiceInMemory subscriptionCrudServiceInMemory = new SubscriptionCrudServiceInMemory();
+    UserCrudServiceInMemory userCrudServiceInMemory = new UserCrudServiceInMemory();
+    AuditCrudServiceInMemory auditCrudServiceInMemory = new AuditCrudServiceInMemory();
+
+    DeleteSubscriptionDomainService service;
+
+    @BeforeEach
+    void setUp() {
+        var auditDomainService = new AuditDomainService(auditCrudServiceInMemory, userCrudServiceInMemory, new JacksonJsonDiffProcessor());
+
+        service = new DeleteSubscriptionDomainService(subscriptionCrudServiceInMemory, auditDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(subscriptionCrudServiceInMemory, userCrudServiceInMemory, auditCrudServiceInMemory).forEach(InMemoryAlternative::reset);
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SubscriptionEntity.Status.class)
+    void should_delete_subscription(SubscriptionEntity.Status status) {
+        var subscription = SubscriptionFixtures.aSubscription().toBuilder().planId("federated").status(status).build();
+        subscriptionCrudServiceInMemory.initWith(List.of(subscription));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+        service.delete(subscription, auditInfo);
+
+        assertThat(subscriptionCrudServiceInMemory.storage()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void should_create_audit_log() {
+        var subscription = SubscriptionFixtures.aSubscription().toBuilder().planId("federated").build();
+        subscriptionCrudServiceInMemory.initWith(List.of(subscription));
+        var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+        service.delete(subscription, auditInfo);
+
+        assertThat(auditCrudServiceInMemory.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+            .containsExactly(
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId(MY_API)
+                    .user(USER_ID)
+                    .event(SubscriptionAuditEvent.SUBSCRIPTION_DELETED.name())
+                    .properties(Map.of())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -16,8 +16,10 @@
 package io.gravitee.apim.infra.crud_service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -391,6 +393,25 @@ public class ApiCrudServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalDomainException.class)
                 .hasMessage("An error occurs while trying to update the api: my-api");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_an_api() throws TechnicalException {
+            service.delete("api-id");
+            verify(apiRepository).delete("api-id");
+        }
+
+        @Test
+        void should_throw_if_deletion_problem_occurs() throws TechnicalException {
+            doThrow(new TechnicalException("exception")).when(apiRepository).delete("api-id");
+            assertThatThrownBy(() -> service.delete("api-id"))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to delete the api: api-id");
+            verify(apiRepository).delete("api-id");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/membership/MembershipCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/membership/MembershipCrudServiceImplTest.java
@@ -16,8 +16,10 @@
 package io.gravitee.apim.infra.crud_service.membership;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -100,6 +102,25 @@ class MembershipCrudServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalDomainException.class)
                 .hasMessage("An error occurs while trying to create the membership: membership-id");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_membership() throws TechnicalException {
+            service.delete("membership-id");
+            verify(membershipRepository).delete("membership-id");
+        }
+
+        @Test
+        void should_throw_if_deletion_problem_occurs() throws TechnicalException {
+            doThrow(new TechnicalException("exception")).when(membershipRepository).delete("membership-id");
+            assertThatThrownBy(() -> service.delete("membership-id"))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to delete the membership: membership-id");
+            verify(membershipRepository).delete("membership-id");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/metadata/MetadataCrudServiceImplTest.java
@@ -16,8 +16,10 @@
 package io.gravitee.apim.infra.crud_service.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -212,6 +214,39 @@ class MetadataCrudServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalDomainException.class)
                 .hasMessage("An error occurs while trying to create the my-key metadata of [apiId=api-id]");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_metadata() throws TechnicalException {
+            var id = MetadataId
+                .builder()
+                .key("metadata-key")
+                .referenceId("api-id")
+                .referenceType(io.gravitee.apim.core.metadata.model.Metadata.ReferenceType.API)
+                .build();
+            service.delete(id);
+            verify(metadataRepository).delete(id.getKey(), id.getReferenceId(), MetadataReferenceType.API);
+        }
+
+        @Test
+        void should_throw_if_deletion_problem_occurs() throws TechnicalException {
+            var id = MetadataId
+                .builder()
+                .key("metadata-key")
+                .referenceId("api-id")
+                .referenceType(io.gravitee.apim.core.metadata.model.Metadata.ReferenceType.API)
+                .build();
+            doThrow(new TechnicalException("exception"))
+                .when(metadataRepository)
+                .delete(id.getKey(), id.getReferenceId(), MetadataReferenceType.API);
+            assertThatThrownBy(() -> service.delete(id))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to delete the metadata with key: " + id.getKey());
+            verify(metadataRepository).delete(id.getKey(), id.getReferenceId(), MetadataReferenceType.API);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/subscription/SubscriptionCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/subscription/SubscriptionCrudServiceImplTest.java
@@ -16,13 +16,16 @@
 package io.gravitee.apim.infra.crud_service.subscription;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.SubscriptionFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
@@ -186,6 +189,25 @@ public class SubscriptionCrudServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalManagementException.class)
                 .hasMessage("An error occurs while trying to update the subscription: subscription-id");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_membership() throws TechnicalException {
+            service.delete("subscription-id");
+            verify(subscriptionRepository).delete("subscription-id");
+        }
+
+        @Test
+        void should_throw_if_deletion_problem_occurs() throws TechnicalException {
+            doThrow(new TechnicalException("exception")).when(subscriptionRepository).delete("subscription-id");
+            assertThatThrownBy(() -> service.delete("subscription-id"))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to delete the subscription with id: subscription-id");
+            verify(subscriptionRepository).delete("subscription-id");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -107,6 +107,7 @@ public class V4ApiServiceCockpitTest {
     NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
     ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
     MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory();
     RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
@@ -166,7 +167,7 @@ public class V4ApiServiceCockpitTest {
                 new ApiCategoryQueryServiceInMemory(),
                 indexer
             ),
-            new ApiMetadataDomainService(metadataCrudService, auditService),
+            new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditService),
             apiPrimaryOwnerDomainService,
             flowCrudService,
             notificationConfigCrudService,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4894

## Description

PR with a new use case for deleting all the APIs previously ingested by this integration.

According the ACs the only APIs that are not deleted are these with PUBLISHED status 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcwhjdwodm.chromatic.com)
<!-- Storybook placeholder end -->
