### PR TITLE
fix: added missing ssl configuration missing from helm chart

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.24
+
+- Improve redis ratelimit configuration [issues/9726](https://github.com/gravitee-io/issues/issues/9726). Thanks [@gh0stsrc](https://github.com/gh0stsrc) 
+
 ### 4.0.17
 
 - BREAKING CHANGE: deprecated api|gateway|ui|portal.securityContext has been removed

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -207,7 +207,46 @@ data:
         {{- end }}
         {{- if .Values.gateway.ratelimit.redis.ssl }}
         ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
+        hostnameVerificationAlgorithm: {{ .Values.gateway.ratelimit.redis.hostnameVerificationAlgorithm | default "NONE" }}
+        trustAll: {{.Values.gateway.ratelimit.redis.trustAll | default true }}
+        tlsProtocols: {{ .Values.gateway.ratelimit.redis.tlsProtocols | default "TLSv1.2" }}
+        {{- if .Values.gateway.ratelimit.redis.tlsCiphers }}
+        tlsCiphers: {{ .Values.gateway.ratelimit.redis.tlsCiphers | quote }}
         {{- end }}
+        alpn: {{ .Values.gateway.ratelimit.redis.alpn | default false }}
+        openssl: {{ .Values.gateway.ratelimit.redis.openssl | default false }}
+        {{/* end of ssl block */}}
+        {{- end }}
+        {{- if .Values.gateway.ratelimit.redis.keystore }}
+        keystore:
+          type: {{ .Values.gateway.ratelimit.redis.keystore.type | default "pem" }}
+          path: {{ .Values.gateway.ratelimit.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
+          password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.keystore.password }}
+          {{- if .Values.gateway.ratelimit.redis.keystore.keyPassword }}
+          keyPassword: {{ .Values.gateway.ratelimit.redis.keystore.keyPassword | quote }}
+          {{- end }}
+          {{- if .Values.gateway.ratelimit.redis.keystore.alias }}
+          alias: {{ .Values.gateway.ratelimit.redis.keystore.alias }}
+          {{- end }}
+          {{/* guard clause for pem mTLS requirements */}}
+          {{- if and ( eq .Values.gateway.ratelimit.redis.keystore.type "pem" ) ( empty .Values.gateway.ratelimit.redis.keystore.certificates ) }}
+            {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
+          {{- end }}
+          certificates:
+            {{- range .Values.gateway.ratelimit.redis.keystore.certificates }}
+            - cert: {{ .cert }}
+              key: {{ .key }}
+            {{- end }}
+        {{- end}}
+        {{- if .Values.gateway.ratelimit.redis.truststore }}
+        truststore:
+          type: {{ .Values.gateway.ratelimit.redis.truststore.type | default "pem" }}
+          path: {{ .Values.gateway.ratelimit.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
+          password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.truststore.password }}
+          {{- if .Values.gateway.ratelimit.redis.truststore.alias }}
+          alias: {{ .Values.gateway.ratelimit.redis.truststore.alias }}
+          {{- end }}
+        {{- end }}        
         {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
         sentinel:
           master: {{ .Values.gateway.ratelimit.redis.sentinel.master }}

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -68,3 +68,70 @@ tests:
                      *      port: 26379\n
                      *    - host: sent2\n
                      *      port: 26379\n"
+  - it: Set full SSL configuration
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: redis
+      gateway:
+        ratelimit:
+          redis:
+            host: redis
+            port: 6379
+            password: mypassword
+            ssl: true
+            hostnameVerificationAlgorithm: NONE
+            trustAll: "false"
+            tlsProtocols: TLSv1.2, TLSv1.3
+            tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+            alpn: true
+            openssl: true
+            keystore:
+              type: jks
+              path: ${gravitee.home}/security/redis-keystore.jks
+              password: secret
+              keyPassword: secretKey
+              alias: myAlias
+              certificates:
+                - cert: ${gravitee.home}/security/redis-mycompany.org.pem
+                  key: ${gravitee.home}/security/redis-mycompany.org.key
+                - cert: ${gravitee.home}/security/redis-mycompany.com.pem
+                  key: ${gravitee.home}/security/redis-mycompany.com.key
+            truststore:
+              type: jks
+              path: ${gravitee.home}/security/redis-truststore.jks
+              password: secret
+              alias: anotheralias
+
+    asserts:
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: " * redis:\n
+                     *   host: redis\n
+                     *   port: 6379\n
+                     *   password: mypassword\n
+                     *   ssl: true\n
+                     *   hostnameVerificationAlgorithm: NONE\n
+                     *   trustAll: false\n
+                     *   tlsProtocols: TLSv1.2, TLSv1.3\n
+                     *   tlsCiphers: \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384\"\n
+                     *   alpn: true\n
+                     *   openssl: true\n
+                     *   \n
+                     *   keystore:\n
+                     *     type: jks\n
+                     *     path: \\${gravitee.home}/security/redis-keystore.jks\n
+                     *     password: secret\n
+                     *     keyPassword: \"secretKey\"\n
+                     *     alias: myAlias\n
+                     *   \n
+                     *     certificates:\n
+                     *       - cert: \\${gravitee.home}/security/redis-mycompany.org.pem\n
+                     *         key: \\${gravitee.home}/security/redis-mycompany.org.key\n
+                     *     - cert: \\${gravitee.home}/security/redis-mycompany.com.pem\n
+                     *       key: \\${gravitee.home}/security/redis-mycompany.com.key\n
+                     *   truststore:\n
+                     *     type: jks\n
+                     *     path: \\${gravitee.home}/security/redis-truststore.jks\n
+                     *     password: secret\n
+                     *     alias: anotheralias\n"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -863,19 +863,42 @@ gateway:
   # tenant:
   websocket: false
   ratelimit:
-    redis:
-#      host: redis
-#      port: 6379
-#      password:
-#      ssl: false
-#      sentinel:
-#        master: redis-master
-#        nodes:
-#          - host: sentinel1
-#            port: 26379
-#          - host: sentinel2
-#            port: 26379
-  management: 
+    # redis:
+    #   host: redis
+    #   port: 6379
+    #   password:
+    #   ssl: false
+    #   hostnameVerificationAlgorithm: NONE
+    #   trustAll: true # default value is true to keep backward compatibility but you should set it to false and configure a truststore for security concerns
+    #   tlsProtocols: # List of TLS protocols to allow comma separated i.e: TLSv1.2, TLSv1.3
+    #   tlsCiphers: # List of TLS ciphers to allow comma separated i.e: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+    #   alpn: false
+    #   openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
+    #   # Keystore for redis mTLS (client certificate)
+    #   keystore:
+    #     type: pem # Supports jks, pem, pkcs12
+    #     path: ${gravitee.home}/security/redis-keystore.jks # A path is required if certificate's type is jks or pkcs12
+    #     password: secret
+    #     keyPassword:
+    #     alias:
+    #     certificates: # Certificates are required if keystore's type is pem
+    #       - cert: ${gravitee.home}/security/redis-mycompany.org.pem
+    #         key: ${gravitee.home}/security/redis-mycompany.org.key
+    #       - cert: ${gravitee.home}/security/redis-mycompany.com.pem
+    #         key: ${gravitee.home}/security/redis-mycompany.com.key
+    #   truststore:
+    #     type: pem # Supports jks, pem, pkcs12
+    #     path: ${gravitee.home}/security/redis-truststore.jks
+    #     password: secret
+    #     alias:      
+    #   sentinel:
+    #     master: redis-master
+    #     nodes:
+    #       - host: sentinel1
+    #         port: 26379
+    #       - host: sentinel2
+    #         port: 26379
+  management:
     http:
       # url: 
       # keepAlive: true


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4891
https://github.com/gravitee-io/issues/issues/9726

## Description

The helm chart currently does not support propagating required SSL configurations for Redis to the gateway configmap and ultimately underlying deployed pods. This causes pods to enter a crash loop, as Gravitee is unable to locate required SSL configurations for Redis in the `gravitee.yml` config file and establishes invalid connections with the Redis Instance/Cluster.

## Evidence
### log
![k9s](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/6ea116a2-c69c-47e1-9814-7cef6867fcc6)
### gravitee.yml
![image (2)](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/e161f725-f10e-46b1-a58a-4002bab8e051)
### gateway-configmap.yaml
![image (1)](https://github.com/gravitee-io/gravitee-api-management/assets/10835086/7405193b-4329-4a5a-abfa-d84ed4822f56)

## Additional context
This fix was tested and [adrien.lacombe@graviteesource.com](mailto:adrien.lacombe@graviteesource.com) was informed of the tested fix in a Graviteeio client environment.

## Steps to Reproduce
Simply enable SSL in the helm chart and point to the correct port, Gravitee pods will immediately enter a crashloop once the configmap is reloaded.


