### PR TITLE
test: add failover case with real endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.html
@@ -84,6 +84,12 @@
             </ng-container>
           </div>
         </div>
+        @if (group.type === 'kafka' && api?.failover?.enabled) {
+          <gio-banner-warning class="failover-card__info">
+            Failover is enabled but it is not supported for Kafka endpoints. Use the native Kafka Failover by providing multiple bootstrap
+            servers.
+          </gio-banner-warning>
+        }
         <table
           mat-table
           [dataSource]="group.endpoints"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.spec.ts
@@ -146,6 +146,27 @@ describe('ApiEndpointGroupsComponent', () => {
         ['another endpoint', '', '5', ''],
       ]);
     });
+    it('should a warning in kafka endpoint group if failover is enabled', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [group1, group2],
+        failover: {
+          enabled: true,
+        },
+      });
+      await initComponent(apiV4);
+
+      expect(await componentHarness.getTableRows(0)).toEqual([
+        ['an endpoint', '', '1', ''],
+        ['another endpoint', '', '5', ''],
+      ]);
+
+      const warningFailoverBanner = await componentHarness.getWarningFailoverBanner();
+      expect(warningFailoverBanner).toHaveLength(1);
+      expect(await warningFailoverBanner[0].getText()).toContain(
+        'Failover is enabled but it is not supported for Kafka endpoints. Use the native Kafka Failover by providing multiple bootstrap servers.',
+      );
+    });
   });
 
   describe('deleteEndpoint', () => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.harness.ts
@@ -17,6 +17,7 @@ import { ComponentHarness, HarnessLoader } from '@angular/cdk/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 
 export class ApiEndpointGroupsHarness extends ComponentHarness {
   static hostSelector = 'api-endpoint-groups';
@@ -27,6 +28,7 @@ export class ApiEndpointGroupsHarness extends ComponentHarness {
   private getEditEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint"]' }));
   private getEditEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint group"]' }));
   private getAddEndpointGroupButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add endpoint group"]' }));
+  public getWarningFailoverBanner = this.locatorForAll(DivHarness.with({ selector: '.banner__wrapper__title' }));
 
   public async getTableRows(index: number) {
     const table = this.locatorFor(MatTableHarness.with({ selector: `#groupsTable-${index}` }));

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.html
@@ -29,6 +29,13 @@
         ></mat-slide-toggle>
       </gio-form-slide-toggle>
 
+      @if (hasKafkaEndpointsGroup) {
+        <gio-banner-warning class="failover-card__info">
+          Failover is not supported for Kafka endpoints. Enabling it will have no effect. Use the native Kafka Failover by providing
+          multiple bootstrap servers.
+        </gio-banner-warning>
+      }
+
       <gio-banner-info class="failover-card__info">
         Failover mechanism operates using a circuit breaker system. When a certain threshold of slow calls or connection failures (ssl
         error, unknown host, ...) is reached, the circuit breaker reaches "open" state, stopping all requests to the backend. During this

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
@@ -51,6 +51,7 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
 
   public failoverForm: FormGroup<FailoverForm>;
   public initialFailoverFormValue: Failover;
+  public hasKafkaEndpointsGroup = false;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -68,6 +69,7 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
         onlyApiV4Filter(this.snackBarService),
         tap((api: ApiV4) => {
           const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.definitionContext?.origin === 'KUBERNETES';
+          this.hasKafkaEndpointsGroup = api?.endpointGroups?.some((endpointGroup) => endpointGroup.type === 'kafka');
           this.createForm(isReadOnly, api?.failover);
           this.setupDisablingFields();
         }),

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4Mqtt5EndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4Mqtt5EndpointIntegrationTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.failover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.fake.MessageFlowReadyPolicy;
+import io.gravitee.apim.integration.tests.messages.AbstractMqtt5EndpointIntegrationTest;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.subjects.ReplaySubject;
+import io.reactivex.rxjava3.subjects.Subject;
+import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@Nested
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FailoverV4Mqtt5EndpointIntegrationTest extends AbstractMqtt5EndpointIntegrationTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/mqtt-two-endpoints.json")
+    void should_publish_on_first_retry(HttpClient client) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.put("field", "value");
+
+        final Subject<Void> readyObs = ReplaySubject.create();
+        final TestSubscriber<Mqtt5Publish> testSubscriber = subscribeToMqtt5(TEST_TOPIC, readyObs).take(1).test();
+
+        readyObs
+            .ignoreElements()
+            .andThen(postMessage(client, "/test", requestBody, Map.of("X-Test-Header", "header-value")))
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS);
+
+        testSubscriber
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(message -> {
+                assertThat(message.getTopic()).hasToString(TEST_TOPIC);
+                assertThat(message.getResponseTopic()).isEmpty();
+                assertThat(message.isRetain()).isFalse();
+                assertThat(message.getPayloadAsBytes()).isEqualTo(requestBody.toBuffer().getBytes());
+
+                assertThat(message.getUserProperties().asList().stream().map(Object::toString))
+                    .containsAnyOf(
+                        "(content-length, " + requestBody.toString().length() + ")",
+                        "(host, " + mqtt5.getHost() + ":" + mqtt5.getMqttPort() + ")",
+                        "(X-Test-Header, header-value)"
+                    );
+                return true;
+            });
+
+        // Verify there is no message since retain is false
+        subscribeToMqtt5(TEST_TOPIC).take(1, TimeUnit.SECONDS).test().awaitDone(10, TimeUnit.SECONDS).assertNoValues();
+    }
+
+    private Completable postMessage(HttpClient client, String requestURI, JsonObject requestBody, Map<String, String> headers) {
+        return client
+            .rxRequest(HttpMethod.POST, requestURI)
+            .flatMap(request -> {
+                headers.forEach(request::putHeader);
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapCompletable(response -> {
+                assertThat(response.statusCode()).isEqualTo(202);
+                return response.rxBody().ignoreElement();
+            });
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/mqtt-two-endpoints.json")
+    void should_subscribe_on_first_retry(HttpClient client) {
+        final int messageCount = 2;
+        final List<Completable> readyObs = new ArrayList<>();
+
+        final Single<HttpClientResponse> get = client
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> {
+                request.putHeader(HttpHeaderNames.ACCEPT.toString(), MediaType.APPLICATION_JSON);
+                return request.send();
+            })
+            .doOnSuccess(response -> readyObs.add(MessageFlowReadyPolicy.readyObs(extractTransactionId(response))));
+
+        final TestSubscriber<JsonObject> obs = Flowable
+            .fromSingle(get.doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200)))
+            .concatWith(publishMessagesWhenReady(readyObs, TEST_TOPIC, MqttQos.EXACTLY_ONCE))
+            .flatMap(response -> response.rxBody().flatMapPublisher(buffer -> extractMessages(buffer, extractTransactionId(response))))
+            .take(messageCount)
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValueCount(messageCount);
+
+        verifyMessagesAreOrdered(messageCount, obs);
+        verifyMessagesAreUniques(messageCount, obs);
+
+        verifyMessagesAreBetweenRange(0, messageCount, obs);
+    }
+
+    private void verifyMessagesAreOrdered(int messageCount, TestSubscriber<JsonObject> obs) {
+        final Map<String, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+        for (int i = 0; i < messageCount; i++) {
+            obs.assertValueAt(
+                i,
+                jsonObject -> {
+                    final Integer messageCounter = jsonObject.getInteger("counter");
+                    final AtomicInteger requestCounter = counters.computeIfAbsent(
+                        jsonObject.getString("transactionId"),
+                        s -> new AtomicInteger(messageCounter)
+                    );
+
+                    // A same request must receive a subset of all messages but always in order (ie: can't receive message-3 then message-1).
+                    assertThat(messageCounter).isGreaterThanOrEqualTo(requestCounter.get());
+                    requestCounter.set(messageCounter);
+                    assertThat(jsonObject.getString("content")).matches("message-" + messageCounter);
+
+                    return true;
+                }
+            );
+        }
+    }
+
+    private void verifyMessagesAreUniques(int messageCount, TestSubscriber<JsonObject> obs) {
+        final HashSet<String> messages = new HashSet<>();
+
+        for (int i = 0; i < messageCount; i++) {
+            obs.assertValueAt(
+                i,
+                jsonObject -> {
+                    final String content = jsonObject.getString("content");
+                    assertThat(messages.contains(content)).isFalse();
+                    messages.add(content);
+
+                    return true;
+                }
+            );
+        }
+    }
+
+    private void verifyMessagesAreBetweenRange(int start, int end, TestSubscriber<JsonObject> obs) {
+        final HashSet<Integer> messages = new HashSet<>();
+
+        for (int i = 0; i < end - start; i++) {
+            obs.assertValueAt(
+                i,
+                jsonObject -> {
+                    final Integer messageCounter = jsonObject.getInteger("counter");
+
+                    assertThat(messageCounter).isGreaterThanOrEqualTo(start);
+                    assertThat(messageCounter).isLessThan(end);
+                    messages.add(messageCounter);
+
+                    return true;
+                }
+            );
+        }
+
+        assertThat(messages.size()).isEqualTo(end - start);
+    }
+
+    @NonNull
+    private Flowable<JsonObject> extractMessages(Buffer body, String transactionId) {
+        final JsonObject jsonResponse = new JsonObject(body.toString());
+        final JsonArray items = jsonResponse.getJsonArray("items");
+        final List<JsonObject> messages = new ArrayList<>();
+
+        for (int i = 0; i < items.size(); i++) {
+            final JsonObject message = items.getJsonObject(i);
+            message.put("transactionId", transactionId);
+            message.put("counter", Integer.parseInt(message.getString("content").replaceFirst(".*message-", "")));
+            messages.add(message);
+        }
+
+        return Flowable.fromIterable(messages);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4RabbitMQEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4RabbitMQEndpointIntegrationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.failover;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.rabbitmq.client.impl.LongStringHelper;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.messages.AbstractRabbitMQEndpointIntegrationTest;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@Nested
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FailoverV4RabbitMQEndpointIntegrationTest extends AbstractRabbitMQEndpointIntegrationTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/rabbitmq-two-endpoints.json")
+    void should_publish_on_first_retry(HttpClient client) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.put("field", "value");
+
+        subscribeToRabbitMQ(exchange, routingKey)
+            .zipWith(
+                postMessage(client, "/test", requestBody, Map.of("X-Test-Header", "header-value"))
+                    .delaySubscription(750, MILLISECONDS)
+                    .isEmpty()
+                    .toFlowable(),
+                (c, o) -> c
+            )
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(message -> {
+                assertThat(message.getBody()).isEqualTo(requestBody.toBuffer().getBytes());
+
+                var headers = message.getProperties().getHeaders();
+                assertThat(headers)
+                    .containsEntry("X-Test-Header", LongStringHelper.asLongString("header-value"))
+                    .containsKey("X-Gravitee-Transaction-Id")
+                    .containsKey("X-Gravitee-Request-Id");
+
+                return true;
+            });
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/rabbitmq-two-endpoints.json")
+    void should_subscribe_on_first_retry(HttpClient client) {
+        client
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> {
+                request.putHeader(HttpHeaderNames.ACCEPT.toString(), MediaType.APPLICATION_JSON);
+                return request.send();
+            })
+            .doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .flatMap(response -> publishToRabbitMQ(exchange, routingKey, List.of("message")).andThen(response.body()))
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(body -> {
+                final JsonObject jsonResponse = new JsonObject(body.toString());
+                final JsonArray items = jsonResponse.getJsonArray("items");
+                assertThat(items).hasSize(1);
+                final JsonObject message = items.getJsonObject(0);
+                assertThat(message.getString("content")).isEqualTo("message");
+                return true;
+            });
+    }
+
+    private Flowable<Buffer> postMessage(HttpClient client, String requestURI, JsonObject requestBody, Map<String, String> headers) {
+        return client
+            .rxRequest(HttpMethod.POST, requestURI)
+            .flatMap(request -> {
+                headers.forEach(request::putHeader);
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(202);
+                return response.toFlowable();
+            });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4SolaceEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4SolaceEndpointIntegrationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.failover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import com.solace.messaging.publisher.DirectMessagePublisher;
+import com.solace.messaging.publisher.OutboundMessage;
+import com.solace.messaging.publisher.OutboundMessageBuilder;
+import com.solace.messaging.resources.Topic;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.messages.AbstractSolaceEndpointIntegrationTest;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@Nested
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FailoverV4SolaceEndpointIntegrationTest extends AbstractSolaceEndpointIntegrationTest {
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/solace-two-endpoints.json")
+    void should_publish_on_first_retry(HttpClient client) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.put("field", "value");
+
+        subscribeToSolace(topic)
+            .zipWith(postMessage(client, "/test", requestBody, Map.of("X-Test-Header", "header-value")).isEmpty().toFlowable(), (c, o) -> c)
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(message -> {
+                assertThat(message.getDestinationName()).hasToString(topic);
+                assertThat(message.getPayloadAsBytes()).isEqualTo(requestBody.toBuffer().getBytes());
+
+                assertThat(message.getProperty("content-length")).isEqualTo(String.valueOf(requestBody.toString().length()));
+                assertThat(message.getProperty("host")).isNotNull();
+                assertThat(message.getProperty("X-Test-Header")).isEqualTo("header-value");
+                assertThat(message.getProperty("X-Gravitee-Transaction-Id")).isNotNull();
+                assertThat(message.getProperty("X-Gravitee-Request-Id")).isNotNull();
+                return true;
+            });
+    }
+
+    @Test
+    @DeployApi("/apis/v4/http/failover/solace-two-endpoints.json")
+    void should_subscribe_on_first_retry(HttpClient client) {
+        client
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> {
+                request.putHeader(HttpHeaderNames.ACCEPT.toString(), MediaType.APPLICATION_JSON);
+                return request.send();
+            })
+            .doOnSuccess(response -> assertThat(response.statusCode()).isEqualTo(200))
+            .flatMap(response -> {
+                final DirectMessagePublisher publisher = messagingService.createDirectMessagePublisherBuilder().build();
+                return Completable
+                    .fromCompletionStage(publisher.startAsync())
+                    .andThen(
+                        Completable.fromRunnable(() -> {
+                            Topic topic1 = Topic.of(topic);
+                            OutboundMessageBuilder messageBuilder = messagingService.messageBuilder();
+                            messageBuilder.withProperty("key", "value");
+                            OutboundMessage outboundMessage = messageBuilder.build("message".getBytes());
+                            publisher.publish(outboundMessage, topic1);
+                        })
+                    )
+                    .andThen(response.body());
+            })
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(body -> {
+                final JsonObject jsonResponse = new JsonObject(body.toString());
+                final JsonArray items = jsonResponse.getJsonArray("items");
+                assertThat(items).hasSize(1);
+                final JsonObject message = items.getJsonObject(0);
+                assertThat(message.getString("content")).isEqualTo("message");
+                return true;
+            });
+    }
+
+    private Flowable<Buffer> postMessage(HttpClient client, String requestURI, JsonObject requestBody, Map<String, String> headers) {
+        return client
+            .rxRequest(HttpMethod.POST, requestURI)
+            .flatMap(request -> {
+                headers.forEach(request::putHeader);
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(202);
+                return response.toFlowable();
+            });
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/kafka-two-endpoints.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/kafka-two-endpoints.json
@@ -1,0 +1,96 @@
+{
+  "id": "http-get-entrypoint-kafka-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount": 2,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": true,
+            "metadataInPayload": true
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "kafka",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "http://localhost:9098"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"],
+              "autoOffsetReset": "earliest",
+              "checkTopicExistence": true
+            },
+            "producer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "bootstrap-server"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"],
+              "autoOffsetReset": "earliest",
+              "checkTopicExistence": true
+            },
+            "producer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "maxFailures": 2,
+    "perSubscription": false
+  },
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/mqtt-two-endpoints.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/mqtt-two-endpoints.json
@@ -1,0 +1,110 @@
+{
+  "id": "http-get-entrypoint-mqtt5-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "qos": "none",
+          "configuration": {
+            "messagesLimitCount": 2,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": false,
+            "metadataInPayload": false
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mqtt5",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mqtt5",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "serverHost": "invalid-host",
+            "serverPort": "-1"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topic": "test-topic"
+            },
+            "producer": {
+              "enabled": true,
+              "topic": "test-topic"
+            },
+            "sessionExpiryInterval": 3600
+          }
+        },
+        {
+          "name": "second",
+          "type": "mqtt5",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "serverHost": "localhost",
+            "serverPort": "mqtt5-port"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topic": "test-topic"
+            },
+            "producer": {
+              "enabled": true,
+              "topic": "test-topic"
+            },
+            "sessionExpiryInterval": 3600
+          }
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "maxFailures": 2,
+    "perSubscription": false
+  },
+  "flows": [
+    {
+      "name": "Flow ready",
+      "enabled": true,
+      "subscribe": [
+        {
+          "name": "Message Flow Ready",
+          "description": "Detect the message flow is ready",
+          "enabled": true,
+          "policy": "message-flow-ready"
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/rabbitmq-two-endpoints.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/rabbitmq-two-endpoints.json
@@ -1,0 +1,130 @@
+{
+  "id": "http-get-entrypoint-mqtt5-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount": 2,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": true,
+            "metadataInPayload": true
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "rabbitmq",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "rabbitmq",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "serverHost": "fake-host",
+            "serverPort": -1
+          },
+          "sharedConfigurationOverride": {
+            "security": {
+              "auth": {
+                "username": "admin",
+                "password": "admin"
+              }
+            },
+            "producer": {
+              "enabled": true,
+              "routingKey": "a.routing.key",
+              "exchange": {
+                "name": "my-exchange",
+                "type": "topic",
+                "durable": false,
+                "autoDelete": true
+              }
+            },
+            "consumer": {
+              "enabled": true,
+              "routingKey": "a.routing.key",
+              "exchange": {
+                "name": "my-exchange",
+                "type": "topic",
+                "durable": false,
+                "autoDelete": true
+              }
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "rabbitmq",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "serverHost": "rabbitmq-host",
+            "serverPort": 5672
+          },
+          "sharedConfigurationOverride": {
+            "security": {
+              "auth": {
+                "username": "admin",
+                "password": "admin"
+              }
+            },
+            "producer": {
+              "enabled": true,
+              "routingKey": "a.routing.key",
+              "exchange": {
+                "name": "my-exchange",
+                "type": "topic",
+                "durable": false,
+                "autoDelete": true
+              }
+            },
+            "consumer": {
+              "enabled": true,
+              "routingKey": "a.routing.key",
+              "exchange": {
+                "name": "my-exchange",
+                "type": "topic",
+                "durable": false,
+                "autoDelete": true
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "maxFailures": 2,
+    "perSubscription": false
+  },
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/solace-two-endpoints.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/solace-two-endpoints.json
@@ -1,0 +1,106 @@
+{
+  "id": "http-get-entrypoint-kafka-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount": 2,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": true,
+            "metadataInPayload": true
+          }
+        },
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "solace",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "solace",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "url": "solace-invalid-url",
+            "vpnName": "default"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            },
+            "producer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            },
+            "security": {
+              "auth" : {
+                "username" : "admin",
+                "password" : "admin"
+              }
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "solace",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "url": "solace-url",
+            "vpnName": "default"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            },
+            "producer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            },
+            "security": {
+              "auth" : {
+                "username" : "admin",
+                "password" : "admin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "maxFailures": 2,
+    "perSubscription": false
+  },
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4812

## Description

Add scenario with real endpoint implementation
Each class deploys an API with the first endpoint which is unavailable and the second one is correct.

There are two test per class:
- consume messages
- publish messages

The goal is to verify failover works and redirects traffic to the second endpoint.

⚠️ Failover is not supported for Kafka endpoint, so we add a warning banner explaining it:

![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/6c315e98-2fee-4f5b-98a1-cab834079465)
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/a64137cd-e7cb-4925-af32-134a4886d9b4)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wxdphiabln.chromatic.com)
<!-- Storybook placeholder end -->
