### PR TITLE
fix(console): inverse message when category is hidden or shown

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
@@ -154,7 +154,7 @@ export class CategoriesComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (_) => {
-          this.snackBarService.success(`Category [${category.name}] is now ${isHidden ? 'shown' : 'hidden'}`);
+          this.snackBarService.success(`Category [${category.name}] is now ${isHidden ? 'hidden' : 'shown'}`);
           this.categoryList.next(1);
         },
         error: ({ error }) => this.snackBarService.error(error.message),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4006

## Description

Inverse message in snackbar for when a category is hidden or shown.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ydyhxssiaw.chromatic.com)
<!-- Storybook placeholder end -->
