### PR TITLE
chore: bump kafka and hivemq versions used in integration tests with …

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractKafkaEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractKafkaEndpointIntegrationTest.java
@@ -74,7 +74,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractKafkaEndpointIntegrationTest extends AbstractGatewayTest {
 
     @Container
-    protected static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"));
+    protected static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1"));
 
     protected Vertx vertx = Vertx.vertx();
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractMqtt5EndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/AbstractMqtt5EndpointIntegrationTest.java
@@ -126,7 +126,7 @@ public abstract class AbstractMqtt5EndpointIntegrationTest extends AbstractGatew
     }
 
     @Container
-    protected static final HiveMQContainer mqtt5 = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2023.3"))
+    protected static final HiveMQContainer mqtt5 = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.4"))
         .withTmpFs(null);
 
     @Override


### PR DESCRIPTION
…TestContainer

## Description

When running integration tests on an arm64 system, tests that are using Kafka or HiveMq could be very slow as the current version used with TestContainer do not have an arm64 image. This PR aims to bump these versions to fix that issue.

