### PR TITLE
Update fetcher plugins for APIM 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-common.version>3.4.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
-        <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
+        <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.2.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>4.8.6</gravitee-node.version>
@@ -227,11 +227,11 @@
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>4.0.2</gravitee-cockpit-connectors-ws.version>
-        <gravitee-fetcher-bitbucket.version>1.7.1</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>1.8.2</gravitee-fetcher-git.version>
-        <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
-        <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
-        <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
+        <gravitee-fetcher-bitbucket.version>2.0.0</gravitee-fetcher-bitbucket.version>
+        <gravitee-fetcher-git.version>2.0.0</gravitee-fetcher-git.version>
+        <gravitee-fetcher-github.version>2.0.0</gravitee-fetcher-github.version>
+        <gravitee-fetcher-gitlab.version>2.0.0</gravitee-fetcher-gitlab.version>
+        <gravitee-fetcher-http.version>2.0.0</gravitee-fetcher-http.version>
         <gravitee-notifier-email.version>1.5.1</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4957
https://github.com/gravitee-io/issues/issues/9733

**Description**

Starting with APIM 4.3, Spring 6.1.8 is used. But in this version, the `CronSequenceGenerator` has been replaced by `CronExpression`
We need to update every fetcher libs and plugins to handle this change.

All plugins and libraries have been updated to follow the dependencies of APIM 4.0.x. (See other PRs attached to the ticket)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-decrfovbxf.chromatic.com)
<!-- Storybook placeholder end -->
