### PR TITLE
feat(platform logs): add filter for admin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -143,7 +143,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
     private Set<String> findApplicationIds() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (isAdmin()) {
-            return applicationService.findIdsByUser(executionContext, null);
+            return applicationService.findIdsByEnvironment(executionContext);
         }
         return applicationService.findIdsByUserAndPermission(executionContext, getAuthenticatedUser(), null, APPLICATION_ANALYTICS, READ);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
@@ -21,11 +21,14 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 import static java.lang.String.format;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.management.rest.model.wrapper.PlatformRequestItemSearchLogResponse;
 import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.analytics.query.LogQuery;
+import io.gravitee.rest.api.model.application.ApplicationExcludeFilter;
+import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.model.log.ApiRequest;
 import io.gravitee.rest.api.model.log.PlatformRequestItem;
 import io.gravitee.rest.api.model.log.SearchLogResponse;
@@ -44,7 +47,9 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -86,35 +91,41 @@ public class PlatformLogsResource extends AbstractResource {
         logQuery.setField(param.getField());
         logQuery.setOrder(param.isOrder());
 
-        if (!isAdmin()) {
-            String extraFilter = getExtratFilterForAccessibleAPIsAndApplications(logQuery);
-            if (extraFilter == null) {
-                return new SearchLogResponse<>(0);
-            } else if (logQuery.getQuery() == null || logQuery.getQuery().isEmpty()) {
-                logQuery.setQuery(extraFilter);
-            } else {
-                logQuery.setQuery(format("(%s) AND (%s)", logQuery.getQuery(), extraFilter));
-            }
+        String extraFilter = getExtraFilterForAccessibleAPIsAndApplications(logQuery);
+        if (extraFilter == null) {
+            return new SearchLogResponse<>(0);
+        } else if (logQuery.getQuery() == null || logQuery.getQuery().isEmpty()) {
+            logQuery.setQuery(extraFilter);
+        } else {
+            logQuery.setQuery(format("(%s) AND (%s)", logQuery.getQuery(), extraFilter));
         }
 
         return logsService.findPlatform(GraviteeContext.getExecutionContext(), logQuery);
     }
 
-    private String getExtratFilterForAccessibleAPIsAndApplications(LogQuery logQuery) {
+    private String getExtraFilterForAccessibleAPIsAndApplications(LogQuery logQuery) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
-        List<String> applicationIds = applicationService
-            .findIdsByUser(executionContext, getAuthenticatedUser())
-            .stream()
-            .filter(appId -> permissionService.hasPermission(executionContext, APPLICATION_LOG, appId, READ))
-            .collect(Collectors.toList());
+        Set<String> applicationIds;
+        if (isAdmin()) {
+            applicationIds = applicationService.findIdsByEnvironment(executionContext);
+        } else {
+            applicationIds =
+                applicationService.findIdsByUserAndPermission(executionContext, getAuthenticatedUser(), null, APPLICATION_LOG, READ);
+        }
         String applicationsFilter = getExtraFilter("application", applicationIds);
 
-        List<String> apiIds = apiAuthorizationService
-            .findIdsByUser(executionContext, getAuthenticatedUser(), null, true)
-            .stream()
-            .filter(appId -> permissionService.hasPermission(executionContext, API_LOG, appId, READ))
-            .collect(Collectors.toList());
+        Set<String> apiIds;
+        if (isAdmin()) {
+            apiIds = apiAuthorizationService.findIdsByEnvironment(executionContext);
+        } else {
+            apiIds =
+                apiAuthorizationService
+                    .findIdsByUser(executionContext, getAuthenticatedUser(), null, true)
+                    .stream()
+                    .filter(appId -> permissionService.hasPermission(executionContext, API_LOG, appId, READ))
+                    .collect(Collectors.toSet());
+        }
         String apisFilter = getExtraFilter("api", apiIds);
 
         String extraFilter;
@@ -167,9 +178,9 @@ public class PlatformLogsResource extends AbstractResource {
             .build();
     }
 
-    private String getExtraFilter(String fieldName, List<String> ids) {
+    private String getExtraFilter(String fieldName, Set<String> ids) {
         if (ids != null && !ids.isEmpty()) {
-            return fieldName + ":(" + ids.stream().collect(Collectors.joining(" OR ")) + ")";
+            return fieldName + ":(" + String.join(" OR ", ids) + ")";
         }
         return null;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_Admin_GetTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Set;
@@ -40,7 +41,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
     @Before
     public void init() {
-        reset(applicationService, apiAuthorizationService, permissionService);
+        reset(applicationService, apiAuthorizationServiceV4, permissionService);
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -54,7 +55,7 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
 
     @Test
     public void should_return_no_content_when_user_admin_and_application_analytics() {
-        when(applicationService.findIdsByUser(GraviteeContext.getExecutionContext(), null)).thenReturn(Set.of());
+        when(applicationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of());
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -73,12 +74,12 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(applicationService, never()).findIdsByUser(any(), any(), any());
+        verify(applicationService).findIdsByEnvironment(any(ExecutionContext.class));
     }
 
     @Test
     public void should_return_no_content_when_user_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of());
+        when(apiAuthorizationServiceV4.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of());
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -96,12 +97,12 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(apiAuthorizationService, never()).findIdsByUser(any(), any(), anyBoolean());
+        verify(apiAuthorizationServiceV4).findIdsByEnvironment(any(ExecutionContext.class));
     }
 
     @Test
     public void should_return_analytics_when_user_admin_and_application_analytics() {
-        when(applicationService.findIdsByUser(GraviteeContext.getExecutionContext(), null)).thenReturn(Set.of("app-1"));
+        when(applicationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of("app-1"));
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
@@ -128,12 +129,12 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(applicationService, never()).findIdsByUser(any(), any(), any());
+        verify(applicationService).findIdsByEnvironment(any(ExecutionContext.class));
     }
 
     @Test
     public void should_return_analytics_when_user_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of("api-1"));
+        when(apiAuthorizationServiceV4.findIdsByEnvironment(GraviteeContext.getExecutionContext())).thenReturn(Set.of("api-1"));
 
         HitsAnalytics analytics = new HitsAnalytics();
         analytics.setHits(100L);
@@ -159,6 +160,6 @@ public class PlatformAnalyticsResource_Admin_GetTest extends AbstractResourceTes
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(applicationService, never()).findIdsByUser(any(), any(), any());
+        verify(apiAuthorizationServiceV4).findIdsByEnvironment(any(ExecutionContext.class));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource_NotAdmin_GetTest.java
@@ -16,6 +16,9 @@
 
 package io.gravitee.rest.api.management.rest.resource;
 
+import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_ANALYTICS;
+import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_LOG;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -26,6 +29,7 @@ import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Set;
@@ -47,7 +51,7 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
 
     @Before
     public void init() {
-        reset(applicationService, apiAuthorizationService, permissionService);
+        reset(applicationService, apiAuthorizationServiceV4, permissionService);
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -61,7 +65,16 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
 
     @Test
     public void should_return_no_content_when_user_not_admin_and_application_analytics() {
-        when(applicationService.findIdsByUser(GraviteeContext.getExecutionContext(), null)).thenReturn(Set.of());
+        when(
+            applicationService.findIdsByUserAndPermission(
+                GraviteeContext.getExecutionContext(),
+                USER_NAME,
+                null,
+                APPLICATION_ANALYTICS,
+                READ
+            )
+        )
+            .thenReturn(Set.of());
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -80,12 +93,13 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(applicationService, never()).findIdsByUser(any(), any(), any());
+        verify(applicationService)
+            .findIdsByUserAndPermission(GraviteeContext.getExecutionContext(), USER_NAME, null, APPLICATION_ANALYTICS, READ);
     }
 
     @Test
     public void should_return_no_content_when_user_not_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true)).thenReturn(Set.of());
+        when(apiAuthorizationServiceV4.findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true)).thenReturn(Set.of());
 
         final Response response = envTarget()
             .queryParam("to", 122222L)
@@ -103,7 +117,7 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(apiAuthorizationService, never()).findIdsByEnvironment(any());
+        verify(apiAuthorizationServiceV4).findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true);
     }
 
     @Test
@@ -113,8 +127,8 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
                 GraviteeContext.getExecutionContext(),
                 USER_NAME,
                 null,
-                RolePermission.APPLICATION_ANALYTICS,
-                RolePermissionAction.READ
+                APPLICATION_ANALYTICS,
+                READ
             )
         )
             .thenReturn(Set.of("app-1"));
@@ -144,12 +158,13 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(apiAuthorizationService, never()).findIdsByEnvironment(any());
+        verify(applicationService)
+            .findIdsByUserAndPermission(GraviteeContext.getExecutionContext(), USER_NAME, null, APPLICATION_ANALYTICS, READ);
     }
 
     @Test
     public void should_return_analytics_when_user_not_admin_and_api_analytics() {
-        when(apiAuthorizationService.findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true)).thenReturn(Set.of("api-1"));
+        when(apiAuthorizationServiceV4.findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true)).thenReturn(Set.of("api-1"));
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -184,6 +199,6 @@ public class PlatformAnalyticsResource_NotAdmin_GetTest extends AbstractResource
                 "DEFAULT",
                 RolePermissionAction.READ
             );
-        verify(apiAuthorizationService, never()).findIdsByEnvironment(any());
+        verify(apiAuthorizationServiceV4).findIdsByUser(GraviteeContext.getExecutionContext(), USER_NAME, true);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
@@ -16,11 +16,12 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_LOG;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -66,13 +67,23 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     @Test
     public void shouldGetPlatformLogsAsNonAdmin() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
-        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
+        when(
+            applicationService.findIdsByUserAndPermission(
+                any(ExecutionContext.class),
+                eq(USER_NAME),
+                isNull(),
+                eq(APPLICATION_LOG),
+                eq(READ)
+            )
+        )
+            .thenReturn(Set.of("app1"));
         when(apiAuthorizationServiceV4.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true)))
             .thenReturn(Set.of("api1"));
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
-        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(applicationService)
+            .findIdsByUserAndPermission(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(APPLICATION_LOG), eq(READ));
         verify(apiAuthorizationServiceV4).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
@@ -92,13 +103,23 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     @Test
     public void shouldGetPlatformLogsAsNonAdminFilterOnlyApp() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
-        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
+        when(
+            applicationService.findIdsByUserAndPermission(
+                any(ExecutionContext.class),
+                eq(USER_NAME),
+                isNull(),
+                eq(APPLICATION_LOG),
+                eq(READ)
+            )
+        )
+            .thenReturn(Set.of("app1"));
         when(apiAuthorizationServiceV4.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true)))
             .thenReturn(emptySet());
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
-        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(applicationService)
+            .findIdsByUserAndPermission(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(APPLICATION_LOG), eq(READ));
         verify(apiAuthorizationServiceV4).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
@@ -118,14 +139,24 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     @Test
     public void shouldGetPlatformLogsAsNonAdminFilterOnlyAPI() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
-        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(emptySet());
+        when(
+            applicationService.findIdsByUserAndPermission(
+                any(ExecutionContext.class),
+                eq(USER_NAME),
+                isNull(),
+                eq(APPLICATION_LOG),
+                eq(READ)
+            )
+        )
+            .thenReturn(emptySet());
         when(apiAuthorizationServiceV4.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true)))
             .thenReturn(Set.of("api1"));
 
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
-        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(applicationService)
+            .findIdsByUserAndPermission(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(APPLICATION_LOG), eq(READ));
         verify(apiAuthorizationServiceV4).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
@@ -144,7 +175,16 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoLogsAsNonAdminWithNoAPINoApp() {
-        when(applicationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME))).thenReturn(emptySet());
+        when(
+            applicationService.findIdsByUserAndPermission(
+                any(ExecutionContext.class),
+                eq(USER_NAME),
+                isNull(),
+                eq(APPLICATION_LOG),
+                eq(READ)
+            )
+        )
+            .thenReturn(emptySet());
         when(apiAuthorizationServiceV4.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true)))
             .thenReturn(emptySet());
         Response logs = sendRequest();
@@ -153,7 +193,8 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
         JsonNode jsonNode = logs.readEntity(JsonNode.class);
         assertEquals(0, jsonNode.get("total").intValue());
         assertNull(jsonNode.get("logs"));
-        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(applicationService)
+            .findIdsByUserAndPermission(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(APPLICATION_LOG), eq(READ));
         verify(apiAuthorizationServiceV4).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService, never()).findPlatform(any(ExecutionContext.class), any(LogQuery.class));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.Objects;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,19 +63,20 @@ public class PlatformLogsResourceTest extends AbstractResourceTest {
             )
         )
             .thenReturn(true);
+        when(applicationService.findIdsByEnvironment(any(ExecutionContext.class))).thenReturn(Set.of("app1"));
+        when(apiAuthorizationServiceV4.findIdsByEnvironment(any(ExecutionContext.class))).thenReturn(Set.of("api1"));
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
-        verify(applicationService, never()).findIdsByUser(any(ExecutionContext.class), any());
-        verify(apiAuthorizationServiceV4, never())
-            .findIdsByUser(any(ExecutionContext.class), anyString(), any(ApiQuery.class), anyBoolean());
+        verify(applicationService).findIdsByEnvironment(any(ExecutionContext.class));
+        verify(apiAuthorizationServiceV4).findIdsByEnvironment(any(ExecutionContext.class));
 
         verify(logsService)
             .findPlatform(
                 any(ExecutionContext.class),
                 argThat(query ->
-                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1) OR api:(api1))") &&
                     query.getPage() == 1 &&
                     query.getSize() == 10 &&
                     query.getFrom() == 0 &&

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -79,6 +79,8 @@ public interface ApplicationService {
 
     Set<String> findIdsByOrganization(String organizationId);
 
+    Set<String> findIdsByEnvironment(final ExecutionContext executionContext);
+
     Set<ApplicationListItem> findByGroups(ExecutionContext executionContext, List<String> groupId);
 
     Set<ApplicationListItem> findByGroupsAndStatus(ExecutionContext executionContext, List<String> groupId, String status);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.Application.AuditEvent.*;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -283,6 +284,16 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
 
         return this.searchIds(new ExecutionContext(organizationId, null), new ApplicationQuery(), null);
+    }
+
+    @Override
+    public Set<String> findIdsByEnvironment(final ExecutionContext executionContext) {
+        LOGGER.debug("Find applications by environment {} ", executionContext.getEnvironmentId());
+        if (isBlank(executionContext.getEnvironmentId())) {
+            return Set.of();
+        }
+
+        return this.searchIds(executionContext, null, null);
     }
 
     @Override
@@ -1258,29 +1269,31 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             criteriaBuilder.environmentIds(environmentIds);
         }
 
-        if (applicationQuery.getIds() != null && !applicationQuery.getIds().isEmpty()) {
-            criteriaBuilder.ids(applicationQuery.getIds());
-        }
-
-        ApplicationStatus applicationStatus = null;
-        if (applicationQuery.getGroups() != null && !applicationQuery.getGroups().isEmpty()) {
-            criteriaBuilder.groups(applicationQuery.getGroups());
-        }
-
-        if (applicationQuery.getStatus() != null && !applicationQuery.getStatus().isBlank()) {
-            applicationStatus = ApplicationStatus.valueOf(applicationQuery.getStatus().toUpperCase());
-            criteriaBuilder.status(applicationStatus);
-        }
-
-        if (applicationQuery.getName() != null && !applicationQuery.getName().isBlank()) {
-            criteriaBuilder.name(applicationQuery.getName());
-        }
-        if (applicationQuery.getUser() != null && !applicationQuery.getUser().isBlank()) {
-            Set<String> userApplicationsIds = findUserApplicationsIds(executionContext, applicationQuery.getUser(), applicationStatus);
-            if (userApplicationsIds.isEmpty()) {
-                return null;
+        if (applicationQuery != null) {
+            if (applicationQuery.getIds() != null && !applicationQuery.getIds().isEmpty()) {
+                criteriaBuilder.ids(applicationQuery.getIds());
             }
-            criteriaBuilder.ids(userApplicationsIds);
+
+            ApplicationStatus applicationStatus = null;
+            if (applicationQuery.getGroups() != null && !applicationQuery.getGroups().isEmpty()) {
+                criteriaBuilder.groups(applicationQuery.getGroups());
+            }
+
+            if (applicationQuery.getStatus() != null && !applicationQuery.getStatus().isBlank()) {
+                applicationStatus = ApplicationStatus.valueOf(applicationQuery.getStatus().toUpperCase());
+                criteriaBuilder.status(applicationStatus);
+            }
+
+            if (applicationQuery.getName() != null && !applicationQuery.getName().isBlank()) {
+                criteriaBuilder.name(applicationQuery.getName());
+            }
+            if (applicationQuery.getUser() != null && !applicationQuery.getUser().isBlank()) {
+                Set<String> userApplicationsIds = findUserApplicationsIds(executionContext, applicationQuery.getUser(), applicationStatus);
+                if (userApplicationsIds.isEmpty()) {
+                    return null;
+                }
+                criteriaBuilder.ids(userApplicationsIds);
+            }
         }
         return criteriaBuilder.build();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4079
https://github.com/gravitee-io/issues/issues/9599

## Description

Add a filter for APIs and applications when current user is admin, to force looking into one environment only.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-chkxydddea.chromatic.com)
<!-- Storybook placeholder end -->
