### PR TITLE
feat(analytics-v4): add api v4 analytics empty page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -284,21 +284,28 @@ export class ApiV4MenuService implements ApiMenuService {
   }
 
   private addApiTrafficMenuEntry(hasTcpListeners: boolean): MenuItem {
-    const logsTabs = [];
+    const apiTrafficTabs = [];
+
+    if (this.permissionService.hasAnyMatching(['api-analytics-r'])) {
+      apiTrafficTabs.push({
+        displayName: 'Analytics',
+        routerLink: 'v4/analytics',
+      });
+    }
 
     if (this.permissionService.hasAnyMatching(['api-log-r'])) {
-      logsTabs.push({
+      apiTrafficTabs.push({
         displayName: 'Runtime Logs',
         routerLink: 'v4/runtime-logs',
       });
     }
     if (this.permissionService.hasAnyMatching(['api-definition-u', 'api-log-u'])) {
-      logsTabs.push({
+      apiTrafficTabs.push({
         displayName: 'Settings',
         routerLink: 'v4/runtime-logs-settings',
       });
     }
-    if (logsTabs.length > 0) {
+    if (apiTrafficTabs.length > 0) {
       return {
         displayName: 'API Traffic',
         icon: 'bar-chart-2',
@@ -307,7 +314,7 @@ export class ApiV4MenuService implements ApiMenuService {
           title: 'API Traffic',
           subtitle: 'Gain actionable insights into API performance with real-time metrics, logs, and notifications',
         },
-        tabs: logsTabs,
+        tabs: apiTrafficTabs,
       };
     }
     return null;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.harness.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiAnalyticsHarness extends ComponentHarness {
+  static hostSelector = 'api-analytics';
+
+  public emptyPanelHarness = this.locatorForOptional('gio-card-empty-state');
+
+  async isEmptyPanelDisplayed(): Promise<boolean> {
+    return (await this.emptyPanelHarness()) !== null;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.html
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card class="analytics">
+  <mat-card-header>
+    <mat-card-title>Analytics</mat-card-title>
+    <mat-card-subtitle>Gain actionable insights into API performance with real-time metrics</mat-card-subtitle>
+  </mat-card-header>
+  @if (isEmptyAnalytics) {
+    <mat-card-content>
+      <gio-card-empty-state
+        icon="folder-plus"
+        title="Enable Analytics"
+        subtitle="Your metrics live here. Start monitoring your API by enabling the Analytics in the settings."
+      ></gio-card-empty-state>
+    </mat-card-content>
+  } @else {
+    <ng-container>
+      <div class="container"></div>
+    </ng-container>
+  }
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.scss
@@ -1,0 +1,8 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiAnalyticsComponent } from './api-analytics.component';
+import { ApiAnalyticsHarness } from './api-analytics.component.harness';
+
+import { GioTestingModule } from '../../../../shared/testing';
+
+describe('ApiAnalyticsComponent', () => {
+  let fixture: ComponentFixture<ApiAnalyticsComponent>;
+  let componentHarness: ApiAnalyticsHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiAnalyticsComponent, NoopAnimationsModule, HttpClientTestingModule, MatIconTestingModule, GioTestingModule],
+    }).compileComponents();
+
+    await TestBed.compileComponents();
+    fixture = TestBed.createComponent(ApiAnalyticsComponent);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiAnalyticsHarness);
+    fixture.detectChanges();
+  });
+
+  describe('GIVEN Analytics are disabled', () => {
+    it('should display the empty panel', async () => {
+      expect(await componentHarness.isEmptyPanelDisplayed()).toBeTruthy();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics.component.ts
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CommonModule } from '@angular/common';
-import { NgModule } from '@angular/core';
+import { Component } from '@angular/core';
+import { GioCardEmptyStateModule } from '@gravitee/ui-particles-angular';
+import { MatButton } from '@angular/material/button';
+import { MatCard, MatCardContent, MatCardHeader, MatCardSubtitle, MatCardTitle } from '@angular/material/card';
 
-import { ApiRuntimeLogsSettingsModule } from './runtime-logs-settings/api-runtime-logs-settings.module';
-import { ApiRuntimeLogsModule } from './runtime-logs/api-runtime-logs.module';
-import { ApiRuntimeLogsDetailsModule } from './runtime-logs-details/api-runtime-logs-details.module';
-
-@NgModule({
-  imports: [CommonModule, ApiRuntimeLogsModule, ApiRuntimeLogsSettingsModule, ApiRuntimeLogsDetailsModule],
+@Component({
+  selector: 'api-analytics',
+  standalone: true,
+  imports: [GioCardEmptyStateModule, MatButton, MatCard, MatCardContent, MatCardHeader, MatCardSubtitle, MatCardTitle],
+  templateUrl: './api-analytics.component.html',
+  styleUrl: './api-analytics.component.scss',
 })
-export class ApiRuntimeLogsV4Module {}
+export class ApiAnalyticsComponent {
+  isEmptyAnalytics = true;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ApiRuntimeLogsSettingsModule } from './runtime-logs-settings/api-runtime-logs-settings.module';
+import { ApiRuntimeLogsModule } from './runtime-logs/api-runtime-logs.module';
+import { ApiRuntimeLogsDetailsModule } from './runtime-logs-details/api-runtime-logs-details.module';
+import { ApiAnalyticsComponent } from './analytics/api-analytics.component';
+
+@NgModule({
+  imports: [CommonModule, ApiRuntimeLogsModule, ApiRuntimeLogsSettingsModule, ApiRuntimeLogsDetailsModule, ApiAnalyticsComponent],
+})
+export class ApiTrafficV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -83,6 +83,7 @@ import { ApiHistoryV4Component } from './history-v4/api-history-v4.component';
 import { ApiHistoryV4DeploymentInfoComponent } from './history-v4/deployment-info/api-history-v4-deployment-info.component';
 import { ApiFailoverV4Component } from './failover-v4/api-failover-v4.component';
 import { ApiImportV4Component } from './import-v4/api-import-v4.component';
+import { ApiAnalyticsComponent } from './api-traffic-v4/analytics/api-analytics.component';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -860,6 +861,15 @@ const apisRoutes: Routes = [
           docs: null,
         },
         component: ApiV4PolicyStudioDesignComponent,
+      },
+      {
+        path: 'v4/analytics',
+        data: {
+          permissions: {
+            anyOf: ['api-analytics-r'],
+          },
+        },
+        component: ApiAnalyticsComponent,
       },
       {
         path: 'v4/runtime-logs',

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -21,7 +21,7 @@ import { ApiAnalyticsModule } from './analytics/api-analytics.module';
 import { ApiListModule } from './list/api-list.module';
 import { ApiNavigationModule } from './api-navigation/api-navigation.module';
 import { ApiV4PolicyStudioModule } from './policy-studio-v4/api-v4-policy-studio.module';
-import { ApiRuntimeLogsV4Module } from './api-traffic-v4/api-runtime-logs-v4.module';
+import { ApiTrafficV4Module } from './api-traffic-v4/api-traffic-v4.module';
 import { ApiEndpointsV4Module } from './endpoints-v4/api-endpoints-v4.module';
 import { ApiEntrypointsV4Module } from './entrypoints-v4/api-entrypoints-v4.module';
 import { GioPolicyStudioRoutingModule } from './policy-studio-v2/gio-policy-studio-routing.module';
@@ -94,7 +94,7 @@ import { AlertsModule } from '../../components/alerts/alerts.module';
     ApiPropertiesModule,
     ApiResourcesModule,
     ApiResponseTemplatesModule,
-    ApiRuntimeLogsV4Module,
+    ApiTrafficV4Module,
     ApiRuntimeAlertsModule,
     ApiSubscriptionsModule,
     ApiV4PolicyStudioModule,


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-3488

## Description
Add the empty page for Analytics for a V4 API
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/cafb1745-b96c-470c-8c33-cb5ba2b8c762)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wnlkorvcvj.chromatic.com)
<!-- Storybook placeholder end -->
