### PR TITLE
Apim 3945 add `/themes` entrypoint to mapi-v2

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ThemeCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ThemeCriteria.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api.search;
+
+import io.gravitee.repository.management.model.ThemeType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ThemeCriteria {
+
+    private Boolean enabled;
+    private ThemeType type;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoThemeRepository.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.repository.mongodb.management;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ThemeRepository;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.ThemeCriteria;
 import io.gravitee.repository.management.model.Theme;
 import io.gravitee.repository.management.model.ThemeType;
-import io.gravitee.repository.mongodb.management.internal.ThemeMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
+import io.gravitee.repository.mongodb.management.internal.theme.ThemeMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
@@ -126,5 +129,12 @@ public class MongoThemeRepository implements ThemeRepository {
         throws TechnicalException {
         final Set<ThemeMongo> themes = internalThemeRepo.findByReferenceIdAndReferenceTypeAndType(referenceId, referenceType, type);
         return themes.stream().map(themeMongo -> mapper.map(themeMongo)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Page<Theme> search(ThemeCriteria criteria, Pageable pageable) {
+        final Page<ThemeMongo> page = internalThemeRepo.search(criteria, pageable);
+        final List<Theme> content = page.getContent().stream().map(themeMongo -> mapper.map(themeMongo)).toList();
+        return new Page<>(content, page.getPageNumber(), (int) page.getPageElements(), page.getTotalElements());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepository.java
@@ -13,21 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.api;
+package io.gravitee.repository.mongodb.management.internal.theme;
 
-import io.gravitee.common.data.domain.Page;
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.api.search.ThemeCriteria;
-import io.gravitee.repository.management.model.Theme;
 import io.gravitee.repository.management.model.ThemeType;
+import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
 import java.util.Set;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ThemeRepository extends CrudRepository<Theme, String> {
-    Set<Theme> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type) throws TechnicalException;
-    Page<Theme> search(ThemeCriteria criteria, Pageable pageable) throws TechnicalException;
+@Repository
+public interface ThemeMongoRepository extends MongoRepository<ThemeMongo, String>, ThemeMongoRepositoryCustom {
+    Set<ThemeMongo> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryCustom.java
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.api;
+package io.gravitee.repository.mongodb.management.internal.theme;
 
 import io.gravitee.common.data.domain.Page;
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.ThemeCriteria;
-import io.gravitee.repository.management.model.Theme;
-import io.gravitee.repository.management.model.ThemeType;
-import java.util.Set;
+import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
 
-/**
- * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
- * @author GraviteeSource Team
- */
-public interface ThemeRepository extends CrudRepository<Theme, String> {
-    Set<Theme> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type) throws TechnicalException;
-    Page<Theme> search(ThemeCriteria criteria, Pageable pageable) throws TechnicalException;
+public interface ThemeMongoRepositoryCustom {
+    Page<ThemeMongo> search(ThemeCriteria criteria, Pageable pageable);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.theme;
+
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.search.*;
+import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
+import java.util.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+/**
+ * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ThemeMongoRepositoryImpl implements ThemeMongoRepositoryCustom {
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<ThemeMongo> search(ThemeCriteria criteria, Pageable pageable) {
+        var query = buildQuery(criteria, pageable);
+
+        long total = mongoTemplate.count(query, ThemeMongo.class);
+
+        List<ThemeMongo> apis = mongoTemplate.find(query, ThemeMongo.class);
+
+        return new Page<>(apis, pageable != null ? pageable.pageNumber() : 0, pageable != null ? pageable.pageSize() : 0, total);
+    }
+
+    private Query buildQuery(ThemeCriteria themeCriteria, Pageable pageable) {
+        Query query = new Query();
+
+        if (Objects.nonNull(themeCriteria.getEnabled())) {
+            query.addCriteria(where("enabled").is(themeCriteria.getEnabled()));
+        }
+
+        if (Objects.nonNull(themeCriteria.getType())) {
+            query.addCriteria(where("type").is(themeCriteria.getType().name()));
+        }
+
+        Sort sort = Sort.by(ASC, "name");
+
+        if (pageable != null) {
+            query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));
+        } else {
+            query.with(sort);
+        }
+        return query;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/themes/EnabledIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/themes/EnabledIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.themes;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("EnabledIndexUpgrader")
+public class EnabledIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("themes")
+            .name("e1")
+            .key("enabled", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/themes/TypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/themes/TypeIndexUpgrader.java
@@ -13,19 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.internal;
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.themes;
 
-import io.gravitee.repository.management.model.ThemeType;
-import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
-import java.util.Set;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
 
 /**
- * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Repository
-public interface ThemeMongoRepository extends MongoRepository<ThemeMongo, String> {
-    Set<ThemeMongo> findByReferenceIdAndReferenceTypeAndType(String referenceId, String referenceType, ThemeType type);
+@Component("TypeIndexUpgrader")
+public class TypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("themes")
+            .name("t1")
+            .key("type", ascending())
+            .build();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ThemeRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ThemeRepositoryTest.java
@@ -18,6 +18,8 @@ package io.gravitee.repository.management;
 import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static org.junit.Assert.*;
 
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.search.ThemeCriteria;
 import io.gravitee.repository.management.model.Theme;
 import io.gravitee.repository.management.model.ThemeType;
 import java.util.*;
@@ -35,7 +37,7 @@ public class ThemeRepositoryTest extends AbstractManagementRepositoryTest {
         final Set<Theme> themes = themeRepository.findAll();
 
         assertNotNull(themes);
-        assertEquals(3, themes.size());
+        assertEquals(4, themes.size());
         final Theme themeSimple = themes.stream().filter(theme -> "simple".equals(theme.getId())).findAny().get();
         assertEquals("Theme simple", themeSimple.getName());
         assertEquals("PORTAL", themeSimple.getType().name());
@@ -60,6 +62,28 @@ public class ThemeRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals("Theme dark", darkTheme.getName());
         final Theme lightTheme = themes.stream().filter(theme -> "light".equals(theme.getId())).findAny().get();
         assertEquals("Light", lightTheme.getName());
+    }
+
+    @Test
+    public void shouldSearchByType() throws TechnicalException {
+        var results = themeRepository.search(ThemeCriteria.builder().type(ThemeType.PORTAL).build(), null);
+        assertNotNull(results);
+        assertEquals(3, results.getContent().size());
+    }
+
+    @Test
+    public void shouldSearchByTypeAndEnabled() throws TechnicalException {
+        var results = themeRepository.search(ThemeCriteria.builder().type(ThemeType.PORTAL).enabled(true).build(), null);
+        assertNotNull(results);
+        assertEquals(1, results.getContent().size());
+        assertEquals("dark", results.getContent().get(0).getId());
+    }
+
+    @Test
+    public void shouldSearchAndReturnAll() throws TechnicalException {
+        var results = themeRepository.search(ThemeCriteria.builder().build(), null);
+        assertNotNull(results);
+        assertEquals(4, results.getContent().size());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/theme-tests/themes.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/theme-tests/themes.json
@@ -41,5 +41,20 @@
       "backgroundImage": "backgroundImage",
       "optionalLogo": "optionalLogo",
       "favicon": "favicon"
+   },
+   {
+      "id":"next",
+      "referenceType": "ENVIRONMENT",
+      "referenceId": "TEST",
+      "name":"Portal next theme",
+      "type": "PORTAL_NEXT",
+      "enabled": true,
+      "definition": "{\"def\": \"value\"}",
+      "createdAt": 1000002222222,
+      "updatedAt": 1111111111111,
+      "logo": "logo",
+      "backgroundImage": "backgroundImage",
+      "optionalLogo": "optionalLogo",
+      "favicon": "favicon"
    }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.rest.api.management.v2.rest.model.ThemePortal;
+import io.gravitee.rest.api.management.v2.rest.model.ThemePortalNext;
+import io.gravitee.rest.api.management.v2.rest.model.ThemeType;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = { DateMapper.class })
+public interface ThemeMapper {
+    ThemeMapper INSTANCE = Mappers.getMapper(ThemeMapper.class);
+
+    Theme.ThemeType map(ThemeType type);
+
+    @Mapping(source = "definitionPortal", target = "definition")
+    ThemePortal mapToThemePortal(Theme theme);
+
+    @Mapping(source = "definitionPortalNext", target = "definition")
+    ThemePortalNext mapToThemePortalNext(Theme theme);
+
+    default io.gravitee.rest.api.management.v2.rest.model.Theme map(Theme theme) {
+        if (Theme.ThemeType.PORTAL.equals(theme.getType())) {
+            return new io.gravitee.rest.api.management.v2.rest.model.Theme(this.mapToThemePortal(theme));
+        }
+        if (Theme.ThemeType.PORTAL_NEXT.equals(theme.getType())) {
+            return new io.gravitee.rest.api.management.v2.rest.model.Theme(this.mapToThemePortalNext(theme));
+        }
+        return null;
+    }
+
+    List<io.gravitee.rest.api.management.v2.rest.model.Theme> map(List<Theme> themes);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApiMembersResource;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApisResource;
 import io.gravitee.rest.api.management.v2.rest.resource.group.GroupsResource;
+import io.gravitee.rest.api.management.v2.rest.resource.ui.ThemesResource;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
@@ -54,6 +55,11 @@ public class EnvironmentResource extends AbstractResource {
     @Path("/groups")
     public GroupsResource getGroupsResource() {
         return resourceContext.getResource(GroupsResource.class);
+    }
+
+    @Path("/ui/themes")
+    public ThemesResource getThemesResource() {
+        return resourceContext.getResource(ThemesResource.class);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.ui;
+
+import io.gravitee.apim.core.theme.use_case.GetPortalThemesUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.ThemeMapper;
+import io.gravitee.rest.api.management.v2.rest.model.ThemeType;
+import io.gravitee.rest.api.management.v2.rest.model.ThemesResponse;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThemesResource extends AbstractResource {
+
+    @Inject
+    private GetPortalThemesUseCase getPortalThemesUseCase;
+
+    @GET
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = { RolePermissionAction.READ }) })
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getPortalThemes(
+        @BeanParam @Valid PaginationParam paginationParam,
+        @QueryParam("type") ThemeType type,
+        @QueryParam("enabled") Boolean enabled
+    ) {
+        var result = getPortalThemesUseCase
+            .execute(
+                GetPortalThemesUseCase.Input
+                    .builder()
+                    .type(ThemeMapper.INSTANCE.map(type))
+                    .enabled(enabled)
+                    .size(paginationParam.getPerPage())
+                    .page(paginationParam.getPage())
+                    .build()
+            )
+            .result();
+        return Response
+            .ok(
+                ThemesResponse
+                    .builder()
+                    .data(ThemeMapper.INSTANCE.map(result.getContent()))
+                    .pagination(
+                        PaginationInfo.computePaginationInfo(result.getTotalElements(), (int) result.getPageElements(), paginationParam)
+                    )
+                    .links(computePaginationLinks(result.getTotalElements(), paginationParam))
+                    .build()
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -75,6 +75,58 @@ paths:
                     description: The license does not contain OEM Customization
                 default:
                     $ref: "#/components/responses/Error"
+
+    /environments/{envId}/ui/themes:
+      servers:
+        - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+          description: APIM Management API v2 - Base URL to target specific organizations
+          variables:
+            protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                - https
+                - http
+            managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+            orgId:
+              description: The unique ID of your organization
+              default: DEFAULT
+        - url: "{protocol}://{managementAPIHost}/management/v2"
+          description: APIM Management API v2 - Default base URL
+          variables:
+            protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                - https
+                - http
+            managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+      parameters:
+        - $ref: "#/components/parameters/envIdParam"
+      get:
+        parameters:
+          - $ref: "#/components/parameters/pageParam"
+          - $ref: "#/components/parameters/perPageParam"
+          - $ref: "#/components/parameters/themeTypeParam"
+          - $ref: "#/components/parameters/enabledThemeParam"
+        tags:
+          - Management UI
+        summary: Get page of portal themes
+        description: |
+          Get a page of the portal themes used in the given environment.
+          
+          These themes can be used with either Portal or Portal-Next.
+          User must have the ENVIRONMENT_THEME[READ] permission.
+        operationId: getPortalThemes
+        responses:
+          "200":
+            $ref: "#/components/responses/ThemesResponse"
+          default:
+            $ref: "#/components/responses/Error"
 components:
     schemas:
         ConsoleCustomization:
@@ -162,7 +214,231 @@ components:
                                 example: updateApi.properties[0].key
                             invalidValue:
                                 description: The invalid value.
+        GenericTheme:
+          type: object
+          title: "GenericTheme"
+          properties:
+            id:
+              type: string
+              description: Theme ID
+              example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+            name:
+              type: string
+              description: Theme ID
+              example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+            type:
+              $ref: "#/components/schemas/ThemeType"
+            createdAt:
+              type: string
+              format: date-time
+              description: The date (as timestamp) when the Theme was created.
+              example: 1581256457163
+            updatedAt:
+              type: string
+              format: date-time
+              description: The last date (as timestamp) when the Theme was updated.
+              example: 1581256457163
+            enabled:
+              type: boolean
+              description: If the theme is active
+              example: true
+            logo:
+              type: string
+              description: Theme logo
+            optionalLogo:
+              type: string
+              description: Optional Theme logo
+            favicon:
+              type: string
+              description: Theme favicon
+          discriminator:
+            propertyName: type
+            mapping:
+              PORTAL: ThemePortal
+              PORTAL_NEXT: ThemePortalNext
+
+        Links:
+          description: List of links for pagination
+          properties:
+            self:
+              type: string
+              description: Link to current resource
+            first:
+              type: string
+              description: In a paginated response, link to the first page
+            last:
+              type: string
+              description: In a paginated response, link to the last page
+            previous:
+              type: string
+              description: In a paginated response, link to the previous page. Maybe null if current is the first page
+            next:
+              type: string
+              description: In a paginated response, link to the next page. Maybe null if current is the last page
+
+        Pagination:
+          description: Generic object to handle pagination data.
+          type: object
+          properties:
+            page:
+              type: integer
+              description: The current page.
+            perPage:
+              type: integer
+              description: The number of items requested per page.
+            pageCount:
+              type: integer
+              description: The total number of pages.
+            pageItemsCount:
+              type: integer
+              description: The number of items for the current page.
+            totalCount:
+              type: integer
+              format: int64
+              description: The total number of items.
+
+        PortalComponentDefinition:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the component
+              example: gv-tree
+            css:
+              type: array
+              description: List of CSS variables
+              items:
+                $ref: "#/components/schemas/PortalCssDefinition"
+
+        PortalCssDefinition:
+          type: object
+          description: CSS variable values
+          properties:
+            name:
+              type: string
+              description: Name of the CSS variable
+              example: --gv-tree-color
+            description:
+              type: string
+              description: Description of CSS variable
+              example: Color of gv-tree
+            value:
+              type: string
+              description: Value for CSS variable
+              example: #000
+            defaultValue:
+              type: string
+              description: Default value for CSS variable
+              example: #FFF
+            type:
+              type: string
+              enum:
+                - color
+                - length
+                - string
+                - image
+
+        PortalDefinition:
+          type: object
+          properties:
+            data:
+              type: array
+              description: List of component definitions
+              items:
+                $ref: "#/components/schemas/PortalComponentDefinition"
+
+        PortalNextDefinition:
+          type: object
+          description: Theme definition used for Portal-Next
+          properties:
+            primary:
+              type: string
+              description: Primary hex code color seed for Theme palette
+              example: #e1f200
+            secondary:
+              type: string
+              description: Secondary hex code color seed for Theme palette
+              example: #e1f200
+            tertiary:
+              type: string
+              description: Tertiary hex code color seed for Theme palette
+              example: #e1f200
+            error:
+              type: string
+              description: Error hex code color seed for Theme palette
+              example: #e1f200
+            background:
+              type: string
+              description: Background hex code color
+              example: #e1f200
+            banner:
+              type: object
+              description: Banner customization
+              properties:
+                text:
+                  type: string
+                  description: Banner text hex code color
+                  example: #e1f200
+                background:
+                  type: string
+                  description: Banner background hex code color
+                  example: #e1f200
+        Theme:
+          oneOf:
+            - $ref: "#/components/schemas/ThemePortal"
+            - $ref: "#/components/schemas/ThemePortalNext"
+          discriminator:
+            propertyName: type
+            mapping:
+              PORTAL: ThemePortal
+              PORTAL_NEXT: ThemePortalNext
+
+        ThemePortal:
+          title: "ThemePortal"
+          description: Theme used on the Portal
+          allOf:
+            - $ref: "#/components/schemas/GenericTheme"
+            - properties:
+                definition:
+                  $ref: "#/components/schemas/PortalDefinition"
+                backgroundImage:
+                  type: string
+                  description: Background image used in header
+
+        ThemePortalNext:
+          title: "ThemePortalNext"
+          description: Theme used in Portal-Next
+          allOf:
+            - $ref: "#/components/schemas/GenericTheme"
+            - properties:
+                definition:
+                  $ref: "#/components/schemas/PortalNextDefinition"
+
+
+        ThemeType:
+          type: string
+          description: Available theme types
+          default: PORTAL
+          enum:
+            - PORTAL
+            - PORTAL_NEXT
+
     parameters:
+        enabledThemeParam:
+          name: enabled
+          in: query
+          required: false
+          description: Filter for enabled themes.
+          schema:
+            type: boolean
+        envIdParam:
+          name: envId
+          in: path
+          required: true
+          description: Id or Hrid (Human readable Id) of an environment.
+          schema:
+            type: string
+            default: DEFAULT
         orgIdParam:
             name: orgId
             in: path
@@ -171,7 +447,30 @@ components:
             schema:
                 type: string
                 default: DEFAULT
-
+        pageParam:
+          name: page
+          in: query
+          required: false
+          description: The page number for pagination.
+          schema:
+            type: integer
+            default: 1
+        perPageParam:
+          name: perPage
+          in: query
+          required: false
+          description: |
+            The number of items per page for pagination.
+          schema:
+            type: integer
+            default: 10
+        themeTypeParam:
+          name: type
+          in: query
+          required: false
+          description: Filter by theme type
+          schema:
+            $ref: "#/components/schemas/ThemeType"
     responses:
         Error:
             description: Generic error response
@@ -179,3 +478,19 @@ components:
                 application/json:
                     schema:
                         $ref: "#/components/schemas/Error"
+        ThemesResponse:
+          description: Page of themes
+          content:
+            application/json:
+              schema:
+                title: "ThemesResponse"
+                properties:
+                  data:
+                    description: List of themes.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Theme"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+                  links:
+                    $ref: "#/components/schemas/Links"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResourceTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.ui;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import assertions.MAPIAssertions;
+import inmemory.ThemeQueryServiceInMemory;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.model.ThemesResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ThemesResourceTest extends AbstractResourceTest {
+
+    private final String ENVIRONMENT = "env-id";
+    private final String PORTAL_THEME_ID = "portal-id";
+    private final String PORTAL_NEXT_THEME_ID = "portal-next-id";
+
+    @Autowired
+    private ThemeQueryServiceInMemory themeQueryService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/ui/themes";
+    }
+
+    @BeforeEach
+    void init() {
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        doReturn(environmentEntity).when(environmentService).findById(ENVIRONMENT);
+        doReturn(environmentEntity).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        themeQueryService.reset();
+    }
+
+    @Nested
+    class GetThemes {
+
+        @BeforeEach
+        void setUp() {
+            themeQueryService.initWith(List.of(aPortalTheme(), aPortalNextTheme()));
+        }
+
+        @Test
+        public void should_return_403_if_incorrect_permissions() {
+            when(
+                permissionService.hasPermission(
+                    eq(GraviteeContext.getExecutionContext()),
+                    eq(RolePermission.ENVIRONMENT_THEME),
+                    eq(ENVIRONMENT),
+                    eq(RolePermissionAction.READ)
+                )
+            )
+                .thenReturn(false);
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(FORBIDDEN_403)
+                .asError()
+                .hasHttpStatus(FORBIDDEN_403)
+                .hasMessage("You do not have sufficient rights to access this resource");
+        }
+
+        @Test
+        public void should_get_empty_list() {
+            final Response response = rootTarget().queryParam("enabled", false).request().get();
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ThemesResponse.class)
+                .extracting(ThemesResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).isEmpty();
+                });
+        }
+
+        @Test
+        public void should_return_page_of_results() {
+            final Response response = rootTarget().queryParam("type", "PORTAL").queryParam("enabled", true).request().get();
+            assertThat(response.getStatus()).isEqualTo(200);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ThemesResponse.class)
+                .extracting(ThemesResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).hasSize(1);
+                    assertThat(list.get(0).getThemePortal().getId()).isEqualTo(PORTAL_THEME_ID);
+                });
+        }
+
+        @Test
+        public void should_return_all_results_if_no_search_criteria_specified() {
+            final Response response = rootTarget().request().get();
+            assertThat(response.getStatus()).isEqualTo(200);
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ThemesResponse.class)
+                .extracting(ThemesResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).hasSize(2);
+                });
+        }
+    }
+
+    private Theme aPortalTheme() {
+        var portalDefinition = new ThemeDefinition();
+        portalDefinition.setData(List.of());
+        return Theme
+            .builder()
+            .id(PORTAL_THEME_ID)
+            .name(PORTAL_THEME_ID)
+            .type(Theme.ThemeType.PORTAL)
+            .definitionPortal(portalDefinition)
+            .createdAt(ZonedDateTime.now())
+            .updatedAt(ZonedDateTime.now())
+            .backgroundImage("hehe")
+            .enabled(true)
+            .build();
+    }
+
+    private Theme aPortalNextTheme() {
+        var portalDefinition = new io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition();
+        portalDefinition.setPrimary("#fff");
+        return Theme
+            .builder()
+            .id(PORTAL_NEXT_THEME_ID)
+            .name(PORTAL_NEXT_THEME_ID)
+            .type(Theme.ThemeType.PORTAL_NEXT)
+            .definitionPortalNext(portalDefinition)
+            .createdAt(ZonedDateTime.now())
+            .updatedAt(ZonedDateTime.now())
+            .enabled(true)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.model;
+
+import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Theme {
+
+    private String id;
+    private String name;
+
+    private ThemeDefinition definitionPortal;
+    private io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition definitionPortalNext;
+
+    private ThemeType type;
+
+    private ZonedDateTime createdAt;
+    private ZonedDateTime updatedAt;
+
+    private boolean enabled;
+    private String logo;
+    private String optionalLogo;
+    private String favicon;
+    private String backgroundImage;
+
+    public enum ThemeType {
+        PORTAL,
+        PORTAL_NEXT,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeSearchCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeSearchCriteria.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ThemeSearchCriteria {
+
+    private Theme.ThemeType type;
+    private Boolean enabled;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/query_service/ThemeQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/query_service/ThemeQueryService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.query_service;
+
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+
+public interface ThemeQueryService {
+    Page<Theme> searchByCriteria(ThemeSearchCriteria criteria, Pageable pageable);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetPortalThemesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetPortalThemesUseCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetPortalThemesUseCase {
+
+    private final ThemeQueryService themeQueryService;
+
+    public Output execute(Input input) {
+        return new Output(
+            themeQueryService.searchByCriteria(
+                ThemeSearchCriteria.builder().enabled(input.enabled()).type(input.type()).build(),
+                new PageableImpl(input.page(), input.size())
+            )
+        );
+    }
+
+    @Builder
+    public record Input(Theme.ThemeType type, Boolean enabled, int page, int size) {}
+
+    public record Output(Page<Theme> result) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ThemeAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ThemeAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.repository.management.model.ThemeType;
+import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface ThemeAdapter {
+    Logger LOGGER = LoggerFactory.getLogger(ThemeAdapter.class);
+    ThemeAdapter INSTANCE = Mappers.getMapper(ThemeAdapter.class);
+
+    @Mapping(target = "definitionPortal", expression = "java(deserializeDefinitionPortal(theme))")
+    @Mapping(target = "definitionPortalNext", expression = "java(deserializeDefinitionPortalNext(theme))")
+    Theme map(io.gravitee.repository.management.model.Theme theme);
+
+    List<Theme> map(List<io.gravitee.repository.management.model.Theme> themes);
+
+    default ThemeDefinition deserializeDefinitionPortal(io.gravitee.repository.management.model.Theme theme) {
+        if (Objects.nonNull(theme.getDefinition()) && ThemeType.PORTAL.equals(theme.getType())) {
+            try {
+                return GraviteeJacksonMapper.getInstance().readValue(theme.getDefinition(), ThemeDefinition.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Unexpected error while deserializing PORTAL theme definition", ioe);
+            }
+        }
+
+        return null;
+    }
+
+    default io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition deserializeDefinitionPortalNext(
+        io.gravitee.repository.management.model.Theme theme
+    ) {
+        if (Objects.nonNull(theme.getDefinition()) && ThemeType.PORTAL_NEXT.equals(theme.getType())) {
+            try {
+                return GraviteeJacksonMapper
+                    .getInstance()
+                    .readValue(theme.getDefinition(), io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Unexpected error while deserializing PORTAL_NEXT theme definition", ioe);
+            }
+        }
+
+        return null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.theme;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
+import io.gravitee.apim.infra.adapter.ThemeAdapter;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ThemeRepository;
+import io.gravitee.repository.management.api.search.ThemeCriteria;
+import io.gravitee.repository.management.model.ThemeType;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ThemeQueryServiceImpl extends AbstractService implements ThemeQueryService {
+
+    private final ThemeRepository themeRepository;
+
+    public ThemeQueryServiceImpl(@Lazy final ThemeRepository themeRepository) {
+        this.themeRepository = themeRepository;
+    }
+
+    @Override
+    public Page<Theme> searchByCriteria(ThemeSearchCriteria criteria, Pageable pageable) {
+        var type = criteria.getType() == null ? null : ThemeType.valueOf(criteria.getType().name());
+        try {
+            var page =
+                this.themeRepository.search(ThemeCriteria.builder().enabled(criteria.getEnabled()).type(type).build(), convert(pageable));
+
+            return new Page<>(
+                ThemeAdapter.INSTANCE.map(page.getContent()),
+                page.getPageNumber(),
+                (int) page.getPageElements(),
+                page.getTotalElements()
+            );
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(e.getMessage(), e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ThemeQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ThemeQueryServiceInMemory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class ThemeQueryServiceInMemory implements ThemeQueryService, InMemoryAlternative<Theme> {
+
+    private final List<Theme> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<Theme> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Theme> storage() {
+        return Collections.unmodifiableList(this.storage);
+    }
+
+    @Override
+    public Page<Theme> searchByCriteria(ThemeSearchCriteria criteria, Pageable pageable) {
+        var themes = storage
+            .stream()
+            .filter(theme ->
+                (Objects.isNull(criteria.getType()) || criteria.getType().equals(theme.getType())) &&
+                (Objects.isNull(criteria.getEnabled()) || criteria.getEnabled().equals(theme.isEnabled()))
+            )
+            .toList();
+
+        return new Page<>(themes, 1, themes.size(), themes.size());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -258,4 +258,9 @@ public class InMemoryConfiguration {
     public PrimaryOwnerDomainServiceInMemory primaryOwnerDomainService() {
         return new PrimaryOwnerDomainServiceInMemory();
     }
+
+    @Bean
+    public ThemeQueryServiceInMemory themeQueryService() {
+        return new ThemeQueryServiceInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetPortalThemesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetPortalThemesUseCaseTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ThemeQueryServiceInMemory;
+import io.gravitee.apim.core.theme.model.Theme;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class GetPortalThemesUseCaseTest {
+
+    public final ThemeQueryServiceInMemory themeQueryServiceInMemory = new ThemeQueryServiceInMemory();
+    private GetPortalThemesUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new GetPortalThemesUseCase(themeQueryServiceInMemory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        themeQueryServiceInMemory.reset();
+    }
+
+    @Test
+    void should_return_empty_page() {
+        var result = cut
+            .execute(GetPortalThemesUseCase.Input.builder().page(1).size(10).enabled(false).type(Theme.ThemeType.PORTAL).build())
+            .result();
+
+        assertThat(result).hasFieldOrPropertyWithValue("content", List.of());
+    }
+
+    @Test
+    void should_return_page_of_results() {
+        var portalTheme = Theme.builder().id("portal-id").type(Theme.ThemeType.PORTAL).enabled(true).build();
+        themeQueryServiceInMemory.initWith(List.of(portalTheme));
+        var result = cut
+            .execute(GetPortalThemesUseCase.Input.builder().page(1).size(10).enabled(true).type(Theme.ThemeType.PORTAL).build())
+            .result();
+
+        assertThat(result).hasFieldOrPropertyWithValue("content", List.of(portalTheme));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.theme;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.ThemeRepository;
+import io.gravitee.repository.management.api.search.ThemeCriteria;
+import io.gravitee.repository.management.model.Theme;
+import io.gravitee.repository.management.model.ThemeType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.theme.portal.ThemeDefinition;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ThemeQueryServiceImplTest {
+
+    private final String PORTAL_THEME_ID = "portal-id";
+    private final String PORTAL_NEXT_THEME_ID = "portal-next-id";
+
+    @Mock
+    ThemeRepository themeRepository;
+
+    ThemeQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ThemeQueryServiceImpl(themeRepository);
+    }
+
+    @Nested
+    class Search {
+
+        @Test
+        void should_return_empty_page() throws Throwable {
+            var criteria = ThemeCriteria.builder().build();
+            when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<Theme>(List.of(), 0, 0, 0));
+            var result = service.searchByCriteria(ThemeSearchCriteria.builder().build(), new PageableImpl(1, 1));
+
+            Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of());
+        }
+
+        @Test
+        void should_return_page_of_mixed_themes() throws Throwable {
+            var criteria = ThemeCriteria.builder().build();
+            when(themeRepository.search(eq(criteria), any()))
+                .thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme(), aPortalNextRepoTheme()), 1, 2, 2));
+            var result = service.searchByCriteria(ThemeSearchCriteria.builder().build(), new PageableImpl(1, 1));
+
+            var portalDefinition = new ThemeDefinition();
+            portalDefinition.setData(List.of());
+            var portalTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_THEME_ID)
+                .name(PORTAL_THEME_ID)
+                .definitionPortal(portalDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .build();
+
+            var portalNextDefinition = new io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition();
+            portalNextDefinition.setPrimary("#fff");
+            var portalNextTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_NEXT_THEME_ID)
+                .name(PORTAL_NEXT_THEME_ID)
+                .definitionPortalNext(portalNextDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL_NEXT)
+                .build();
+
+            Assertions
+                .assertThat(result)
+                .isNotNull()
+                .hasFieldOrPropertyWithValue("totalElements", 2L)
+                .hasFieldOrPropertyWithValue("pageNumber", 1)
+                .hasFieldOrPropertyWithValue("pageElements", 2L);
+            Assertions.assertThat(result.getContent()).hasSize(2).contains(portalTheme, portalNextTheme);
+        }
+
+        @Test
+        void should_allow_null_type() throws Throwable {
+            var criteria = ThemeCriteria.builder().type(null).build();
+            when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme()), 0, 0, 0));
+            var result = service.searchByCriteria(ThemeSearchCriteria.builder().type(null).build(), new PageableImpl(1, 1));
+
+            var portalDefinition = new ThemeDefinition();
+            portalDefinition.setData(List.of());
+            var portalTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_THEME_ID)
+                .name(PORTAL_THEME_ID)
+                .definitionPortal(portalDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .build();
+
+            Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
+        }
+
+        @Test
+        void should_allow_specified_type() throws Throwable {
+            var criteria = ThemeCriteria.builder().type(ThemeType.PORTAL).build();
+            when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme()), 0, 0, 0));
+            var result = service.searchByCriteria(
+                ThemeSearchCriteria.builder().type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL).build(),
+                new PageableImpl(1, 1)
+            );
+
+            var portalDefinition = new ThemeDefinition();
+            portalDefinition.setData(List.of());
+            var portalTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_THEME_ID)
+                .name(PORTAL_THEME_ID)
+                .definitionPortal(portalDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .build();
+
+            Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
+        }
+
+        @Test
+        void should_allow_null_enabled() throws Throwable {
+            var criteria = ThemeCriteria.builder().enabled(null).build();
+            when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme()), 0, 0, 0));
+            var result = service.searchByCriteria(ThemeSearchCriteria.builder().enabled(null).build(), new PageableImpl(1, 1));
+
+            var portalDefinition = new ThemeDefinition();
+            portalDefinition.setData(List.of());
+            var portalTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_THEME_ID)
+                .name(PORTAL_THEME_ID)
+                .definitionPortal(portalDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .build();
+
+            Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
+        }
+
+        @Test
+        void should_allow_specified_enabled() throws Throwable {
+            var criteria = ThemeCriteria.builder().enabled(true).build();
+            when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme()), 0, 0, 0));
+            var result = service.searchByCriteria(ThemeSearchCriteria.builder().enabled(true).build(), new PageableImpl(1, 1));
+
+            var portalDefinition = new ThemeDefinition();
+            portalDefinition.setData(List.of());
+            var portalTheme = io.gravitee.apim.core.theme.model.Theme
+                .builder()
+                .id(PORTAL_THEME_ID)
+                .name(PORTAL_THEME_ID)
+                .definitionPortal(portalDefinition)
+                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .build();
+
+            Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
+        }
+    }
+
+    private Theme aPortalRepoTheme() {
+        var theme = new Theme();
+        theme.setId(PORTAL_THEME_ID);
+        theme.setName(PORTAL_THEME_ID);
+        theme.setType(ThemeType.PORTAL);
+        theme.setDefinition("{ \"data\": [] }");
+        return theme;
+    }
+
+    private Theme aPortalNextRepoTheme() {
+        var theme = new Theme();
+        theme.setId(PORTAL_NEXT_THEME_ID);
+        theme.setName(PORTAL_NEXT_THEME_ID);
+        theme.setType(ThemeType.PORTAL_NEXT);
+        theme.setDefinition("{ \"primary\": \"#fff\" }");
+        return theme;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3945

## Description

MAPI-v2: create /themes for list of themes that filter by enabled and type

The logic will be used in PAPI to return the current portal next theme.

Next PR:
- MAPI-v2: create POST /themes to create theme
- MAPI-v2: create GET /:themeId/theme to get a theme
- MAPI-v2: create DELETE /:themeId/theme to delete a theme
- MAPI-v2: create PUT /:themeId/theme to update a theme
- PAPI: create GET /theme/next

Next PR: 
- hook it up with the front end services

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mamsvwbgpx.chromatic.com)
<!-- Storybook placeholder end -->
