### PR TITLE
fix: correct API v4 analytics ES average

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
@@ -44,7 +44,7 @@ public class SearchAverageConnectionDurationQueryAdapter {
             ENTRYPOINTS_AGG,
             JsonObject.of(
                 "terms",
-                JsonObject.of(FIELD, "entrypoint-id"),
+                JsonObject.of(FIELD, "entrypoint-id.keyword"),
                 "aggs",
                 JsonObject.of(AVG_ENDED_REQUEST_DURATION_MS, JsonObject.of("avg", JsonObject.of(FIELD, "gateway-response-time-ms")))
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
@@ -37,7 +37,7 @@ public class SearchRequestsCountQueryAdapter {
     }
 
     private static JsonObject buildEntrypointIdAggregate() {
-        return JsonObject.of("entrypoints", JsonObject.of("terms", JsonObject.of("field", "entrypoint-id")));
+        return JsonObject.of("entrypoints", JsonObject.of("terms", JsonObject.of("field", "entrypoint-id.keyword")));
     }
 
     private static JsonObject buildElasticQuery(RequestsCountQuery query) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
@@ -46,7 +46,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                        "aggs": {
                          "entrypoints_agg": {
                            "terms": {
-                             "field": "entrypoint-id"
+                             "field": "entrypoint-id.keyword"
                            },
                            "aggs": {
                              "avg_ended_request_duration_ms": {
@@ -101,7 +101,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                                "aggs": {
                                  "entrypoints_agg": {
                                    "terms": {
-                                     "field": "entrypoint-id"
+                                     "field": "entrypoint-id.keyword"
                                    },
                                    "aggs": {
                                      "avg_ended_request_duration_ms": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
@@ -35,7 +35,7 @@ class SearchRequestsCountQueryAdapterTest {
               {
                   "aggs": {
                       "entrypoints": {
-                              "terms": {"field":"entrypoint-id"}
+                              "terms": {"field":"entrypoint-id.keyword"}
                       }
                   }
               }
@@ -74,7 +74,7 @@ class SearchRequestsCountQueryAdapterTest {
                                     },
                                     "aggs": {
                                         "entrypoints": {
-                                                "terms": {"field":"entrypoint-id"}
+                                                "terms": {"field":"entrypoint-id.keyword"}
                                         }
                                     }
                                 }


### PR DESCRIPTION
 queries

## Issue

https://gravitee.atlassian.net/browse/APIM-5102

## Description

Avoid error for user running APIM + Elasticsearch in ILM mode. Today if a user upgrade APIM from version 4.3.x to 4.4.x and call the new analytics endpoints an error occurs saying:
```
Unable to search: url[/dev_apim_master-v4-metrics/_search?ignore_unavailable=true] status[400] query[{"query":{"bool":{"must":[{"term":{"api-id":"0e6dab30-df20-437b-adab-30df20a37b43"}}]}},"aggs":{"entrypoints":{"terms":{"field":"entrypoint-id"}}}}] 
response[{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Fielddata is disabled on [entrypoint-id] in [dev_apim_master-v4-metrics-000008]. 
Text fields are not optimised for operations that require per-document field data like aggregations and sorting, 
so these operations are disabled by default. Please use a keyword field instead. 
```

From the official documentation here is a potential fix: https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html#before-enabling-fielddata

Here are screenshots with tests on my local ES & Kibana in ILM mode
![image](https://github.com/gravitee-io/gravitee-api-management/assets/25704259/d08efadc-bbcc-4750-8a91-882211b75d9f)

![image](https://github.com/gravitee-io/gravitee-api-management/assets/25704259/e73b9266-a886-4d55-9769-3bcf51ec4c5b)

**_NB_**: 
We didn't reproduced the issue with APIM + ES running with daily indexes. It really happens only with ILM.
We have tested the migration from 4.3.x to 4.4.x and everything looked ok with this fix. This only happens with the new API V4 analytics endpoints ( `apis/${apiId}/analytics/requests-count` and  `apis/${apiId}/analytics/average-connection-duration` )


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

