### PR TITLE
fix(mapi): validate qos entrypoint with endpoint supported qos

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.spec.ts
@@ -128,6 +128,7 @@ describe('ApiEntrypointsV4EditComponent', () => {
       httpTestingController = TestBed.inject(HttpTestingController);
 
       createComponent(API, 'http-get');
+      expectEndpointsGetRequest();
       fixture.detectChanges();
       loader = TestbedHarnessEnvironment.loader(fixture);
     });
@@ -511,11 +512,15 @@ describe('ApiEntrypointsV4EditComponent', () => {
   };
 
   const expectEndpointsGetRequest = () => {
-    httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' })
-      .flush([
-        fakeConnectorPlugin({ id: 'kafka', name: 'kafka' }),
-        fakeConnectorPlugin({ id: 'mock', name: 'mock', supportedApiType: 'MESSAGE', supportedModes: ['PUBLISH'] }),
-      ]);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints`, method: 'GET' }).flush([
+      fakeConnectorPlugin({ id: 'kafka', name: 'kafka', supportedQos: ['AUTO', 'AT_MOST_ONCE'] }),
+      fakeConnectorPlugin({
+        id: 'mock',
+        name: 'mock',
+        supportedApiType: 'MESSAGE',
+        supportedModes: ['PUBLISH'],
+        supportedQos: ['AUTO', 'AT_MOST_ONCE'],
+      }),
+    ]);
   };
 });

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/edit/api-entrypoints-v4-edit.component.ts
@@ -45,6 +45,7 @@ export class ApiEntrypointsV4EditComponent implements OnInit {
   public entrypoint: Entrypoint;
   public entrypointName: string;
   public entrypointSchema: GioJsonSchema;
+  public supportQos: boolean;
   public supportedQos: Qos[];
   public supportDlq: boolean;
   public enabledDlq: boolean;
@@ -83,6 +84,7 @@ export class ApiEntrypointsV4EditComponent implements OnInit {
               const matchingEntrypoint = this.availableEntrypoints.find((entrypoint) => entrypoint.id === this.entrypoint.type);
               if (matchingEntrypoint) {
                 this.entrypointName = matchingEntrypoint.name;
+                this.supportQos = !!matchingEntrypoint.supportedQos?.length;
                 this.supportedQos = matchingEntrypoint.supportedQos;
 
                 this.supportDlq = matchingEntrypoint.availableFeatures?.includes('DLQ');
@@ -97,11 +99,22 @@ export class ApiEntrypointsV4EditComponent implements OnInit {
         tap((schema) => {
           this.entrypointSchema = schema;
         }),
-        switchMap((_) => (this.supportDlq ? this.connectorPluginsV2Service.listEndpointPlugins() : of(null))),
+        switchMap((_) => (this.supportDlq || this.supportQos ? this.connectorPluginsV2Service.listEndpointPlugins() : of(null))),
         tap((plugins: ConnectorPlugin[] | null) => {
           this.form = new FormGroup({});
           this.form.addControl(`${this.entrypoint.type}-config`, new FormControl(this.entrypoint.configuration));
           this.form.addControl(`${this.entrypoint.type}-qos`, new FormControl(this.entrypoint.qos));
+
+          if (this.supportQos && plugins) {
+            const eligibleEndpointTypesForQos = this.getEligibleEndpointTypesForQos(plugins);
+
+            this.api.endpointGroups.forEach((endpointGroup) => {
+              const eligibleEndpointType = eligibleEndpointTypesForQos.find((value) => value.id === endpointGroup.type);
+              if (eligibleEndpointType) {
+                this.supportedQos = this.supportedQos.filter((value) => eligibleEndpointType.supportedQos.includes(value));
+              }
+            });
+          }
 
           if (this.supportDlq && plugins) {
             this.dlqElements = this.getEligibleApiEndpointsAndEndpointGroupsForDlq(plugins);
@@ -161,6 +174,14 @@ export class ApiEntrypointsV4EditComponent implements OnInit {
       .filter((plugin) => plugin.supportedModes.includes('PUBLISH') && plugin.supportedApiType === 'MESSAGE')
       .map((plugin) => {
         return { id: plugin.id, name: plugin.name, icon: this.iconService.registerSvg(plugin.id, plugin.icon) };
+      });
+  }
+
+  private getEligibleEndpointTypesForQos(plugins: ConnectorPlugin[]) {
+    return plugins
+      .filter((plugin) => plugin.supportedApiType === 'MESSAGE')
+      .map((plugin) => {
+        return { id: plugin.id, name: plugin.name, supportedQos: plugin.supportedQos };
       });
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Dlq;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
@@ -171,13 +172,17 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
             final ConnectorPluginEntity connectorPlugin = entrypointService.findById(entrypoint.getType());
 
             checkEntrypointListenerType(type, connectorPlugin);
-            checkEntrypointQos(entrypoint, connectorPlugin);
+            checkEntrypointQos(entrypoint, endpointGroups, connectorPlugin);
             checkEntrypointDlq(entrypoint, endpointGroups, connectorPlugin);
             checkEntrypointConfiguration(entrypoint);
         });
     }
 
-    private void checkEntrypointQos(final Entrypoint entrypoint, final ConnectorPluginEntity connectorPlugin) {
+    private void checkEntrypointQos(
+        final Entrypoint entrypoint,
+        final List<EndpointGroup> endpointGroups,
+        final ConnectorPluginEntity connectorPlugin
+    ) {
         if (connectorPlugin.getSupportedApiType() == ApiType.MESSAGE) {
             if (entrypoint.getQos() == null) {
                 throw new ListenerEntrypointInvalidQosException(entrypoint.getType());
@@ -188,7 +193,25 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
             ) {
                 throw new ListenerEntrypointUnsupportedQosException(entrypoint.getType(), entrypoint.getQos().getLabel());
             }
+
+            if (!checkEntrypointQosEndpoint(endpointGroups, entrypoint.getQos())) {
+                throw new ListenerEntrypointInvalidQosException(entrypoint.getType());
+            }
         }
+    }
+
+    private boolean checkEntrypointQosEndpoint(List<EndpointGroup> endpointGroups, Qos Qos) {
+        return endpointGroups
+            .stream()
+            .allMatch(endpointGroup -> {
+                final ConnectorPluginEntity endpointConnectorPlugin = endpointService.findById(endpointGroup.getType());
+                return (
+                    endpointConnectorPlugin != null &&
+                    endpointConnectorPlugin.getSupportedApiType() == ApiType.MESSAGE &&
+                    endpointConnectorPlugin.getSupportedQos() != null &&
+                    endpointConnectorPlugin.getSupportedQos().contains(Qos)
+                );
+            });
     }
 
     private void checkEntrypointDlq(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -50,6 +50,7 @@ import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointDuplicatedException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointInvalidDlqException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointInvalidQosException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingTypeException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedDlqException;
@@ -379,6 +380,93 @@ class ListenerValidationServiceImplTest {
                     emptyList()
                 )
             );
+    }
+
+    @Test
+    void should_throw_invalid_qos_exception_when_target_endpoint_does_not_support_at_least_once_qos() {
+        HttpListener httpListener = new HttpListener();
+        httpListener.setPaths(List.of(new Path("path")));
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setType("type");
+        entrypoint.setQos(Qos.AT_LEAST_ONCE);
+        httpListener.setEntrypoints(List.of(entrypoint));
+        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+        when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+        when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AUTO));
+        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+        final EndpointGroup endpointGroup = buildEndpointGroup();
+
+        assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
+            .isThrownBy(() ->
+                listenerValidationService.validateAndSanitize(
+                    GraviteeContext.getExecutionContext(),
+                    null,
+                    List.of(httpListener),
+                    List.of(endpointGroup)
+                )
+            );
+    }
+
+    @Test
+    void should_throw_invalid_qos_exception_when_target_endpoint_does_not_have_connector() {
+        HttpListener httpListener = new HttpListener();
+        httpListener.setPaths(List.of(new Path("path")));
+        httpListener.setType(ListenerType.HTTP);
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setType("type");
+        entrypoint.setQos(Qos.AT_LEAST_ONCE);
+        httpListener.setEntrypoints(List.of(entrypoint));
+        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+        when(endpointService.findById("endpoint-test")).thenReturn(null);
+
+        final EndpointGroup endpointGroup = buildEndpointGroup();
+
+        assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
+            .isThrownBy(() ->
+                listenerValidationService.validateAndSanitize(
+                    GraviteeContext.getExecutionContext(),
+                    null,
+                    List.of(httpListener),
+                    List.of(endpointGroup)
+                )
+            );
+    }
+
+    @Test
+    void should_validate_qos_config_when_targeting_endpoint() {
+        HttpListener httpListener = new HttpListener();
+        httpListener.setPaths(List.of(new Path("path")));
+        Entrypoint entrypoint = new Entrypoint();
+        entrypoint.setType("type");
+        entrypoint.setQos(Qos.AT_LEAST_ONCE);
+        httpListener.setEntrypoints(List.of(entrypoint));
+        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+        when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+        when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE));
+        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+        final EndpointGroup endpointGroup = buildEndpointGroup();
+
+        listenerValidationService.validateAndSanitize(
+            GraviteeContext.getExecutionContext(),
+            null,
+            List.of(httpListener),
+            List.of(endpointGroup)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4201

## Description

validate qos entrypoint with endpoint supported qos

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fbrawpoulo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7542/console](https://pr.team-apim.gravitee.dev/7542/console)
      Portal: [https://pr.team-apim.gravitee.dev/7542/portal](https://pr.team-apim.gravitee.dev/7542/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7542/api/management](https://pr.team-apim.gravitee.dev/7542/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7542](https://pr.team-apim.gravitee.dev/7542)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7542](https://pr.gateway-v3.team-apim.gravitee.dev/7542)

<!-- Environment placeholder end -->
