### PR TITLE
feat(portal-next): add portalNext configuration to ui

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<app-nav-bar [currentUser]="currentUser()" />
+<app-nav-bar [currentUser]="currentUser()" [siteTitle]="siteTitle" />
 <div class="content">
   <router-outlet />
 </div>

--- a/gravitee-apim-portal-webui-next/src/app/app.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.component.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 import { Component, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { RouterOutlet } from '@angular/router';
 
 import { FooterComponent } from '../components/footer/footer.component';
 import { NavBarComponent } from '../components/nav-bar/nav-bar.component';
+import { ConfigService } from '../services/config.service';
 import { CurrentUserService } from '../services/current-user.service';
 
 @Component({
@@ -28,6 +30,14 @@ import { CurrentUserService } from '../services/current-user.service';
   styleUrl: './app.component.scss',
 })
 export class AppComponent {
-  // TODO: Implement service to get title
   currentUser = inject(CurrentUserService).user;
+  siteTitle: string;
+
+  constructor(
+    private configService: ConfigService,
+    private title: Title,
+  ) {
+    this.siteTitle = configService.portalNext.siteTitle ?? 'Developer Portal';
+    this.title.setTitle(this.siteTitle);
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/app.config.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.config.ts
@@ -31,7 +31,10 @@ function initApp(
   themeService: ThemeService,
   currentUserService: CurrentUserService,
 ): () => Observable<unknown> {
-  return () => configService.initBaseURL().pipe(switchMap(_ => combineLatest([themeService.loadTheme(), currentUserService.loadUser()])));
+  return () =>
+    configService
+      .initBaseURL()
+      .pipe(switchMap(_ => combineLatest([themeService.loadTheme(), currentUserService.loadUser(), configService.loadConfiguration()])));
 }
 
 export const appConfig: ApplicationConfig = {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -29,6 +29,7 @@ import { SearchBarComponent } from '../../components/search-bar/search-bar.compo
 import { Category } from '../../entities/categories/categories';
 import { ApiService } from '../../services/api.service';
 import { CategoriesService } from '../../services/categories.service';
+import { ConfigService } from '../../services/config.service';
 
 export interface ApiVM {
   id: string;
@@ -66,9 +67,8 @@ export class CatalogComponent {
   filterList$: Observable<Category[]> = of([]);
   loadingPage$ = new BehaviorSubject(true);
 
-  // TODO: Get banner title + subtitle from configuration
-  bannerTitle: string = 'Welcome to Gravitee Developer Portal!';
-  bannerSubtitle: string = 'Discover powerful APIs to supercharge your projects.';
+  bannerTitle: string;
+  bannerSubtitle: string;
   selectedFilter: string = 'all';
   searchInput: string = '';
 
@@ -76,7 +76,9 @@ export class CatalogComponent {
   private categoriesService = inject(CategoriesService);
   private page$ = new BehaviorSubject(1);
 
-  constructor() {
+  constructor(private configService: ConfigService) {
+    this.bannerTitle = this.configService.portalNext.bannerTitle ?? 'Welcome to Gravitee Developer Portal!';
+    this.bannerSubtitle = this.configService.portalNext.bannerSubtitle ?? 'Discover powerful APIs to supercharge your projects.';
     this.apiPaginator$ = this.loadApis$();
     this.filterList$ = this.loadCategories$();
   }

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="nav-bar__container">
-  <app-company-title></app-company-title>
+  <app-company-title [title]="siteTitle" />
   <div class="menu-items">
     <app-nav-bar-button i18n="@@catalog" [path]="['catalog']">Catalog</app-nav-bar-button>
   </div>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input, InputSignal } from '@angular/core';
+import { Component, Input, input, InputSignal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { RouterLink } from '@angular/router';
 import { isEmpty } from 'lodash';
@@ -31,6 +31,8 @@ import { UserAvatarComponent } from '../user-avatar/user-avatar.component';
   styleUrl: './nav-bar.component.scss',
 })
 export class NavBarComponent {
+  @Input()
+  siteTitle!: string;
   currentUser: InputSignal<User> = input({});
   protected readonly isEmpty = isEmpty;
 }

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-analytics.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-analytics.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ConfigurationAnalytics {
+  /**
+   * HTTP Client Timeout
+   */
+  clientTimeout?: number;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-application-types.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-application-types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Enabled } from './enabled';
+
+export interface ConfigurationApplicationTypes {
+  simple?: Enabled;
+  browser?: Enabled;
+  web?: Enabled;
+  _native?: Enabled;
+  backend_to_backend?: Enabled;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-application.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigurationApplicationTypes } from './configuration-application-types';
+import { Enabled } from './enabled';
+
+export interface ConfigurationApplication {
+  registration?: Enabled;
+  types?: ConfigurationApplicationTypes;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-authentication.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-authentication.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Enabled } from './enabled';
+
+export interface ConfigurationAuthentication {
+  forceLogin?: Enabled;
+  localLogin?: Enabled;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-documentation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-documentation.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ConfigurationDocumentation {
+  /**
+   * URL of the main documentation.
+   */
+  url?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-plan-security.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-plan-security.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Enabled } from './enabled';
+
+export interface ConfigurationPlanSecurity {
+  apikey?: Enabled;
+  sharedApiKey?: Enabled;
+  oauth2?: Enabled;
+  keyless?: Enabled;
+  jwt?: Enabled;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-plan.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-plan.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigurationPlanSecurity } from './configuration-plan-security';
+
+export interface ConfigurationPlan {
+  security?: ConfigurationPlanSecurity;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class ConfigurationPortalNext {
+  siteTitle?: string;
+  bannerTitle?: string;
+  bannerSubtitle?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-re-captcha.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-re-captcha.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ConfigurationReCaptcha {
+  /**
+   * flag indication if recaptcha is enabled or not
+   */
+  enabled?: boolean;
+  /**
+   * reCaptcha site key
+   */
+  siteKey?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-scheduler.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-scheduler.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ConfigurationScheduler {
+  /**
+   * Number of seconds for notification scheduler.
+   */
+  notificationsInSeconds?: number;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigurationAnalytics } from './configuration-analytics';
+import { ConfigurationApplication } from './configuration-application';
+import { ConfigurationAuthentication } from './configuration-authentication';
+import { ConfigurationDocumentation } from './configuration-documentation';
+import { ConfigurationPlan } from './configuration-plan';
+import { ConfigurationPortalNext } from './configuration-portal-next';
+import { ConfigurationReCaptcha } from './configuration-re-captcha';
+import { ConfigurationScheduler } from './configuration-scheduler';
+import { Enabled } from './enabled';
+
+export interface Configuration {
+  portalNext?: ConfigurationPortalNext;
+  authentication?: ConfigurationAuthentication;
+  scheduler?: ConfigurationScheduler;
+  documentation?: ConfigurationDocumentation;
+  plan?: ConfigurationPlan;
+  apiReview?: Enabled;
+  analytics?: ConfigurationAnalytics;
+  application?: ConfigurationApplication;
+  recaptcha?: ConfigurationReCaptcha;
+  alert?: Enabled;
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/enabled.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/enabled.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Enabled {
+  /**
+   * true, if the property is enabled
+   */
+  enabled?: boolean;
+}

--- a/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
@@ -17,6 +17,7 @@ import { HttpClientTestingModule, HttpTestingController, provideHttpClientTestin
 import { TestBed } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
+import { ConfigurationPortalNext } from '../entities/configuration/configuration-portal-next';
 
 describe('ConfigService', () => {
   let service: ConfigService;
@@ -88,6 +89,32 @@ describe('ConfigService', () => {
 
       httpTestingController.expectOne('./assets/config.json').flush(configJson);
       httpTestingController.expectOne('http://localhost:8083/portal/ui/bootstrap?environmentId=DEFAULT').flush(configBootstrap);
+    });
+  });
+
+  describe('loadConfiguration', () => {
+    it('should load portal next', done => {
+      const portalNext: ConfigurationPortalNext = {
+        siteTitle: 'a site title',
+        bannerTitle: 'a title',
+        bannerSubtitle: 'a subtitle',
+      };
+      service.loadConfiguration().subscribe(() => {
+        expect(service.portalNext).toEqual(portalNext);
+        done();
+      });
+
+      httpTestingController.expectOne(`/configuration`).flush({ portalNext });
+    });
+
+    it('should load missing portal next', done => {
+      const portalNext: ConfigurationPortalNext = {};
+      service.loadConfiguration().subscribe(() => {
+        expect(service.portalNext).toEqual(portalNext);
+        done();
+      });
+
+      httpTestingController.expectOne(`/configuration`).flush({});
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -20,6 +20,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs/internal/observable/of';
 
+import { ConfigurationPortalNext } from '../entities/configuration/configuration-portal-next';
 import { ConfigService } from '../services/config.service';
 
 export const TESTING_BASE_URL = 'http://localhost:8083/portal/environments/DEFAULT';
@@ -32,6 +33,10 @@ export const TESTING_ACTIVATED_ROUTE = {
 export class ConfigServiceStub {
   get baseURL(): string {
     return TESTING_BASE_URL;
+  }
+
+  get portalNext(): ConfigurationPortalNext {
+    return {};
   }
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3945

## Description

Bring portal next configuration into the front-end

Site title + banner title + banner subtitle
![Screenshot 2024-05-17 at 14 55 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/cd082b26-d653-47e5-baf3-02d629437b48)

Site title + html title
![Screenshot 2024-05-17 at 15 02 25](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/3c9586ba-4642-4426-a2cc-8cd1ee79e08a)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dgqszvtjyf.chromatic.com)
<!-- Storybook placeholder end -->
