### PR TITLE
fix(gateway): pause the WS endpoint request when upgrading

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
@@ -67,8 +67,9 @@ public class WebSocketConnector extends HttpConnector {
             return httpClientFactory
                 .getOrBuildHttpClient(ctx, configuration, sharedConfiguration)
                 .rxWebSocket(webSocketConnectOptions)
-                .flatMap(endpointWebSocket ->
-                    request
+                .flatMap(endpointWebSocket -> {
+                    endpointWebSocket.pause();
+                    return request
                         .webSocket()
                         .upgrade()
                         .doOnSuccess(requestWebSocket -> {
@@ -87,8 +88,9 @@ public class WebSocketConnector extends HttpConnector {
                                 serverWebSocket.close()
                             );
                             endpointWebSocket.exceptionHandler(throwable -> serverWebSocket.close((short) HttpStatusCode.BAD_REQUEST_400));
-                        })
-                )
+                            endpointWebSocket.resume();
+                        });
+                })
                 .ignoreElement()
                 .onErrorResumeNext(throwable -> {
                     if (throwable instanceof UpgradeRejectedException) {

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.1.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>3.1.2</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.1.3</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>4.0.1</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>2.0.1</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>2.0.1</gravitee-policy-assign-content.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5257

## Description

with the current implementation we miss the first “connection” frame sent by socket.io server, the solution is to pause the endpoint request when upgrading the client request, link them together then resume the endpoint websocket.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sfhqyhdcos.chromatic.com)
<!-- Storybook placeholder end -->
