### PR TITLE
fix: move setting default ingested API version to APIM

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -77,10 +77,12 @@ public class ApiModelFactory {
     public static Api fromIntegration(IntegrationApi integrationApi, Integration integration) {
         var id = generateFederatedApiId(integrationApi, integration);
         var now = TimeProvider.now();
+        var defaultVersion = "0.0.0";
+        var version = integrationApi.version() != null ? integrationApi.version() : defaultVersion;
         return Api
             .builder()
             .id(id)
-            .version(integrationApi.version())
+            .version(version)
             .definitionVersion(DefinitionVersion.FEDERATED)
             .name(integrationApi.name())
             .description(integrationApi.description())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
@@ -327,6 +327,21 @@ class IngestIntegrationApisUseCaseTest {
         }
 
         @Test
+        void should_create_federated_api_with_default_version_if_none_exist() {
+            // Given
+            var expectedDefaultApiVersion = "0.0.0";
+            var nullVersionApi = IntegrationApiFixtures.anIntegrationApiForIntegration(INTEGRATION_ID).toBuilder().version(null).build();
+            givenAnIntegration(IntegrationFixture.anIntegration(ENVIRONMENT_ID).withId(INTEGRATION_ID));
+            givenIntegrationApis(nullVersionApi);
+
+            // When
+            useCase.execute(new IngestIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO)).test().awaitDone(10, TimeUnit.SECONDS);
+
+            //Then
+            assertThat(apiCrudService.storage()).extracting(Api::getVersion).containsExactly(expectedDefaultApiVersion);
+        }
+
+        @Test
         void should_create_an_audit() {
             // Given
             givenAnIntegration(IntegrationFixture.anIntegration(ENVIRONMENT_ID).withId(INTEGRATION_ID));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5036

## Description

Setting the default ingested API version is now in APIM because we want to share this behavior across all providers. 

