### PR TITLE
Apim 5279 simple filter integrated apis

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
@@ -23,29 +23,35 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.Visibility;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
+@EqualsAndHashCode
 public class ApiCriteria {
 
-    private Collection<String> ids;
-    private Collection<String> groups;
-    private String category;
-    private String label;
-    private LifecycleState state;
-    private Visibility visibility;
-    private String version;
-    private String name;
-    private List<ApiLifecycleState> lifecycleStates;
-    private String environmentId;
-    private List<String> environments;
+    private final Collection<String> ids;
+    private final Collection<String> groups;
+    private final String category;
+    private final String label;
+    private final LifecycleState state;
+    private final Visibility visibility;
+    private final String version;
+    private final String name;
+    private final List<ApiLifecycleState> lifecycleStates;
+    private final String environmentId;
+    private final List<String> environments;
     private String crossId;
     private List<DefinitionVersion> definitionVersion;
     private String integrationId;
+    private String filterName;
 
     ApiCriteria(ApiCriteria.Builder builder) {
         this.ids = builder.ids;
@@ -62,117 +68,7 @@ public class ApiCriteria {
         this.crossId = builder.crossId;
         this.definitionVersion = builder.definitionVersion;
         this.integrationId = builder.integrationId;
-    }
-
-    public Collection<String> getIds() {
-        return ids;
-    }
-
-    public Collection<String> getGroups() {
-        return groups;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public LifecycleState getState() {
-        return state;
-    }
-
-    public Visibility getVisibility() {
-        return visibility;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public List<ApiLifecycleState> getLifecycleStates() {
-        return lifecycleStates;
-    }
-
-    public String getEnvironmentId() {
-        return environmentId;
-    }
-
-    public List<String> getEnvironments() {
-        return environments;
-    }
-
-    public String getCrossId() {
-        return crossId;
-    }
-
-    public void setCrossId(String crossId) {
-        this.crossId = crossId;
-    }
-
-    public List<DefinitionVersion> getDefinitionVersion() {
-        return definitionVersion;
-    }
-
-    public void setDefinitionVersion(List<DefinitionVersion> definitionVersion) {
-        this.definitionVersion = definitionVersion;
-    }
-
-    public String getIntegrationId() {
-        return integrationId;
-    }
-
-    public void setIntegrationId(String integrationId) {
-        this.integrationId = integrationId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ApiCriteria)) return false;
-        ApiCriteria that = (ApiCriteria) o;
-        return (
-            Objects.equals(ids, that.ids) &&
-            Objects.equals(groups, that.groups) &&
-            Objects.equals(category, that.category) &&
-            Objects.equals(label, that.label) &&
-            Objects.equals(state, that.state) &&
-            Objects.equals(visibility, that.visibility) &&
-            Objects.equals(version, that.version) &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(lifecycleStates, that.lifecycleStates) &&
-            Objects.equals(environmentId, that.environmentId) &&
-            Objects.equals(environments, that.environments) &&
-            Objects.equals(crossId, that.crossId) &&
-            Objects.equals(definitionVersion, that.definitionVersion) &&
-            Objects.equals(integrationId, that.integrationId)
-        );
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-            ids,
-            groups,
-            category,
-            label,
-            state,
-            visibility,
-            version,
-            name,
-            lifecycleStates,
-            environmentId,
-            environments,
-            crossId,
-            definitionVersion,
-            integrationId
-        );
+        this.filterName = builder.filterName;
     }
 
     public static class Builder {
@@ -191,6 +87,7 @@ public class ApiCriteria {
         private String crossId;
         private List<DefinitionVersion> definitionVersion;
         private String integrationId;
+        private String filterName;
 
         public ApiCriteria.Builder ids(final String... id) {
             this.ids = Set.of(id);
@@ -269,6 +166,11 @@ public class ApiCriteria {
 
         public ApiCriteria.Builder integrationId(final String integrationId) {
             this.integrationId = integrationId;
+            return this;
+        }
+
+        public ApiCriteria.Builder filterName(final String filterName) {
+            this.filterName = filterName;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcApiRepositoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.model.Api;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Random;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class JdbcApiRepositoryTest {
+
+    static Random RANDOM = new Random();
+
+    @Nested
+    class MappingCriteriaToQuery {
+
+        @Test
+        void should_map_filter_name_as_lower_like() {
+            // Given
+            JdbcObjectMapper<Api> orm = JdbcObjectMapper.builder(Api.class, "mytable").build();
+            ApiCriteria criteria = new ApiCriteria.Builder().filterName("my-name").build();
+
+            // When
+            String result = JdbcApiRepository.convert(criteria, orm);
+
+            // Then
+            assertThat(result).isEqualTo("LOWER( a.name ) LIKE ?");
+        }
+    }
+
+    @Nested
+    class FillParametersToPreparedStatement {
+
+        @Test
+        void should_map_filter_name_as_lower_like() throws SQLException {
+            // Given
+            JdbcObjectMapper<Api> orm = JdbcObjectMapper.builder(Api.class, "mytable").build();
+            ApiCriteria criteria = new ApiCriteria.Builder().filterName("mY-naMe").build();
+            PreparedStatement ps = mock(PreparedStatement.class);
+            int lastIdx = RANDOM.nextInt(1000);
+
+            // When
+            int newLastIdx = JdbcApiRepository.fillPreparedStatement(criteria, ps, lastIdx, orm);
+
+            // Then
+            assertThat(newLastIdx).isEqualTo(lastIdx + 1);
+            verify(ps).setString(eq(lastIdx), eq("%my-name%"));
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.query.CriteriaDefinition;
+import org.springframework.data.mongodb.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class ApiMongoRepositoryImplTest {
+
+    @Nested
+    class FillQuery {
+
+        @Captor
+        private ArgumentCaptor<CriteriaDefinition> criteriaDefinition;
+
+        @Test
+        void should_not_update_query_if_no_criteria() {
+            // Given
+            Query query = mock(Query.class);
+            ApiCriteria criteria = new ApiCriteria.Builder().build();
+            List<ApiCriteria> criterias = List.of(criteria);
+
+            // When
+            ApiMongoRepositoryImpl.fillQuery(query, criterias);
+
+            // Then
+            verifyNoInteractions(query);
+        }
+
+        @Test
+        void filterName() {
+            // Given
+            Query query = mock(Query.class);
+            ApiCriteria criteria = new ApiCriteria.Builder().filterName("my-name").build();
+
+            // When
+            ApiMongoRepositoryImpl.fillQuery(query, List.of(criteria));
+
+            // Then
+            verify(query).addCriteria(criteriaDefinition.capture());
+            var definition = criteriaDefinition.getValue().getCriteriaObject();
+            assertThat(definition).containsOnlyKeys("name");
+            var pattern = (Pattern) definition.get("name");
+            assertThat(pattern)
+                .is(matcherOf("my-name"))
+                .is(matcherOf("my-Name"))
+                .is(matcherOf("something my-name"))
+                .is(matcherOf("my-name something"))
+                .isNot(matcherOf("name"));
+        }
+
+        private Condition<Pattern> matcherOf(String s) {
+            return new Condition<>(pattern -> pattern.asPredicate().test(s), "match '%s'", s);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
@@ -185,8 +185,7 @@ public class IntegrationResource extends AbstractResource {
         @PathParam("integrationId") String integrationId,
         @BeanParam @Valid PaginationParam paginationParam
     ) {
-        var pageable = new PageableImpl(paginationParam.getPage(), paginationParam.getPerPage());
-        var input = new GetIngestedApisUseCase.Input(integrationId, pageable);
+        var input = new GetIngestedApisUseCase.Input(integrationId, paginationParam.toPageable());
 
         var ingestedApis = getIngestedApisUseCase.execute(input).ingestedApis();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/PaginationParam.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.param;
 
+import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import jakarta.validation.constraints.Min;
 import jakarta.ws.rs.DefaultValue;
@@ -30,6 +31,7 @@ public class PaginationParam {
 
     public static final String PAGE_QUERY_PARAM_NAME = "page";
     public static final String PER_PAGE_QUERY_PARAM_NAME = "perPage";
+    public static final String FILTER_QUERY_PARAM_NAME = "filter";
 
     private static final String PAGE_QUERY_PARAM_DEFAULT = "1";
     private static final String PER_PAGE_QUERY_PARAM_DEFAULT = "10";
@@ -44,6 +46,9 @@ public class PaginationParam {
     @Min(value = 1, message = "Pagination perPage param must be >= 1")
     Integer perPage;
 
+    @QueryParam(FILTER_QUERY_PARAM_NAME)
+    String filter;
+
     public PaginationParam(Integer page, Integer perPage) {
         if (perPage < 1) throw new IllegalArgumentException("Pagination perPage param must be >= 1");
 
@@ -51,7 +56,7 @@ public class PaginationParam {
         this.perPage = perPage;
     }
 
-    public io.gravitee.rest.api.model.common.Pageable toPageable() {
-        return new PageableImpl(this.getPage(), this.getPerPage());
+    public Pageable toPageable() {
+        return new PageableImpl(this.getPage(), this.getPerPage(), filter);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/Pageable.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/Pageable.java
@@ -15,13 +15,21 @@
  */
 package io.gravitee.rest.api.model.common;
 
+import javax.annotation.Nullable;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Pageable {
-    // must be > 0
+    /**
+     * must be > 0
+     * @return page number (starts at 1)
+     */
     int getPageNumber();
 
     int getPageSize();
+
+    @Nullable
+    String getFilter();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/PageableImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/common/PageableImpl.java
@@ -15,22 +15,21 @@
  */
 package io.gravitee.rest.api.model.common;
 
-import lombok.EqualsAndHashCode;
+import javax.annotation.Nullable;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@EqualsAndHashCode
-public class PageableImpl implements Pageable {
-
-    // must be > 0;
-    private final int pageNumber;
-    private final int pageSize;
-
-    public PageableImpl(final int pageNumber, final int pageSize) {
+public record PageableImpl(int pageNumber, int pageSize, String filter) implements Pageable {
+    public PageableImpl(final int pageNumber, final int pageSize, final String filter) {
         this.pageNumber = Math.max(1, pageNumber);
         this.pageSize = pageSize;
+        this.filter = filter;
+    }
+
+    public PageableImpl(final int pageNumber, final int pageSize) {
+        this(pageNumber, pageSize, null);
     }
 
     @Override
@@ -41,5 +40,15 @@ public class PageableImpl implements Pageable {
     @Override
     public int getPageSize() {
         return pageSize;
+    }
+
+    @Nullable
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    public static PageableImpl defaultPageable() {
+        return new PageableImpl(1, 10, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/GetIngestedApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/GetIngestedApisUseCase.java
@@ -34,7 +34,7 @@ public class GetIngestedApisUseCase {
     }
 
     public Output execute(Input input) {
-        var pageable = input.pageable.orElse(new PageableImpl(1, 10));
+        var pageable = input.pageable.orElse(PageableImpl.defaultPageable());
 
         Page<Api> ingestedApis = apiQueryService.findByIntegrationId(input.integrationId, pageable);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImpl.java
@@ -70,7 +70,10 @@ public class ApiQueryServiceImpl extends AbstractService implements ApiQueryServ
 
     @Override
     public Page<Api> findByIntegrationId(String integrationId, Pageable pageable) {
-        var searchCriteria = new ApiCriteria.Builder().integrationId(integrationId).build();
+        var searchCriteria = new ApiCriteria.Builder()
+            .integrationId(integrationId)
+            .filterName(pageable.getFilter())
+            .build();
         var sortable = SortableAdapter.INSTANCE.toSortableForRepository(
             Sortable.builder().field("updatedAt").order(Sortable.Order.DESC).build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImpl.java
@@ -70,10 +70,7 @@ public class ApiQueryServiceImpl extends AbstractService implements ApiQueryServ
 
     @Override
     public Page<Api> findByIntegrationId(String integrationId, Pageable pageable) {
-        var searchCriteria = new ApiCriteria.Builder()
-            .integrationId(integrationId)
-            .filterName(pageable.getFilter())
-            .build();
+        var searchCriteria = new ApiCriteria.Builder().integrationId(integrationId).filterName(pageable.getFilter()).build();
         var sortable = SortableAdapter.INSTANCE.toSortableForRepository(
             Sortable.builder().field("updatedAt").order(Sortable.Order.DESC).build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiQueryServiceImplTest.java
@@ -70,7 +70,7 @@ class ApiQueryServiceImplTest {
     void should_list_apis_matching_integration_id() {
         //Given
         var integrationId = "integration-id";
-        var pageable = new PageableImpl(1, 5);
+        var pageable = new PageableImpl(1, 5, null);
 
         var expectedApis = List.of(fixtures.repository.ApiFixtures.aFederatedApi());
         var page = new Page<>(expectedApis, pageable.getPageNumber(), expectedApis.size(), expectedApis.size());


### PR DESCRIPTION
## Issue

[Search Integration backend work first implementation without lucene](https://gravitee.atlassian.net/browse/APIM-5279)

## Description

We need to allow user to filter the ingested APIs. As first implementation (before [APIM-5152](https://gravitee.atlassian.net/browse/APIM-5152)) we implement it by native database feature instead of lucene. This task is only about backend part and [APIM-5153](https://gravitee.atlassian.net/browse/APIM-5153) is about frontend part.

Currently that use

- regex for mongo
- like for SQL

Complete user story is [APIM-4367](https://gravitee.atlassian.net/browse/APIM-4367)

[APIM-5152]: https://gravitee.atlassian.net/browse/APIM-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-5153]: https://gravitee.atlassian.net/browse/APIM-5153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-4367]: https://gravitee.atlassian.net/browse/APIM-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-divskdneos.chromatic.com)
<!-- Storybook placeholder end -->
