### PR TITLE
feat(console): add enabling portal-next to console settings

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -188,6 +188,11 @@ export function fakePortalSettings(attributes?: Partial<PortalSettings>): Portal
         enabled: true,
       },
     },
+    portalNext: {
+      access: {
+        enabled: true,
+      },
+    },
   };
 
   return {

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -32,6 +32,7 @@ export interface PortalSettings {
   openAPIDocViewer?: PortalSettingsOpenAPIDocViewer;
   cors?: PortalSettingsCors;
   email?: PortalSettingsEmail;
+  portalNext?: PortalSettingsPortalNext;
 }
 
 export type PortalSettingsMetadata = Record<string, string[]>;
@@ -215,5 +216,10 @@ export interface PortalSettingsOpenAPIDocViewer {
     redoc: {
       enabled: boolean;
     };
+  };
+}
+export interface PortalSettingsPortalNext {
+  access: {
+    enabled: boolean;
   };
 }

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -376,6 +376,37 @@
       </mat-card-content>
     </mat-card>
 
+    @if (hasEnterpriseLicense$ | async; as hasEnterpriseLicense) {
+      @if (hasEnterpriseLicense) {
+        <h2>New Portal</h2>
+        <mat-card class="portal__form__card">
+          <mat-card-content formGroupName="portalNext">
+            <gio-banner-info>
+              This feature is a tech preview. Gravitee provides limited support for tech preview features and they are generally not
+              recommended for production use.
+            </gio-banner-info>
+            <gio-form-slide-toggle formGroupName="access" class="portal__form__card__form-field">
+              <gio-form-label>Enable the New Developer Portal</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="New Portal Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
+            @if (portalUrl && !!settings.portalNext?.access?.enabled) {
+              <div class="open-new-portal-button">
+                <a mat-raised-button [href]="portalUrl" target="_blank" color="primary" class="open-new-portal-button__content">
+                  <div>Open the New Developer Portal</div>
+                  <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
+                </a>
+              </div>
+            }
+          </mat-card-content>
+        </mat-card>
+      }
+    }
+
     <mat-card class="portal__form__card">
       <mat-card-content formGroupName="cors">
         <h3>CORS</h3>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
@@ -54,3 +54,15 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 }
+.open-new-portal-button {
+  width: fit-content;
+  &__content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    & mat-icon {
+      width: 12px;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -191,9 +191,12 @@ export class PortalSettingsComponent implements OnInit {
         tap(([portalSettings]) => {
           this.settings = portalSettings;
           this.initialPortalForm();
+          const isPortalNextEnabled = portalSettings?.portalNext?.access?.enabled;
           this.portalUrl = isEmpty(portalSettings.portal.url)
             ? undefined
-            : this.constants.env.baseURL.replace('{:envId}', this.constants.org.currentEnv.id) + '/portal/redirect';
+            : this.constants.env.baseURL.replace('{:envId}', this.constants.org.currentEnv.id) +
+              '/portal/redirect' +
+              (isPortalNextEnabled ? '?version=next' : '');
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.module.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.module.ts
@@ -18,7 +18,13 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { GioBannerModule, GioFormSlideToggleModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import {
+  GioBannerModule,
+  GioFormSlideToggleModule,
+  GioFormTagsInputModule,
+  GioSaveBarModule,
+  GioTopBarLinkModule,
+} from '@gravitee/ui-particles-angular';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
@@ -65,6 +71,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioBannerModule,
     MatOptionModule,
     MatSelectModule,
+    GioTopBarLinkModule,
   ],
 })
 export class PortalSettingsModule {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5348

## Description

Add enabling portal next to console

<img width="720" alt="Screenshot 2024-06-07 at 16 27 04" src="https://github.com/gravitee-io/gravitee-api-management/assets/42294616/ad9cd157-5c67-44fb-942a-9bd2c6bbb7a9">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lrimbacaaw.chromatic.com)
<!-- Storybook placeholder end -->
