### PR TITLE
fix(mapi): suppress html comments to prevent XSS attack

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
@@ -15,9 +15,14 @@
  */
 package io.gravitee.rest.api.service.sanitizer;
 
+import com.vladsch.flexmark.ast.HtmlCommentBlock;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.ast.NodeVisitor;
+import com.vladsch.flexmark.util.ast.VisitHandler;
 import com.vladsch.flexmark.util.data.MutableDataSet;
+import com.vladsch.flexmark.util.sequence.BasedSequence;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,8 +78,7 @@ public final class HtmlSanitizer {
         .toFactory();
 
     /**
-     * Allow a set of HTML tags to support GitHub Flavoured Markdown.
-     * Spec is available at: <a href="https://github.github.com/gfm">https://github.github.com/gfm</a>
+     * Allow a set of HTML tags to support GitHub Flavoured Markdown. Spec is available at: <a href="https://github.github.com/gfm">https://github.github.com/gfm</a>
      */
     private static final PolicyFactory GITHUB_FLAVOURED_MARKDOWN = new HtmlPolicyBuilder().allowElements("summary", "details").toFactory();
 
@@ -118,8 +122,13 @@ public final class HtmlSanitizer {
         if (content == null || content.isEmpty()) {
             return new SanitizeInfos(true);
         }
+        Document document = mdParser.parse(content);
 
-        String toSanitize = htmlRenderer.render(mdParser.parse(content));
+        // Create a custom visitor to remove invalid comments
+        InvalidCommentVisitor visitor = new InvalidCommentVisitor();
+        visitor.visit(document);
+
+        String toSanitize = htmlRenderer.render(document);
         List<String> sanitizedChanges = new ArrayList<>();
         HtmlChangeListener<List<String>> listener = new HtmlChangeListener<List<String>>() {
             @Override
@@ -157,6 +166,21 @@ public final class HtmlSanitizer {
 
         public String getRejectedMessage() {
             return rejectedMessage;
+        }
+    }
+
+    static class InvalidCommentVisitor extends NodeVisitor {
+
+        InvalidCommentVisitor() {
+            super(
+                new VisitHandler<>(
+                    HtmlCommentBlock.class,
+                    htmlBlock -> {
+                        String removedInvalidComments = htmlBlock.getChars().toString().replaceAll("<!-{2,3}>", "");
+                        htmlBlock.setChars(BasedSequence.of(removedInvalidComments));
+                    }
+                )
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -18,18 +18,24 @@ package io.gravitee.rest.api.service.sanitizer;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.assertj.core.api.BDDSoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.rules.ErrorCollector;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(SoftAssertionsExtension.class)
 public class HtmlSanitizerTest {
 
-    @Rule
-    public ErrorCollector collector = new ErrorCollector();
+    @InjectSoftAssertions
+    public BDDSoftAssertions softly;
 
     private static String ONLY_OPENED_IMG_TAG = "<img src=\"myPic.png\">";
     private static String SELF_CLOSING_IMG_TAG = "<img src=\"myPic.png\"/>";
@@ -90,6 +96,24 @@ public class HtmlSanitizerTest {
         assertEquals("[Tag not allowed: script]", sanitizeInfos.getRejectedMessage());
     }
 
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "<!-><img src=x onerror=alert(1) />",
+            "<!--><img src=x onerror=alert(1) />",
+            "<!---><img src=x onerror=alert(1) />",
+            "<!--->\\n<img src=x onerror=alert(1) />",
+            "<!--->\\n\\n\\n\\n<img src=x onerror=alert(1) />",
+            "<!------->\\n<img src=x onerror=alert(1) />",
+        }
+    )
+    public void isXssNotSafe(String content) {
+        HtmlSanitizer.SanitizeInfos sanitizeInfos = HtmlSanitizer.isSafe(content);
+
+        assertFalse(sanitizeInfos.isSafe());
+        assertEquals("[Attribute not allowed: [img][onerror]]", sanitizeInfos.getRejectedMessage());
+    }
+
     private String getSafe() {
         String html = "";
         html += "<div>Test div</div>";
@@ -123,65 +147,62 @@ public class HtmlSanitizerTest {
 
     @Test
     public void shouldBeSafe() {
-        collector.checkThat("ONLY_OPENED_IMG_TAG", HtmlSanitizer.isSafe(ONLY_OPENED_IMG_TAG).isSafe(), is(true));
-        collector.checkThat("SELF_CLOSING_IMG_TAG", HtmlSanitizer.isSafe(SELF_CLOSING_IMG_TAG).isSafe(), is(true));
-        collector.checkThat("CLOSED_IMG_TAG", HtmlSanitizer.isSafe(CLOSED_IMG_TAG).isSafe(), is(true));
-        collector.checkThat("BASE64_IMG_TAG", HtmlSanitizer.isSafe(BASE64_IMG_TAG).isSafe(), is(true));
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SEMICOLON",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SEMICOLON).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES_AND_SEMICOLON",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES_AND_SEMICOLON).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_FLOAT_FIELD",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_FLOAT_FIELD).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SEMICOLON",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SEMICOLON).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES_AND_SEMICOLON",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES_AND_SEMICOLON).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_QUOTE",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_QUOTE).isSafe(),
-            is(true)
-        );
-        collector.checkThat(
-            "DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON",
-            HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON).isSafe(),
-            is(true)
-        );
-        collector.checkThat("SUMMARY_DETAILS", HtmlSanitizer.isSafe(SUMMARY_DETAILS).isSafe(), is(true));
+        softly.then(HtmlSanitizer.isSafe(ONLY_OPENED_IMG_TAG).isSafe()).as("ONLY_OPENED_IMG_TAG").isTrue();
+        softly.then(HtmlSanitizer.isSafe(SELF_CLOSING_IMG_TAG).isSafe()).as("SELF_CLOSING_IMG_TAG").isTrue();
+        softly.then(HtmlSanitizer.isSafe(CLOSED_IMG_TAG).isSafe()).as("CLOSED_IMG_TAG").isTrue();
+        softly.then(HtmlSanitizer.isSafe(BASE64_IMG_TAG).isSafe()).as("BASE64_IMG_TAG").isTrue();
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD")
+            .isTrue();
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SEMICOLON).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SEMICOLON")
+            .isTrue();
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES_AND_SEMICOLON).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_FIELD_WITH_SPACES_AND_SEMICOLON")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_FLOAT_FIELD).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_FLOAT_FIELD")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SEMICOLON).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SEMICOLON")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES_AND_SEMICOLON).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_TWO_FIELD_WITH_SPACES_AND_SEMICOLON")
+            .isTrue();
+
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_QUOTE).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_QUOTE")
+            .isTrue();
+        softly
+            .then(HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON).isSafe())
+            .as("DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON")
+            .isTrue();
+
+        softly.then(HtmlSanitizer.isSafe(SUMMARY_DETAILS).isSafe()).as("SUMMARY_DETAILS").isTrue();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5139

## Description

suppress HTML comment before sanitising to prevent xss attack
 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fihsuicepo.chromatic.com)
<!-- Storybook placeholder end -->
