### PR TITLE
feat: add cloud initializer and reporter-cloud plugin

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1262,6 +1262,19 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.reporter</groupId>
+                    <artifactId>gravitee-reporter-cloud</artifactId>
+                    <version>${gravitee-reporter-cloud.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Policies -->
                 <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggingContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.core.logging;
 
+import io.gravitee.common.utils.SizeUtils;
 import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.definition.model.Logging;
 import io.gravitee.gateway.api.ExecutionContext;
@@ -100,34 +101,11 @@ public class LoggingContext implements ConditionSupplier {
     public void setMaxSizeLogMessage(String maxSizeLogMessage) {
         // log max size limit is in MB format
         // -1 means no limit
-        if (maxSizeLogMessage != null) {
-            try {
-                int value = Integer.parseInt(maxSizeLogMessage);
-                if (value >= 0) {
-                    // By default, consider MB
-                    this.maxSizeLogMessage = Integer.parseInt(maxSizeLogMessage) * (1024 * 1024);
-                }
-            } catch (NumberFormatException nfe) {
-                maxSizeLogMessage = maxSizeLogMessage.toUpperCase();
-
-                try {
-                    if (maxSizeLogMessage.endsWith("MB") || maxSizeLogMessage.endsWith("M")) {
-                        int value = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('M')));
-                        this.maxSizeLogMessage = value * (1024 * 1024);
-                    } else if (maxSizeLogMessage.endsWith("KB") || maxSizeLogMessage.endsWith("K")) {
-                        int value = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('K')));
-                        this.maxSizeLogMessage = value * (1024);
-                    } else if (maxSizeLogMessage.endsWith("B")) {
-                        this.maxSizeLogMessage = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('B')));
-                    } else {
-                        logger.error("Max size for API logging is invalid, no limit is defined. (value: {})", maxSizeLogMessage);
-                        this.maxSizeLogMessage = -1;
-                    }
-                } catch (NumberFormatException nfe2) {
-                    logger.error("Max size for API logging is invalid, no limit is defined. (value: {})", maxSizeLogMessage);
-                    this.maxSizeLogMessage = -1;
-                }
-            }
+        try {
+            final long sizeInBytes = SizeUtils.toBytes(maxSizeLogMessage);
+            this.maxSizeLogMessage = Math.toIntExact(sizeInBytes);
+        } catch (ArithmeticException | NumberFormatException ae) {
+            this.maxSizeLogMessage = -1;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.core.v4.analytics;
 
+import io.gravitee.common.utils.SizeUtils;
 import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.definition.model.MessageConditionSupplier;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
@@ -105,34 +106,11 @@ public class LoggingContext implements ConditionSupplier {
     public void setMaxSizeLogMessage(String maxSizeLogMessage) {
         // log max size limit is in MB format
         // -1 means no limit
-        if (maxSizeLogMessage != null) {
-            try {
-                int value = Integer.parseInt(maxSizeLogMessage);
-                if (value >= 0) {
-                    // By default, consider MB
-                    this.maxSizeLogMessage = Integer.parseInt(maxSizeLogMessage) * (1024 * 1024);
-                }
-            } catch (NumberFormatException nfe) {
-                maxSizeLogMessage = maxSizeLogMessage.toUpperCase();
-
-                try {
-                    if (maxSizeLogMessage.endsWith("MB") || maxSizeLogMessage.endsWith("M")) {
-                        int value = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('M')));
-                        this.maxSizeLogMessage = value * (1024 * 1024);
-                    } else if (maxSizeLogMessage.endsWith("KB") || maxSizeLogMessage.endsWith("K")) {
-                        int value = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('K')));
-                        this.maxSizeLogMessage = value * (1024);
-                    } else if (maxSizeLogMessage.endsWith("B")) {
-                        this.maxSizeLogMessage = Integer.parseInt(maxSizeLogMessage.substring(0, maxSizeLogMessage.indexOf('B')));
-                    } else {
-                        log.error("Max size for API logging is invalid, no limit is defined. (value: {})", maxSizeLogMessage);
-                        this.maxSizeLogMessage = -1;
-                    }
-                } catch (NumberFormatException nfe2) {
-                    log.error("Max size for API logging is invalid, no limit is defined. (value: {})", maxSizeLogMessage);
-                    this.maxSizeLogMessage = -1;
-                }
-            }
+        try {
+            final long sizeInBytes = SizeUtils.toBytes(maxSizeLogMessage);
+            this.maxSizeLogMessage = Math.toIntExact(sizeInBytes);
+        } catch (ArithmeticException | NumberFormatException ae) {
+            this.maxSizeLogMessage = -1;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -459,6 +459,22 @@
                 </dependency>
             </dependencies>
         </profile>
+
+        <profile>
+            <id>bundle-default</id>
+            <activation>
+                <property>
+                    <name>bundle</name>
+                </property>
+            </activation>
+            <dependencies>
+                <!-- Cloud -->
+                <dependency>
+                    <groupId>com.graviteesource.cloud</groupId>
+                    <artifactId>gravitee-cloud-initializer</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -348,7 +348,7 @@ reporters:
 #    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
   # Elasticsearch reporter
   elasticsearch:
-    enabled: true # Is the reporter enabled or not (default to true)
+    # enabled: true # Is the reporter enabled or not (default to true)
     endpoints:
       - http://${ds.elastic.host}:${ds.elastic.port}
 #    lifecycle:

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -355,7 +355,9 @@ data:
     reporters:
       # Elasticsearch reporter
       elasticsearch:
+        {{- if (hasKey ((.Values.gateway).reporters).elasticsearch "enabled") }}
         enabled: {{ .Values.gateway.reporters.elasticsearch.enabled }}
+        {{- end }}
         {{- with .Values.es.endpoints }}
         endpoints:
           {{ toYaml . | nindent 10 | trim -}}

--- a/helm/tests/gateway/configmap_es_reporter_test.yaml
+++ b/helm/tests/gateway/configmap_es_reporter_test.yaml
@@ -43,7 +43,6 @@ tests:
             reporters:
               # Elasticsearch reporter
               elasticsearch:
-                enabled: true
                 endpoints:
                   - http://graviteeio-apim-elasticsearch-ingest-hl:9200
                 index_mode: daily
@@ -76,7 +75,6 @@ tests:
             reporters:
               # Elasticsearch reporter
               elasticsearch:
-                enabled: true
                 endpoints:
                   - http://graviteeio-apim-elasticsearch-ingest-hl:9200
                 index_mode: daily
@@ -91,3 +89,39 @@ tests:
                 bulk:
                   actions: 1000           # Number of requests action before flush
                   flush_interval: 5       # Flush interval in seconds
+
+  - it: Check explicitly enable es
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        reporters:
+          elasticsearch:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            reporters:
+              # Elasticsearch reporter
+              elasticsearch:
+                enabled: true
+
+  - it: Check explicitly disable es
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        reporters:
+          elasticsearch:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data.[gravitee.yml]
+          pattern: |
+            reporters:
+              # Elasticsearch reporter
+              elasticsearch:
+                enabled: false

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1189,9 +1189,9 @@ gateway:
   #       header: X-Gravitee-Transaction-Id
   #     request:
   #       header: X-Gravitee-Request-Id
-  reporters:
-    elasticsearch:
-      enabled: true
+#  reporters:
+#    elasticsearch:
+#      enabled: true
 #    tcp:
 #      enabled: true
 #      host: localhost

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-bom.version>8.0.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.0.18</gravitee-cockpit-api.version>
-        <gravitee-common.version>4.2.0</gravitee-common.version>
+        <gravitee-common.version>4.3.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-exchange.version>1.5.0</gravitee-exchange.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-kubernetes.version>3.3.0</gravitee-kubernetes.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
+        <gravitee-cloud-initializer.version>1.0.0-alpha.3</gravitee-cloud-initializer.version>
         <!-- Other dependencies version -->
         <angus-mail.version>2.0.1</angus-mail.version>
         <angus-activation.version>2.0.0</angus-activation.version>
@@ -248,6 +249,7 @@
         <gravitee-reporter-elasticsearch.version>5.3.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.1</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.1</gravitee-reporter-tcp.version>
+        <gravitee-reporter-cloud.version>1.0.0-alpha.1</gravitee-reporter-cloud.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-tracer-jaeger.version>3.0.1</gravitee-tracer-jaeger.version>
@@ -281,7 +283,7 @@
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>3.0.0-alpha.1</gravitee-resource-schema-registry-confluent.version>
         <gravitee-reactor-message.version>2.1.0-alpha.3</gravitee-reactor-message.version>
-        <gravitee-repository-bridge.version>4.3.1</gravitee-repository-bridge.version>
+        <gravitee-repository-bridge.version>4.4.0-alpha.2</gravitee-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>1.0.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-policy-interops.version>1.0.0</gravitee-policy-interops.version>
 
@@ -1048,6 +1050,12 @@
                 <artifactId>archunit-junit5</artifactId>
                 <version>${archunit-junit5.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.graviteesource.cloud</groupId>
+                <artifactId>gravitee-cloud-initializer</artifactId>
+                <version>${gravitee-cloud-initializer.version}</version>
+                <scope>runtime</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-349

## Description

This PR includes the `cloud-initializer` and the `reporter-cloud` plugin in the final distribution.
It contains also a commit that brings a small refactoring since the [following feature](https://github.com/gravitee-io/gravitee-common/pull/120) has been introduced into gravitee-common.

Cloud initializer aims to auto-configure the gateway to connect to the cloud by specifying a cloud token:

- Automatically configure the `bridge-client` to connect to the cloudgate
- Automatically configure and enable the `reporter-cloud`. The following rules apply in that case:
  - The Cloud Reporter cannot be disabled. The elastic reporter is disabled by default in favor of the cloud reporter.
  - The logged payload size will be limited.
  - It stays possible to enable additional reporters if wanted (e.g. TCP, File, …). In that case, the same limitation on the payloads applies.

The `reporters.elasticsearch.enabled` configuration in the `gravitee.yaml` is now commented to directly use the default value in the reporter-elastic plugin (enabled by default). This allows to detect if the reporter elastic has been explicitly enabled by the user or not.
Similar changes have been made in the helm `values.yaml`.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fgvrpvrbgv.chromatic.com)
<!-- Storybook placeholder end -->
