### PR TITLE
feat: ingestion preview use case to see what APIs will be created

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -383,7 +383,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                              type: object
+                                type: object
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/deployments/_verify:
@@ -496,16 +496,16 @@ paths:
                   required: false
                   description: Exclude additional data from the API definition export
                   schema:
-                    type: array
-                    items:
-                      type: string
-                      enum:
-                        - groups
-                        - members
-                        - metadata
-                        - pages
-                        - plans
-                    default: [ 'groups', 'members', 'metadata', 'pages', 'plans' ]
+                      type: array
+                      items:
+                          type: string
+                          enum:
+                              - groups
+                              - members
+                              - metadata
+                              - pages
+                              - plans
+                      default: ["groups", "members", "metadata", "pages", "plans"]
             tags:
                 - APIs
             summary: Export an API
@@ -642,29 +642,29 @@ paths:
                     $ref: "#/components/responses/Error"
 
     /environments/{envId}/apis/{apiId}/_rollback:
-      parameters:
-          - $ref: "#/components/parameters/envIdParam"
-          - $ref: "#/components/parameters/apiIdParam"
-      post:
-          tags:
-              - APIs
-          summary: Rollback an API
-          description: |-
-              Rollback an API to a previous version.
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Rollback an API
+            description: |-
+                Rollback an API to a previous version.
 
-              User must have the API_DEFINITION[UPDATE] permission.
-          operationId: rollbackApi
-          requestBody:
-              content:
-                application/json:
-                  schema:
-                    $ref: "#/components/schemas/ApiRollback"
-              required: true
-          responses:
-              "204":
-                description: API successfully rollbacked
-              default:
-                $ref: "#/components/responses/Error"
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: rollbackApi
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiRollback"
+                required: true
+            responses:
+                "204":
+                    description: API successfully rollbacked
+                default:
+                    $ref: "#/components/responses/Error"
 
     # API Reviews
     /environments/{envId}/apis/{apiId}/reviews/_ask:
@@ -1228,6 +1228,29 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/IntegrationIngestionResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/integrations/{integrationId}/_preview:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/integrationIdParam"
+        get:
+            tags:
+                - Integrations
+            summary: Preview APIs to ingest for a specific Integration
+            description: |-
+                Preview APIs to ingest before actual ingestion.
+
+                User must have both the ENVIRONMENT_INTEGRATION[READ] and the ENVIRONMENT_API[CREATE] permission 
+                to perform ingestion preview.
+            operationId: previewIntegration
+            responses:
+                "200":
+                    description: Preview successful
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/IngestionPreviewResponse"
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/integrations/{integrationId}/apis:
@@ -1820,61 +1843,61 @@ paths:
 
     # Analytics
     /environments/{envId}/apis/{apiId}/analytics/requests-count:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - Analytics - Requests count
-        summary: Get API Analytics requests count
-        description: |-
-          Get API analytics request count.
-          TCP Proxy APIs are not supported.
-          
-          User must have the API_ANALYTICS[READ] permission.
-        operationId: getApiAnalyticsRequestCount
-        responses:
-          "200":
-            $ref: "#/components/responses/ApiAnalyticsRequestsCountResponse"
-          default:
-            $ref: "#/components/responses/Error"
-    /environments/{envId}/apis/{apiId}/analytics/average-messages-per-request:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - Analytics - Average messages per request
-        summary: Get API Analytics average messages per request
-        description: |-
-          Get API analytics average messages per request.
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - Analytics - Requests count
+            summary: Get API Analytics requests count
+            description: |-
+                Get API analytics request count.
+                TCP Proxy APIs are not supported.
 
-          User must have the API_ANALYTICS[READ] permission.
-        operationId: getAverageMessagesPerRequest
-        responses:
-          "200":
-            $ref: "#/components/responses/ApiAnalyticsAverageMessagesPerRequestResponse"
-          default:
-            $ref: "#/components/responses/Error"
+                User must have the API_ANALYTICS[READ] permission.
+            operationId: getApiAnalyticsRequestCount
+            responses:
+                "200":
+                    $ref: "#/components/responses/ApiAnalyticsRequestsCountResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/analytics/average-messages-per-request:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - Analytics - Average messages per request
+            summary: Get API Analytics average messages per request
+            description: |-
+                Get API analytics average messages per request.
+
+                User must have the API_ANALYTICS[READ] permission.
+            operationId: getAverageMessagesPerRequest
+            responses:
+                "200":
+                    $ref: "#/components/responses/ApiAnalyticsAverageMessagesPerRequestResponse"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/analytics/average-connection-duration:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - Analytics - Average connection duration
-        summary: Get API Analytics average connection duration
-        description: |-
-          Get API analytics average connection duration. Duration is only computed for ended requests.
-          TCP Proxy APIs are not supported.
-          
-          User must have the API_ANALYTICS[READ] permission.
-        operationId: getAverageConnectionDuration
-        responses:
-          "200":
-            $ref: "#/components/responses/ApiAnalyticsAverageConnectionDurationResponse"
-          default:
-            $ref: "#/components/responses/Error"
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - Analytics - Average connection duration
+            summary: Get API Analytics average connection duration
+            description: |-
+                Get API analytics average connection duration. Duration is only computed for ended requests.
+                TCP Proxy APIs are not supported.
+
+                User must have the API_ANALYTICS[READ] permission.
+            operationId: getAverageConnectionDuration
+            responses:
+                "200":
+                    $ref: "#/components/responses/ApiAnalyticsAverageConnectionDurationResponse"
+                default:
+                    $ref: "#/components/responses/Error"
     # Analytics - Logs
     /environments/{envId}/apis/{apiId}/logs:
         parameters:
@@ -2494,9 +2517,9 @@ components:
                     type: string
                     description: The name of the role that will be assigned to the current primary owner after the transfer.
         ApiRollback:
-              type: object
-              properties:
-                 eventId:
+            type: object
+            properties:
+                eventId:
                     type: string
                     description: The event ID to rollback to.
 
@@ -3396,6 +3419,14 @@ components:
                     enum:
                         - CONNECTED
                         - DISCONNECTED
+
+        IngestionPreviewResponse:
+            type: object
+            properties:
+                totalCount:
+                    type: number
+                    description: number of new APIs found to ingest
+                    example: 12
 
         IntegrationIngestionResponse:
             type: object
@@ -6866,59 +6897,59 @@ components:
 
         # Analytics
         ApiAnalyticsRequestsCountResponse:
-          description: Analytics for requests count by entrypoint
-          content:
-            application/json:
-              schema:
-                title: "ApiAnalyticsRequestsCountResponse"
-                description: API Analytics for requests count by entrypoint.
-                properties:
-                  total:
-                    type: integer
-                    format: int64
-                    description: The total count of requests
-                    example: 100
-                  countsByEntrypoint:
-                    type: object
-                    additionalProperties:
-                      description: A map of metrics by entrypoint
-                      type: number
+            description: Analytics for requests count by entrypoint
+            content:
+                application/json:
+                    schema:
+                        title: "ApiAnalyticsRequestsCountResponse"
+                        description: API Analytics for requests count by entrypoint.
+                        properties:
+                            total:
+                                type: integer
+                                format: int64
+                                description: The total count of requests
+                                example: 100
+                            countsByEntrypoint:
+                                type: object
+                                additionalProperties:
+                                    description: A map of metrics by entrypoint
+                                    type: number
         ApiAnalyticsAverageMessagesPerRequestResponse:
-          description: Analytics for average messages per request by entrypoint
-          content:
-            application/json:
-              schema:
-                title: "ApiAnalyticsAverageMessagesPerRequestResponse"
-                description: API Analytics for average messages per request by entrypoint.
-                properties:
-                  average:
-                    type: number
-                    format: double
-                    description: The rounded global average of messages per request
-                    example: 1000
-                  averagesByEntrypoint:
-                    type: object
-                    additionalProperties:
-                      description: A map of rounded average messages request by entrypoint
-                      type: number
+            description: Analytics for average messages per request by entrypoint
+            content:
+                application/json:
+                    schema:
+                        title: "ApiAnalyticsAverageMessagesPerRequestResponse"
+                        description: API Analytics for average messages per request by entrypoint.
+                        properties:
+                            average:
+                                type: number
+                                format: double
+                                description: The rounded global average of messages per request
+                                example: 1000
+                            averagesByEntrypoint:
+                                type: object
+                                additionalProperties:
+                                    description: A map of rounded average messages request by entrypoint
+                                    type: number
         ApiAnalyticsAverageConnectionDurationResponse:
-          description: Analytics for average connection duration by entrypoint
-          content:
-            application/json:
-              schema:
-                title: "ApiAnalyticsAverageConnectionDurationResponse"
-                description: API Analytics for average connection duration by entrypoint.
-                properties:
-                  average:
-                    type: number
-                    format: double
-                    description: The rounded global average of connection duration
-                    example: 1000
-                  averagesByEntrypoint:
-                    type: object
-                    additionalProperties:
-                      description: A map of rounded average connection duration by entrypoint
-                      type: number
+            description: Analytics for average connection duration by entrypoint
+            content:
+                application/json:
+                    schema:
+                        title: "ApiAnalyticsAverageConnectionDurationResponse"
+                        description: API Analytics for average connection duration by entrypoint.
+                        properties:
+                            average:
+                                type: number
+                                format: double
+                                description: The rounded global average of connection duration
+                                example: 1000
+                            averagesByEntrypoint:
+                                type: object
+                                additionalProperties:
+                                    description: A map of rounded average connection duration by entrypoint
+                                    type: number
 
         # Analytics - Logs
         ApiLogsResponse:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -114,7 +114,7 @@ public class ApiModelFactory {
      * @param integration The integration
      * @return The generated id
      */
-    private static String generateFederatedApiId(IntegrationApi integrationApi, Integration integration) {
+    public static String generateFederatedApiId(IntegrationApi integrationApi, Integration integration) {
         return UuidString.generateForEnvironment(integration.getEnvironmentId(), integration.getId(), integrationApi.uniqueId());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/exception/IntegrationDiscoveryException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/exception/IntegrationDiscoveryException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.exception;
+
+public class IntegrationDiscoveryException extends RuntimeException {
+
+    public IntegrationDiscoveryException(String message) {
+        super(message);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.federation.FederatedPlan;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import java.util.List;
 
 public interface IntegrationAgent {
     Flowable<IntegrationApi> fetchAllApis(Integration integration);
@@ -54,4 +55,6 @@ public interface IntegrationAgent {
      * @return {Completable}
      */
     Completable unsubscribe(String integrationId, FederatedApi api, SubscriptionEntity subscription);
+
+    Flowable<IntegrationApi> discoverApis(String integrationId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/PreviewNewIntegrationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/PreviewNewIntegrationApisUseCase.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import static io.gravitee.apim.core.exception.NotAllowedDomainException.noLicenseForFederation;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.integration.exception.IntegrationNotFoundException;
+import io.gravitee.apim.core.integration.service_provider.IntegrationAgent;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.reactivex.rxjava3.core.Single;
+
+@UseCase
+public class PreviewNewIntegrationApisUseCase {
+
+    private final IntegrationAgent integrationAgent;
+    private final LicenseDomainService licenseDomainService;
+    private final ApiQueryService apiQueryService;
+    private final IntegrationCrudService integrationCrudService;
+
+    public PreviewNewIntegrationApisUseCase(
+        IntegrationAgent integrationAgent,
+        LicenseDomainService licenseDomainService,
+        ApiQueryService apiQueryService,
+        IntegrationCrudService integrationCrudService
+    ) {
+        this.integrationAgent = integrationAgent;
+        this.licenseDomainService = licenseDomainService;
+        this.apiQueryService = apiQueryService;
+        this.integrationCrudService = integrationCrudService;
+    }
+
+    public Output execute(Input input) {
+        if (!licenseDomainService.isFederationFeatureAllowed(input.auditInfo.organizationId())) {
+            throw noLicenseForFederation();
+        }
+
+        var integrationId = input.integrationId;
+
+        var alreadyIngestedApisIds = apiQueryService
+            .search(
+                ApiSearchCriteria.builder().integrationId(input.integrationId).build(),
+                null,
+                ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build()
+            )
+            .map(Api::getId)
+            .toList();
+
+        var newApisCount = Single
+            .fromCallable(() ->
+                integrationCrudService
+                    .findById(integrationId)
+                    .filter(integration -> integration.getEnvironmentId().equals(input.auditInfo.environmentId()))
+                    .orElseThrow(() -> new IntegrationNotFoundException(integrationId))
+            )
+            .flatMapPublisher(integration ->
+                integrationAgent
+                    .discoverApis(integrationId)
+                    .filter(discoveredApi -> {
+                        var discoveredApiId = ApiModelFactory.generateFederatedApiId(discoveredApi, integration);
+                        return !alreadyIngestedApisIds.contains(discoveredApiId);
+                    })
+            )
+            .count()
+            .blockingGet();
+
+        return new Output(newApisCount);
+    }
+
+    public record Input(String integrationId, AuditInfo auditInfo) {}
+
+    public record Output(Long newApisCount) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationAgentInMemory.java
@@ -79,6 +79,11 @@ public class IntegrationAgentInMemory implements IntegrationAgent, InMemoryAlter
     }
 
     @Override
+    public Flowable<IntegrationApi> discoverApis(String integrationId) {
+        return Flowable.fromIterable(storage).filter(asset -> asset.integrationId().equals(integrationId));
+    }
+
+    @Override
     public void initWith(List<IntegrationApi> items) {
         this.storage.addAll(items);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/PreviewNewIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/PreviewNewIntegrationApisUseCaseTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.IntegrationApiFixtures;
+import fixtures.core.model.IntegrationFixture;
+import fixtures.core.model.LicenseFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.IntegrationAgentInMemory;
+import inmemory.IntegrationCrudServiceInMemory;
+import inmemory.LicenseCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.NotAllowedDomainException;
+import io.gravitee.apim.core.integration.exception.IntegrationNotFoundException;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PreviewNewIntegrationApisUseCaseTest {
+
+    private static final String ENV_ID = "my-env";
+    private static final String ORGANIZATION_ID = "my-org";
+    private static final String INTEGRATION_ID = "integration-id";
+    private static final String USER_ID = "user-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENV_ID, USER_ID);
+
+    IntegrationAgentInMemory integrationAgent = new IntegrationAgentInMemory();
+    ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
+    LicenseManager licenseManager = mock(LicenseManager.class);
+    PreviewNewIntegrationApisUseCase usecase;
+
+    @BeforeEach
+    void setUp() {
+        usecase =
+            new PreviewNewIntegrationApisUseCase(
+                integrationAgent,
+                new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
+                apiQueryService,
+                integrationCrudService
+            );
+
+        when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION_ID)).thenReturn(LicenseFixtures.anEnterpriseLicense());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(integrationAgent, integrationCrudService, apiQueryService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_throw_exception_if_no_license_found() {
+        // Given
+        when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION_ID)).thenReturn(LicenseFixtures.anOssLicense());
+
+        // When
+        var throwable = Assertions.catchThrowable(() ->
+            usecase.execute(new PreviewNewIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO))
+        );
+
+        // Then
+        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(NotAllowedDomainException.class);
+    }
+
+    @Test
+    void should_throw_exception_if_no_integration_found() {
+        //When
+        var throwable = Assertions.catchThrowable(() ->
+            usecase.execute(new PreviewNewIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO))
+        );
+
+        // Then
+        AssertionsForClassTypes.assertThat(throwable).isInstanceOf(IntegrationNotFoundException.class);
+    }
+
+    @Test
+    void should_discover_new_api_if_this_api_not_exist() {
+        //Given
+        integrationCrudService.initWith(List.of(IntegrationFixture.anIntegration(ENV_ID)));
+        integrationAgent.initWith(List.of(IntegrationApiFixtures.anIntegrationApiForIntegration(INTEGRATION_ID)));
+
+        //When
+        var newApisCount = usecase.execute(new PreviewNewIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO)).newApisCount();
+
+        //Then
+        assertThat(newApisCount).isEqualTo(1L);
+    }
+
+    @Test
+    void should_not_discover_new_api_if_this_api_is_already_ingested() {
+        //Given
+        var discoveredApiId = "dbd87a33-d226-349f-a29b-77dd3fafd3ee";
+        integrationCrudService.initWith(List.of(IntegrationFixture.anIntegration(ENV_ID)));
+        integrationAgent.initWith(List.of(IntegrationApiFixtures.anIntegrationApiForIntegration(INTEGRATION_ID)));
+        apiQueryService.initWith(List.of(ApiFixtures.aFederatedApi().toBuilder().id(discoveredApiId).build()));
+
+        //When
+        var newApisCount = usecase.execute(new PreviewNewIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO)).newApisCount();
+
+        //Then
+        assertThat(newApisCount).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4370

## Description

The new endpoint for federation API returns the number of APIs that will be ingested.
It only counts APIs that will be created and skips the existing ones that won't be imported. 

## Additional Information
ACs option 2 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ebkatzccij.chromatic.com)
<!-- Storybook placeholder end -->
