### PR TITLE
chore: allow cloud instead of cockpit properties in preparation for rebrand

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractCloudAuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/AbstractCloudAuthenticationResourceTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.auth;
+
+import static io.gravitee.rest.api.management.rest.resource.auth.CockpitAuthenticationResource.API_CLAIM;
+import static io.gravitee.rest.api.management.rest.resource.auth.CockpitAuthenticationResource.APPLICATION_CLAIM;
+import static io.gravitee.rest.api.management.rest.resource.auth.CockpitAuthenticationResource.ENVIRONMENT_CLAIM;
+import static io.gravitee.rest.api.management.rest.resource.auth.CockpitAuthenticationResource.ORG_CLAIM;
+import static io.gravitee.rest.api.management.rest.resource.auth.CockpitAuthenticationResource.REDIRECT_URI_CLAIM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.common.utils.UUID;
+import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.common.JWTHelper;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import jakarta.ws.rs.core.Response;
+import java.io.File;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.Date;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Guillaume Cusnieux (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractCloudAuthenticationResourceTest extends AbstractResourceTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String PATH = "auth/cockpit";
+    private static final String JWT_ISSUER = "test-issuer";
+    private static final String JWT_SUBJECT = "test-user-id";
+    private static final String ISSUER = "https://gravitee.cockpit";
+    private static final String KID = "cockpit";
+    private static final String ALGORITHM = "RS512";
+    private static final int TTL_SECONDS = 10;
+
+    @Autowired
+    private InstallationAccessQueryService installationAccessQueryService;
+
+    @Autowired
+    private ApiSearchService apiSearchService;
+
+    @Autowired
+    protected Environment environment;
+
+    @Override
+    protected String contextPath() {
+        return "";
+    }
+
+    @Override
+    protected boolean followRedirect() {
+        return false;
+    }
+
+    protected abstract String getPropertyPrefix();
+
+    protected abstract String getKeystorePropertyPrefix();
+
+    @Before
+    public void init() {
+        System.setProperty(getPropertyPrefix() + ".enabled", "true");
+        System.setProperty(
+            getKeystorePropertyPrefix() + ".keystore.path",
+            new File(getClass().getClassLoader().getResource("auth/keystore.p12").getFile()).getAbsolutePath()
+        );
+        System.setProperty(getKeystorePropertyPrefix() + ".keystore.password", "keystore-secret");
+        System.setProperty(getKeystorePropertyPrefix() + ".keystore.type", "PKCS12");
+        System.setProperty(getKeystorePropertyPrefix() + ".keystore.key.alias", "cockpit-ca");
+        System.setProperty(getPropertyPrefix() + ".connector.ws.ssl.keystore.type", "PKCS12");
+        reset(userService);
+    }
+
+    @After
+    public void teardown() {
+        System.clearProperty(getPropertyPrefix() + ".enabled");
+        System.clearProperty(getKeystorePropertyPrefix() + ".keystore.path");
+        System.clearProperty(getKeystorePropertyPrefix() + ".keystore.password");
+        System.clearProperty(getKeystorePropertyPrefix() + ".keystore.type");
+        System.clearProperty(getKeystorePropertyPrefix() + ".keystore.key.alias");
+        System.clearProperty(getPropertyPrefix() + ".connector.ws.ssl.keystore.type");
+    }
+
+    @Test
+    public void shouldNotAuthenticateIfCockpitIsNotEnabled() {
+        System.clearProperty(getPropertyPrefix() + ".enabled");
+        final Response response = rootTarget(PATH).queryParam("token", "test").request().get();
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotAuthenticateIfUserNotFound() {
+        UserEntity userEntity = mockUserEntity();
+
+        String jwt = this.generateJWT(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID, "audience", null, null, null);
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true))
+            .thenThrow(new UserNotFoundException(JWT_SUBJECT));
+        final Response response = rootTarget(PATH).queryParam("token", jwt).request().get();
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldNotAuthenticateWithInvalidToken() throws JOSEException {
+        UserEntity userEntity = mockUserEntity();
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true)).thenReturn(userEntity);
+        when(authoritiesProvider.retrieveAuthorities(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(Set.of());
+        when(installationAccessQueryService.getConsoleUrl(ORGANIZATION_ID)).thenReturn(rootTarget("console").getUri().toString());
+        final Response response = rootTarget(PATH).queryParam("token", "invalid").request().get();
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+
+    @Test
+    public void shouldAuthenticateToConsole() {
+        UserEntity userEntity = mockUserEntity();
+
+        String jwt = this.generateJWT(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID, "audience", null, null, null);
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true)).thenReturn(userEntity);
+        when(authoritiesProvider.retrieveAuthorities(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(Set.of());
+        when(installationAccessQueryService.getConsoleUrl(ORGANIZATION_ID)).thenReturn(rootTarget("console").getUri().toString());
+        final Response response = rootTarget(PATH).queryParam("token", jwt).request().get();
+        assertEquals(HttpStatusCode.TEMPORARY_REDIRECT_307, response.getStatus());
+        assertTrue(response.getLocation().toString().contains("/console/#!/environment-id/"));
+    }
+
+    @Test
+    public void shouldAuthenticateToConsoleAndRedirectToApi() {
+        UserEntity userEntity = mockUserEntity();
+
+        String jwt = this.generateJWT(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID, "audience", "apiId", null, null);
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true)).thenReturn(userEntity);
+        when(authoritiesProvider.retrieveAuthorities(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(Set.of());
+        when(installationAccessQueryService.getConsoleUrl(ORGANIZATION_ID)).thenReturn(rootTarget("console").getUri().toString());
+        when(apiSearchService.findIdByEnvironmentIdAndCrossId(ENVIRONMENT_ID, "apiId")).thenReturn(Optional.of("apiId"));
+        final Response response = rootTarget(PATH).queryParam("token", jwt).request().get();
+        assertEquals(HttpStatusCode.TEMPORARY_REDIRECT_307, response.getStatus());
+        assertTrue(response.getLocation().toString().contains("/console/#!/environment-id/apis/apiId"));
+    }
+
+    @Test
+    public void shouldAuthenticateToPortal() {
+        UserEntity userEntity = mockUserEntity();
+
+        String jwt = this.generateJWT(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID, "audience", null, null, "portal");
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true)).thenReturn(userEntity);
+        when(authoritiesProvider.retrieveAuthorities(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(Set.of());
+        when(installationAccessQueryService.getPortalAPIUrl(ENVIRONMENT_ID)).thenReturn(rootTarget("portal").getUri().toString());
+        final Response response = rootTarget(PATH).queryParam("token", jwt).request().get();
+        assertEquals(HttpStatusCode.TEMPORARY_REDIRECT_307, response.getStatus());
+        assertTrue(response.getLocation().toString().contains("/portal/environments/environment-id/auth/console?token="));
+        assertToken(response, userEntity);
+    }
+
+    @Test
+    public void shouldAuthenticateToPortalFromRequest() {
+        UserEntity userEntity = mockUserEntity();
+
+        String jwt = this.generateJWT(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID, "audience", null, null, "portal");
+        when(userService.findBySource(ORGANIZATION_ID, "cockpit", userEntity.getId(), true)).thenReturn(userEntity);
+        when(authoritiesProvider.retrieveAuthorities(userEntity.getId(), ORGANIZATION_ID, ENVIRONMENT_ID)).thenReturn(Set.of());
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer(rootTarget(PATH).getUri().toString()));
+
+        final Response response = rootTarget(PATH).queryParam("token", jwt).request().get();
+        assertEquals(HttpStatusCode.TEMPORARY_REDIRECT_307, response.getStatus());
+        assertTrue(response.getLocation().toString().contains("/portal/environments/environment-id/auth/console?token="));
+        assertToken(response, userEntity);
+    }
+
+    private void assertToken(Response response, UserEntity userEntity) {
+        String token = URLEncodedUtils
+            .parse(response.getLocation(), "UTF-8")
+            .stream()
+            .filter(pair -> "token".equalsIgnoreCase(pair.getName()))
+            .findFirst()
+            .get()
+            .getValue();
+        Algorithm algorithm = Algorithm.HMAC256(environment.getProperty("jwt.secret"));
+        JWTVerifier jwtVerifier = JWT.require(algorithm).build();
+        final DecodedJWT decodedJwt = jwtVerifier.verify(token);
+        assertNotNull(decodedJwt);
+        assertNotNull(decodedJwt.getId());
+        assertNotNull(decodedJwt.getExpiresAt());
+        assertNotNull(decodedJwt.getSubject());
+        assertNotNull(decodedJwt.getIssuer());
+        assertNotNull(decodedJwt.getIssuedAt());
+        assertNotNull(decodedJwt.getClaim(JWTHelper.Claims.PERMISSIONS));
+        assertEquals(userEntity.getEmail(), decodedJwt.getClaim(JWTHelper.Claims.EMAIL).asString());
+        assertEquals(userEntity.getFirstname(), decodedJwt.getClaim(JWTHelper.Claims.FIRSTNAME).asString());
+        assertEquals(userEntity.getLastname(), decodedJwt.getClaim(JWTHelper.Claims.LASTNAME).asString());
+        assertEquals(ORGANIZATION_ID, decodedJwt.getClaim(JWTHelper.Claims.ORG).asString());
+    }
+
+    private KeyStore loadKeyStore(String type, String path, String password) throws CertificateException {
+        if (password == null) {
+            throw new CertificateException("keystore password can't be null");
+        }
+        try (InputStream is = new File(path).toURI().toURL().openStream()) {
+            final KeyStore keystore = KeyStore.getInstance(type);
+            keystore.load(is, password.toCharArray());
+            return keystore;
+        } catch (Exception e) {
+            throw new CertificateException(String.format("Unable to load keystore %s", path), e);
+        }
+    }
+
+    private String generateJWT(
+        String userId,
+        String organizationId,
+        String environmentId,
+        String audience,
+        String apiId,
+        String redirectUri,
+        String application
+    ) {
+        var issueTime = TimeProvider.now();
+        var expirationTime = issueTime.plusSeconds(TTL_SECONDS);
+        try {
+            KeyStore keystore =
+                this.loadKeyStore(
+                        System.getProperty(getKeystorePropertyPrefix() + ".keystore.type"),
+                        System.getProperty(getKeystorePropertyPrefix() + ".keystore.path"),
+                        System.getProperty(getKeystorePropertyPrefix() + ".keystore.password")
+                    );
+            PrivateKey privateKey = (PrivateKey) keystore.getKey(
+                System.getProperty(getKeystorePropertyPrefix() + ".keystore.key.alias"),
+                System.getProperty(getKeystorePropertyPrefix() + ".keystore.password").toCharArray()
+            );
+
+            JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder()
+                .jwtID(UUID.random().toString())
+                .issuer(ISSUER)
+                .issueTime(new Date(issueTime.toInstant().toEpochMilli()))
+                .expirationTime(new Date(expirationTime.toInstant().toEpochMilli()))
+                .subject(userId)
+                .audience(audience)
+                .claim(ORG_CLAIM, organizationId)
+                .claim(ENVIRONMENT_CLAIM, environmentId)
+                .claim(API_CLAIM, apiId)
+                .claim(APPLICATION_CLAIM, application)
+                .claim(REDIRECT_URI_CLAIM, redirectUri);
+            var claims = claimsBuilder.build();
+
+            // Sign then serialize the JWT.
+            var signer = new RSASSASigner(privateKey);
+            var header = new JWSHeader.Builder(new JWSAlgorithm(ALGORITHM)).keyID(KID).build();
+            SignedJWT signedJWT = new SignedJWT(header, claims);
+            signedJWT.sign(signer);
+
+            return signedJWT.serialize();
+        } catch (CertificateException | UnrecoverableKeyException | KeyStoreException | NoSuchAlgorithmException | JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private UserEntity mockUserEntity() {
+        UserEntity createdUser = new UserEntity();
+        createdUser.setId(JWT_SUBJECT);
+        createdUser.setOrganizationId(ORGANIZATION_ID);
+        createdUser.setSource(JWT_ISSUER);
+        createdUser.setSourceId(JWT_SUBJECT);
+        createdUser.setLastname("Doe");
+        createdUser.setFirstname("Jane");
+        createdUser.setEmail("janedoe@example.com");
+        createdUser.setPicture("http://example.com/janedoe/me.jpg");
+        return createdUser;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/CloudAuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/CloudAuthenticationResourceTest.java
@@ -18,18 +18,16 @@ package io.gravitee.rest.api.management.rest.resource.auth;
 /**
  * @author Guillaume Cusnieux (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
- *
- * Usefull to validate retro-compatibility after rebranding
  */
-public class CockpitAuthenticationResourceTest extends AbstractCloudAuthenticationResourceTest {
+public class CloudAuthenticationResourceTest extends AbstractCloudAuthenticationResourceTest {
 
     @Override
     protected String getPropertyPrefix() {
-        return "cockpit";
+        return "cloud";
     }
 
     @Override
     protected String getKeystorePropertyPrefix() {
-        return "cockpit";
+        return "cloud.connector.ws.ssl";
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
@@ -52,7 +52,7 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
     private final InstallationTypeDomainService installationTypeDomainService;
     private final AccessPointQueryService accessPointQueryService;
 
-    @Value("${cockpit.enabled:false}")
+    @Value("${cockpit.enabled:${cloud.enabled:false}}")
     private boolean cockpitEnabled;
 
     @Value("${installation.api.url:#{null}}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
@@ -44,7 +44,7 @@ public class InstallationServiceImpl implements InstallationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstallationServiceImpl.class);
 
-    @Value("${cockpit.url:https://cockpit.gravitee.io}")
+    @Value("${cockpit.url:${cloud.url:https://cockpit.gravitee.io}}")
     private String cockpitURL;
 
     @Lazy

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -180,6 +180,30 @@ spec:
             - name: gravitee_cockpit_ssl_verifyHostname
               value: "{{ .Values.cockpit.ssl.verifyHostname }}"
             {{- end }}
+            {{- if .Values.cloud.enabled }}
+            - name: gravitee_cloud_enabled
+              value: "true"
+            - name: gravitee_cloud_url
+              value: {{ .Values.cloud.url }}
+            - name: gravitee_cloud_ws_endpoints_0
+              value: {{ .Values.cloud.controller }}
+            - name: gravitee_cloud_connector_ws_ssl_keystore_type
+              value: pkcs12
+            - name: gravitee_cloud_connector_ws_ssl_keystore_path
+              value: /opt/graviteeio-management-api/cloud/keystore.p12
+            - name: gravitee_cloud_connector_ws_ssl_keystore_password
+              {{- toYaml .Values.cloud.connector.ws.ssl.keystore.password | nindent 14}}
+            {{- if .Values.cloud.connector.ws.ssl.truststore }}
+            - name: gravitee_cloud_connector_ws_ssl_truststore_type
+              value: pkcs12
+            - name: gravitee_cloud_connector_ws_ssl_truststore_path
+              value: /opt/graviteeio-management-api/cloud/truststore.p12
+            - name: gravitee_cloud_connector_ws_ssl_truststore_password
+              {{- toYaml .Values.cloud.connector.ws.ssl.truststore.password | nindent 14}}
+            {{- end }}
+            - name: gravitee_cloud_connector_ws_ssl_verifyHostname
+              value: "{{ .Values.cloud.connector.ws.ssl.verifyHostname }}"
+            {{- end }}
             {{- if .Values.gateway.enabled }}
             - name: portal.entrypoint
               value: "https://{{ index .Values.gateway.ingress.hosts 0 }}{{ .Values.gateway.ingress.path }}"
@@ -236,6 +260,11 @@ spec:
               mountPath: /opt/graviteeio-management-api/cockpit
               readOnly: true
           {{- end }}
+          {{- if .Values.cloud.enabled }}
+            - name: gravitee-cloud-certificates
+              mountPath: /opt/graviteeio-management-api/cloud
+              readOnly: true
+          {{- end }}
           {{- with .Values.license }}
           {{- if .key }}
             - name: licensekey
@@ -275,6 +304,11 @@ spec:
         - name: gravitee-cockpit-certificates
           secret:
             secretName: {{ template "gravitee.api.fullname" . }}-cockpit-certificates
+        {{- end }}
+        {{- if .Values.cloud.enabled }}
+        - name: gravitee-cloud-certificates
+          secret:
+            secretName: {{ template "gravitee.api.fullname" . }}-cloud-certificates
         {{- end }}
         {{- with .Values.license }}
         {{- if .key }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -121,6 +121,8 @@ spec:
               value: "false"
             - name: GRAVITEE_COCKPIT_ENABLED
               value: "false"
+            - name: GRAVITEE_CLOUD_ENABLED
+              value: "false"
             {{- if $plugins }}
             - name: GRAVITEE_PLUGINS_PATH_0
               value: '${gravitee.home}/plugins'

--- a/helm/templates/cloud/cloud-certificates.yaml
+++ b/helm/templates/cloud/cloud-certificates.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.cloud.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "gravitee.api.fullname" . }}-cloud-certificates
+data:
+  keystore.p12: {{ .Values.cloud.connector.ws.ssl.keystore.value }}
+  {{- if .Values.cloud.connector.ws.ssl.truststore }}
+  truststore.p12: {{ .Values.cloud.connector.ws.ssl.truststore.value }}
+  {{- end -}}  
+{{- end -}}

--- a/helm/tests/api/deployment_cloud_test.yaml
+++ b/helm/tests/api/deployment_cloud_test.yaml
@@ -1,0 +1,127 @@
+suite: Test Management API with Gravitee Cloud
+templates:
+  - "api/api-deployment.yaml"
+  - "api/api-configmap.yaml"
+tests:
+  - it: Check Gravitee Cloud deployment
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        connector:
+          ws:
+            ssl:
+              keystore:
+                password:
+                  value: my_password
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_connector_ws_ssl_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].value
+          value: "my_password"
+
+  - it: Check cloud deployment with keystore from secretKeyRef
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        connector:
+          ws:
+            ssl:
+              keystore:
+                password:
+                  valueFrom:
+                    secretKeyRef:
+                      name: mysecret
+                      key: password-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_connector_ws_ssl_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].valueFrom
+          value:
+            secretKeyRef:
+              name: mysecret
+              key: password-key
+
+  - it: Check cloud deployment with keystore from secretKeyRef
+    template: api/api-deployment.yaml
+    set:
+      cloud:
+        enabled: true
+        connector:
+          ws:
+            ssl:
+              keystore:
+                password:
+                  valueFrom:
+                    configMapKeyRef:
+                      name: special-config
+                      key: password-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: gravitee-cloud-certificates
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /opt/graviteeio-management-api/cloud
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: gravitee_cloud_enabled
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+      - equal:
+          path: spec.template.spec.containers[0].env[5].name
+          value: gravitee_cloud_connector_ws_ssl_keystore_password
+      - equal:
+          path: spec.template.spec.containers[0].env[5].valueFrom
+          value:
+            configMapKeyRef:
+              name: special-config
+              key: password-key

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -73,6 +73,20 @@ tests:
             name: GRAVITEE_COCKPIT_ENABLED
             value: "false"
 
+  - it: Check that cloud has been disabled
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITEE_CLOUD_ENABLED
+            value: "false"
+
   - it: Check if the helm hook annotations are present
     set:
       api:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -425,6 +425,30 @@ cockpit:
   ssl:
     verifyHostname: true
 
+# Support for Gravitee.io Cloud (cloud.gravitee.io)
+cloud:
+  enabled: false
+  connector:
+    ws:
+      ssl:
+        keystore:
+          value: "base64 encoded value of the keystore provided by Gravitee Cloud (required)"
+          password:
+          #value: "keystores password provided by Gravitee Cloud"
+          #valueFrom:
+          #secretKeyRef:
+          #configMapKeyRef:
+          #truststore:
+          #value: base64 encoded value of the truststore provided by Gravitee Cloud (optional)
+          #password:
+          #value: "truststore password provided by Gravitee Cloud"
+          #valueFrom:
+          #secretKeyRef:
+          #configMapKeyRef:
+  url: https://cloud.gravitee.io
+  controller: https://cloud-controller.gravitee.io
+  ssl:
+    verifyHostname: true
 
 api:
   enabled: true
@@ -1044,7 +1068,7 @@ gateway:
     #     type: pem # Supports jks, pem, pkcs12
     #     path: ${gravitee.home}/security/redis-truststore.jks
     #     password: secret
-    #     alias:      
+    #     alias:
     #   sentinel:
     #     master: redis-master
     #     nodes:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1220

## Description

Cockpit is being rebranded Gravitee Cloud. As part of these changes, we want to support cloud.xx properties as well as current cockpit.xx properties.

For now, we don't want to enforce property renames so both cockpit.xx and cloud.xx will be supported with existing cockpit.xx properties taken first. 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

