### PR TITLE
feat: button to delete federated APIs and provide feedback about deleted items

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/integration-configuration/integration-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-configuration/integration-configuration.component.html
@@ -79,7 +79,21 @@
                 *gioPermission="{ anyOf: ['environment-integration-d'] }"
                 [disabled]="hasFederatedAPIs"
               >
-                Delete
+                Delete Integration
+              </button>
+            </span>
+          </div>
+          <div class="danger-action" *gioPermission="{ anyOf: ['environment-api-d'] }">
+            <span>Delete all the Federated APIs associated with this integration.</span>
+            <span [matTooltipDisabled]="hasFederatedAPIs" matTooltip="There is no federated APIs to delete.">
+              <button
+                mat-button
+                color="warn"
+                (click)="deleteFederatedApis()"
+                data-testid="delete-federated-apis-button"
+                [disabled]="!hasFederatedAPIs"
+              >
+                Delete APIs
               </button>
             </span>
           </div>

--- a/gravitee-apim-console-webui/src/management/integrations/integration-configuration/integration-configuration.harness.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-configuration/integration-configuration.harness.ts
@@ -33,6 +33,9 @@ export class IntegrationConfigurationHarness extends ComponentHarness {
   private deleteIntegrationButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorForOptional(
     MatButtonHarness.with({ selector: '[data-testid=delete-integration-button]' }),
   );
+  private deleteFederatedApisButtonLocator: AsyncFactoryFn<MatButtonHarness> = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="delete-federated-apis-button"]' }),
+  );
 
   public updateSectionLocator: AsyncFactoryFn<MatCardHarness> = this.locatorForOptional(
     MatCardHarness.with({ selector: '[data-testid=update-card]' }),
@@ -64,5 +67,9 @@ export class IntegrationConfigurationHarness extends ComponentHarness {
 
   public getDeleteIntegrationButton = async (): Promise<MatButtonHarness> => {
     return this.deleteIntegrationButtonLocator();
+  };
+
+  public getDeleteFederatedApisButton = async (): Promise<MatButtonHarness> => {
+    return this.deleteFederatedApisButtonLocator();
   };
 }

--- a/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
@@ -64,3 +64,9 @@ export interface FederatedAPIsResponse {
   data: FederatedAPI[];
   pagination: Pagination;
 }
+
+export interface DeletedFederatedAPIsResponse {
+  deleted: number;
+  skipped: number;
+  errors: number;
+}

--- a/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
@@ -21,6 +21,7 @@ import { tap } from 'rxjs/operators';
 
 import {
   CreateIntegrationPayload,
+  DeletedFederatedAPIsResponse,
   FederatedAPIsResponse,
   Integration,
   IntegrationResponse,
@@ -74,5 +75,9 @@ export class IntegrationsService {
 
   public getFederatedAPIs(id: string, page: number = 1, size: number = 10): Observable<FederatedAPIsResponse> {
     return this.httpClient.get<FederatedAPIsResponse>(`${this.url}/${id}/apis?page=${page}&perPage=${size}`);
+  }
+
+  public deleteFederatedAPIs(id: string): Observable<DeletedFederatedAPIsResponse> {
+    return this.httpClient.delete<DeletedFederatedAPIsResponse>(`${this.url}/${id}/apis`);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4897

## Description

PR is adding a new button to the Federation configuration page enabling deleting all associated APIs ingested using this integration. 

## Additional context

This PR also contains changes required for completing this subtask: 
https://gravitee.atlassian.net/browse/APIM-5061

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cnrrvbeibq.chromatic.com)
<!-- Storybook placeholder end -->
