### PR TITLE
Lucene index: compute the max clause count limit only if necessary

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -46,8 +46,8 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
     protected static final String FIELD_API_TYPE_VALUE = "api";
 
     protected static void increaseMaxClauseCountIfNecessary(int size) {
-        if (size > BooleanQuery.getMaxClauseCount()) {
-            BooleanQuery.setMaxClauseCount(size);
+        if (size > IndexSearcher.getMaxClauseCount()) {
+            IndexSearcher.setMaxClauseCount(size);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -44,6 +44,7 @@ import org.apache.lucene.queryparser.classic.QueryParserBase;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PhraseQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -136,10 +137,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         io.gravitee.rest.api.service.search.query.Query<?> query
     ) {
         if (!isBlank(query.getQuery()) && query.getIds() != null && !query.getIds().isEmpty()) {
-            increaseMaxClauseCountIfNecessary(query.getIds().size());
-
             BooleanQuery.Builder mainQuery = new BooleanQuery.Builder();
-
             query
                 .getIds()
                 .forEach(id -> {
@@ -197,22 +195,45 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
     @Override
     public SearchResult search(ExecutionContext executionContext, io.gravitee.rest.api.service.search.query.Query<?> query)
         throws TechnicalException {
+        BooleanQuery.Builder apiQuery = new BooleanQuery.Builder();
+
         try {
             final Optional<Query> baseFilterQuery = this.buildFilterQuery(FIELD_ID, query.getFilters());
-
-            BooleanQuery.Builder apiQuery = new BooleanQuery.Builder();
             this.buildExcludedFilters(query.getExcludedFilters()).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.MUST_NOT));
             this.buildExplicitQuery(executionContext, query, baseFilterQuery).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.MUST));
             this.buildExactMatchQuery(executionContext, query, baseFilterQuery)
                 .ifPresent(q -> apiQuery.add(new BoostQuery(q, 4.0f), BooleanClause.Occur.SHOULD));
             this.buildWildcardQuery(executionContext, query, baseFilterQuery).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
             this.buildIdsQuery(executionContext, query).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
-
-            return this.search(apiQuery.build(), query.getSort());
         } catch (ParseException pe) {
             logger.error("Invalid query to search for API documents", pe);
             throw new TechnicalException("Invalid query to search for API documents", pe);
         }
+
+        BooleanQuery finalQuery = apiQuery.build();
+
+        try {
+            return this.search(finalQuery, query.getSort());
+        } catch (IndexSearcher.TooManyClauses tooManyClauses) {
+            int maxClauseCount = getClauseCount(finalQuery);
+            increaseMaxClauseCountIfNecessary(maxClauseCount);
+            return this.search(finalQuery, query.getSort());
+        }
+    }
+
+    private int getClauseCount(Query query) {
+        int result = 0;
+        if (query instanceof BooleanQuery) {
+            List<BooleanClause> clauses = ((BooleanQuery) query).clauses();
+            result = clauses.size();
+            for (BooleanClause clause : clauses) {
+                result += getClauseCount(clause.getQuery());
+            }
+        } else if (query instanceof BoostQuery) {
+            result += getClauseCount(((BoostQuery) query).getQuery());
+        }
+
+        return result;
     }
 
     private Optional<BooleanQuery> buildExcludedFilters(Map<String, Collection<String>> excludedFilters) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4901
https://github.com/gravitee-io/issues/issues/9730

## Description

Compute the max clause count limit only if necessary