### PR TITLE
Rest-api: add GET apis/:apiId/deployments/current to return the current deployment of an API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -364,6 +364,28 @@ paths:
                     description: API deployment request received
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/deployments/current:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - APIs
+            summary: Get the current deployment of an API
+            description: |-
+                Get the current deployment of an API.
+
+                User must have the API_DEFINITION[READ] permission.
+            operationId: getCurrentApiDeployment
+            responses:
+                "200":
+                    description: Current API deployment found
+                    content:
+                        application/json:
+                            schema:
+                              type: object
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/deployments/_verify:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DeploymentsCurrentTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_DeploymentsCurrentTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import fixtures.definition.ApiDefinitionFixtures;
+import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApiResource_DeploymentsCurrentTest extends ApiResourceTest {
+
+    private static final String UNKNOWN_API = "unknown";
+
+    @Autowired
+    GetApiDefinitionUseCase getApiDefinitionUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @Test
+    public void should_get_api_v4_deployments() {
+        when(getApiDefinitionUseCase.execute(any()))
+            .thenReturn(new GetApiDefinitionUseCase.Output(DefinitionVersion.V4, ApiDefinitionFixtures.anApiV4(), null));
+
+        final Response response = rootTarget(API + "/deployments/current").request().get();
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    @Test
+    public void should_get_api_v2_deployments() {
+        when(getApiDefinitionUseCase.execute(any()))
+            .thenReturn(new GetApiDefinitionUseCase.Output(DefinitionVersion.V2, null, ApiDefinitionFixtures.anApiV2()));
+
+        final Response response = rootTarget(API + "/deployments/current").request().get();
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    @Test
+    public void should_throw_with_insufficient_rights() {
+        doReturn(false)
+            .when(permissionService)
+            .hasPermission(eq(GraviteeContext.getExecutionContext()), eq(RolePermission.API_DEFINITION), eq(API), any());
+        final Response response = rootTarget(API + "/deployments/current").request().get();
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -31,6 +31,7 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
+import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
@@ -359,5 +360,10 @@ public class ResourceContextConfiguration {
     @Bean
     public RollbackApiUseCase rollbackApiUseCase() {
         return mock(RollbackApiUseCase.class);
+    }
+
+    @Bean
+    public GetApiDefinitionUseCase getApiDefinitionUseCase() {
+        return mock(GetApiDefinitionUseCase.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api.model;
 
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
@@ -25,6 +26,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -204,6 +206,17 @@ public class Api {
     public Api setFederatedApiDefinition(io.gravitee.definition.model.federation.FederatedApi federatedApiDefinition) {
         this.federatedApiDefinition = federatedApiDefinition;
         this.definitionVersion = federatedApiDefinition.getDefinitionVersion();
+        return this;
+    }
+
+    public Api setPlans(List<Plan> plans) {
+        switch (definitionVersion) {
+            case V4 -> apiDefinitionV4.setPlans(plans.stream().map(Plan::getPlanDefinitionV4).collect(Collectors.toList()));
+            case V1, V2 -> apiDefinition.setPlans(plans.stream().map(Plan::getPlanDefinitionV2).collect(Collectors.toList()));
+            case FEDERATED -> {
+                // do nothing
+            }
+        }
         return this;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetApiDefinitionUseCase {
+
+    private final ApiCrudService apiCrudService;
+    private final FlowCrudService flowCrudService;
+    private final PlanQueryService planQueryService;
+
+    public record Input(String apiId) {}
+
+    public record Output(
+        DefinitionVersion definitionVersion,
+        io.gravitee.definition.model.v4.Api apiDefinitionV4,
+        io.gravitee.definition.model.Api apiDefinition
+    ) {}
+
+    public Output execute(Input input) {
+        Api api = apiCrudService.get(input.apiId);
+
+        switch (api.getDefinitionVersion()) {
+            case V1, V2 -> api.getApiDefinition().setFlows(flowCrudService.getApiV2Flows(api.getId()));
+            case V4 -> api.getApiDefinitionV4().setFlows(flowCrudService.getApiV4Flows(api.getId()));
+        }
+
+        List<Plan> plans = planQueryService
+            .findAllByApiId(api.getId())
+            .stream()
+            .filter(plan -> plan.getPlanStatus() == PlanStatus.PUBLISHED || plan.getPlanStatus() == PlanStatus.DEPRECATED)
+            .peek(plan -> {
+                switch (plan.getDefinitionVersion()) {
+                    case V1, V2 -> plan.getPlanDefinitionV2().setFlows(flowCrudService.getPlanV2Flows(plan.getId()));
+                    case V4 -> plan.getPlanDefinitionV4().setFlows(flowCrudService.getPlanV4Flows(plan.getId()));
+                }
+            })
+            .toList();
+        api.setPlans(plans);
+
+        return new Output(api.getDefinitionVersion(), api.getApiDefinitionV4(), api.getApiDefinition());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
@@ -22,4 +22,12 @@ public interface FlowCrudService {
     List<Flow> savePlanFlows(String planId, List<Flow> flows);
 
     List<Flow> saveApiFlows(String apiId, List<Flow> flows);
+
+    List<Flow> getApiV4Flows(String apiId);
+
+    List<Flow> getPlanV4Flows(String planId);
+
+    List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId);
+
+    List<io.gravitee.definition.model.flow.Flow> getPlanV2Flows(String planId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.model.context.IntegrationContext;
 import io.gravitee.rest.api.model.context.ManagementContext;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -160,7 +161,7 @@ public class ApiFixtures {
                             )
                             .build()
                     )
-                    .plans(Map.of())
+                    .plans(new HashMap<>())
                     .build()
             )
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FlowCrudServiceInMemory.java
@@ -29,6 +29,9 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
     final Map<String, List<Flow>> apiFlows = new HashMap<>();
     final Map<String, List<Flow>> planFlows = new HashMap<>();
 
+    final Map<String, List<io.gravitee.definition.model.flow.Flow>> apiFlowsV2 = new HashMap<>();
+    final Map<String, List<io.gravitee.definition.model.flow.Flow>> planFlowsV2 = new HashMap<>();
+
     @Override
     public List<Flow> savePlanFlows(String planId, List<Flow> flows) {
         planFlows.put(planId, flows);
@@ -37,8 +40,28 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
 
     @Override
     public List<Flow> saveApiFlows(String apiId, List<Flow> flows) {
-        planFlows.put(apiId, flows);
+        apiFlows.put(apiId, flows);
         return flows;
+    }
+
+    @Override
+    public List<Flow> getApiV4Flows(String apiId) {
+        return apiFlows.getOrDefault(apiId, new ArrayList<>());
+    }
+
+    @Override
+    public List<Flow> getPlanV4Flows(String planId) {
+        return planFlows.getOrDefault(planId, new ArrayList<>());
+    }
+
+    @Override
+    public List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId) {
+        return apiFlowsV2.getOrDefault(apiId, new ArrayList<>());
+    }
+
+    @Override
+    public List<io.gravitee.definition.model.flow.Flow> getPlanV2Flows(String planId) {
+        return planFlowsV2.getOrDefault(planId, new ArrayList<>());
     }
 
     @Override
@@ -64,5 +87,15 @@ public class FlowCrudServiceInMemory implements FlowCrudService, InMemoryAlterna
                     }
                 )
         );
+    }
+
+    public List<io.gravitee.definition.model.flow.Flow> savePlanFlowsV2(String planId, List<io.gravitee.definition.model.flow.Flow> flows) {
+        planFlowsV2.put(planId, flows);
+        return flows;
+    }
+
+    public List<io.gravitee.definition.model.flow.Flow> saveApiFlowsV2(String apiId, List<io.gravitee.definition.model.flow.Flow> flows) {
+        apiFlowsV2.put(apiId, flows);
+        return flows;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.ApiFixtures.aMessageApiV4;
+import static fixtures.core.model.ApiFixtures.aProxyApiV2;
+import static fixtures.core.model.PlanFixtures.aPlanV2;
+import static fixtures.core.model.PlanFixtures.aPlanV4;
+import static fixtures.core.model.PlanFixtures.aPushPlan;
+import static org.junit.jupiter.api.Assertions.*;
+
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetApiDefinitionUseCaseTest {
+
+    private final String API_ID = "api-id";
+    private final String ENV_ID = "env-id";
+
+    private final ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+    private final FlowCrudServiceInMemory flowCrudServiceInMemory = new FlowCrudServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryServiceInMemory = new PlanQueryServiceInMemory();
+
+    private GetApiDefinitionUseCase getApiDefinitionUseCase;
+
+    @BeforeEach
+    void setUp() {
+        getApiDefinitionUseCase = new GetApiDefinitionUseCase(apiCrudServiceInMemory, flowCrudServiceInMemory, planQueryServiceInMemory);
+    }
+
+    @Nested
+    class WithV4Api {
+
+        private final Api API = aMessageApiV4().toBuilder().id(API_ID).environmentId(ENV_ID).build();
+
+        @Test
+        void should_return_api_definition_v4() {
+            // Given
+            apiCrudServiceInMemory.create(API);
+
+            // When
+            var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals(API.getApiDefinitionV4(), output.apiDefinitionV4());
+        }
+
+        @Test
+        void should_return_api_definition_with_flows() {
+            // Given
+            //   Api flow
+            var flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
+            flowCrudServiceInMemory.saveApiFlows(API_ID, flows);
+
+            //   Plan flow
+            var planPublished = aPlanV4().setPlanId("plan-push-id").toBuilder().apiId(API_ID).build();
+            planPublished.setPlanStatus(PlanStatus.PUBLISHED);
+            var planDeprecated = aPlanV4().setPlanId("plan-deprecate-id").toBuilder().apiId(API_ID).build();
+            planDeprecated.setPlanStatus(PlanStatus.DEPRECATED);
+            var planStaging = aPlanV4().setPlanId("plan-staging-id").toBuilder().apiId(API_ID).build();
+            planStaging.setPlanStatus(PlanStatus.STAGING);
+            planQueryServiceInMemory.initWith(List.of(planPublished, planDeprecated, planStaging));
+
+            var planFlows = List.of(Flow.builder().name("plan-flow").selectors(List.of(new HttpSelector())).build());
+            flowCrudServiceInMemory.savePlanFlows(planPublished.getId(), planFlows);
+            flowCrudServiceInMemory.savePlanFlows(planDeprecated.getId(), planFlows);
+            flowCrudServiceInMemory.savePlanFlows(planStaging.getId(), planFlows);
+
+            apiCrudServiceInMemory.create(API);
+
+            apiCrudServiceInMemory.create(API);
+
+            // When
+            var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals(API.getApiDefinitionV4(), output.apiDefinitionV4());
+            assertEquals(flows, output.apiDefinitionV4().getFlows());
+            assertEquals(2, output.apiDefinitionV4().getPlans().size());
+            assertEquals(planFlows, output.apiDefinitionV4().getPlans().get(0).getFlows());
+            assertEquals(PlanStatus.PUBLISHED, output.apiDefinitionV4().getPlans().get(0).getStatus());
+            assertEquals(planFlows, output.apiDefinitionV4().getPlans().get(1).getFlows());
+            assertEquals(PlanStatus.DEPRECATED, output.apiDefinitionV4().getPlans().get(1).getStatus());
+        }
+    }
+
+    @Nested
+    class WithV2Api {
+
+        private final Api API = aProxyApiV2().toBuilder().id(API_ID).environmentId(ENV_ID).build();
+
+        @Test
+        void should_return_api_definition_v2() {
+            // Given
+            apiCrudServiceInMemory.create(API);
+
+            // When
+            var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals(API.getApiDefinition(), output.apiDefinition());
+        }
+
+        @Test
+        void should_return_api_definition_with_flows() {
+            // Given
+            //   Api flow
+            var flows = List.of(io.gravitee.definition.model.flow.Flow.builder().name("flow").build());
+            flowCrudServiceInMemory.saveApiFlowsV2(API_ID, flows);
+
+            //   Plan flow
+            var planPublished = aPlanV2().setPlanId("plan-push-id").toBuilder().apiId(API_ID).build();
+            planPublished.setPlanStatus(PlanStatus.PUBLISHED);
+            var planDeprecated = aPlanV2().setPlanId("plan-deprecate-id").toBuilder().apiId(API_ID).build();
+            planDeprecated.setPlanStatus(PlanStatus.DEPRECATED);
+            var planStaging = aPlanV2().setPlanId("plan-staging-id").toBuilder().apiId(API_ID).build();
+            planStaging.setPlanStatus(PlanStatus.STAGING);
+            planQueryServiceInMemory.initWith(List.of(planPublished, planDeprecated, planStaging));
+
+            var planFlows = List.of(io.gravitee.definition.model.flow.Flow.builder().name("plan-flow").build());
+            flowCrudServiceInMemory.savePlanFlowsV2(planPublished.getId(), planFlows);
+            flowCrudServiceInMemory.savePlanFlowsV2(planDeprecated.getId(), planFlows);
+            flowCrudServiceInMemory.savePlanFlowsV2(planStaging.getId(), planFlows);
+
+            apiCrudServiceInMemory.create(API);
+
+            // When
+            var output = getApiDefinitionUseCase.execute(new GetApiDefinitionUseCase.Input(API_ID));
+
+            // Then
+            assertNotNull(output);
+            assertEquals(API.getApiDefinition(), output.apiDefinition());
+            assertEquals(flows, output.apiDefinition().getFlows());
+            assertEquals(2, output.apiDefinition().getPlans().size());
+            assertEquals(planFlows, output.apiDefinition().getPlans().get(0).getFlows());
+            assertEquals("PUBLISHED", output.apiDefinition().getPlans().get(0).getStatus());
+            assertEquals(planFlows, output.apiDefinition().getPlans().get(1).getFlows());
+            assertEquals("DEPRECATED", output.apiDefinition().getPlans().get(1).getStatus());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.FlowRepository;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.repository.management.model.flow.selector.FlowOperator;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Clock;
 import java.time.Instant;
@@ -286,6 +287,185 @@ class FlowCrudServiceImplTest {
             verify(flowRepository, never()).deleteAllById(anySet());
             verify(flowRepository, times(1)).create(any());
             verify(flowRepository, times(1)).update(any());
+        }
+    }
+
+    @Nested
+    class GetApiV4Flows {
+
+        @Test
+        @SneakyThrows
+        void should_return_flows() {
+            // Given
+            var repoFlows = List.of(
+                io.gravitee.repository.management.model.flow.Flow
+                    .builder()
+                    .id("flow-id")
+                    .referenceType(FlowReferenceType.API)
+                    .referenceId(API_ID)
+                    .order(0)
+                    .name("My flow")
+                    .enabled(true)
+                    .createdAt(Date.from(INSTANT_NOW))
+                    .updatedAt(Date.from(INSTANT_NOW))
+                    .build()
+            );
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenReturn(repoFlows);
+
+            // When
+            var result = service.getApiV4Flows(API_ID);
+
+            // Then
+            assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(Flow.builder().id("flow-id").name("My flow").enabled(true).build()));
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_list_when_no_flows() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenReturn(List.of());
+
+            // When
+            var result = service.getApiV4Flows(API_ID);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getApiV4Flows(API_ID));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to get flows for API: api-id");
+        }
+    }
+
+    @Nested
+    class GetPlanV4Flows {
+
+        @Test
+        @SneakyThrows
+        void should_return_flows() {
+            // Given
+            var repoFlows = List.of(
+                io.gravitee.repository.management.model.flow.Flow
+                    .builder()
+                    .id("flow-id")
+                    .referenceType(FlowReferenceType.PLAN)
+                    .referenceId(PLAN_ID)
+                    .order(0)
+                    .name("My flow")
+                    .enabled(true)
+                    .createdAt(Date.from(INSTANT_NOW))
+                    .updatedAt(Date.from(INSTANT_NOW))
+                    .build()
+            );
+            when(flowRepository.findByReference(FlowReferenceType.PLAN, PLAN_ID)).thenReturn(repoFlows);
+
+            // When
+            var result = service.getPlanV4Flows(PLAN_ID);
+
+            // Then
+            assertThat(result)
+                .usingRecursiveComparison()
+                .isEqualTo(List.of(Flow.builder().id("flow-id").name("My flow").enabled(true).build()));
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_list_when_no_flows() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.PLAN, PLAN_ID)).thenReturn(List.of());
+
+            // When
+            var result = service.getPlanV4Flows(PLAN_ID);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.PLAN, PLAN_ID)).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getPlanV4Flows(PLAN_ID));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to get flows for PLAN: plan-id");
+        }
+    }
+
+    @Nested
+    class GetApiV2Flows {
+
+        @Test
+        @SneakyThrows
+        void should_return_flows() {
+            // Given
+            var repoFlows = List.of(
+                io.gravitee.repository.management.model.flow.Flow
+                    .builder()
+                    .id("flow-id")
+                    .referenceType(FlowReferenceType.API)
+                    .referenceId(API_ID)
+                    .order(0)
+                    .name("My flow")
+                    .enabled(true)
+                    .createdAt(Date.from(INSTANT_NOW))
+                    .updatedAt(Date.from(INSTANT_NOW))
+                    .build()
+            );
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenReturn(repoFlows);
+
+            // When
+            var result = service.getApiV2Flows(API_ID);
+
+            // Then
+            assertThat(result.get(0)).isNotNull();
+            assertThat(result.get(0).getName()).isEqualTo("My flow");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_list_when_no_flows() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenReturn(List.of());
+
+            // When
+            var result = service.getApiV2Flows(API_ID);
+
+            // Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            // Given
+            when(flowRepository.findByReference(FlowReferenceType.API, API_ID)).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getApiV2Flows(API_ID));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurs while trying to get flows for API: api-id");
         }
     }
 }


### PR DESCRIPTION

## Issue

Part of https://gravitee.atlassian.net/browse/APIM-3913 

## Description

Add an endpoint to be used in the history screen to compare the difference between the last deployment and the one to come (current).

## Additional context

Link to https://github.com/gravitee-io/gravitee-api-management/pull/6797

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rlxsurhhzo.chromatic.com)
<!-- Storybook placeholder end -->
