### PR TITLE
Test/adjust cypress tests to new api creation screen run e2e

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-get-started/api-creation-get-started.component.html
@@ -32,7 +32,7 @@
 
         <div class="api-creation-get-started__row__card__action">
           <button mat-stroked-button [routerLink]="'./v4'" data-testid="api_create_v4_button">Create</button>
-          <button mat-stroked-button [routerLink]="'../import/v4'" data-testid="api_create_v4_button">Import</button>
+          <button mat-stroked-button [routerLink]="'../import/v4'" data-testid="api_import_v4_button">Import</button>
         </div>
       </div>
 

--- a/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
+++ b/gravitee-apim-e2e/docker/ui-tests/docker-compose-ui-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   cypress:
-    image: cypress/included:13.6.6
+    image: cypress/included:13.9.0
     working_dir: /test
     command: "--e2e --browser=chrome --spec 'ui-test/integration/apim/ui/**/*.ts' --config-file '/test/cypress-ui-config.ts' --record"
     volumes:

--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -40,7 +40,7 @@
         "@types/node": "16.10.9",
         "@types/node-fetch": "2.6.1",
         "ansi-regex": "6.0.1",
-        "cypress": "13.6.6",
+        "cypress": "13.9.0",
         "dotenv": "16.0.0",
         "har-validator": "5.1.5",
         "jest": "27.5.1",

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -41,7 +41,7 @@ describe('API List feature', { defaultCommandTimeout: 10000 }, () => {
     it("should load API creation page when 'Add API' button is clicked", function () {
       cy.getByDataTestId('api_list_addApi_button').click();
       cy.url().should('include', '/apis/new');
-      cy.get('h1').contains('Get started building your API').should('be.visible');
+      cy.get('h1').contains('Choose API creation method').should('be.visible');
     });
 
     it('should have correct table header', function () {

--- a/gravitee-apim-e2e/yarn.lock
+++ b/gravitee-apim-e2e/yarn.lock
@@ -1911,9 +1911,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:13.6.6":
-  version: 13.6.6
-  resolution: "cypress@npm:13.6.6"
+"cypress@npm:13.9.0":
+  version: 13.9.0
+  resolution: "cypress@npm:13.9.0"
   dependencies:
     "@cypress/request": "npm:^3.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
@@ -1959,7 +1959,7 @@ __metadata:
     yauzl: "npm:^2.10.0"
   bin:
     cypress: bin/cypress
-  checksum: 10c0/1f152ac3708fc35c822b6fe428c0856b568c9b2d3f03a22de0526b9f21d6c345139061ae3515a652538a9570a2a632516e4548b29b39843865b9c88288b2d668
+  checksum: 10c0/1254609d8186c438f59c3f5bbef77fd22309260c1204228c39d07a9c9a555a823f24a69cbe9169d1e79af0d93f9cc9fee5e74b85cd0aa265e0add471cba86f32
   languageName: node
   linkType: hard
 
@@ -2861,7 +2861,7 @@ __metadata:
     "@types/node": "npm:16.10.9"
     "@types/node-fetch": "npm:2.6.1"
     ansi-regex: "npm:6.0.1"
-    cypress: "npm:13.6.6"
+    cypress: "npm:13.9.0"
     dotenv: "npm:16.0.0"
     har-validator: "npm:5.1.5"
     jest: "npm:27.5.1"


### PR DESCRIPTION
## Description

The UI has changed on a screen where the user creates a new API. Two Cypress tests had to be adjusted to reflect these changes in the UI tests.

Also, the Cypress version is updated from 13.6.6 to 13.9.0.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hbgclnmbuo.chromatic.com)
<!-- Storybook placeholder end -->
