### PR TITLE
fix(portal-next): extend nav-bar blur across screen

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.scss
@@ -15,7 +15,6 @@
  */
 :host {
   display: flex;
-  max-width: 1040px;
   min-height: 95vh;
   flex-flow: column;
   margin: auto;
@@ -23,5 +22,7 @@
 }
 
 .content {
+  width: 1040px;
   flex: 1 1 100%;
+  margin: auto;
 }

--- a/gravitee-apim-portal-webui-next/src/components/footer/footer.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/footer/footer.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,7 +15,9 @@
  */
 :host {
   display: flex;
+  width: 1040px;
   flex-flow: row;
   align-items: center;
   justify-content: space-between;
+  margin: auto;
 }

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -15,15 +15,17 @@
     limitations under the License.
 
 -->
-<app-company-title></app-company-title>
-<div class="menu-items">
-  <app-nav-bar-button i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
-</div>
-<div class="actions">
-  @if (!isEmpty(currentUser())) {
-    <app-user-avatar [user]="currentUser()" />
-  } @else {
-    <app-nav-bar-button i18n="@@logIn" [path]="['log-in']">Log in</app-nav-bar-button>
-    <button i18n="@@signUp" mat-flat-button color="primary">Sign up</button>
-  }
+<div class="nav-bar__container">
+  <app-company-title></app-company-title>
+  <div class="menu-items">
+    <app-nav-bar-button i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
+  </div>
+  <div class="actions">
+    @if (!isEmpty(currentUser())) {
+      <app-user-avatar [user]="currentUser()" />
+    } @else {
+      <app-nav-bar-button i18n="@@logIn" [path]="['log-in']">Log in</app-nav-bar-button>
+      <button i18n="@@signUp" mat-flat-button color="primary">Sign up</button>
+    }
+  </div>
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.scss
@@ -19,12 +19,17 @@
   position: sticky;
   z-index: 99;
   top: 0;
+  backdrop-filter: blur(10px);
+  background-color: color-mix(in srgb, theme.$background-color, transparent 20%);
+}
+
+.nav-bar__container {
   display: flex;
+  width: 1040px;
   flex-flow: row;
   align-items: center;
   padding: 18px 0;
-  backdrop-filter: blur(10px);
-  background-color: color-mix(in srgb, theme.$background-color, transparent 20%);
+  margin: auto;
   gap: 40px;
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Slight touch up to extend nav bar background across screen to avoid sharp edges.

Before:
![Screenshot 2024-05-14 at 17 30 50](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/8da4c8a3-b061-47bb-9424-8216969fd5b1)

After:
![Screenshot 2024-05-14 at 17 30 39](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/28b8501e-b86d-4837-8050-84dfd5a1ef12)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yebevnlklv.chromatic.com)
<!-- Storybook placeholder end -->
