### PR TITLE
fix: hide shared/custom API Key option when subscribing to Federated API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -35,6 +35,7 @@ import { ApplicationSubscription } from '../../../../../../entities/subscription
 export type ApiPortalSubscriptionCreationDialogData = {
   availableSubscriptionEntrypoints?: Entrypoint[];
   plans: Plan[];
+  isFederatedApi?: boolean;
 };
 
 export type ApiPortalSubscriptionCreationDialogResult = {
@@ -76,8 +77,8 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   ) {
     this.plans = dialogData.plans.filter((plan) => plan.security?.type !== 'KEY_LESS');
     this.availableSubscriptionEntrypoints = dialogData.availableSubscriptionEntrypoints.map((entrypoint) => ({ type: entrypoint.type }));
-    this.canUseCustomApiKey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
-    this.canUseSharedApiKeys = this.constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
+    this.canUseCustomApiKey = !dialogData.isFederatedApi && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
+    this.canUseSharedApiKeys = !dialogData.isFederatedApi && this.constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -269,6 +269,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
         role: 'alertdialog',
         id: 'createSubscriptionDialog',
         data: {
+          isFederatedApi: this.api.definitionVersion === 'FEDERATED',
           availableSubscriptionEntrypoints: this.getApiSubscriptionEntrypoints(this.api),
           plans: this.plans.filter((plan) => plan.status),
         },

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
@@ -55,6 +55,7 @@ type SubscriptionCreationForm = FormGroup<{
 export class ApplicationSubscriptionCreationDialogComponent {
   private destroyRef = inject(DestroyRef);
   private canUseSharedApiKeys = this.environmentSettingsService.getSnapshot().plan?.security?.sharedApiKey?.enabled;
+  private isFederatedApi = false;
   private apiKeySubscriptions: ApplicationSubscription[];
   private entrypointsMap = new Map<string, { icon: string; name: string }>();
   protected availableSubscriptionEntrypoints: { type: string; name?: string; icon?: string }[] = [];
@@ -141,6 +142,7 @@ export class ApplicationSubscriptionCreationDialogComponent {
       share(),
       takeUntilDestroyed(this.destroyRef),
     );
+    this.isFederatedApi = selectedApi.definitionVersion === 'FEDERATED';
     if (selectedApi.definitionVersion === 'V4') {
       this.availableSubscriptionEntrypoints = selectedApi.listeners
         .filter((listener) => listener.type === 'SUBSCRIPTION')
@@ -195,7 +197,8 @@ export class ApplicationSubscriptionCreationDialogComponent {
         filter((plan) => plan?.security?.type === 'API_KEY'),
         switchMap((plan) =>
           of(
-            this.canUseSharedApiKeys &&
+            !this.isFederatedApi &&
+              this.canUseSharedApiKeys &&
               this.application.api_key_mode === ApiKeyMode.UNSPECIFIED &&
               this.apiKeySubscriptions.some((subscription) => subscription?.api !== plan.apiId),
           ),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4376

## Description

Hide options in the console as I forgot that in previous PR:
https://github.com/gravitee-io/gravitee-api-management/pull/7445
https://github.com/gravitee-io/gravitee-api-management/pull/7436

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qeczytinzv.chromatic.com)
<!-- Storybook placeholder end -->
