### PR TITLE
Apim portal next update UI buttons

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.html
@@ -24,7 +24,7 @@
         <div>{{ api.name }}</div>
         <div class="api-details__header-content-version">{{ api.version }}</div>
       </div>
-      <button i18n="@@logInOrSignUpToSubscribe" mat-stroked-button disabled color="primary api-details__header-button">
+      <button i18n="@@logInOrSignUpToSubscribe" mat-flat-button disabled class="api-details__header-button secondary-button">
         Log in / Sign up to subscribe
       </button>
     </div>

--- a/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api-details/api-details.component.scss
@@ -30,8 +30,6 @@
 
   &__header-button {
     margin-left: auto;
-
-    --mdc-outlined-button-container-height: 48px;
   }
 
   &__banner {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -17,8 +17,8 @@
 -->
 <app-banner>
   <div class="welcome-banner-content">
-    <h1>{{ bannerTitle }}</h1>
-    <h5>{{ bannerSubtitle }}</h5>
+    <div class="m3-headline-large">{{ bannerTitle }}</div>
+    <div class="m3-title-small">{{ bannerSubtitle }}</div>
   </div>
 </app-banner>
 @if (apiPaginator$ | async; as apis) {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
@@ -20,7 +20,10 @@
 }
 
 .welcome-banner-content {
-  padding: 0 16px;
+  display: flex;
+  flex-flow: column;
+  padding: 16px;
+  gap: 24px;
 }
 
 .api-list__container {

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -77,7 +77,7 @@ describe('CatalogComponent', () => {
 
     it('should render banner text', () => {
       const compiled = fixture.nativeElement as HTMLElement;
-      expect(compiled.querySelector('h1')?.textContent).toContain('Welcome to Gravitee Developer Portal!');
+      expect(compiled.querySelector('app-banner')?.textContent).toContain('Welcome to Gravitee Developer Portal!');
     });
 
     it('should show API list', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/log-in/log-in.component.html
@@ -45,9 +45,8 @@
           [disabled]="logInForm.invalid"
           type="submit"
           mat-flat-button
-          color="primary"
           i18n="@@logInAction"
-          class="log-in__form__submit">
+          class="log-in__form__submit secondary-button">
           Log in
         </button>
       </mat-card-actions>

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.scss
@@ -15,7 +15,7 @@
  */
 :host {
   display: flex;
-  height: 25vh;
+  min-height: 256px;
   flex-flow: column;
 }
 
@@ -55,10 +55,12 @@
   &__description {
     display: -webkit-box;
     overflow: hidden;
+    max-height: 98px;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 4;
     line-clamp: 4;
     text-overflow: ellipsis;
+    word-wrap: break-word;
   }
 
   &__actions {

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<a [routerLink]="['']">
+<a class="company-logo" [routerLink]="['']">
   <img i18n-alt="@@logo" ngSrc="assets/images/logo.png" height="36" width="36" alt="Company logo" priority />
 </a>
-<h3 class="site-title">{{ title }}</h3>
+<div class="m3-title-medium">{{ title }}</div>

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.scss
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,4 +19,8 @@
   align-items: center;
   gap: 8px;
   white-space: nowrap;
+}
+
+.company-logo {
+  height: 36px;
 }

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.harness.ts
@@ -17,7 +17,7 @@ import { ComponentHarness } from '@angular/cdk/testing';
 
 export class CompanyTitleHarness extends ComponentHarness {
   public static hostSelector = 'app-company-title';
-  protected locateTitle = this.locatorFor('.site-title');
+  protected locateTitle = this.locatorFor('div');
 
   public async getTitle(): Promise<string> {
     const div = await this.locateTitle();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Some small fixes

Banner + site title:
![Screenshot 2024-05-23 at 11 30 00](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/c831f391-f6fa-4a2d-b0c4-009b1f940f0a)


Text overflow + card height:
![Screenshot 2024-05-21 at 18 06 45](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/836f4ef9-1e0a-434d-a33a-cdaa90f736c5)

Subscribe button as secondary:
![Screenshot 2024-05-21 at 17 35 36](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/bf54b3d8-936a-4d76-92c1-5b5310d69518)

Log in form:
![Screenshot 2024-05-21 at 17 34 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/8bbbd11b-b9ca-494c-abf8-c81035025c6e)



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ixmvlaexcg.chromatic.com)
<!-- Storybook placeholder end -->
