### PR TITLE
fix(console): Display API Events in Home Overview only when user is permitted

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -74,7 +74,7 @@
     </mat-card>
   </div>
 </div>
-<div class="home-api-events">
+<div class="home-api-events" *gioPermission="{ anyOf: ['environment-platform-r'] }">
   <h2>API Events</h2>
   <ng-container *ngIf="timeRangeParams; else loader">
     <gio-api-events-table [timeRangeParams]="timeRangeParams"></gio-api-events-table>

--- a/gravitee-apim-console-webui/src/management/home/home.module.ts
+++ b/gravitee-apim-console-webui/src/management/home/home.module.ts
@@ -42,6 +42,7 @@ import { GioApiEventsTableModule } from './components/gio-api-events-table/gio-a
 import { GioCircularPercentageModule } from '../../shared/components/gio-circular-percentage/gio-circular-percentage.module';
 import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { TasksComponent } from '../tasks/tasks.component';
+import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 
 export const states: Ng2StateDeclaration[] = [
   {
@@ -128,6 +129,7 @@ export const states: Ng2StateDeclaration[] = [
     GioApiStateModule,
     GioApiLifecycleStateModule,
     GioApiEventsTableModule,
+    GioPermissionModule,
   ],
   declarations: [HomeLayoutComponent, HomeOverviewComponent, HomeApiHealthCheckComponent],
 })


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4943

## Description

Added checking permission before displaying API Events

## Additional context

N/A

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nwaqciqkyo.chromatic.com)
<!-- Storybook placeholder end -->
