### PR TITLE
feat(api): Return response status counts by entrypoint

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -21,6 +21,9 @@ import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQu
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
+import io.gravitee.repository.log.v4.model.analytics.TopHitsAnalyticsByEntrypointQuery;
+import io.reactivex.rxjava3.annotations.NonNull;
+import java.util.Map;
 import java.util.Optional;
 
 public interface AnalyticsRepository {
@@ -29,4 +32,6 @@ public interface AnalyticsRepository {
     Optional<AverageAggregate> searchAverageMessagesPerRequest(QueryContext queryContext, AverageMessagesPerRequestQuery query);
 
     Optional<AverageAggregate> searchAverageConnectionDuration(QueryContext queryContext, AverageConnectionDurationQuery query);
+
+    @NonNull Optional<Map<String, Map<String, Long>>> searchTopHitsAnalyticsByEntrypoint(QueryContext queryContext, TopHitsAnalyticsByEntrypointQuery query);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/TopHitsAnalyticsByEntrypointQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/TopHitsAnalyticsByEntrypointQuery.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TopHitsAnalyticsByEntrypointQuery {
+
+    String apiId;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -26,12 +26,17 @@ import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageMe
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageMessagesPerRequestResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchRequestsCountQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchRequestsCountResponseAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopHitsAnalyticsByEntrypointQueryAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopHitsAnalyticsByEntrypointResponseAdapter;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
+import io.gravitee.repository.log.v4.model.analytics.TopHitsAnalyticsByEntrypointQuery;
+import io.reactivex.rxjava3.annotations.NonNull;
+import java.util.Map;
 import java.util.Optional;
 
 public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepository implements AnalyticsRepository {
@@ -65,5 +70,13 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         return this.client.search(index, null, SearchAverageConnectionDurationQueryAdapter.adapt(query))
             .map(SearchAverageConnectionDurationResponseAdapter::adapt)
             .blockingGet();
+    }
+
+    @Override
+    public @NonNull Optional<Map<String, Map<String, Long>>> searchTopHitsAnalyticsByEntrypoint(QueryContext queryContext, TopHitsAnalyticsByEntrypointQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_MESSAGE_METRICS, clusters);
+        return this.client.search(index, null, SearchTopHitsAnalyticsByEntrypointQueryAdapter.adapt(query))
+                .map(SearchTopHitsAnalyticsByEntrypointResponseAdapter::adapt)
+                .blockingGet();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchTopHitsAnalyticsByEntrypointQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchTopHitsAnalyticsByEntrypointQueryAdapter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import io.gravitee.repository.log.v4.model.analytics.TopHitsAnalyticsByEntrypointQuery;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.HashMap;
+import java.util.Optional;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchTopHitsAnalyticsByEntrypointQueryAdapter {
+
+    public static final String ENTRYPOINT_ID_AGG = "entrypoint_id_agg";
+    public static final String FIELD = "field";
+    public static final String STATUS_RANGES = "status_ranges";
+
+    public static String adapt(TopHitsAnalyticsByEntrypointQuery query) {
+        var jsonContent = new HashMap<String, Object>();
+        var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(TopHitsAnalyticsByEntrypointQuery.builder().build()));
+        jsonContent.put("query", esQuery);
+        jsonContent.put("aggs", buildTopHistAnalyticsByEntrypointAggregation());
+        return new JsonObject(jsonContent).encode();
+    }
+
+    private static JsonObject buildTopHistAnalyticsByEntrypointAggregation() {
+        return JsonObject.of(
+                ENTRYPOINT_ID_AGG,
+            JsonObject.of(
+                // Group by entrypoint id (already filtered by <connector-type: entrypoint>
+                "terms",
+                JsonObject.of(FIELD, "entrypoint-id"),
+                "aggs",
+                JsonObject.of(
+                    // Compute count of messages for an entrypoint
+                        STATUS_RANGES,
+                    JsonObject.of("range", JsonObject.of(FIELD, "count-increment", "ranges", JsonArray.of(
+                            JsonObject.of("from", 100.0, "to", 200.0),
+                            JsonObject.of("from", 200.0, "to", 300.0),
+                            JsonObject.of("from", 300.0, "to", 400.0),
+                            JsonObject.of("from", 400.0, "to", 500.0),
+                            JsonObject.of("from", 500.0, "to", 600.0)
+                    )),
+                        "aggs",
+                        JsonObject.of("count", JsonObject.of("value_count", JsonObject.of(FIELD, "_id"))))
+                )
+            )
+        );
+    }
+
+    private static JsonObject buildElasticQuery(TopHitsAnalyticsByEntrypointQuery query) {
+        return JsonObject.of("term", JsonObject.of("api-id", query.getApiId()));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchTopHitsAnalyticsByEntrypointResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchTopHitsAnalyticsByEntrypointResponseAdapter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import static io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopHitsAnalyticsByEntrypointQueryAdapter.ENTRYPOINT_ID_AGG;
+import static io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopHitsAnalyticsByEntrypointQueryAdapter.STATUS_RANGES;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchTopHitsAnalyticsByEntrypointResponseAdapter {
+
+    public static Optional<Map<String, Map<String, Long>>> adapt(SearchResponse response) {
+        final Map<String, Aggregation> aggregations = response.getAggregations();
+        if (aggregations == null || aggregations.isEmpty()) {
+            return Optional.empty();
+        }
+        final var entrypointsAggregation = aggregations.get(ENTRYPOINT_ID_AGG);
+        if (entrypointsAggregation == null) {
+            return Optional.empty();
+        }
+
+        final var result = entrypointsAggregation.getBuckets().stream()
+                .collect(
+                        Collectors.toMap(
+                                jsonNode -> jsonNode.get("key").asText(),
+                                jsonNode -> processStatusRanges(jsonNode.get(STATUS_RANGES))
+                        )
+                );
+        return Optional.of(result);
+    }
+
+    private static Map<String, Long> processStatusRanges(JsonNode jsonNode) {
+        if (jsonNode == null) {
+            return Collections.emptyMap();
+        }
+
+        final var buckets = jsonNode.get("buckets");
+        if (buckets == null || buckets.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        final var result = new HashMap<String, Long>();
+        for (final var bucket : buckets) {
+            final var count = bucket.get("count").get("value").asLong();
+            result.put(bucket.get("key").asText(), count);
+        }
+
+        return result;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiAnalyticsTopHitsByEntrypointResponse.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiAnalyticsTopHitsByEntrypointResponse.java
@@ -1,0 +1,16 @@
+package io.gravitee.rest.api.management.v2.rest.model;
+
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
+import lombok.Data;
+import java.util.Map;
+
+@Data
+public class ApiAnalyticsTopHitsByEntrypointResponse {
+    private Map<String, TopHitsAnalytics> statusCodesByEntrypoint;
+
+    public static ApiAnalyticsTopHitsByEntrypointResponse ofMap(Map<String, TopHitsAnalytics> stringTopHitsAnalyticsMap) {
+        final var result = new ApiAnalyticsTopHitsByEntrypointResponse();
+        result.statusCodesByEntrypoint = stringTopHitsAnalyticsMap;
+        return result;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/analytics/ApiAnalyticsResource.java
@@ -18,10 +18,12 @@ package io.gravitee.rest.api.management.v2.rest.resource.api.analytics;
 import io.gravitee.apim.core.analytics.use_case.SearchAverageConnectionDurationUseCase;
 import io.gravitee.apim.core.analytics.use_case.SearchAverageMessagesPerRequestAnalyticsUseCase;
 import io.gravitee.apim.core.analytics.use_case.SearchRequestsCountAnalyticsUseCase;
+import io.gravitee.apim.core.analytics.use_case.SearchTopHitsByEntrypointUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiAnalyticsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsAverageConnectionDurationResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsAverageMessagesPerRequestResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsRequestsCountResponse;
+import io.gravitee.rest.api.management.v2.rest.model.ApiAnalyticsTopHitsByEntrypointResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -49,6 +51,9 @@ public class ApiAnalyticsResource extends AbstractResource {
 
     @Inject
     private SearchAverageConnectionDurationUseCase searchAverageConnectionDurationUseCase;
+
+    @Inject
+    private SearchTopHitsByEntrypointUseCase searchTopHitsByEntrypointUseCase;
 
     @Path("/requests-count")
     @GET
@@ -90,5 +95,15 @@ public class ApiAnalyticsResource extends AbstractResource {
             .averageConnectionDuration()
             .map(ApiAnalyticsMapper.INSTANCE::map)
             .orElseThrow(() -> new NotFoundException("No connection duration found for api: " + apiId));
+    }
+
+    @Path("/status-codes-by-entrypoint")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({@Permission(value = RolePermission.API_ANALYTICS, acls = {RolePermissionAction.READ})})
+    public ApiAnalyticsTopHitsByEntrypointResponse getStatusCodesByEntrypoint() {
+        var request = new SearchTopHitsByEntrypointUseCase.Input(apiId, GraviteeContext.getCurrentEnvironment());
+
+        return searchTopHitsByEntrypointUseCase.execute(request).topHitsAnalyticsByEntrypoint().map(ApiAnalyticsTopHitsByEntrypointResponse::ofMap).orElseThrow(() -> new NotFoundException("No data found for api: " + apiId));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/TopHitsAnalytics.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/TopHitsAnalytics.java
@@ -42,4 +42,10 @@ public class TopHitsAnalytics implements Analytics {
     public void setMetadata(Map<String, Map<String, String>> metadata) {
         this.metadata = metadata;
     }
+
+    public static TopHitsAnalytics ofValues(Map<String, Long> values) {
+        TopHitsAnalytics analytics = new TopHitsAnalytics();
+        analytics.setValues(values);
+        return analytics;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
@@ -15,10 +15,12 @@
  */
 package io.gravitee.apim.core.analytics.query_service;
 
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Map;
 import java.util.Optional;
 
 public interface AnalyticsQueryService {
@@ -27,4 +29,6 @@ public interface AnalyticsQueryService {
     Optional<AverageMessagesPerRequest> searchAverageMessagesPerRequest(ExecutionContext executionContext, String apiId);
 
     Optional<AverageConnectionDuration> searchAverageConnectionDuration(ExecutionContext executionContext, String apiId);
+
+    Optional<Map<String, TopHitsAnalytics>> searchTopHitsByEntrypoint(ExecutionContext executionContext, String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchTopHitsByEntrypointUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchTopHitsByEntrypointUseCase.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@UseCase
+public class SearchTopHitsByEntrypointUseCase {
+
+    private final AnalyticsQueryService analyticsQueryService;
+    private final ApiCrudService apiCrudService;
+
+    public Output execute(Input input) {
+        validateApiRequirements(input);
+
+        // Verify v4 api
+        return analyticsQueryService.searchTopHitsByEntrypoint(GraviteeContext.getExecutionContext(), input.apiId()).map(Output::new).orElse(new Output());
+    }
+
+    private void validateApiRequirements(Input input) {
+        final Api api = apiCrudService.get(input.apiId);
+        validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
+        validateApiMultiTenancyAccess(api, input.environmentId);
+    }
+
+    private static void validateApiMultiTenancyAccess(Api api, String environmentId) {
+        if (!api.belongsToEnvironment(environmentId)) {
+            throw new ApiNotFoundException(api.getId());
+        }
+    }
+
+    private static void validateApiDefinitionVersion(DefinitionVersion definitionVersion, String apiId) {
+        if (!DefinitionVersion.V4.equals(definitionVersion)) {
+            throw new ApiInvalidDefinitionVersionException(apiId);
+        }
+    }
+
+    public record Input(String apiId, String environmentId) {}
+
+    public record Output(Optional<Map<String, TopHitsAnalytics>> topHitsAnalyticsByEntrypoint) {
+        Output(Map<String, TopHitsAnalytics> topHitsAnalyticsByEntrypoint) {
+            this(Optional.of(topHitsAnalyticsByEntrypoint));
+        }
+
+        Output() {
+            this(Optional.empty());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
@@ -20,14 +20,18 @@ import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
+import io.gravitee.repository.log.v4.model.analytics.TopHitsAnalyticsByEntrypointQuery;
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -66,6 +70,15 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
                     .averagesByEntrypoint(averageAggregate.getAverageBy())
                     .build()
             );
+    }
+
+    @Override
+    public Optional<Map<String, TopHitsAnalytics>> searchTopHitsByEntrypoint(ExecutionContext executionContext, String apiId) {
+        final var queryResult =  analyticsRepository
+                .searchTopHitsAnalyticsByEntrypoint(executionContext.getQueryContext(), TopHitsAnalyticsByEntrypointQuery.builder().apiId(apiId).build());
+        return queryResult.map(
+                analytics -> analytics.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> TopHitsAnalytics.ofValues(entry.getValue())))
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
@@ -16,9 +16,11 @@
 package fakes;
 
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
+import java.util.Map;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
@@ -31,6 +33,7 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     public RequestsCount requestsCount;
     public AverageMessagesPerRequest averageMessagesPerRequest;
     public AverageConnectionDuration averageConnectionDuration;
+    public Map<String, TopHitsAnalytics> topHitsAnalyticsByEntrypoint;
 
     @Override
     public Optional<RequestsCount> searchRequestsCount(ExecutionContext executionContext, String apiId) {
@@ -51,5 +54,10 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
         requestsCount = null;
         averageMessagesPerRequest = null;
         averageConnectionDuration = null;
+    }
+
+    @Override
+    public Optional<Map<String, TopHitsAnalytics>> searchTopHitsByEntrypoint(ExecutionContext executionContext, String apiId) {
+        return Optional.ofNullable(topHitsAnalyticsByEntrypoint);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3482

## Description

Added endpoint to return response statuses with counts per entrypoint

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-udimpubiyk.chromatic.com)
<!-- Storybook placeholder end -->
