### PR TITLE
feat: elasticsearch index can use orgId/envId placeholder

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/api/AnalyticsRepository.java
@@ -18,11 +18,12 @@ package io.gravitee.repository.analytics.api;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.Response;
+import io.gravitee.repository.common.query.QueryContext;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface AnalyticsRepository {
-    <T extends Response> T query(Query<T> query) throws AnalyticsException;
+    <T extends Response> T query(QueryContext queryContext, Query<T> query) throws AnalyticsException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/common/query/QueryContext.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/common/query/QueryContext.java
@@ -13,20 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.healthcheck.api;
+package io.gravitee.repository.common.query;
 
-import io.gravitee.repository.analytics.AnalyticsException;
-import io.gravitee.repository.common.query.QueryContext;
-import io.gravitee.repository.healthcheck.query.Query;
-import io.gravitee.repository.healthcheck.query.Response;
-import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
- * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author Aurelien PACAUD (aurelien.pacaud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface HealthCheckRepository {
-    <T extends Response> T query(QueryContext queryContext, Query<T> query) throws AnalyticsException;
+@AllArgsConstructor
+@Getter
+public class QueryContext {
 
-    ExtendedLog findById(QueryContext queryContext, String logId) throws AnalyticsException;
+    private static final String ORG_ID_PLACEHOLDER_KEY = "orgId";
+    private static final String ENV_ID_PLACEHOLDER_KEY = "envId";
+
+    private final String orgId;
+    private final String envId;
+
+    public Map<String, String> placeholder() {
+        return Map.of(ORG_ID_PLACEHOLDER_KEY, orgId, ENV_ID_PLACEHOLDER_KEY, envId);
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/api/LogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/api/LogRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.log.api;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.tabular.TabularQuery;
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.model.ExtendedLog;
 
 /**
@@ -25,7 +26,7 @@ import io.gravitee.repository.log.model.ExtendedLog;
  * @author GraviteeSource Team
  */
 public interface LogRepository {
-    TabularResponse query(TabularQuery query) throws AnalyticsException;
+    TabularResponse query(QueryContext queryContext, TabularQuery query) throws AnalyticsException;
 
-    ExtendedLog findById(String logId, Long timestamp) throws AnalyticsException;
+    ExtendedLog findById(QueryContext queryContext, String logId, Long timestamp) throws AnalyticsException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.log.v4.api;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
@@ -23,9 +24,9 @@ import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
 import java.util.Optional;
 
 public interface AnalyticsRepository {
-    Optional<CountAggregate> searchRequestsCount(RequestsCountQuery requestsCountQuery);
+    Optional<CountAggregate> searchRequestsCount(QueryContext queryContext, RequestsCountQuery requestsCountQuery);
 
-    Optional<AverageAggregate> searchAverageMessagesPerRequest(AverageMessagesPerRequestQuery query);
+    Optional<AverageAggregate> searchAverageMessagesPerRequest(QueryContext queryContext, AverageMessagesPerRequestQuery query);
 
-    Optional<AverageAggregate> searchAverageConnectionDuration(AverageConnectionDurationQuery query);
+    Optional<AverageAggregate> searchAverageConnectionDuration(QueryContext queryContext, AverageConnectionDurationQuery query);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/LogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/LogRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.log.v4.api;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLogDetail;
@@ -26,7 +27,9 @@ import io.gravitee.repository.log.v4.model.message.MessageLogQuery;
 import java.util.Optional;
 
 public interface LogRepository {
-    LogResponse<ConnectionLog> searchConnectionLogs(ConnectionLogQuery query) throws AnalyticsException;
-    Optional<ConnectionLogDetail> searchConnectionLogDetail(ConnectionLogDetailQuery query) throws AnalyticsException;
-    LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(MessageLogQuery query) throws AnalyticsException;
+    LogResponse<ConnectionLog> searchConnectionLogs(QueryContext queryContext, ConnectionLogQuery query) throws AnalyticsException;
+    Optional<ConnectionLogDetail> searchConnectionLogDetail(QueryContext queryContext, ConnectionLogDetailQuery query)
+        throws AnalyticsException;
+    LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(QueryContext queryContext, MessageLogQuery query)
+        throws AnalyticsException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/monitoring/MonitoringRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/monitoring/MonitoringRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.monitoring;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 
 /**
@@ -22,5 +23,5 @@ import io.gravitee.repository.monitoring.model.MonitoringResponse;
  * @author GraviteeSource Team
  */
 public interface MonitoringRepository {
-    MonitoringResponse query(String gatewayId);
+    MonitoringResponse query(QueryContext queryContext, String gatewayId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <gravitee-reporter-common.version>1.2.1</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>5.1.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.0.0</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.0.1</opensearch-testcontainers.version>
     </properties>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchAnalyticsRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.api.AnalyticsRepository;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.Response;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import jakarta.annotation.PostConstruct;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class ElasticsearchAnalyticsRepository extends AbstractElasticsearchRepos
     }
 
     @Override
-    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+    public <T extends Response> T query(final QueryContext queryContext, final Query<T> query) throws AnalyticsException {
         @SuppressWarnings("unchecked")
         final ElasticsearchQueryCommand<T> handler = (ElasticsearchQueryCommand<T>) this.queryCommands.get(query.getClass());
 
@@ -67,6 +68,6 @@ public class ElasticsearchAnalyticsRepository extends AbstractElasticsearchRepos
             logger.error("No command found to handle query of type {}", query.getClass());
             throw new AnalyticsException("No command found to handle query of type " + query.getClass());
         }
-        return handler.executeQuery(handler.prepareQuery(query));
+        return handler.executeQuery(queryContext, handler.prepareQuery(query));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchQueryCommand.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.analytics;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.Response;
+import io.gravitee.repository.common.query.QueryContext;
 
 /**
  * Common interface used to execute an analytic Elasticsearch query.
@@ -48,7 +49,7 @@ public interface ElasticsearchQueryCommand<T extends Response> {
      * @throws AnalyticsException
      *             in case of analytic exception
      */
-    T executeQuery(final Query<T> query) throws AnalyticsException;
+    T executeQuery(final QueryContext queryContext, final Query<T> query) throws AnalyticsException;
 
     /**
      * Get the supported query

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/AbstractElasticsearchQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/AbstractElasticsearchQueryCommand.java
@@ -25,6 +25,7 @@ import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.gravitee.repository.analytics.query.AbstractQuery;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.Response;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.analytics.ElasticsearchQueryCommand;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
@@ -115,7 +116,7 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
         return request;
     }
 
-    Single<SearchResponse> execute(AbstractQuery<T> query, Type type, String sQuery) {
+    Single<SearchResponse> execute(QueryContext queryContext, AbstractQuery<T> query, Type type, String sQuery) {
         final Single<SearchResponse> result;
 
         String[] clusters = ClusterUtils.extractClusterIndexPrefixes(query, configuration);
@@ -127,14 +128,14 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
 
             result =
                 this.client.search(
-                        this.indexNameGenerator.getIndexName(type, from, to, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), type, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : type.getType(),
                         sQuery
                     );
         } else {
             result =
                 this.client.search(
-                        this.indexNameGenerator.getTodayIndexName(type, clusters),
+                        this.indexNameGenerator.getTodayIndexName(queryContext.placeholder(), type, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : type.getType(),
                         sQuery
                     );
@@ -143,7 +144,7 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
         return result;
     }
 
-    Single<CountResponse> executeCount(AbstractQuery<T> query, Type type, String sQuery) {
+    Single<CountResponse> executeCount(QueryContext queryContext, AbstractQuery<T> query, Type type, String sQuery) {
         final Single<CountResponse> result;
 
         String[] clusters = ClusterUtils.extractClusterIndexPrefixes(query, configuration);
@@ -155,14 +156,14 @@ public abstract class AbstractElasticsearchQueryCommand<T extends Response> impl
 
             result =
                 this.client.count(
-                        this.indexNameGenerator.getIndexName(type, from, to, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), type, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : type.getType(),
                         sQuery
                     );
         } else {
             result =
                 this.client.count(
-                        this.indexNameGenerator.getTodayIndexName(type, clusters),
+                        this.indexNameGenerator.getTodayIndexName(queryContext.placeholder(), type, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : type.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/CountQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/CountQueryCommand.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.count.CountQuery;
 import io.gravitee.repository.analytics.query.count.CountResponse;
+import io.gravitee.repository.common.query.QueryContext;
 
 /**
  * Commmand used to handle CountQuery
@@ -38,12 +39,13 @@ public class CountQueryCommand extends AbstractElasticsearchQueryCommand<CountRe
     }
 
     @Override
-    public CountResponse executeQuery(Query<CountResponse> query) throws AnalyticsException {
+    public CountResponse executeQuery(QueryContext queryContext, Query<CountResponse> query) throws AnalyticsException {
         final CountQuery countQuery = (CountQuery) query;
         final String sQuery = this.createQuery(TEMPLATE, query);
 
         try {
-            io.gravitee.elasticsearch.model.CountResponse response = executeCount(countQuery, Type.REQUEST, sQuery).blockingGet();
+            io.gravitee.elasticsearch.model.CountResponse response = executeCount(queryContext, countQuery, Type.REQUEST, sQuery)
+                .blockingGet();
             return this.toCountResponse(response);
         } catch (final Exception eex) {
             logger.error("Impossible to perform CountQuery", eex);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommand.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.histogram.Bucket;
 import io.gravitee.repository.analytics.query.response.histogram.Data;
 import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -93,7 +94,7 @@ public class DateHistogramQueryCommand extends AbstractElasticsearchQueryCommand
     }
 
     @Override
-    public DateHistogramResponse executeQuery(Query<DateHistogramResponse> query) throws AnalyticsException {
+    public DateHistogramResponse executeQuery(QueryContext queryContext, Query<DateHistogramResponse> query) throws AnalyticsException {
         final DateHistogramQuery dateHistogramQuery = (DateHistogramQuery) query;
 
         final Long from = dateHistogramQuery.timeRange().range().from();
@@ -107,7 +108,7 @@ public class DateHistogramQueryCommand extends AbstractElasticsearchQueryCommand
         final String sQuery = this.createQuery(TEMPLATE, query, roundedFrom, roundedTo);
 
         try {
-            SearchResponse searchResponse = execute(dateHistogramQuery, Type.REQUEST, sQuery).blockingGet();
+            SearchResponse searchResponse = execute(queryContext, dateHistogramQuery, Type.REQUEST, sQuery).blockingGet();
             return this.toDateHistogramResponse(searchResponse, dateHistogramQuery);
         } catch (final Exception eex) {
             logger.error("Impossible to perform DateHistogramQuery", eex);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/GroupByQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/GroupByQueryCommand.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.groupby.GroupByQuery;
 import io.gravitee.repository.analytics.query.groupby.GroupByResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import java.util.Iterator;
 
 /**
@@ -43,13 +44,13 @@ public class GroupByQueryCommand extends AbstractElasticsearchQueryCommand<Group
     }
 
     @Override
-    public GroupByResponse executeQuery(Query<GroupByResponse> query) throws AnalyticsException {
+    public GroupByResponse executeQuery(QueryContext queryContext, Query<GroupByResponse> query) throws AnalyticsException {
         final GroupByQuery groupByQuery = (GroupByQuery) query;
 
         final String sQuery = this.createQuery(TEMPLATE, query);
 
         try {
-            SearchResponse searchResponse = execute(groupByQuery, Type.REQUEST, sQuery).blockingGet();
+            SearchResponse searchResponse = execute(queryContext, groupByQuery, Type.REQUEST, sQuery).blockingGet();
             return this.toGroupByResponse(searchResponse);
         } catch (Exception eex) {
             logger.error("Impossible to perform GroupByQuery", eex);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/StatsQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/analytics/query/StatsQueryCommand.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.stats.StatsQuery;
 import io.gravitee.repository.analytics.query.stats.StatsResponse;
+import io.gravitee.repository.common.query.QueryContext;
 
 /**
  * Commmand used to handle StatsQuery
@@ -39,12 +40,12 @@ public class StatsQueryCommand extends AbstractElasticsearchQueryCommand<StatsRe
     }
 
     @Override
-    public StatsResponse executeQuery(Query<StatsResponse> query) throws AnalyticsException {
+    public StatsResponse executeQuery(QueryContext queryContext, Query<StatsResponse> query) throws AnalyticsException {
         final StatsQuery statsQuery = (StatsQuery) query;
         final String sQuery = this.createQuery(TEMPLATE, query);
 
         try {
-            SearchResponse searchResponse = execute(statsQuery, Type.REQUEST, sQuery).blockingGet();
+            SearchResponse searchResponse = execute(queryContext, statsQuery, Type.REQUEST, sQuery).blockingGet();
             return this.toStatsResponse(searchResponse);
         } catch (final Exception eex) {
             logger.error("Impossible to perform StatsQuery", eex);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchHealthCheckRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchHealthCheckRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.elasticsearch.model.SearchHit;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.healthcheck.query.LogBuilder;
@@ -76,7 +77,7 @@ public class ElasticsearchHealthCheckRepository extends AbstractElasticsearchRep
     }
 
     @Override
-    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+    public <T extends Response> T query(final QueryContext queryContext, final Query<T> query) throws AnalyticsException {
         @SuppressWarnings("unchecked")
         final ElasticsearchQueryCommand<T> handler = (ElasticsearchQueryCommand<T>) this.queryCommands.get(query.getClass());
 
@@ -85,11 +86,11 @@ public class ElasticsearchHealthCheckRepository extends AbstractElasticsearchRep
             throw new AnalyticsException("No command found to handle query of type " + query.getClass());
         }
 
-        return handler.executeQuery(query);
+        return handler.executeQuery(queryContext, query);
     }
 
     @Override
-    public ExtendedLog findById(String id) throws AnalyticsException {
+    public ExtendedLog findById(QueryContext queryContext, String id) throws AnalyticsException {
         final Map<String, Object> data = new HashMap<>();
         data.put("id", id);
 
@@ -99,7 +100,7 @@ public class ElasticsearchHealthCheckRepository extends AbstractElasticsearchRep
         try {
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getWildcardIndexName(Type.HEALTH_CHECK, clusters),
+                        this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.HEALTH_CHECK, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.HEALTH_CHECK.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchQueryCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/ElasticsearchQueryCommand.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.healthcheck;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.healthcheck.query.Query;
 import io.gravitee.repository.healthcheck.query.Response;
 
@@ -38,7 +39,7 @@ public interface ElasticsearchQueryCommand<T extends Response> {
      * @throws AnalyticsException
      *             in case of analytic exception
      */
-    T executeQuery(final Query<T> query) throws AnalyticsException;
+    T executeQuery(final QueryContext queryContext, final Query<T> query) throws AnalyticsException;
 
     /**
      * Get the supported query

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageAvailabilityCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageAvailabilityCommand.java
@@ -20,6 +20,7 @@ import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.healthcheck.query.Bucket;
@@ -64,7 +65,7 @@ public class AverageAvailabilityCommand extends AbstractElasticsearchQueryComman
     }
 
     @Override
-    public AvailabilityResponse executeQuery(Query<AvailabilityResponse> query) throws AnalyticsException {
+    public AvailabilityResponse executeQuery(QueryContext queryContext, Query<AvailabilityResponse> query) throws AnalyticsException {
         final AvailabilityQuery availabilityQuery = (AvailabilityQuery) query;
 
         final String sQuery = this.createQuery(TEMPLATE, availabilityQuery);
@@ -80,7 +81,7 @@ public class AverageAvailabilityCommand extends AbstractElasticsearchQueryComman
 
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, now, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.HEALTH_CHECK, from, now, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.HEALTH_CHECK.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageDateHistogramCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageDateHistogramCommand.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.AggregationType;
 import io.gravitee.repository.analytics.query.response.histogram.Bucket;
 import io.gravitee.repository.analytics.query.response.histogram.Data;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.healthcheck.query.DateHistogramQuery;
@@ -63,7 +64,7 @@ public class AverageDateHistogramCommand extends AbstractElasticsearchQueryComma
     }
 
     @Override
-    public DateHistogramResponse executeQuery(Query<DateHistogramResponse> query) throws AnalyticsException {
+    public DateHistogramResponse executeQuery(QueryContext queryContext, Query<DateHistogramResponse> query) throws AnalyticsException {
         final DateHistogramQuery dateHistogramQuery = (DateHistogramQuery) query;
 
         try {
@@ -92,7 +93,7 @@ public class AverageDateHistogramCommand extends AbstractElasticsearchQueryComma
             final String sQuery = this.createQuery(TEMPLATE, dateHistogramQuery, roundedFrom, roundedTo);
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, to, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.HEALTH_CHECK, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.HEALTH_CHECK.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageResponseTimeCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/AverageResponseTimeCommand.java
@@ -20,6 +20,7 @@ import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.healthcheck.query.Bucket;
@@ -64,7 +65,8 @@ public class AverageResponseTimeCommand extends AbstractElasticsearchQueryComman
     }
 
     @Override
-    public AverageResponseTimeResponse executeQuery(Query<AverageResponseTimeResponse> query) throws AnalyticsException {
+    public AverageResponseTimeResponse executeQuery(QueryContext queryContext, Query<AverageResponseTimeResponse> query)
+        throws AnalyticsException {
         final AverageResponseTimeQuery averageResponseTimeQuery = (AverageResponseTimeQuery) query;
 
         final String sQuery = this.createQuery(TEMPLATE, averageResponseTimeQuery);
@@ -80,7 +82,7 @@ public class AverageResponseTimeCommand extends AbstractElasticsearchQueryComman
 
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, now, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.HEALTH_CHECK, from, now, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.HEALTH_CHECK.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/LogsCommand.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/healthcheck/query/LogsCommand.java
@@ -21,6 +21,7 @@ import io.gravitee.elasticsearch.model.SearchHits;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.utils.Type;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.healthcheck.query.Query;
@@ -63,7 +64,7 @@ public class LogsCommand extends AbstractElasticsearchQueryCommand<LogsResponse>
     }
 
     @Override
-    public LogsResponse executeQuery(Query<LogsResponse> query) throws AnalyticsException {
+    public LogsResponse executeQuery(QueryContext queryContext, Query<LogsResponse> query) throws AnalyticsException {
         final LogsQuery logsQuery = (LogsQuery) query;
 
         long queryFrom = logsQuery.from();
@@ -84,7 +85,7 @@ public class LogsCommand extends AbstractElasticsearchQueryCommand<LogsResponse>
 
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getIndexName(Type.HEALTH_CHECK, from, to, clusters),
+                        this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.HEALTH_CHECK, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.HEALTH_CHECK.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.elasticsearch.model.SearchHits;
 import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
-import io.gravitee.repository.elasticsearch.analytics.ElasticsearchAnalyticsRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
 import io.gravitee.repository.monitoring.MonitoringRepository;
@@ -67,14 +67,14 @@ public class ElasticsearchMonitoringRepository extends AbstractElasticsearchRepo
     protected RepositoryConfiguration configuration;
 
     @Override
-    public MonitoringResponse query(final String gatewayId) {
+    public MonitoringResponse query(final QueryContext queryContext, final String gatewayId) {
         final String sQuery = this.createElasticsearchJsonQuery(gatewayId);
         String[] clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
 
         try {
             final Single<SearchResponse> result =
                 this.client.search(
-                        this.indexNameGenerator.getTodayIndexName(Type.MONITOR, clusters),
+                        this.indexNameGenerator.getTodayIndexName(queryContext.placeholder(), Type.MONITOR, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.MONITOR.getType(),
                         sQuery
                     );

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.analytics;
 
 import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
@@ -42,8 +43,8 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     }
 
     @Override
-    public Optional<CountAggregate> searchRequestsCount(RequestsCountQuery query) {
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_METRICS, clusters);
+    public Optional<CountAggregate> searchRequestsCount(QueryContext queryContext, RequestsCountQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
 
         return this.client.search(index, null, SearchRequestsCountQueryAdapter.adapt(query))
             .map(SearchRequestsCountResponseAdapter::adapt)
@@ -51,16 +52,16 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     }
 
     @Override
-    public Optional<AverageAggregate> searchAverageMessagesPerRequest(AverageMessagesPerRequestQuery query) {
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_MESSAGE_METRICS, clusters);
+    public Optional<AverageAggregate> searchAverageMessagesPerRequest(QueryContext queryContext, AverageMessagesPerRequestQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_MESSAGE_METRICS, clusters);
         return this.client.search(index, null, SearchAverageMessagesPerRequestQueryAdapter.adapt(query))
             .map(SearchAverageMessagesPerRequestResponseAdapter::adapt)
             .blockingGet();
     }
 
     @Override
-    public Optional<AverageAggregate> searchAverageConnectionDuration(AverageConnectionDurationQuery query) {
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_METRICS, clusters);
+    public Optional<AverageAggregate> searchAverageConnectionDuration(QueryContext queryContext, AverageConnectionDurationQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
         return this.client.search(index, null, SearchAverageConnectionDurationQueryAdapter.adapt(query))
             .map(SearchAverageConnectionDurationResponseAdapter::adapt)
             .blockingGet();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.log;
 import io.gravitee.elasticsearch.model.SearchHits;
 import io.gravitee.elasticsearch.model.TotalHits;
 import io.gravitee.elasticsearch.utils.Type;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepository;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.utils.ClusterUtils;
@@ -47,9 +48,9 @@ public class LogElasticsearchRepository extends AbstractElasticsearchRepository 
     }
 
     @Override
-    public LogResponse<ConnectionLog> searchConnectionLogs(ConnectionLogQuery query) {
+    public LogResponse<ConnectionLog> searchConnectionLogs(QueryContext queryContext, ConnectionLogQuery query) {
         var clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_METRICS, clusters);
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
 
         return this.client.search(index, null, SearchConnectionLogQueryAdapter.adapt(query))
             .map(SearchConnectionLogResponseAdapter::adapt)
@@ -57,9 +58,9 @@ public class LogElasticsearchRepository extends AbstractElasticsearchRepository 
     }
 
     @Override
-    public Optional<ConnectionLogDetail> searchConnectionLogDetail(ConnectionLogDetailQuery query) {
+    public Optional<ConnectionLogDetail> searchConnectionLogDetail(QueryContext queryContext, ConnectionLogDetailQuery query) {
         var clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_LOG, clusters);
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_LOG, clusters);
 
         return this.client.search(index, null, SearchConnectionLogDetailQueryAdapter.adapt(query))
             .map(SearchConnectionLogDetailResponseAdapter::adapt)
@@ -67,9 +68,9 @@ public class LogElasticsearchRepository extends AbstractElasticsearchRepository 
     }
 
     @Override
-    public LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(MessageLogQuery query) {
+    public LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(QueryContext queryContext, MessageLogQuery query) {
         var clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
-        var index = this.indexNameGenerator.getWildcardIndexName(Type.V4_MESSAGE_LOG, clusters);
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_MESSAGE_LOG, clusters);
 
         var entrypointMessages =
             this.client.search(

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchAnalyticsRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/ElasticsearchAnalyticsRepositoryTest.java
@@ -34,6 +34,7 @@ import io.gravitee.repository.analytics.query.groupby.GroupByResponse;
 import io.gravitee.repository.analytics.query.groupby.GroupByResponse.Bucket;
 import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
 import io.gravitee.repository.analytics.query.stats.StatsResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,12 +45,14 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchRepositoryTest {
 
+    private final QueryContext queryContext = new QueryContext("org#1", "env#1");
+
     @Autowired
     private AnalyticsRepository analyticsRepository;
 
     @Test
     public void testDateHistogram() throws Exception {
-        DateHistogramResponse response = analyticsRepository.query(dateHistogram().timeRange(lastDays(30), hours(1)).build());
+        DateHistogramResponse response = analyticsRepository.query(queryContext, dateHistogram().timeRange(lastDays(30), hours(1)).build());
 
         assertThat(response).isNotNull();
     }
@@ -57,6 +60,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testDateHistogram_root() throws Exception {
         DateHistogramResponse response = analyticsRepository.query(
+            queryContext,
             dateHistogram().timeRange(lastDays(90), hours(1)).root("api", "be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").build()
         );
 
@@ -66,6 +70,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testDateHistogram_singleAggregation() throws Exception {
         DateHistogramResponse response = analyticsRepository.query(
+            queryContext,
             dateHistogram().timeRange(lastDays(60), hours(1)).aggregation(AggregationType.AVG, "response-time").build()
         );
 
@@ -75,6 +80,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testDateHistogram_multipleAggregation_average() throws Exception {
         DateHistogramResponse response = analyticsRepository.query(
+            queryContext,
             dateHistogram()
                 .timeRange(lastDays(30), hours(1))
                 .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
@@ -89,6 +95,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testDateHistogram_multipleAggregation_averageAndField() throws Exception {
         DateHistogramResponse response = analyticsRepository.query(
+            queryContext,
             dateHistogram()
                 .timeRange(lastDays(30), hours(1))
                 .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
@@ -103,6 +110,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testGroupBy_simpleField() throws Exception {
         GroupByResponse response = analyticsRepository.query(
+            queryContext,
             groupBy().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").field("application").build()
         );
 
@@ -112,6 +120,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testGroupBy_simpleField_withOrder() throws Exception {
         GroupByResponse response = analyticsRepository.query(
+            queryContext,
             groupBy()
                 .timeRange(lastDays(30), hours(1))
                 .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
@@ -126,6 +135,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testGroupBy_simpleField_withRanges() throws Exception {
         GroupByResponse response = analyticsRepository.query(
+            queryContext,
             groupBy()
                 .timeRange(lastDays(30), hours(1))
                 .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
@@ -157,6 +167,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testCount() throws Exception {
         CountResponse response = analyticsRepository.query(
+            queryContext,
             count().timeRange(lastDays(30), hours(1)).query("api:4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1").build()
         );
 
@@ -166,7 +177,10 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
 
     @Test
     public void testCountByPath() throws Exception {
-        CountResponse response = analyticsRepository.query(count().timeRange(lastDays(30), hours(1)).query("(path:/mypath)").build());
+        CountResponse response = analyticsRepository.query(
+            queryContext,
+            count().timeRange(lastDays(30), hours(1)).query("(path:/mypath)").build()
+        );
 
         assertThat(response).isNotNull();
         assertThat(response.getCount()).isOne();
@@ -175,6 +189,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testCountByHost() throws Exception {
         CountResponse response = analyticsRepository.query(
+            queryContext,
             count().timeRange(lastDays(30), hours(1)).query("(host:localhost:8082)").build()
         );
 
@@ -185,6 +200,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testCountByHostAndPath() throws Exception {
         CountResponse response = analyticsRepository.query(
+            queryContext,
             count().timeRange(lastDays(30), hours(1)).query("((path:/mypath) AND (host:localhost:8082))").build()
         );
 
@@ -195,6 +211,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
     @Test
     public void testStats() throws Exception {
         final StatsResponse response = analyticsRepository.query(
+            queryContext,
             stats().timeRange(lastDays(30), hours(1)).query("api:4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1").field("response-time").build()
         );
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommandTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/analytics/query/DateHistogramQueryCommandTest.java
@@ -29,6 +29,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.DateHistogramQuery;
 import io.gravitee.repository.analytics.query.DateRange;
 import io.gravitee.repository.analytics.query.TimeRangeFilter;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +91,7 @@ public class DateHistogramQueryCommandTest {
         when(timeRangeFilter.interval()).thenReturn(() -> interval);
         when(dateRange.from()).thenReturn(from);
         when(dateRange.to()).thenReturn(to);
-        dateHistogramQueryCommand.executeQuery(dateHistogramQuery);
+        dateHistogramQueryCommand.executeQuery(new QueryContext("org#1", "env#1"), dateHistogramQuery);
 
         verify(freeMarkerComponent)
             .generateFromTemplate(

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/ElasticsearchLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/ElasticsearchLogRepositoryTest.java
@@ -21,8 +21,8 @@ import static io.gravitee.repository.analytics.query.QueryBuilders.tabular;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
-import io.gravitee.repository.elasticsearch.log.ElasticLogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,13 +33,19 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchRepositoryTest {
 
+    private QueryContext queryContext = new QueryContext("org#1", "env#1");
+
     @Autowired
     private ElasticLogRepository logRepository;
 
     @Test
     public void testFindById() throws Exception {
         // 29381bce-df59-47b2-b81b-cedf59c7b23e request is stored in the yesterday index
-        ExtendedLog log = logRepository.findById("29381bce-df59-47b2-b81b-cedf59c7b23e", System.currentTimeMillis() - 24 * 60 * 60 * 1000);
+        ExtendedLog log = logRepository.findById(
+            queryContext,
+            "29381bce-df59-47b2-b81b-cedf59c7b23e",
+            System.currentTimeMillis() - 24 * 60 * 60 * 1000
+        );
 
         assertThat(log).isNotNull();
     }
@@ -47,6 +53,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withQuery() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").page(1).size(20).build()
         );
 
@@ -57,6 +64,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withLogQuery() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("client-response.body:*not valid or is expired*").page(1).size(10).build()
         );
 
@@ -68,6 +76,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withLogQuery_page1() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("client-response.body:*not valid or is expired*").page(1).size(5).build()
         );
 
@@ -79,6 +88,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withLogQuery_termWithCurrency() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("client-response.body:*10$*").page(1).size(5).build()
         );
         assertThat(response).isNotNull();
@@ -89,6 +99,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withLogQuery_termWithEmail() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("client-response.body:*john@yopmail.com*").page(1).size(5).build()
         );
         assertThat(response).isNotNull();
@@ -99,6 +110,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withLogQuery_page2() throws Exception {
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("client-response.body:*not valid or is expired*").page(2).size(5).build()
         );
 
@@ -110,7 +122,7 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
 
     @Test
     public void testTabular_withoutQuery() throws Exception {
-        TabularResponse response = logRepository.query(tabular().timeRange(lastDays(60), hours(1)).page(1).size(100).build());
+        TabularResponse response = logRepository.query(queryContext, tabular().timeRange(lastDays(60), hours(1)).page(1).size(100).build());
 
         assertThat(response).isNotNull();
         assertThat(response.getLogs().size()).isEqualTo(response.getSize());

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepositoryTest.java
@@ -18,8 +18,8 @@ package io.gravitee.repository.elasticsearch.monitoring;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
-import io.gravitee.repository.elasticsearch.monitoring.ElasticsearchMonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
@@ -44,7 +44,10 @@ public class ElasticsearchMonitoringRepositoryTest extends AbstractElasticsearch
     @Test
     public void testQuery() throws IOException {
         //Do the call
-        final MonitoringResponse monitoringResponse = elasticMonitoringRepository.query("1876c024-c6a2-409a-b6c0-24c6a2e09a5f");
+        final MonitoringResponse monitoringResponse = elasticMonitoringRepository.query(
+            new QueryContext("org#1", "env#1"),
+            "1876c024-c6a2-409a-b6c0-24c6a2e09a5f"
+        );
 
         final ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepositoryTest.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
@@ -50,7 +51,10 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
 
         @Test
         void should_return_all_the_requests_count_by_entrypoint_for_a_given_api() {
-            var result = cut.searchRequestsCount(RequestsCountQuery.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build());
+            var result = cut.searchRequestsCount(
+                new QueryContext("org#1", "env#1"),
+                RequestsCountQuery.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()
+            );
 
             assertThat(result)
                 .hasValueSatisfying(countAggregate -> {
@@ -67,6 +71,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         @Test
         void should_return_average_messages_per_request_by_entrypoint_for_a_given_api() {
             var result = cut.searchAverageMessagesPerRequest(
+                new QueryContext("org#1", "env#1"),
                 AverageMessagesPerRequestQuery.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()
             );
 
@@ -85,6 +90,7 @@ class AnalyticsElasticsearchRepositoryTest extends AbstractElasticsearchReposito
         @Test
         void should_return_average_connection_duration_by_entrypoint_for_a_given_api() {
             var result = cut.searchAverageConnectionDuration(
+                new QueryContext("org#1", "env#1"),
                 AverageConnectionDurationQuery.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()
             );
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/LogElasticsearchRepositoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.elasticsearch.AbstractElasticsearchRepositoryTest;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLogDetail;
@@ -45,6 +46,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 public class LogElasticsearchRepositoryTest extends AbstractElasticsearchRepositoryTest {
 
+    private final QueryContext queryContext = new QueryContext("org#1", "env#1");
+
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.systemDefault());
 
     @Autowired
@@ -58,6 +61,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var today = DATE_FORMATTER.format(Instant.now());
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery.builder().filter(Filter.builder().apiId("f1608475-dd77-4603-a084-75dd775603e9").build()).size(2).build()
             );
             assertThat(result).isNotNull();
@@ -100,6 +104,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery
                     .builder()
                     .page(3)
@@ -167,6 +172,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                 1000;
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery.builder().page(1).size(10).filter(Filter.builder().from(from).to(to).build()).build()
             );
             assertThat(result).isNotNull();
@@ -194,6 +200,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                 1000;
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery.builder().page(1).size(10).filter(Filter.builder().to(to).build()).build()
             );
             assertThat(result).isNotNull();
@@ -214,6 +221,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
                 1000;
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery.builder().page(1).size(10).filter(Filter.builder().from(from).build()).build()
             );
             assertThat(result).isNotNull();
@@ -234,6 +242,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery
                     .builder()
                     .page(1)
@@ -263,6 +272,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var today = DATE_FORMATTER.format(Instant.now());
 
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery
                     .builder()
                     .page(1)
@@ -290,6 +300,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         @Test
         void should_return_the_connection_logs_for_methods() {
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery
                     .builder()
                     .page(1)
@@ -313,6 +324,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         @Test
         void should_return_the_connection_logs_for_statuses() {
             var result = logV4Repository.searchConnectionLogs(
+                queryContext,
                 ConnectionLogQuery.builder().page(1).size(10).filter(Filter.builder().statuses(Set.of(500, 200)).build()).build()
             );
             assertThat(result).isNotNull();
@@ -329,6 +341,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         @Test
         void should_return_empty_result() {
             var result = logV4Repository.searchConnectionLogDetail(
+                queryContext,
                 ConnectionLogDetailQuery.builder().filter(ConnectionLogDetailQuery.Filter.builder().apiId("notExisting").build()).build()
             );
             assertThat(result).isEmpty();
@@ -339,6 +352,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var today = DATE_FORMATTER.format(Instant.now());
 
             var result = logV4Repository.searchConnectionLogDetail(
+                queryContext,
                 ConnectionLogDetailQuery
                     .builder()
                     .filter(
@@ -399,6 +413,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(
@@ -444,6 +459,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(
@@ -489,6 +505,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(
@@ -546,6 +563,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
             var yesterday = DATE_FORMATTER.format(Instant.now().minus(1, ChronoUnit.DAYS));
 
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(
@@ -601,6 +619,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         @Test
         void should_return_the_1st_page_of_aggregated_message_logs_of_an_api_and_request_id() {
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(
@@ -627,6 +646,7 @@ public class LogElasticsearchRepositoryTest extends AbstractElasticsearchReposit
         @Test
         void should_return_the_2nd_page_of_aggregated_message_logs_of_an_api_and_request_id() {
             var result = logV4Repository.searchAggregatedMessageLog(
+                queryContext,
                 MessageLogQuery
                     .builder()
                     .filter(

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/analytics/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/analytics/NoOpAnalyticsRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.api.AnalyticsRepository;
 import io.gravitee.repository.analytics.query.Query;
 import io.gravitee.repository.analytics.query.response.Response;
+import io.gravitee.repository.common.query.QueryContext;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -27,7 +28,7 @@ import io.gravitee.repository.analytics.query.response.Response;
 public class NoOpAnalyticsRepository implements AnalyticsRepository {
 
     @Override
-    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+    public <T extends Response> T query(final QueryContext queryContext, final Query<T> query) throws AnalyticsException {
         return null;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/healthcheck/NoOpHealthCheckRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/healthcheck/NoOpHealthCheckRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.noop.healthcheck;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
 import io.gravitee.repository.healthcheck.query.Query;
 import io.gravitee.repository.healthcheck.query.Response;
@@ -28,12 +29,12 @@ import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
 public class NoOpHealthCheckRepository implements HealthCheckRepository {
 
     @Override
-    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+    public <T extends Response> T query(final QueryContext queryContext, final Query<T> query) throws AnalyticsException {
         return null;
     }
 
     @Override
-    public ExtendedLog findById(String id) throws AnalyticsException {
+    public ExtendedLog findById(QueryContext queryContext, String id) throws AnalyticsException {
         return null;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/NoOpLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/NoOpLogRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.noop.log;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.tabular.TabularQuery;
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.api.LogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
 import org.slf4j.Logger;
@@ -35,12 +36,12 @@ public class NoOpLogRepository implements LogRepository {
     private final Logger logger = LoggerFactory.getLogger(NoOpLogRepository.class);
 
     @Override
-    public TabularResponse query(final TabularQuery query) throws AnalyticsException {
+    public TabularResponse query(final QueryContext queryContext, final TabularQuery query) throws AnalyticsException {
         return null;
     }
 
     @Override
-    public ExtendedLog findById(String logId, Long timestamp) throws AnalyticsException {
+    public ExtendedLog findById(QueryContext queryContext, String logId, Long timestamp) throws AnalyticsException {
         return null;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpLogRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.noop.log.v4;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.LogRepository;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
@@ -29,17 +30,18 @@ import java.util.Optional;
 public class NoOpLogRepository implements LogRepository {
 
     @Override
-    public LogResponse<ConnectionLog> searchConnectionLogs(ConnectionLogQuery query) {
+    public LogResponse<ConnectionLog> searchConnectionLogs(QueryContext queryContext, ConnectionLogQuery query) {
         return null;
     }
 
     @Override
-    public Optional<ConnectionLogDetail> searchConnectionLogDetail(ConnectionLogDetailQuery query) throws AnalyticsException {
+    public Optional<ConnectionLogDetail> searchConnectionLogDetail(QueryContext queryContext, ConnectionLogDetailQuery query)
+        throws AnalyticsException {
         return Optional.empty();
     }
 
     @Override
-    public LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(MessageLogQuery query) {
+    public LogResponse<AggregatedMessageLog> searchAggregatedMessageLog(QueryContext queryContext, MessageLogQuery query) {
         return null;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.noop.monitor;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 import org.slf4j.Logger;
@@ -32,7 +33,7 @@ public class NoOpMonitoringRepository implements MonitoringRepository {
     private final Logger logger = LoggerFactory.getLogger(NoOpMonitoringRepository.class);
 
     @Override
-    public MonitoringResponse query(final String gatewayId) {
+    public MonitoringResponse query(final QueryContext queryContext, final String gatewayId) {
         return null;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/analytics/NoOpAnalyticsRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/analytics/NoOpAnalyticsRepositoryTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.analytics.query.QueryBuilders.dateHistogram
 
 import io.gravitee.repository.analytics.api.AnalyticsRepository;
 import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
 import org.junit.Assert;
 import org.junit.Test;
@@ -39,7 +40,10 @@ public class NoOpAnalyticsRepositoryTest extends AbstractNoOpRepositoryTest {
     public void testQuery() throws Exception {
         Assert.assertNotNull(analyticsRepository);
 
-        DateHistogramResponse response = analyticsRepository.query(dateHistogram().timeRange(lastDays(30), hours(1)).build());
+        DateHistogramResponse response = analyticsRepository.query(
+            new QueryContext("org#1", "env#1"),
+            dateHistogram().timeRange(lastDays(30), hours(1)).build()
+        );
 
         Assert.assertNull(response);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/healthcheck/NoOpHealthCheckRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/healthcheck/NoOpHealthCheckRepositoryTest.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.noop.healthcheck;
 import static io.gravitee.repository.healthcheck.query.QueryBuilders.dateHistogram;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
 import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
 import io.gravitee.repository.healthcheck.query.response.histogram.DateHistogramResponse;
@@ -32,6 +33,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class NoOpHealthCheckRepositoryTest extends AbstractNoOpRepositoryTest {
 
+    private final QueryContext queryContext = new QueryContext("org#1", "env#1");
+
     @Autowired
     private HealthCheckRepository healthCheckRepository;
 
@@ -39,7 +42,7 @@ public class NoOpHealthCheckRepositoryTest extends AbstractNoOpRepositoryTest {
     public void testQuery() throws AnalyticsException {
         Assert.assertNotNull(healthCheckRepository);
 
-        DateHistogramResponse response = healthCheckRepository.query(dateHistogram().query("any_query").build());
+        DateHistogramResponse response = healthCheckRepository.query(queryContext, dateHistogram().query("any_query").build());
 
         Assert.assertNull(response);
     }
@@ -48,7 +51,7 @@ public class NoOpHealthCheckRepositoryTest extends AbstractNoOpRepositoryTest {
     public void testFindById() throws AnalyticsException {
         Assert.assertNotNull(healthCheckRepository);
 
-        ExtendedLog response = healthCheckRepository.findById("any_id");
+        ExtendedLog response = healthCheckRepository.findById(queryContext, "any_id");
 
         Assert.assertNull(response);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/log/NoOpLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/log/NoOpLogRepositoryTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.analytics.query.QueryBuilders.tabular;
 import static org.junit.Assert.*;
 
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.api.LogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
@@ -34,6 +35,8 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class NoOpLogRepositoryTest extends AbstractNoOpRepositoryTest {
 
+    private final QueryContext queryContext = new QueryContext("org#1", "env#1");
+
     @Autowired
     private LogRepository logRepository;
 
@@ -41,7 +44,11 @@ public class NoOpLogRepositoryTest extends AbstractNoOpRepositoryTest {
     public void testFindById() throws Exception {
         Assert.assertNotNull(logRepository);
 
-        ExtendedLog log = logRepository.findById("29381bce-df59-47b2-b81b-cedf59c7b23e", System.currentTimeMillis() - 24 * 60 * 60 * 1000);
+        ExtendedLog log = logRepository.findById(
+            queryContext,
+            "29381bce-df59-47b2-b81b-cedf59c7b23e",
+            System.currentTimeMillis() - 24 * 60 * 60 * 1000
+        );
 
         assertNull(log);
     }
@@ -51,6 +58,7 @@ public class NoOpLogRepositoryTest extends AbstractNoOpRepositoryTest {
         Assert.assertNotNull(logRepository);
 
         TabularResponse response = logRepository.query(
+            queryContext,
             tabular().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").page(1).size(20).build()
         );
 

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/monitor/NoOpMonitoringRepositoryTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.noop.monitor;
 
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 import io.gravitee.repository.noop.AbstractNoOpRepositoryTest;
@@ -37,7 +38,10 @@ public class NoOpMonitoringRepositoryTest extends AbstractNoOpRepositoryTest {
     public void testQuery() throws AnalyticsException, IOException {
         Assert.assertNotNull(monitoringRepository);
 
-        final MonitoringResponse monitoringResponse = monitoringRepository.query("1876c024-c6a2-409a-b6c0-24c6a2e09a5f");
+        final MonitoringResponse monitoringResponse = monitoringRepository.query(
+            new QueryContext("org#1", "env#1"),
+            "1876c024-c6a2-409a-b6c0-24c6a2e09a5f"
+        );
 
         Assert.assertNull(monitoringResponse);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResource.java
@@ -58,7 +58,7 @@ public class ApiAnalyticsResource extends AbstractResource {
         var request = new SearchRequestsCountAnalyticsUseCase.Input(apiId, GraviteeContext.getCurrentEnvironment());
 
         return searchRequestsCountAnalyticsUseCase
-            .execute(request)
+            .execute(GraviteeContext.getExecutionContext(), request)
             .requestsCount()
             .map(ApiAnalyticsMapper.INSTANCE::map)
             .orElseThrow(() -> new NotFoundException("No requests count found for api: " + apiId));
@@ -72,7 +72,7 @@ public class ApiAnalyticsResource extends AbstractResource {
         var request = new SearchAverageMessagesPerRequestAnalyticsUseCase.Input(apiId, GraviteeContext.getCurrentEnvironment());
 
         return searchAverageMessagesPerRequestAnalyticsUseCase
-            .execute(request)
+            .execute(GraviteeContext.getExecutionContext(), request)
             .averageMessagesPerRequest()
             .map(ApiAnalyticsMapper.INSTANCE::map)
             .orElseThrow(() -> new NotFoundException("No average message per request found for api: " + apiId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
@@ -92,7 +92,7 @@ public class ApiLogsResource extends AbstractResource {
             new PageableImpl(paginationParam.getPage(), paginationParam.getPerPage())
         );
 
-        var response = searchMessageLogsUsecase.execute(request);
+        var response = searchMessageLogsUsecase.execute(GraviteeContext.getExecutionContext(), request);
 
         return ApiMessageLogsResponse
             .builder()
@@ -110,7 +110,7 @@ public class ApiLogsResource extends AbstractResource {
         var request = new SearchConnectionLogUseCase.Input(apiId, requestId);
 
         return searchConnectionLogUsecase
-            .execute(request)
+            .execute(GraviteeContext.getExecutionContext(), request)
             .connectionLogDetail()
             .map(ApiLogsMapper.INSTANCE::map)
             .orElseThrow(() -> new NotFoundException("No log found for api: " + apiId + " and requestId: " + requestId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
@@ -102,7 +102,7 @@ public class ApiAnalyticsResource extends AbstractResource {
         query.setRootField("api");
         query.setRootIdentifier(api);
         query.setField(analyticsParam.getField());
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeCount(String api, AnalyticsParam analyticsParam) {
@@ -113,7 +113,7 @@ public class ApiAnalyticsResource extends AbstractResource {
         query.setQuery(analyticsParam.getQuery());
         query.setRootField("api");
         query.setRootIdentifier(api);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeDateHisto(String api, AnalyticsParam analyticsParam) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHealthResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHealthResource.java
@@ -130,7 +130,7 @@ public class ApiHealthResource extends AbstractResource {
                 }
             )
         );
-        return healthCheckService.query(query);
+        return healthCheckService.query(GraviteeContext.getExecutionContext(), query);
     }
 
     @GET
@@ -169,6 +169,6 @@ public class ApiHealthResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.API_HEALTH, acls = RolePermissionAction.READ) })
     public Log getApiHealthCheckLog(@PathParam("log") String logId) {
-        return healthCheckService.findLog(api, logId);
+        return healthCheckService.findLog(GraviteeContext.getExecutionContext(), api, logId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
@@ -105,7 +105,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
         query.setField(analyticsParam.getField());
         query.setRootField("application");
         query.setRootIdentifier(application);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeCount(String application, AnalyticsParam analyticsParam) {
@@ -116,7 +116,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
         query.setQuery(analyticsParam.getQuery());
         query.setRootField("application");
         query.setRootIdentifier(application);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeDateHisto(String application, AnalyticsParam analyticsParam) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -144,7 +144,7 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
         query.setQuery(analyticsParam.getQuery());
         query.setField(analyticsParam.getField());
         addExtraFilter(query, fieldFilter);
-        return analyticsService.execute(query);
+        return analyticsService.execute(executionContext, query);
     }
 
     private Analytics executeCount(final ExecutionContext executionContext, AnalyticsParam analyticsParam) {
@@ -176,7 +176,7 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
                 query.setInterval(analyticsParam.getInterval());
                 query.setQuery(analyticsParam.getQuery());
                 addExtraFilter(query, fieldFilter);
-                return analyticsService.execute(query);
+                return analyticsService.execute(executionContext, query);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
@@ -72,7 +72,7 @@ public class MonitoringResource extends AbstractResource {
         ) {
             throw new InstanceNotFoundException(instance);
         }
-        return monitoringService.findMonitoring(gatewayId);
+        return monitoringService.findMonitoring(GraviteeContext.getExecutionContext(), gatewayId);
     }
 
     private boolean isInstanceAccessibleByOrga(List<String> organizationsHrids, String currentOrganization) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -160,7 +160,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
         query.setQuery(analyticsParam.getQuery());
         query.setField(analyticsParam.getField());
         addExtraFilter(query, extraFilter);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeCount(AnalyticsParam analyticsParam, String extraFilter) {
@@ -170,7 +170,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
         query.setInterval(analyticsParam.getInterval());
         query.setQuery(analyticsParam.getQuery());
         addExtraFilter(query, extraFilter);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeDateHisto(AnalyticsParam analyticsParam, String extraFilter) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Set;
@@ -105,7 +106,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
-        when(analyticsService.execute(any(CountQuery.class))).thenReturn(analytics);
+        when(analyticsService.execute(any(ExecutionContext.class), any(CountQuery.class))).thenReturn(analytics);
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -137,7 +138,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
-        when(analyticsService.execute(any(CountQuery.class))).thenReturn(analytics);
+        when(analyticsService.execute(any(ExecutionContext.class), any(CountQuery.class))).thenReturn(analytics);
 
         final Response response = envTarget()
             .queryParam("to", 122222L)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Set;
@@ -121,7 +122,7 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
-        when(analyticsService.execute(any(CountQuery.class))).thenReturn(analytics);
+        when(analyticsService.execute(any(ExecutionContext.class), any(CountQuery.class))).thenReturn(analytics);
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -162,7 +163,7 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
-        when(analyticsService.execute(any(CountQuery.class))).thenReturn(analytics);
+        when(analyticsService.execute(any(ExecutionContext.class), any(CountQuery.class))).thenReturn(analytics);
 
         final Response response = envTarget()
             .queryParam("to", 122222L)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
@@ -115,7 +115,7 @@ public class ApiMetricsResource extends AbstractResource {
         query.setField("response-time");
 
         try {
-            final StatsAnalytics analytics = analyticsService.execute(query);
+            final StatsAnalytics analytics = analyticsService.execute(GraviteeContext.getExecutionContext(), query);
             if (analytics != null) {
                 return analytics.getCount();
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResource.java
@@ -98,7 +98,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
         query.setField(analyticsParam.getField());
         query.setRootField(ANALYTICS_ROOT_FIELD);
         query.setRootIdentifier(application);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeCount(String application, AnalyticsParam analyticsParam) {
@@ -109,7 +109,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
         query.setQuery(analyticsParam.getQuery());
         query.setRootField(ANALYTICS_ROOT_FIELD);
         query.setRootIdentifier(application);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
     private Analytics executeDateHisto(String application, AnalyticsParam analyticsParam) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
@@ -17,8 +17,11 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -30,11 +33,16 @@ import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.ApiMetrics;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,7 +94,7 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
     public void shouldGetApiMetrics() {
         StatsAnalytics mockAnalytics = new StatsAnalytics();
         mockAnalytics.setCount(API_NB_HITS);
-        doReturn(mockAnalytics).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(mockAnalytics).when(analyticsService).execute(any(ExecutionContext.class), any(StatsQuery.class));
 
         SubscriptionEntity subA1 = new SubscriptionEntity();
         subA1.setApplication("A");
@@ -126,7 +134,7 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetEmptyApiMetrics() {
         // Case 1
-        doReturn(null).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(null).when(analyticsService).execute(any(ExecutionContext.class), any(StatsQuery.class));
         doReturn(null).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(null).when(healthCheckService).getAvailability(eq(GraviteeContext.getExecutionContext()), any(), any());
 
@@ -140,7 +148,7 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
         assertNull(apiMetrics.getSubscribers());
 
         // Case 2
-        doReturn(null).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(null).when(analyticsService).execute(any(ExecutionContext.class), any(StatsQuery.class));
         doReturn(Collections.emptyList()).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(new io.gravitee.rest.api.model.healthcheck.ApiMetrics<Number>())
             .when(healthCheckService)
@@ -156,7 +164,7 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
         assertNull(apiMetrics.getSubscribers());
 
         // Case 3
-        doReturn(null).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(null).when(analyticsService).execute(any(ExecutionContext.class), any(StatsQuery.class));
         doReturn(null).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
         io.gravitee.rest.api.model.healthcheck.ApiMetrics<Number> mockedMetrics = new io.gravitee.rest.api.model.healthcheck.ApiMetrics<>();
         mockedMetrics.setGlobal(Collections.singletonMap("1w", Double.NaN));
@@ -172,7 +180,7 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
         assertNull(apiMetrics.getSubscribers());
 
         // Case 3 - with null globalAvailability 1w
-        doReturn(null).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(null).when(analyticsService).execute(any(ExecutionContext.class), any(StatsQuery.class));
         doReturn(null).when(subscriptionService).search(any(), any());
         io.gravitee.rest.api.model.healthcheck.ApiMetrics<Number> mockedMetrics3 =
             new io.gravitee.rest.api.model.healthcheck.ApiMetrics<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResourceTest.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.analytics.query.DateHistogramQuery;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery.Order;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -142,8 +143,9 @@ public class ApplicationAnalyticsResourceTest extends AbstractResourceTest {
             .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
+        ArgumentCaptor<ExecutionContext> queryContextCaptor = ArgumentCaptor.forClass(ExecutionContext.class);
         ArgumentCaptor<CountQuery> queryCaptor = ArgumentCaptor.forClass(CountQuery.class);
-        Mockito.verify(analyticsService).execute(queryCaptor.capture());
+        Mockito.verify(analyticsService).execute(queryContextCaptor.capture(), queryCaptor.capture());
         final CountQuery query = queryCaptor.getValue();
         assertEquals(0, query.getFrom());
         assertEquals(100, query.getTo());
@@ -151,5 +153,9 @@ public class ApplicationAnalyticsResourceTest extends AbstractResourceTest {
         assertEquals(APPLICATION, query.getQuery());
         assertEquals(ANALYTICS_ROOT_FIELD, query.getRootField());
         assertEquals(APPLICATION, query.getRootIdentifier());
+
+        final ExecutionContext executionContext = queryContextCaptor.getValue();
+        assertEquals("DEFAULT", executionContext.getOrganizationId());
+        assertEquals("DEFAULT", executionContext.getEnvironmentId());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
@@ -18,12 +18,13 @@ package io.gravitee.apim.core.analytics.query_service;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
 public interface AnalyticsQueryService {
-    Optional<RequestsCount> searchRequestsCount(String apiId);
+    Optional<RequestsCount> searchRequestsCount(ExecutionContext executionContext, String apiId);
 
-    Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(String apiId);
+    Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(ExecutionContext executionContext, String apiId);
 
-    Optional<AverageConnectionDuration> searchAverageConnectionDuration(String apiId);
+    Optional<AverageConnectionDuration> searchAverageConnectionDuration(ExecutionContext executionContext, String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,10 @@ public class SearchAverageConnectionDurationUseCase {
     public Output execute(Input input) {
         validateApiRequirements(input);
 
-        return analyticsQueryService.searchAverageConnectionDuration(input.apiId()).map(Output::new).orElse(new Output());
+        return analyticsQueryService
+            .searchAverageConnectionDuration(GraviteeContext.getExecutionContext(), input.apiId())
+            .map(Output::new)
+            .orElse(new Output());
     }
 
     private void validateApiRequirements(Input input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +38,11 @@ public class SearchAverageMessagesPerRequestAnalyticsUseCase {
     private final AnalyticsQueryService analyticsQueryService;
     private final ApiCrudService apiCrudService;
 
-    public Output execute(Input input) {
+    public Output execute(ExecutionContext executionContext, Input input) {
         validateApiRequirements(input);
 
         // Verify v4 api
-        return analyticsQueryService.searchAverageMessagesPerRequest(input.apiId()).map(Output::new).orElse(new Output());
+        return analyticsQueryService.searchAverageMessagesPerRequest(executionContext, input.apiId()).map(Output::new).orElse(new Output());
     }
 
     private void validateApiRequirements(Input input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,11 +36,11 @@ public class SearchRequestsCountAnalyticsUseCase {
     private final AnalyticsQueryService analyticsQueryService;
     private final ApiCrudService apiCrudService;
 
-    public Output execute(Input input) {
+    public Output execute(ExecutionContext executionContext, Input input) {
         validateApiRequirements(input);
 
         // Verify v4 api
-        return analyticsQueryService.searchRequestsCount(input.apiId()).map(Output::new).orElse(new Output());
+        return analyticsQueryService.searchRequestsCount(executionContext, input.apiId()).map(Output::new).orElse(new Output());
     }
 
     private void validateApiRequirements(Input input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/ConnectionLogsCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/ConnectionLogsCrudService.java
@@ -20,9 +20,15 @@ import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
 public interface ConnectionLogsCrudService {
-    SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(String apiId, SearchLogsFilters logsFilters, Pageable pageable);
-    Optional<ConnectionLogDetail> searchApiConnectionLog(String apiId, String requestId);
+    SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(
+        ExecutionContext executionContext,
+        String apiId,
+        SearchLogsFilters logsFilters,
+        Pageable pageable
+    );
+    Optional<ConnectionLogDetail> searchApiConnectionLog(ExecutionContext executionContext, String apiId, String requestId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/MessageLogCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/crud_service/MessageLogCrudService.java
@@ -18,11 +18,17 @@ package io.gravitee.apim.core.log.crud_service;
 import io.gravitee.apim.core.log.model.AggregatedMessageLog;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface MessageLogCrudService {
-    SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(String apiId, String requestId, Pageable pageable);
+    SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(
+        ExecutionContext executionContext,
+        String apiId,
+        String requestId,
+        Pageable pageable
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.log.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
 /**
@@ -33,8 +34,11 @@ public class SearchConnectionLogUseCase {
         this.connectionLogsCrudService = connectionLogsCrudService;
     }
 
-    public Output execute(Input input) {
-        return connectionLogsCrudService.searchApiConnectionLog(input.apiId(), input.requestId()).map(Output::new).orElse(new Output());
+    public Output execute(ExecutionContext executionContext, Input input) {
+        return connectionLogsCrudService
+            .searchApiConnectionLog(executionContext, input.apiId(), input.requestId())
+            .map(Output::new)
+            .orElse(new Output());
     }
 
     public record Input(String apiId, String requestId) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogsUseCase.java
@@ -56,7 +56,7 @@ public class SearchConnectionLogsUseCase {
     public Output execute(ExecutionContext executionContext, Input input) {
         var pageable = input.pageable.orElse(new PageableImpl(1, 20));
 
-        var response = connectionLogsCrudService.searchApiConnectionLogs(input.apiId(), input.logsFilters(), pageable);
+        var response = connectionLogsCrudService.searchApiConnectionLogs(executionContext, input.apiId(), input.logsFilters(), pageable);
         return mapToResponse(executionContext, response);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCase.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.log.model.AggregatedMessageLog;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,10 +38,10 @@ public class SearchMessageLogsUseCase {
         this.messageLogCrudService = messageLogCrudService;
     }
 
-    public Output execute(Input input) {
+    public Output execute(ExecutionContext executionContext, Input input) {
         var pageable = input.pageable.orElse(new PageableImpl(1, 20));
 
-        var response = messageLogCrudService.searchApiMessageLog(input.apiId(), input.requestId(), pageable);
+        var response = messageLogCrudService.searchApiMessageLog(executionContext, input.apiId(), input.requestId(), pageable);
         return mapToResponse(response);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.crud_service.log;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.infra.adapter.ConnectionLogAdapter;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.LogRepository;
 import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.connection.ConnectionLog;
@@ -28,6 +29,7 @@ import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -45,9 +47,15 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
     }
 
     @Override
-    public SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(String apiId, SearchLogsFilters logsFilters, Pageable pageable) {
+    public SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(
+        ExecutionContext executionContext,
+        String apiId,
+        SearchLogsFilters logsFilters,
+        Pageable pageable
+    ) {
         try {
             var response = logRepository.searchConnectionLogs(
+                new QueryContext(executionContext.getOrganizationId(), executionContext.getEnvironmentId()),
                 ConnectionLogQuery
                     .builder()
                     .filter(
@@ -75,9 +83,10 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
     }
 
     @Override
-    public Optional<ConnectionLogDetail> searchApiConnectionLog(String apiId, String requestId) {
+    public Optional<ConnectionLogDetail> searchApiConnectionLog(ExecutionContext executionContext, String apiId, String requestId) {
         try {
             var response = logRepository.searchConnectionLogDetail(
+                new QueryContext(executionContext.getOrganizationId(), executionContext.getEnvironmentId()),
                 ConnectionLogDetailQuery
                     .builder()
                     .filter(ConnectionLogDetailQuery.Filter.builder().apiId(apiId).requestId(requestId).build())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/MessageLogCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/MessageLogCrudServiceImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.log.v4.model.LogResponse;
 import io.gravitee.repository.log.v4.model.message.MessageLogQuery;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -44,9 +45,15 @@ class MessageLogCrudServiceImpl implements MessageLogCrudService {
     }
 
     @Override
-    public SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(String apiId, String requestId, Pageable pageable) {
+    public SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(
+        ExecutionContext executionContext,
+        String apiId,
+        String requestId,
+        Pageable pageable
+    ) {
         try {
             var response = logRepository.searchAggregatedMessageLog(
+                executionContext.getQueryContext(),
                 MessageLogQuery
                     .builder()
                     .filter(MessageLogQuery.Filter.builder().apiId(apiId).requestId(requestId).build())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -43,18 +44,21 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
     }
 
     @Override
-    public Optional<RequestsCount> searchRequestsCount(String apiId) {
+    public Optional<RequestsCount> searchRequestsCount(ExecutionContext executionContext, String apiId) {
         return analyticsRepository
-            .searchRequestsCount(RequestsCountQuery.builder().apiId(apiId).build())
+            .searchRequestsCount(executionContext.getQueryContext(), RequestsCountQuery.builder().apiId(apiId).build())
             .map(countAggregate ->
                 RequestsCount.builder().total(countAggregate.getTotal()).countsByEntrypoint(countAggregate.getCountBy()).build()
             );
     }
 
     @Override
-    public Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(String apiId) {
+    public Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(ExecutionContext executionContext, String apiId) {
         return analyticsRepository
-            .searchAverageMessagesPerRequest(AverageMessagesPerRequestQuery.builder().apiId(apiId).build())
+            .searchAverageMessagesPerRequest(
+                executionContext.getQueryContext(),
+                AverageMessagesPerRequestQuery.builder().apiId(apiId).build()
+            )
             .map(averageAggregate ->
                 AverageMessagesPerRequest
                     .builder()
@@ -65,9 +69,12 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
     }
 
     @Override
-    public Optional<AverageConnectionDuration> searchAverageConnectionDuration(String apiId) {
+    public Optional<AverageConnectionDuration> searchAverageConnectionDuration(ExecutionContext executionContext, String apiId) {
         return analyticsRepository
-            .searchAverageConnectionDuration(AverageConnectionDurationQuery.builder().apiId(apiId).build())
+            .searchAverageConnectionDuration(
+                executionContext.getQueryContext(),
+                AverageConnectionDurationQuery.builder().apiId(apiId).build()
+            )
             .map(averageAggregate ->
                 AverageConnectionDuration
                     .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AnalyticsService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AnalyticsService.java
@@ -28,8 +28,8 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
  * @author GraviteeSource Team
  */
 public interface AnalyticsService {
-    StatsAnalytics execute(StatsQuery query);
-    HitsAnalytics execute(CountQuery query);
+    StatsAnalytics execute(ExecutionContext executionContext, StatsQuery query);
+    HitsAnalytics execute(ExecutionContext executionContext, CountQuery query);
     HistogramAnalytics execute(ExecutionContext executionContext, DateHistogramQuery query);
     TopHitsAnalytics execute(ExecutionContext executionContext, GroupByQuery query);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/HealthCheckService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/HealthCheckService.java
@@ -34,7 +34,7 @@ public interface HealthCheckService {
 
     SearchLogResponse findByApi(ExecutionContext executionContext, String api, LogQuery logQuery, Boolean transition);
 
-    Log findLog(String api, String id);
+    Log findLog(ExecutionContext executionContext, String api, String id);
 
-    Analytics query(DateHistogramQuery query);
+    Analytics query(ExecutionContext executionContext, DateHistogramQuery query);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MonitoringService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MonitoringService.java
@@ -16,11 +16,12 @@
 package io.gravitee.rest.api.service;
 
 import io.gravitee.rest.api.model.monitoring.MonitoringData;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 
 /**
  * @author Azize Elamrani (azize dot elamrani at gmail dot com)
  * @author GraviteeSource Team
  */
 public interface MonitoringService {
-    MonitoringData findMonitoring(String gatewayId);
+    MonitoringData findMonitoring(ExecutionContext executionContext, String gatewayId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/ExecutionContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/ExecutionContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.common;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Organization;
 import io.gravitee.rest.api.model.EnvironmentEntity;
@@ -82,6 +83,10 @@ public class ExecutionContext {
                     .map(orgId -> ReferenceContext.builder().referenceId(orgId).referenceType(ReferenceContext.Type.ORGANIZATION).build())
                     .orElse(null)
             );
+    }
+
+    public QueryContext getQueryContext() {
+        return new QueryContext(this.getOrganizationId(), this.getEnvironmentId());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
@@ -123,9 +123,10 @@ public class AnalyticsServiceImpl implements AnalyticsService {
     private TenantService tenantService;
 
     @Override
-    public StatsAnalytics execute(final StatsQuery query) {
+    public StatsAnalytics execute(final ExecutionContext executionContext, final StatsQuery query) {
         try {
             final StatsResponse response = analyticsRepository.query(
+                executionContext.getQueryContext(),
                 QueryBuilders
                     .stats()
                     .query(query.getQuery())
@@ -143,9 +144,10 @@ public class AnalyticsServiceImpl implements AnalyticsService {
     }
 
     @Override
-    public HitsAnalytics execute(CountQuery query) {
+    public HitsAnalytics execute(final ExecutionContext executionContext, CountQuery query) {
         try {
             CountResponse response = analyticsRepository.query(
+                executionContext.getQueryContext(),
                 QueryBuilders
                     .count()
                     .query(query.getQuery())
@@ -179,7 +181,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                     );
             }
 
-            DateHistogramResponse response = analyticsRepository.query(queryBuilder.build());
+            DateHistogramResponse response = analyticsRepository.query(executionContext.getQueryContext(), queryBuilder.build());
             return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
@@ -212,7 +214,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                 );
             }
 
-            GroupByResponse response = analyticsRepository.query(queryBuilder.build());
+            GroupByResponse response = analyticsRepository.query(executionContext.getQueryContext(), queryBuilder.build());
             return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -134,6 +134,7 @@ public class LogsServiceImpl implements LogsService {
         try {
             final String field = query.getField() == null ? "@timestamp" : query.getField();
             TabularResponse response = logRepository.query(
+                executionContext.getQueryContext(),
                 QueryBuilders
                     .tabular()
                     .page(query.getPage())
@@ -185,7 +186,7 @@ public class LogsServiceImpl implements LogsService {
     @Override
     public ApiRequest findApiLog(final ExecutionContext executionContext, String id, Long timestamp) {
         try {
-            final ExtendedLog log = logRepository.findById(id, timestamp);
+            final ExtendedLog log = logRepository.findById(executionContext.getQueryContext(), id, timestamp);
             if (log == null) {
                 return null;
             }
@@ -223,6 +224,7 @@ public class LogsServiceImpl implements LogsService {
         try {
             final String field = query.getField() == null ? "@timestamp" : query.getField();
             TabularResponse response = logRepository.query(
+                executionContext.getQueryContext(),
                 QueryBuilders
                     .tabular()
                     .page(query.getPage())
@@ -276,6 +278,7 @@ public class LogsServiceImpl implements LogsService {
         try {
             final String field = query.getField() == null ? "@timestamp" : query.getField();
             TabularResponse response = logRepository.query(
+                executionContext.getQueryContext(),
                 QueryBuilders
                     .tabular()
                     .page(query.getPage())
@@ -331,7 +334,7 @@ public class LogsServiceImpl implements LogsService {
     @Override
     public ApplicationRequest findApplicationLog(ExecutionContext executionContext, String applicationId, String id, Long timestamp) {
         try {
-            ExtendedLog log = logRepository.findById(id, timestamp);
+            ExtendedLog log = logRepository.findById(executionContext.getQueryContext(), id, timestamp);
             if (log == null) {
                 return null;
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MonitoringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MonitoringServiceImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 import io.gravitee.rest.api.model.monitoring.*;
 import io.gravitee.rest.api.service.MonitoringService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,9 +40,9 @@ public class MonitoringServiceImpl implements MonitoringService {
     private MonitoringRepository monitoringRepository;
 
     @Override
-    public MonitoringData findMonitoring(final String gatewayId) {
+    public MonitoringData findMonitoring(final ExecutionContext executionContext, final String gatewayId) {
         LOGGER.debug("Running monitoring query for Gateway instance '{}'", gatewayId);
-        final MonitoringResponse monitoringResponse = monitoringRepository.query(gatewayId);
+        final MonitoringResponse monitoringResponse = monitoringRepository.query(executionContext.getQueryContext(), gatewayId);
         return monitoringResponse != null ? convert(monitoringResponse) : null;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
 /**
@@ -32,17 +33,17 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     public AverageConnectionDuration averageConnectionDuration;
 
     @Override
-    public Optional<RequestsCount> searchRequestsCount(String apiId) {
+    public Optional<RequestsCount> searchRequestsCount(ExecutionContext executionContext, String apiId) {
         return Optional.ofNullable(requestsCount);
     }
 
     @Override
-    public Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(String apiId) {
+    public Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(ExecutionContext executionContext, String apiId) {
         return Optional.ofNullable(averageMessagesPerRequest);
     }
 
     @Override
-    public Optional<AverageConnectionDuration> searchAverageConnectionDuration(String apiId) {
+    public Optional<AverageConnectionDuration> searchAverageConnectionDuration(ExecutionContext executionContext, String apiId) {
         return Optional.ofNullable(averageConnectionDuration);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Predicate;
@@ -32,7 +33,12 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
     private final InMemoryConnectionLogDetails connectionLogDetails = new InMemoryConnectionLogDetails();
 
     @Override
-    public SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(String apiId, SearchLogsFilters logsFilters, Pageable pageable) {
+    public SearchLogsResponse<BaseConnectionLog> searchApiConnectionLogs(
+        ExecutionContext executionContext,
+        String apiId,
+        SearchLogsFilters logsFilters,
+        Pageable pageable
+    ) {
         Predicate<BaseConnectionLog> predicate = connectionLog -> connectionLog.getApiId().equals(apiId);
         if (null != logsFilters.from()) {
             predicate = predicate.and(connectionLog -> Instant.parse(connectionLog.getTimestamp()).toEpochMilli() >= logsFilters.from());
@@ -78,7 +84,7 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
     }
 
     @Override
-    public Optional<ConnectionLogDetail> searchApiConnectionLog(String apiId, String requestId) {
+    public Optional<ConnectionLogDetail> searchApiConnectionLog(ExecutionContext executionContext, String apiId, String requestId) {
         Predicate<ConnectionLogDetail> predicate = connectionLog -> true;
         if (null != apiId && !apiId.isEmpty()) {
             predicate = predicate.and(connectionLog -> connectionLog.getApiId().equals(apiId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MessageLogCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MessageLogCrudServiceInMemory.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.log.crud_service.MessageLogCrudService;
 import io.gravitee.apim.core.log.model.AggregatedMessageLog;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -30,7 +31,12 @@ public class MessageLogCrudServiceInMemory implements MessageLogCrudService, InM
     private final List<AggregatedMessageLog> storage = new ArrayList<>();
 
     @Override
-    public SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(String apiId, String requestId, Pageable pageable) {
+    public SearchLogsResponse<AggregatedMessageLog> searchApiMessageLog(
+        ExecutionContext executionContext,
+        String apiId,
+        String requestId,
+        Pageable pageable
+    ) {
         Predicate<AggregatedMessageLog> predicate = baseMessageLog ->
             baseMessageLog.getApiId().equals(apiId) && baseMessageLog.getRequestId().equals(requestId);
         var pageNumber = pageable.getPageNumber();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchConnectionLogUseCaseTest.java
@@ -61,7 +61,7 @@ class SearchConnectionLogUseCaseTest {
         final ConnectionLogDetail connectionLogDetail = connectionLogDetailFixtures.aConnectionLogDetail().toBuilder().build();
         logStorageService.initWithConnectionLogDetails(List.of(connectionLogDetail));
 
-        var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
 
         assertThat(result).isEqualTo(new SearchConnectionLogUseCase.Output(Optional.of(connectionLogDetail)));
     }
@@ -72,7 +72,7 @@ class SearchConnectionLogUseCaseTest {
             List.of(connectionLogDetailFixtures.aConnectionLogDetail("other-req").toBuilder().build())
         );
 
-        var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
 
         assertThat(result).isEqualTo(new SearchConnectionLogUseCase.Output(Optional.empty()));
     }
@@ -83,7 +83,7 @@ class SearchConnectionLogUseCaseTest {
             List.of(connectionLogDetailFixtures.aConnectionLogDetail().toBuilder().apiId("other-api").build())
         );
 
-        var result = usecase.execute(new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new SearchConnectionLogUseCase.Input(API_ID, REQUEST_ID));
 
         assertThat(result).isEqualTo(new SearchConnectionLogUseCase.Output(Optional.empty()));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchMessageLogsUseCaseTest.java
@@ -63,7 +63,7 @@ class SearchMessageLogsUseCaseTest {
             )
         );
 
-        var result = usecase.execute(new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID));
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result.total()).isOne();
@@ -99,7 +99,7 @@ class SearchMessageLogsUseCaseTest {
             )
         );
 
-        var result = usecase.execute(new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID));
+        var result = usecase.execute(GraviteeContext.getExecutionContext(), new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result.total()).isEqualTo(3);
@@ -126,7 +126,10 @@ class SearchMessageLogsUseCaseTest {
                 .toList()
         );
 
-        var result = usecase.execute(new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID, new PageableImpl(pageNumber, pageSize)));
+        var result = usecase.execute(
+            GraviteeContext.getExecutionContext(),
+            new SearchMessageLogsUseCase.Input(API_ID, REQUEST_ID, new PageableImpl(pageNumber, pageSize))
+        );
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result.total()).isEqualTo(expectedTotal);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImplTest.java
@@ -20,8 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,17 +58,17 @@ class AnalyticsQueryServiceImplTest {
 
         @Test
         void should_return_empty_requests_count() {
-            when(analyticsRepository.searchRequestsCount(any())).thenReturn(Optional.empty());
-            assertThat(cut.searchRequestsCount(any())).isEmpty();
+            when(analyticsRepository.searchRequestsCount(any(QueryContext.class), any())).thenReturn(Optional.empty());
+            assertThat(cut.searchRequestsCount(GraviteeContext.getExecutionContext(), "api#1")).isEmpty();
         }
 
         @Test
         void should_map_repository_response_to_requests_count() {
-            when(analyticsRepository.searchRequestsCount(any()))
+            when(analyticsRepository.searchRequestsCount(any(QueryContext.class), any()))
                 .thenReturn(
                     Optional.of(CountAggregate.builder().total(10).countBy(Map.of("first", 3L, "second", 4L, "third", 3L)).build())
                 );
-            assertThat(cut.searchRequestsCount(any()))
+            assertThat(cut.searchRequestsCount(GraviteeContext.getExecutionContext(), "api#1"))
                 .hasValueSatisfying(requestsCount -> {
                     assertThat(requestsCount.getTotal()).isEqualTo(10);
                     assertThat(requestsCount.getCountsByEntrypoint()).containsAllEntriesOf(Map.of("first", 3L, "second", 4L, "third", 3L));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.analytics.query.count.CountResponse;
 import io.gravitee.repository.analytics.query.groupby.GroupByResponse;
 import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
 import io.gravitee.repository.analytics.query.stats.StatsResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.rest.api.model.analytics.HistogramAnalytics;
 import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
@@ -56,101 +57,101 @@ public class AnalyticsServiceImplTest {
 
     @Test(expected = AnalyticsCalculateException.class)
     public void shouldThrowExceptionForStatusQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
-        cut.execute(new StatsQuery());
+        cut.execute(EXECUTION_CONTEXT, new StatsQuery());
     }
 
     @Test
     public void shouldExecuteStatusQueryWithNoResponse() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(null);
-        StatsAnalytics execute = cut.execute(new StatsQuery());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(null);
+        StatsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new StatsQuery());
 
         assertNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldExecuteStatusQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(new StatsResponse());
-        StatsAnalytics execute = cut.execute(new StatsQuery());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(new StatsResponse());
+        StatsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new StatsQuery());
 
         assertNotNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test(expected = AnalyticsCalculateException.class)
     public void shouldThrowExceptionForCountQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
-        cut.execute(new CountQuery());
+        cut.execute(EXECUTION_CONTEXT, new CountQuery());
     }
 
     @Test
     public void shouldExecuteCountQueryWithNoResponse() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(null);
-        HitsAnalytics execute = cut.execute(new CountQuery());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(null);
+        HitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new CountQuery());
 
         assertNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldExecuteCountQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(new CountResponse());
-        HitsAnalytics execute = cut.execute(new CountQuery());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(new CountResponse());
+        HitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new CountQuery());
 
         assertNotNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test(expected = AnalyticsCalculateException.class)
     public void shouldThrowExceptionForDateHistogramQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
         cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
     }
 
     @Test
     public void shouldExecuteDateHistogramQueryWithNoResponse() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(null);
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(null);
         HistogramAnalytics execute = cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
 
         assertNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldExecuteDateHistogramQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(new DateHistogramResponse());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(new DateHistogramResponse());
         HistogramAnalytics execute = cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
 
         assertNotNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test(expected = AnalyticsCalculateException.class)
     public void shouldThrowExceptionForGroupByQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
         cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
     }
 
     @Test
     public void shouldExecuteGroupByQueryWithNoResponse() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(null);
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(null);
         TopHitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
 
         assertNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldExecuteGroupByQuery() throws Exception {
-        when(analyticsRepository.query(any())).thenReturn(new GroupByResponse());
+        when(analyticsRepository.query(any(QueryContext.class), any())).thenReturn(new GroupByResponse());
         TopHitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
 
         assertNotNull(execute);
-        verify(analyticsRepository, times(1)).query(any());
+        verify(analyticsRepository, times(1)).query(any(QueryContext.class), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImplTest.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
 import io.gravitee.repository.healthcheck.query.FieldBucket;
 import io.gravitee.repository.healthcheck.query.availability.AvailabilityQuery;
@@ -81,23 +82,23 @@ public class HealthCheckServiceImplTest {
     @Test
     public void should_throw_analytics_exception_for_getAvailability_metadata() throws Exception {
         when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(newApiEntity());
-        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
         ApiMetrics result = cut.getAvailability(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
 
         assertNull(result);
         verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void should_get_noResponse_for_getAvailability_metadata() throws AnalyticsException {
         when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
-        when(healthCheckRepository.query(any())).thenReturn(null);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(null);
         ApiMetrics result = cut.getAvailability(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
 
         assertNull(result);
         verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -111,7 +112,7 @@ public class HealthCheckServiceImplTest {
         AvailabilityResponse availabilityResponse = new AvailabilityResponse();
         availabilityResponse.setEndpointAvailabilities(List.of(fieldBucketEndpoint, fieldBucketDeleted));
 
-        when(healthCheckRepository.query(any())).thenReturn(availabilityResponse);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(availabilityResponse);
 
         when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), "apiId")).thenReturn(newApiEntity());
 
@@ -127,84 +128,84 @@ public class HealthCheckServiceImplTest {
 
     @Test(expected = AnalyticsCalculateException.class)
     public void shouldThrowExceptionForDateHistogramQuery() throws Exception {
-        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
-        cut.query(new DateHistogramQuery());
+        cut.query(GraviteeContext.getExecutionContext(), new DateHistogramQuery());
     }
 
     @Test
     public void shouldFindNoAnalytics() throws AnalyticsException {
-        when(healthCheckRepository.query(any())).thenReturn(null);
-        Analytics execute = cut.query(new DateHistogramQuery());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(null);
+        Analytics execute = cut.query(GraviteeContext.getExecutionContext(), new DateHistogramQuery());
 
         assertNull(execute);
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldFindAnalytics() throws AnalyticsException {
-        when(healthCheckRepository.query(any())).thenReturn(new DateHistogramResponse());
-        Analytics execute = cut.query(new DateHistogramQuery());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(new DateHistogramResponse());
+        Analytics execute = cut.query(GraviteeContext.getExecutionContext(), new DateHistogramQuery());
 
         assertNotNull(execute);
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldThrowExceptionForFindById() throws Exception {
-        when(healthCheckRepository.findById(anyString())).thenThrow(new AnalyticsException());
-        Log result = cut.findLog("test_api", "test_log");
+        when(healthCheckRepository.findById(any(QueryContext.class), anyString())).thenThrow(new AnalyticsException());
+        Log result = cut.findLog(GraviteeContext.getExecutionContext(), "test_api", "test_log");
 
         assertNull(result);
-        verify(healthCheckRepository, times(1)).findById(anyString());
+        verify(healthCheckRepository, times(1)).findById(any(QueryContext.class), anyString());
     }
 
     @Test
     public void shouldFindNoLogById() throws AnalyticsException {
-        when(healthCheckRepository.findById(anyString())).thenReturn(null);
-        Log result = cut.findLog("test_api", "test_log");
+        when(healthCheckRepository.findById(any(QueryContext.class), anyString())).thenReturn(null);
+        Log result = cut.findLog(GraviteeContext.getExecutionContext(), "test_api", "test_log");
 
         assertNull(result);
-        verify(healthCheckRepository, times(1)).findById(anyString());
+        verify(healthCheckRepository, times(1)).findById(any(QueryContext.class), anyString());
     }
 
     @Test
     public void shouldReturnNullBecauseLogDoesNotBelongToApi() throws AnalyticsException {
         ExtendedLog log = newExtendedLog();
-        when(healthCheckRepository.findById(anyString())).thenReturn(log);
-        Log result = cut.findLog("Another_api", "test_log");
+        when(healthCheckRepository.findById(any(QueryContext.class), anyString())).thenReturn(log);
+        Log result = cut.findLog(GraviteeContext.getExecutionContext(), "Another_api", "test_log");
 
         assertNull(result);
-        verify(healthCheckRepository, times(1)).findById(anyString());
+        verify(healthCheckRepository, times(1)).findById(any(QueryContext.class), anyString());
     }
 
     @Test
     public void shouldFindLogById() throws AnalyticsException {
         ExtendedLog log = newExtendedLog();
 
-        when(healthCheckRepository.findById(anyString())).thenReturn(log);
-        Log result = cut.findLog("test_api", "test_log");
+        when(healthCheckRepository.findById(any(QueryContext.class), anyString())).thenReturn(log);
+        Log result = cut.findLog(GraviteeContext.getExecutionContext(), "test_api", "test_log");
 
         assertNotNull(result);
-        verify(healthCheckRepository, times(1)).findById(anyString());
+        verify(healthCheckRepository, times(1)).findById(any(QueryContext.class), anyString());
     }
 
     @Test
     public void shouldThrowExceptionForFindByApi() throws Exception {
-        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
         SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
 
         assertNull(result);
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldFindNoLogByApi() throws AnalyticsException {
-        when(healthCheckRepository.query(any())).thenReturn(null);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(null);
         SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
 
         assertNull(result);
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -214,33 +215,33 @@ public class HealthCheckServiceImplTest {
         logs.add(new io.gravitee.repository.healthcheck.query.log.Log());
         response.setLogs(logs);
 
-        when(healthCheckRepository.query(any())).thenReturn(response);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(response);
         SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
 
         assertNotNull(result);
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldThrowExceptionForGetResponseTime() throws Exception {
         when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(newApiEntity());
-        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
         ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
 
         assertNull(result);
         verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldFindNoResponseTime() throws AnalyticsException {
         when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
-        when(healthCheckRepository.query(any())).thenReturn(null);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(null);
         ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
 
         assertNull(result);
         verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -254,13 +255,13 @@ public class HealthCheckServiceImplTest {
         response.setEndpointResponseTimes(buckets);
 
         when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
-        when(healthCheckRepository.query(any())).thenReturn(response);
+        when(healthCheckRepository.query(any(QueryContext.class), any())).thenReturn(response);
         when(instanceService.findById(any(ExecutionContext.class), anyString())).thenReturn(new InstanceEntity());
         ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.GATEWAY.name());
 
         assertNotNull(result);
         verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
-        verify(healthCheckRepository, times(1)).query(any());
+        verify(healthCheckRepository, times(1)).query(any(QueryContext.class), any());
         verify(instanceService, times(1)).findById(any(ExecutionContext.class), anyString());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/LogsServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/LogsServiceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.api.LogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
 import io.gravitee.repository.log.model.Request;
@@ -94,30 +95,30 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldThrowNotFoundExceptionBecause() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(KEY_LESS));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(KEY_LESS));
         when(apiSearchService.findRepositoryApiById(EXECUTION_CONTEXT, LOG_API_ID)).thenThrow(new ApiNotFoundException(LOG_API_ID));
         assertThrows(LogNotFoundException.class, () -> logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP));
     }
 
     @Test
     void findApiLogShouldThrowException() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenThrow(new AnalyticsException());
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenThrow(new AnalyticsException());
 
         assertThrows(TechnicalManagementException.class, () -> logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP));
     }
 
     @Test
     void findApiLogShouldReturnNull() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(null);
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(null);
 
         ApiRequest result = logService.findApiLog(EXECUTION_CONTEXT, LOG_ID, LOG_TIMESTAMP);
         assertThat(result).isNull();
-        verify(logRepository, times(1)).findById(LOG_ID, LOG_TIMESTAMP);
+        verify(logRepository, times(1)).findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP));
     }
 
     @Test
     void findApiLogShouldFindWithKeyLessPlan() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(KEY_LESS));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(KEY_LESS));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(KEY_LESS));
 
@@ -132,7 +133,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldFindWithApiKeyPlan() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(API_KEY));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(API_KEY));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(API_KEY));
         when(apiKeyService.findByKeyAndApi(EXECUTION_CONTEXT, LOG_API_KEY, LOG_API_ID)).thenReturn(newApiKey());
@@ -149,7 +150,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldFindWithJwtPlan() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(JWT));
         when(subscriptionService.findByApplicationAndPlan(EXECUTION_CONTEXT, LOG_APPLICATION_ID, LOG_PLAN_ID))
@@ -167,7 +168,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldHaveEmptySubscriptionWithNoSecurity() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(null));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(null));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(null));
 
@@ -183,7 +184,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldHaveEmptySubscriptionWithNoSecurityInV4Plan() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(null));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(null));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlanV4(null));
 
@@ -199,7 +200,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldNotFailOnApiKeyNotFoundException() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(API_KEY));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(API_KEY));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(API_KEY));
         when(apiKeyService.findByKeyAndApi(EXECUTION_CONTEXT, LOG_API_KEY, LOG_API_ID)).thenThrow(new ApiKeyNotFoundException());
@@ -216,7 +217,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldNotFailOnPlanNotFoundException() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenThrow(new PlanNotFoundException(LOG_PLAN_ID));
 
@@ -231,7 +232,7 @@ class LogsServiceTest {
 
     @Test
     void findApiLogShouldNotFailOnDuplicatedSubscription() throws Exception {
-        when(logRepository.findById(LOG_ID, LOG_TIMESTAMP)).thenReturn(newLog(JWT));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), eq(LOG_TIMESTAMP))).thenReturn(newLog(JWT));
         when(applicationService.findById(EXECUTION_CONTEXT, LOG_APPLICATION_ID)).thenReturn(newApplication());
         when(planSearchService.findById(EXECUTION_CONTEXT, LOG_PLAN_ID)).thenReturn(newPlan(JWT));
         when(subscriptionService.findByApplicationAndPlan(EXECUTION_CONTEXT, LOG_APPLICATION_ID, LOG_PLAN_ID))
@@ -249,7 +250,7 @@ class LogsServiceTest {
 
     @Test
     void findLogByApiShouldThrowException() throws Exception {
-        when(logRepository.query(any())).thenThrow(new AnalyticsException());
+        when(logRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
         LogQuery query = new LogQuery();
 
@@ -258,13 +259,13 @@ class LogsServiceTest {
 
     @Test
     void findLogByApiShouldReturnEmptyResult() throws Exception {
-        when(logRepository.query(any())).thenReturn(null);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(null);
 
         SearchLogResponse<ApiRequestItem> result = logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isNull();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -272,18 +273,18 @@ class LogsServiceTest {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
-        when(logRepository.query(any())).thenReturn(tabularResponse);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(tabularResponse);
 
         SearchLogResponse<ApiRequestItem> result = logService.findByApi(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isEmpty();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     void findLogByApplicationShouldThrowException() throws Exception {
-        when(logRepository.query(any())).thenThrow(new AnalyticsException());
+        when(logRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
         LogQuery query = new LogQuery();
 
         assertThrows(TechnicalManagementException.class, () -> logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, query));
@@ -291,13 +292,13 @@ class LogsServiceTest {
 
     @Test
     void findLogByApplicationShouldReturnEmptyResult() throws Exception {
-        when(logRepository.query(any())).thenReturn(null);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(null);
 
         SearchLogResponse<ApplicationRequestItem> result = logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isNull();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -305,18 +306,18 @@ class LogsServiceTest {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
-        when(logRepository.query(any())).thenReturn(tabularResponse);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(tabularResponse);
 
         SearchLogResponse<ApplicationRequestItem> result = logService.findByApplication(EXECUTION_CONTEXT, LOG_API_ID, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isEmpty();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     void findLogByPlatformShouldThrowException() throws Exception {
-        when(logRepository.query(any())).thenThrow(new AnalyticsException());
+        when(logRepository.query(any(QueryContext.class), any())).thenThrow(new AnalyticsException());
 
         LogQuery query = new LogQuery();
 
@@ -325,13 +326,13 @@ class LogsServiceTest {
 
     @Test
     void findLogByPlatformShouldReturnEmptyResult() throws Exception {
-        when(logRepository.query(any())).thenReturn(null);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(null);
 
         SearchLogResponse<PlatformRequestItem> result = logService.findPlatform(EXECUTION_CONTEXT, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isNull();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -339,13 +340,13 @@ class LogsServiceTest {
         TabularResponse tabularResponse = new TabularResponse(0L);
         tabularResponse.setLogs(new ArrayList<>());
 
-        when(logRepository.query(any())).thenReturn(tabularResponse);
+        when(logRepository.query(any(QueryContext.class), any())).thenReturn(tabularResponse);
 
         SearchLogResponse<PlatformRequestItem> result = logService.findPlatform(EXECUTION_CONTEXT, new LogQuery());
 
         assertThat(result).isNotNull();
         assertThat(result.getLogs()).isEmpty();
-        verify(logRepository, times(1)).query(any());
+        verify(logRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
@@ -354,7 +355,7 @@ class LogsServiceTest {
         log.setClientRequest(newRequest());
         log.setClientResponse(newResponse());
         log.setApplication("Another_application");
-        when(logRepository.findById(eq(LOG_ID), anyLong())).thenReturn(log);
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), anyLong())).thenReturn(log);
 
         long timestamp = Instant.now().toEpochMilli();
 
@@ -366,7 +367,7 @@ class LogsServiceTest {
 
     @Test
     void findApplicationLogShouldThrowException() throws Exception {
-        when(logRepository.findById(eq(LOG_ID), anyLong())).thenThrow(new AnalyticsException("test_error"));
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), anyLong())).thenThrow(new AnalyticsException("test_error"));
         long timestamp = Instant.now().toEpochMilli();
 
         assertThrows(
@@ -377,7 +378,7 @@ class LogsServiceTest {
 
     @Test
     void findApplicationLogShouldReturnNull() throws Exception {
-        when(logRepository.findById(eq(LOG_ID), anyLong())).thenReturn(null);
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), anyLong())).thenReturn(null);
 
         ApplicationRequest result = logService.findApplicationLog(
             EXECUTION_CONTEXT,
@@ -387,7 +388,7 @@ class LogsServiceTest {
         );
 
         assertThat(result).isNull();
-        verify(logRepository, times(1)).findById(eq(LOG_ID), anyLong());
+        verify(logRepository, times(1)).findById(any(QueryContext.class), eq(LOG_ID), anyLong());
     }
 
     @Test
@@ -395,7 +396,7 @@ class LogsServiceTest {
         ExtendedLog log = newLog(JWT);
         log.setClientRequest(newRequest());
         log.setClientResponse(newResponse());
-        when(logRepository.findById(eq(LOG_ID), anyLong())).thenReturn(log);
+        when(logRepository.findById(any(QueryContext.class), eq(LOG_ID), anyLong())).thenReturn(log);
         when(apiSearchService.findGenericById(any(), anyString())).thenReturn(newApiEntity());
         when(planSearchService.findById(any(), anyString())).thenReturn(newPlan(KEY_LESS));
 
@@ -407,7 +408,7 @@ class LogsServiceTest {
         );
 
         assertThat(result).isNotNull();
-        verify(logRepository, times(1)).findById(eq(LOG_ID), anyLong());
+        verify(logRepository, times(1)).findById(any(QueryContext.class), eq(LOG_ID), anyLong());
         verify(apiSearchService, times(1)).findGenericById(any(), anyString());
         verify(planSearchService, times(1)).findById(any(), anyString());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MonitoringServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MonitoringServiceImplTest.java
@@ -18,11 +18,16 @@ package io.gravitee.rest.api.service.impl;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.monitoring.model.MonitoringResponse;
 import io.gravitee.rest.api.model.monitoring.MonitoringData;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -44,19 +49,19 @@ public class MonitoringServiceImplTest {
 
     @Test
     public void shouldFindNoMonitoring() {
-        when(monitoringRepository.query(anyString())).thenReturn(null);
-        MonitoringData result = cut.findMonitoring("a_gateway_id");
+        when(monitoringRepository.query(any(QueryContext.class), anyString())).thenReturn(null);
+        MonitoringData result = cut.findMonitoring(GraviteeContext.getExecutionContext(), "a_gateway_id");
 
         assertNull(result);
-        verify(monitoringRepository, times(1)).query(any());
+        verify(monitoringRepository, times(1)).query(any(QueryContext.class), any());
     }
 
     @Test
     public void shouldFindMonitoring() {
-        when(monitoringRepository.query(anyString())).thenReturn(new MonitoringResponse());
-        MonitoringData result = cut.findMonitoring("a_gateway_id");
+        when(monitoringRepository.query(any(QueryContext.class), anyString())).thenReturn(new MonitoringResponse());
+        MonitoringData result = cut.findMonitoring(GraviteeContext.getExecutionContext(), "a_gateway_id");
 
         assertNotNull(result);
-        verify(monitoringRepository, times(1)).query(any());
+        verify(monitoringRepository, times(1)).query(any(QueryContext.class), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1757

## Description

The Elasticsearch index name can define placeholders to have a dedicated index per organization/environment. These two placeholders are:
- {orgId}
- {envId}

These values ​​will be retrieved from ExecutionContext and will be propagated to the repository method to target the right index.

