### PR TITLE
feat(rest-api-portal): allow q to be null or empty for apis _search

### DIFF
--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/api.service.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/api.service.ts
@@ -193,12 +193,12 @@ export interface ListCategoriesRequestParams {
 }
 
 export interface SearchApisRequestParams {
-    /** query string to be used in the search engine */
-    q: string;
     /** The page number for pagination. */
     page?: number;
     /** The number of items per page for pagination. If the size is 0, the response contains only metadata and returns the values as for a non-paged resource. If the size is -1, the response contains all datas.  */
     size?: number;
+    /** query string to be used in the search engine */
+    q?: string;
 }
 
 export interface UpdateApiRatingRequestParams {
@@ -1518,12 +1518,9 @@ export class ApiService {
     public searchApis(requestParameters: SearchApisRequestParams, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpResponse<ApisResponse>>;
     public searchApis(requestParameters: SearchApisRequestParams, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpEvent<ApisResponse>>;
     public searchApis(requestParameters: SearchApisRequestParams, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json'}): Observable<any> {
-        const q = requestParameters.q;
-        if (q === null || q === undefined) {
-            throw new Error('Required parameter q was null or undefined when calling searchApis.');
-        }
         const page = requestParameters.page;
         const size = requestParameters.size;
+        const q = requestParameters.q;
 
         let queryParameters = new HttpParams({encoder: this.encoder});
         if (page !== undefined && page !== null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -120,10 +120,7 @@ public class ApisResource extends AbstractResource<Api, String> {
     @Path("_search")
     @Produces(MediaType.APPLICATION_JSON)
     @RequirePortalAuth
-    public Response searchApis(
-        @NotNull(message = "Input must not be null.") @QueryParam("q") String query,
-        @BeanParam PaginationParam paginationParam
-    ) {
+    public Response searchApis(@QueryParam("q") String query, @BeanParam PaginationParam paginationParam) {
         try {
             final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
             Collection<String> apisList = filteringService.searchApis(executionContext, getAuthenticatedUserOrNull(), query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3166,7 +3166,6 @@ components:
     apiQueryParam:
       name: q
       in: query
-      required: true
       description: query string to be used in the search engine
       schema:
         type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -327,6 +327,30 @@ public class ApisResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    public void shouldSearchApisWithEmptyQ() throws TechnicalException {
+        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = target("/_search").queryParam("q", "").request().post(Entity.json(null));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+        assertEquals(1, apiResponse.getData().size());
+        assertTrue(getmaxLabelsListSize(apiResponse) > 0);
+    }
+
+    @Test
+    public void shouldSearchApisWithNoQParameter() throws TechnicalException {
+        doReturn(new HashSet<>(List.of("3"))).when(filteringService).searchApis(eq(GraviteeContext.getExecutionContext()), any(), any());
+
+        final Response response = target("/_search").request().post(Entity.json(null));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+        assertEquals(1, apiResponse.getData().size());
+        assertTrue(getmaxLabelsListSize(apiResponse) > 0);
+    }
+
+    @Test
     public void shouldSearchApisWithoutLabel() throws TechnicalException {
         when(
             parameterService.findAsBoolean(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/Query.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/Query.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.model.search.Indexable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -30,6 +31,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@EqualsAndHashCode
 public class Query<T extends Indexable> {
 
     private String query;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -419,11 +419,13 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     ) {
         QueryBuilder<GenericApiEntity> searchEngineQueryBuilder = QueryBuilder
             .create(GenericApiEntity.class)
-            .setQuery(query)
             .setSort(sortable)
             .setFilters(filters);
         if (excludeV4Definition) {
             searchEngineQueryBuilder.setExcludedFilters(Map.of(FIELD_DEFINITION_VERSION, List.of(DefinitionVersion.V4.getLabel())));
+        }
+        if (!isBlank(query)) {
+            searchEngineQueryBuilder.setQuery(query);
         }
         SearchResult searchResult = searchEngineService.search(executionContext, searchEngineQueryBuilder.build());
         return searchResult.getDocuments();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.converter.ApiConverter;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.FlowService;
+import io.gravitee.rest.api.service.v4.PlanService;
+import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
+import io.gravitee.rest.api.service.v4.mapper.CategoryMapper;
+import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiSearchService_SearchIdsTest {
+
+    private final String USER_ID = "user-1";
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PrimaryOwnerService primaryOwnerService;
+
+    // ApiMapper injections
+    @Mock
+    private PlanService planService;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private ApiAuthorizationService apiAuthorizationService;
+
+    private ApiSearchService apiSearchService;
+
+    @AfterClass
+    public static void cleanSecurityContextHolder() {
+        // reset authentication to avoid side effect during test executions.
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
+        );
+    }
+
+    @Before
+    public void setUp() {
+        ApiMapper apiMapper = new ApiMapper(
+            new ObjectMapper(),
+            planService,
+            flowService,
+            parameterService,
+            workflowService,
+            new CategoryMapper(categoryService)
+        );
+        apiSearchService =
+            new ApiSearchServiceImpl(
+                apiRepository,
+                apiMapper,
+                new GenericApiMapper(apiMapper, new ApiConverter()),
+                primaryOwnerService,
+                categoryService,
+                searchEngineService,
+                apiAuthorizationService
+            );
+    }
+
+    @Test
+    public void should_return_empty_page_if_no_results() {
+        QueryBuilder<GenericApiEntity> apiEntityQueryBuilder = QueryBuilder.create(GenericApiEntity.class).setQuery("*").setSort(null);
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+        apiEntityQueryBuilder.setFilters(filters);
+
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build())))
+            .thenReturn(new SearchResult(List.of()));
+
+        final var apis = apiSearchService.searchIds(GraviteeContext.getExecutionContext(), "*", filters, null, false);
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void should_return_api_ids() {
+        QueryBuilder<GenericApiEntity> apiEntityQueryBuilder = QueryBuilder.create(GenericApiEntity.class).setQuery("*").setSort(null);
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+        apiEntityQueryBuilder.setFilters(filters);
+
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build())))
+            .thenReturn(new SearchResult(List.of("api-id")));
+
+        final var apis = apiSearchService.searchIds(GraviteeContext.getExecutionContext(), "*", filters, null, false);
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.size()).isEqualTo(1);
+        assertThat(apis).isEqualTo(List.of("api-id"));
+    }
+
+    @Test
+    public void should_not_add_empty_query() {
+        QueryBuilder<GenericApiEntity> apiEntityQueryBuilder = QueryBuilder.create(GenericApiEntity.class).setSort(null);
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+        apiEntityQueryBuilder.setFilters(filters);
+
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build())))
+            .thenReturn(new SearchResult(List.of("api-id")));
+
+        final var apis = apiSearchService.searchIds(GraviteeContext.getExecutionContext(), "", filters, null, false);
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.size()).isEqualTo(1);
+        assertThat(apis).isEqualTo(List.of("api-id"));
+    }
+
+    @Test
+    public void should_allow_null_query() {
+        QueryBuilder<GenericApiEntity> apiEntityQueryBuilder = QueryBuilder.create(GenericApiEntity.class).setQuery(null).setSort(null);
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+        apiEntityQueryBuilder.setFilters(filters);
+
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build())))
+            .thenReturn(new SearchResult(List.of("api-id")));
+
+        final var apis = apiSearchService.searchIds(GraviteeContext.getExecutionContext(), null, filters, null, false);
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.size()).isEqualTo(1);
+        assertThat(apis).isEqualTo(List.of("api-id"));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3924

## Description

Allow the 'q' parameter to be null or empty for the `/apis/_search` endpoint in the portal rest-api. This is necessary so that `portal-next` can use the same endpoint to list apis + search + filter

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ltsymjeyxk.chromatic.com)
<!-- Storybook placeholder end -->
