### PR TITLE
fix: add vertx-auth-jwt dependency to avoid classpath issue

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -188,6 +188,12 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-rx-java3</artifactId>
         </dependency>
+        
+        <!-- As vertx-rx-java3 makes use of vertx-auth-jwt, it must be included to avoid classpath issue when auth-jwt is used -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-auth-jwt</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.netty</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -142,6 +142,12 @@
             <artifactId>vertx-rx-java3</artifactId>
         </dependency>
 
+        <!-- As vertx-rx-java3 makes use of vertx-auth-jwt, it must be included to avoid classpath issue when auth-jwt is used -->
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-auth-jwt</artifactId>
+        </dependency>
+
         <!-- Jetty -->
         <dependency>
             <groupId>org.eclipse.jetty.ee10</groupId>


### PR DESCRIPTION
## Description

This PR adds the vertx-auth-jwt dependency on both management and gateway to avoid classpath issues when using the bridge server which makes use of the JWT authentication.
