### PR TITLE
chore: upgrade reporter-cloud to 1.0.0-alpha.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <gravitee-reporter-elasticsearch.version>5.3.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.1</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.1</gravitee-reporter-tcp.version>
-        <gravitee-reporter-cloud.version>1.0.0-alpha.1</gravitee-reporter-cloud.version>
+        <gravitee-reporter-cloud.version>1.0.0-alpha.2</gravitee-reporter-cloud.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-tracer-jaeger.version>3.0.1</gravitee-tracer-jaeger.version>


### PR DESCRIPTION
## Description

Upgrade the reporter-cloud plugin to 1.0.0-alpha.2 (support zip).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bxlkneiupg.chromatic.com)
<!-- Storybook placeholder end -->
