### PR TITLE
fix: hide custom API Key option when validating Federated subscription

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
@@ -43,7 +43,7 @@
           <mat-label>Message (optional)</mat-label>
         </mat-form-field>
       </div>
-      <div class="validate-subscription__content__row" *ngIf="data.canUseCustomApiKey && !data.sharedApiKeyMode">
+      <div class="validate-subscription__content__row" *ngIf="!data.isFederated && data.canUseCustomApiKey && !data.sharedApiKeyMode">
         <div class="mat-body-2">This plan allows custom API Keys. You can provide it here.</div>
         <api-key-validation formControlName="apiKey" [applicationId]="data.applicationId" [apiId]="data.apiId"></api-key-validation>
       </div>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
@@ -619,7 +619,7 @@ describe('ApiSubscriptionEditComponent', () => {
     });
 
     it('should validate a federated Subscription', async () => {
-      await initComponent({ subscription: pendingSubscription, api: fakeApiFederated({ id: API_ID }) });
+      await initComponent({ subscription: pendingSubscription, api: fakeApiFederated({ id: API_ID }), canUseCustomApiKey: true });
       expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiSubscriptionEditHarness);
@@ -628,10 +628,12 @@ describe('ApiSubscriptionEditComponent', () => {
       await harness.openValidateDialog();
 
       const validateDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
-        MatDialogHarness.with({ selector: '#validateSubscriptionDialog' }),
+        ApiPortalSubscriptionValidateDialogHarness,
       );
       const datePicker = await validateDialog.getHarnessOrNull(MatInputHarness.with({ selector: '[formControlName="dateTimeRange"]' }));
       expect(datePicker).toBeNull(); // no validation period for federated subscription
+
+      expect(await validateDialog.isCustomApiKeyInputDisplayed()).toBeFalsy(); // no custom API Key for federated subscription
 
       const validateBtn = await validateDialog.getHarness(MatButtonHarness.with({ text: 'Validate' }));
       await validateBtn.click();


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-4376

## Description

Hide custom API Key option when validating Federated subscription

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqlnojklxi.chromatic.com)
<!-- Storybook placeholder end -->
