### PR TITLE
fix: make sync process sequential

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
@@ -132,7 +132,7 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
                             )
                             .delay(delay, unit)
                             .rebatchRequests(1)
-                            .flatMapCompletable(interval -> synchronize())
+                            .concatMapCompletable(interval -> synchronize())
                             .subscribe();
                 })
             )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.sync.process.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -22,13 +23,20 @@ import io.gravitee.gateway.services.sync.process.distributed.service.NoopDistrib
 import io.gravitee.gateway.services.sync.process.repository.handler.SyncHandler;
 import io.gravitee.node.api.Node;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.plugins.RxJavaPlugins;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
+import io.vertx.rxjava3.core.RxHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -64,7 +72,7 @@ class DefaultSyncManagerTest {
         when(node.metadata()).thenReturn(Map.of(Node.META_ENVIRONMENTS, Set.of("env")));
         when(router.get(any())).thenReturn(route);
         when(route.produces(any())).thenReturn(route);
-        cut = new DefaultSyncManager(router, node, synchronizers, null, new NoopDistributedSyncService(), 200, TimeUnit.MILLISECONDS, 1);
+        cut = new DefaultSyncManager(router, node, synchronizers, null, new NoopDistributedSyncService(), 5, TimeUnit.SECONDS, 1);
     }
 
     @Test
@@ -78,5 +86,56 @@ class DefaultSyncManagerTest {
         inOrder.verify(route).handler(argThat(argument -> argument instanceof SyncHandler));
         inOrder.verify(synchronizer1).synchronize(eq(-1L), any(), anySet());
         inOrder.verify(synchronizer2).synchronize(eq(-1L), any(), anySet());
+    }
+
+    @Test
+    void should_synchronize_sequentially_after_initial_synchronization() throws Exception {
+        try {
+            final TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+            RxJavaPlugins.setIoSchedulerHandler(s -> testScheduler);
+
+            AtomicInteger counter = new AtomicInteger(0);
+
+            RepositorySynchronizer synchronizer1 = spy(new FakeSynchronizer(Completable.complete(), 1));
+            RepositorySynchronizer synchronizer2 = spy(
+                new FakeSynchronizer(
+                    Completable.defer(() -> {
+                        if (counter.getAndIncrement() == 0) {
+                            return Completable.complete();
+                        }
+
+                        return Completable.complete().delay(8, TimeUnit.SECONDS);
+                    }),
+                    2
+                )
+            );
+            synchronizers.add(synchronizer1);
+            synchronizers.add(synchronizer2);
+
+            cut.start();
+
+            InOrder inOrder = inOrder(route, synchronizer1, synchronizer2);
+            inOrder.verify(route).handler(argThat(argument -> argument instanceof SyncHandler));
+            inOrder.verify(synchronizer1).synchronize(eq(-1L), any(), anySet());
+            inOrder.verify(synchronizer2).synchronize(eq(-1L), any(), anySet());
+
+            // Trigger a diff sync.
+            testScheduler.advanceTimeBy(5, TimeUnit.SECONDS);
+            testScheduler.triggerActions();
+
+            // Advance time by another 5 seconds to complete the sync process and exceed the delay between 2 sync at the same time.
+            testScheduler.advanceTimeBy(5, TimeUnit.SECONDS);
+            testScheduler.triggerActions();
+
+            // Synchronizer has been called twice, one on full sync (start), one on diff sync
+            assertThat(counter.get()).isEqualTo(2);
+
+            // Diff sync should be called with a from date != -1.
+            inOrder.verify(synchronizer1).synchronize(argThat(from -> from != -1L), any(), anySet());
+            inOrder.verify(synchronizer2).synchronize(argThat(from -> from != -1L), any(), anySet());
+        } finally {
+            RxJavaPlugins.reset();
+        }
     }
 }


### PR DESCRIPTION
## Description

Quick fix to make sure the sync process is sequential and no other synchronization is launched if the synchronizers haven't finished yet.
This can have an impact especially when using the HTTP bridge client where the timeout is about 10 seconds and the sync process is launched every 5 seconds. 

