### PR TITLE
APIM-4808: Nginx 404 page shown when refreshing page /next/

### DIFF
--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -27,6 +27,7 @@ server {
 
     location /next/ {
         alias /usr/share/nginx/html/next/browser/;
+        try_files $uri $uri/ /next/index.html;
         sub_filter '<base href="/"' '<base href="${PORTAL_BASE_HREF}next/"';
         sub_filter_once on;
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4808

## Description

With this fix this URL
https://apim-master-portal.team-apim.gravitee.dev/next/catalog
Will not be showing 404 error

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7442/console](https://pr.team-apim.gravitee.dev/7442/console)
      Portal: [https://pr.team-apim.gravitee.dev/7442/portal](https://pr.team-apim.gravitee.dev/7442/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7442/api/management](https://pr.team-apim.gravitee.dev/7442/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7442](https://pr.team-apim.gravitee.dev/7442)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7442](https://pr.gateway-v3.team-apim.gravitee.dev/7442)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aovouaoxvd.chromatic.com)
<!-- Storybook placeholder end -->
