### PR TITLE
fix(import): endpoint config inherit by default

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -146,12 +146,14 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
 
             if (evaluatedServerUrl.size() == 1) {
                 defaultEndpoint = evaluatedServerUrl.get(0);
-                defaultGroup.setEndpoints(singleton(Endpoint.builder().name("default").target(defaultEndpoint).build()));
+                defaultGroup.setEndpoints(singleton(Endpoint.builder().name("default").target(defaultEndpoint).inherit(true).build()));
             } else {
                 defaultEndpoint = evaluatedServerUrl.get(0);
                 defaultGroup.setEndpoints(new HashSet<>());
                 for (int i = 0; i < evaluatedServerUrl.size(); i++) {
-                    defaultGroup.getEndpoints().add(Endpoint.builder().name("server" + (i + 1)).target(evaluatedServerUrl.get(i)).build());
+                    defaultGroup
+                        .getEndpoints()
+                        .add(Endpoint.builder().name("server" + (i + 1)).target(evaluatedServerUrl.get(i)).inherit(true).build());
                 }
             }
             proxy.setGroups(singleton(defaultGroup));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverterTest.java
@@ -113,6 +113,7 @@ class OAIToAPIConverterTest {
         Endpoint endpoint = endpointGroup.getEndpoints().stream().findAny().orElseThrow();
         assertThat(endpoint.getName()).isEqualTo("default");
         assertThat(endpoint.getTarget()).isEqualTo("https://api.company.com");
+        assertThat(endpoint.getInherit()).isTrue();
     }
 
     @Test
@@ -154,18 +155,22 @@ class OAIToAPIConverterTest {
         Endpoint endpoint1 = endpoints.get(0);
         assertThat(endpoint1.getName()).isEqualTo("server1");
         assertThat(endpoint1.getTarget()).isEqualTo("https://api.company.com/v1");
+        assertThat(endpoint1.getInherit()).isTrue();
 
         Endpoint endpoint2 = endpoints.get(1);
         assertThat(endpoint2.getName()).isEqualTo("server2");
         assertThat(endpoint2.getTarget()).isEqualTo("https://api2.company.com");
+        assertThat(endpoint2.getInherit()).isTrue();
 
         Endpoint endpoint3 = endpoints.get(2);
         assertThat(endpoint3.getName()).isEqualTo("server3");
         assertThat(endpoint3.getTarget()).isEqualTo("https://api3.company.com/v2");
+        assertThat(endpoint3.getInherit()).isTrue();
 
         Endpoint endpoint4 = endpoints.get(3);
         assertThat(endpoint4.getName()).isEqualTo("server4");
         assertThat(endpoint4.getTarget()).isEqualTo("https://api3.company.com/v3");
+        assertThat(endpoint4.getInherit()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5318

## Description

When importing an OpenAPI spec fil as a V2 API, the inheritance of the endpoint configuration is not set at all. When this API is then updated using the mAPI V2, by default this inheritance boolean is set to fault but specific config stays null (http, ssl, ...).

With this PR, the inheritance field is force to true when importing an OAS into a V2 API.