### PR TITLE
fix: use the pathname in the redirect_uri

### DIFF
--- a/gravitee-apim-console-webui/src/auth/auth.service.ts
+++ b/gravitee-apim-console-webui/src/auth/auth.service.ts
@@ -65,7 +65,7 @@ export class AuthService {
       this.oidcManagers[idp.id] = new UserManager({
         authority: idp.authorizationEndpoint,
         client_id: idp.clientId,
-        redirect_uri: `${window.location.origin}`,
+        redirect_uri: `${(window.location.origin + window.location.pathname).replace(/\/$/, '')}`,
         scope: idp.scopes?.join(idp.scopeDelimiter ?? ' '),
         response_type: 'code',
         post_logout_redirect_uri: `${window.location.origin + this.locationStrategy.prepareExternalUrl('/_login')}`,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5267

## Description

use the pathname in the redirect_uri
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7667/console](https://pr.team-apim.gravitee.dev/7667/console)
      Portal: [https://pr.team-apim.gravitee.dev/7667/portal](https://pr.team-apim.gravitee.dev/7667/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7667/api/management](https://pr.team-apim.gravitee.dev/7667/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7667](https://pr.team-apim.gravitee.dev/7667)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7667](https://pr.gateway-v3.team-apim.gravitee.dev/7667)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lvsshgdlfq.chromatic.com)
<!-- Storybook placeholder end -->
