### PR TITLE
Improve bridge compatibility test - 4.2.x

### DIFF
--- a/.circleci/ci/src/jobs/e2e/job-e2e-test.ts
+++ b/.circleci/ci/src/jobs/e2e/job-e2e-test.ts
@@ -60,7 +60,15 @@ fi
 if [ -z "<< parameters.apim_client_tag >>" ]; then
   APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=${dockerImageTag} APIM_CLIENT_TAG=${dockerImageTag} npm run test:api:<< parameters.database >>
 else 
-  APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=${dockerImageTag} APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+  if [[ "<< parameters.apim_client_tag >>" == *"@"* ]]; then
+    echo "Using custom registry for client"
+    CLIENT_REGISTRY=$(echo "<< parameters.apim_client_tag >>" | cut -f1 -d@)
+    CLIENT_TAG=$(echo "<< parameters.apim_client_tag >>" | cut -f2 -d@)
+    APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=${dockerImageTag} APIM_CLIENT_REGISTRY=\${CLIENT_REGISTRY} APIM_CLIENT_TAG=\${CLIENT_TAG} npm run test:api:<< parameters.database >>
+  else
+    echo "Using ACR registry for client"
+    APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=${dockerImageTag} APIM_CLIENT_REGISTRY=graviteeio.azurecr.io APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+  fi
 fi`,
       }),
       new reusable.ReusedCommand(dockerAzureLogoutCmd),

--- a/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
@@ -50,7 +50,7 @@ describe('Pull requests workflow tests', () => {
       });
 
       const expected = fs.readFileSync(`./src/pipelines/tests/resources/pull-requests/${expectedFileName}`, 'utf-8');
-      expect(expected).toStrictEqual(result.stringify());
+      expect(result.stringify()).toStrictEqual(expected);
     },
   );
 });

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -256,7 +256,15 @@ jobs:
             if [ -z "<< parameters.apim_client_tag >>" ]; then
               APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_TAG=master-latest npm run test:api:<< parameters.database >>
             else 
-              APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              if [[ "<< parameters.apim_client_tag >>" == *"@"* ]]; then
+                echo "Using custom registry for client"
+                CLIENT_REGISTRY=$(echo "<< parameters.apim_client_tag >>" | cut -f1 -d@)
+                CLIENT_TAG=$(echo "<< parameters.apim_client_tag >>" | cut -f2 -d@)
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_REGISTRY=${CLIENT_REGISTRY} APIM_CLIENT_TAG=${CLIENT_TAG} npm run test:api:<< parameters.database >>
+              else
+                echo "Using ACR registry for client"
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_REGISTRY=graviteeio.azurecr.io APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              fi
             fi
       - cmd-docker-azure-logout
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -322,7 +322,7 @@ workflows:
                 - 4.2.x-latest
                 - 4.1.x-latest
                 - 4.0.x-latest
-                - 3.20.x-latest
+                - graviteeio@3.20
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -786,7 +786,15 @@ jobs:
             if [ -z "<< parameters.apim_client_tag >>" ]; then
               APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=4.1.x-latest APIM_CLIENT_TAG=4.1.x-latest npm run test:api:<< parameters.database >>
             else 
-              APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=4.1.x-latest APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              if [[ "<< parameters.apim_client_tag >>" == *"@"* ]]; then
+                echo "Using custom registry for client"
+                CLIENT_REGISTRY=$(echo "<< parameters.apim_client_tag >>" | cut -f1 -d@)
+                CLIENT_TAG=$(echo "<< parameters.apim_client_tag >>" | cut -f2 -d@)
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=4.1.x-latest APIM_CLIENT_REGISTRY=${CLIENT_REGISTRY} APIM_CLIENT_TAG=${CLIENT_TAG} npm run test:api:<< parameters.database >>
+              else
+                echo "Using ACR registry for client"
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=4.1.x-latest APIM_CLIENT_REGISTRY=graviteeio.azurecr.io APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              fi
             fi
       - cmd-docker-azure-logout
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -786,7 +786,15 @@ jobs:
             if [ -z "<< parameters.apim_client_tag >>" ]; then
               APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_TAG=master-latest npm run test:api:<< parameters.database >>
             else 
-              APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              if [[ "<< parameters.apim_client_tag >>" == *"@"* ]]; then
+                echo "Using custom registry for client"
+                CLIENT_REGISTRY=$(echo "<< parameters.apim_client_tag >>" | cut -f1 -d@)
+                CLIENT_TAG=$(echo "<< parameters.apim_client_tag >>" | cut -f2 -d@)
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_REGISTRY=${CLIENT_REGISTRY} APIM_CLIENT_TAG=${CLIENT_TAG} npm run test:api:<< parameters.database >>
+              else
+                echo "Using ACR registry for client"
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest APIM_CLIENT_REGISTRY=graviteeio.azurecr.io APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              fi
             fi
       - cmd-docker-azure-logout
       - cmd-notify-on-failure

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -746,7 +746,15 @@ jobs:
             if [ -z "<< parameters.apim_client_tag >>" ]; then
               APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=apim-1234-run-e2e-latest APIM_CLIENT_TAG=apim-1234-run-e2e-latest npm run test:api:<< parameters.database >>
             else 
-              APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=apim-1234-run-e2e-latest APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              if [[ "<< parameters.apim_client_tag >>" == *"@"* ]]; then
+                echo "Using custom registry for client"
+                CLIENT_REGISTRY=$(echo "<< parameters.apim_client_tag >>" | cut -f1 -d@)
+                CLIENT_TAG=$(echo "<< parameters.apim_client_tag >>" | cut -f2 -d@)
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=apim-1234-run-e2e-latest APIM_CLIENT_REGISTRY=${CLIENT_REGISTRY} APIM_CLIENT_TAG=${CLIENT_TAG} npm run test:api:<< parameters.database >>
+              else
+                echo "Using ACR registry for client"
+                APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=apim-1234-run-e2e-latest APIM_CLIENT_REGISTRY=graviteeio.azurecr.io APIM_CLIENT_TAG=<< parameters.apim_client_tag >> npm run test:api:<< parameters.database >>
+              fi
             fi
       - cmd-docker-azure-logout
       - cmd-notify-on-failure

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -61,7 +61,7 @@ export class BridgeCompatibilityTestsWorkflow {
         matrix: {
           execution_mode: ['v3', 'v4-emulation-engine'],
           database: ['bridge'],
-          apim_client_tag: ['4.2.x-latest', '4.1.x-latest', '4.0.x-latest', '3.20.x-latest'],
+          apim_client_tag: ['4.2.x-latest', '4.1.x-latest', '4.0.x-latest', 'graviteeio@3.20'],
         },
       }),
     ];

--- a/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
@@ -83,8 +83,8 @@ services:
       - storage
       - apim
 
-  gateway:
-    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_CLIENT_TAG:-3}
+  gateway-client:
+    image: ${APIM_CLIENT_REGISTRY:-graviteeio}/apim-gateway:${APIM_CLIENT_TAG:-3}
     container_name: gravitee-apim-e2e-gateway-bridge-client
     restart: always
     depends_on:


### PR DESCRIPTION
## Issue

N/A

## Description

Even if we do not support the version 3.20 of APIM, the bridge repository must be still compatible with it.
This PR adds the possibility to use a custom registry for the bridge client.

By doing this, we can use an official docker image during the bridge tests

