### PR TITLE
fix elastic queries using `entrypoint-id`

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <gravitee-reporter-common.version>1.2.1</gravitee-reporter-common.version>
-        <gravitee-common-elasticsearch.version>6.0.0</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>6.1.0</gravitee-common-elasticsearch.version>
         <opensearch-testcontainers.version>2.0.1</opensearch-testcontainers.version>
     </properties>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -47,7 +47,11 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     public Optional<CountAggregate> searchRequestsCount(QueryContext queryContext, RequestsCountQuery query) {
         var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
 
-        return this.client.search(index, null, SearchRequestsCountQueryAdapter.adapt(query))
+        return this.client.getFieldTypes(index, "entrypoint-id")
+            .map(types -> types.stream().allMatch(KEYWORD::equals))
+            .flatMap(isEntrypointIdKeyword ->
+                this.client.search(index, null, SearchRequestsCountQueryAdapter.adapt(query, isEntrypointIdKeyword))
+            )
             .map(SearchRequestsCountResponseAdapter::adapt)
             .blockingGet();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
@@ -44,7 +44,7 @@ public class SearchAverageConnectionDurationQueryAdapter {
             ENTRYPOINTS_AGG,
             JsonObject.of(
                 "terms",
-                JsonObject.of(FIELD, "entrypoint-id"),
+                JsonObject.of(FIELD, "entrypoint-id.keyword"),
                 "aggs",
                 JsonObject.of(AVG_ENDED_REQUEST_DURATION_MS, JsonObject.of("avg", JsonObject.of(FIELD, "gateway-response-time-ms")))
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
@@ -31,20 +31,20 @@ public class SearchAverageConnectionDurationQueryAdapter {
     public static final String FIELD = "field";
     public static final String AVG_ENDED_REQUEST_DURATION_MS = "avg_ended_request_duration_ms";
 
-    public static String adapt(AverageConnectionDurationQuery query) {
+    public static String adapt(AverageConnectionDurationQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(AverageConnectionDurationQuery.builder().build()));
         jsonContent.put("query", esQuery);
-        jsonContent.put("aggs", buildAverageMessagesPerRequestPerEntrypointAggregate());
+        jsonContent.put("aggs", buildAverageMessagesPerRequestPerEntrypointAggregate(isEntrypointIdKeyword));
         return new JsonObject(jsonContent).encode();
     }
 
-    private static JsonObject buildAverageMessagesPerRequestPerEntrypointAggregate() {
+    private static JsonObject buildAverageMessagesPerRequestPerEntrypointAggregate(boolean isEntrypointIdKeyword) {
         return JsonObject.of(
             ENTRYPOINTS_AGG,
             JsonObject.of(
                 "terms",
-                JsonObject.of(FIELD, "entrypoint-id.keyword"),
+                JsonObject.of(FIELD, isEntrypointIdKeyword ? "entrypoint-id" : "entrypoint-id.keyword"),
                 "aggs",
                 JsonObject.of(AVG_ENDED_REQUEST_DURATION_MS, JsonObject.of("avg", JsonObject.of(FIELD, "gateway-response-time-ms")))
             )

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationResponseAdapter.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.util.CollectionUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SearchAverageConnectionDurationResponseAdapter {
@@ -37,7 +38,7 @@ public class SearchAverageConnectionDurationResponseAdapter {
             return Optional.empty();
         }
         final var entrypointsAggregation = aggregations.get(ENTRYPOINTS_AGG);
-        if (entrypointsAggregation == null) {
+        if (entrypointsAggregation == null || CollectionUtils.isEmpty(entrypointsAggregation.getBuckets())) {
             return Optional.empty();
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
@@ -26,18 +26,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SearchRequestsCountQueryAdapter {
 
-    public static String adapt(RequestsCountQuery query) {
+    public static String adapt(RequestsCountQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(query);
         if (esQuery != null) {
             jsonContent.put("query", esQuery);
         }
-        jsonContent.put("aggs", buildEntrypointIdAggregate());
+        jsonContent.put("aggs", buildEntrypointIdAggregate(isEntrypointIdKeyword));
         return new JsonObject(jsonContent).encode();
     }
 
-    private static JsonObject buildEntrypointIdAggregate() {
-        return JsonObject.of("entrypoints", JsonObject.of("terms", JsonObject.of("field", "entrypoint-id.keyword")));
+    private static JsonObject buildEntrypointIdAggregate(boolean isEntrypointIdKeyword) {
+        return JsonObject.of(
+            "entrypoints",
+            JsonObject.of("terms", JsonObject.of("field", isEntrypointIdKeyword ? "entrypoint-id" : "entrypoint-id.keyword"))
+        );
     }
 
     private static JsonObject buildElasticQuery(RequestsCountQuery query) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
@@ -37,7 +37,7 @@ public class SearchRequestsCountQueryAdapter {
     }
 
     private static JsonObject buildEntrypointIdAggregate() {
-        return JsonObject.of("entrypoints", JsonObject.of("terms", JsonObject.of("field", "entrypoint-id")));
+        return JsonObject.of("entrypoints", JsonObject.of("terms", JsonObject.of("field", "entrypoint-id.keyword")));
     }
 
     private static JsonObject buildElasticQuery(RequestsCountQuery query) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
@@ -46,7 +46,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                        "aggs": {
                          "entrypoints_agg": {
                            "terms": {
-                             "field": "entrypoint-id.keyword"
+                             "field": "entrypoint-id"
                            },
                            "aggs": {
                              "avg_ended_request_duration_ms": {
@@ -62,21 +62,24 @@ class SearchAverageConnectionDurationQueryAdapterTest {
 
     @Test
     void should_build_query_without_filter() {
-        var result = SearchAverageConnectionDurationQueryAdapter.adapt(null);
+        var result = SearchAverageConnectionDurationQueryAdapter.adapt(null, true);
 
         assertThatJson(result).isEqualTo(QUERY_WITHOUT_FILTER);
     }
 
     @Test
     void should_build_query_with_empty_filter() {
-        var result = SearchAverageConnectionDurationQueryAdapter.adapt(AverageConnectionDurationQuery.builder().build());
+        var result = SearchAverageConnectionDurationQueryAdapter.adapt(AverageConnectionDurationQuery.builder().build(), true);
 
         assertThatJson(result).isEqualTo(QUERY_WITHOUT_FILTER);
     }
 
     @Test
     void should_build_query_with_api_filter() {
-        var result = SearchAverageConnectionDurationQueryAdapter.adapt(AverageConnectionDurationQuery.builder().apiId("api-id").build());
+        var result = SearchAverageConnectionDurationQueryAdapter.adapt(
+            AverageConnectionDurationQuery.builder().apiId("api-id").build(),
+            true
+        );
 
         assertThatJson(result)
             .isEqualTo(
@@ -93,6 +96,44 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                                      {
                                        "term": {
                                          "api-id": "api-id"
+                                       }
+                                     }
+                                   ]
+                                 }
+                               },
+                               "aggs": {
+                                 "entrypoints_agg": {
+                                   "terms": {
+                                     "field": "entrypoint-id"
+                                   },
+                                   "aggs": {
+                                     "avg_ended_request_duration_ms": {
+                                       "avg": {
+                                         "field": "gateway-response-time-ms"
+                                       }
+                                     }
+                                   }
+                                 }
+                               }
+                             }
+                             """
+            );
+    }
+
+    @Test
+    void should_adapt_the_query_when_entrypoint_id_is_not_a_keyword() {
+        var result = SearchAverageConnectionDurationQueryAdapter.adapt(AverageConnectionDurationQuery.builder().build(), false);
+
+        assertThatJson(result)
+            .isEqualTo(
+                """
+                             {
+                               "query": {
+                                 "bool": {
+                                   "must": [
+                                     {
+                                       "term": {
+                                         "request-ended": "true"
                                        }
                                      }
                                    ]

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
@@ -46,7 +46,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                        "aggs": {
                          "entrypoints_agg": {
                            "terms": {
-                             "field": "entrypoint-id"
+                             "field": "entrypoint-id.keyword"
                            },
                            "aggs": {
                              "avg_ended_request_duration_ms": {
@@ -101,7 +101,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
                                "aggs": {
                                  "entrypoints_agg": {
                                    "terms": {
-                                     "field": "entrypoint-id"
+                                     "field": "entrypoint-id.keyword"
                                    },
                                    "aggs": {
                                      "avg_ended_request_duration_ms": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationResponseAdapterTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.elasticsearch.model.Aggregation;
 import io.gravitee.elasticsearch.model.SearchResponse;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -81,6 +82,16 @@ class SearchAverageConnectionDurationResponseAdapterTest {
                 assertThat(countAggregate.getAverage()).isEqualTo(expectedCount);
                 assertThat(countAggregate.getAverageBy()).containsAllEntriesOf(buckets);
             });
+    }
+
+    @Test
+    void should_return_empty_result_if_bucket_is_empty() {
+        final SearchResponse searchResponse = new SearchResponse();
+        final Aggregation aggregation = new Aggregation();
+        searchResponse.setAggregations(Map.of(ENTRYPOINTS_AGG, aggregation));
+        aggregation.setBuckets(Collections.emptyList());
+
+        assertThat(SearchAverageConnectionDurationResponseAdapter.adapt(searchResponse)).isEmpty();
     }
 
     private static Stream<Arguments> provideSearchData() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
@@ -35,7 +35,7 @@ class SearchRequestsCountQueryAdapterTest {
               {
                   "aggs": {
                       "entrypoints": {
-                              "terms": {"field":"entrypoint-id"}
+                              "terms": {"field":"entrypoint-id.keyword"}
                       }
                   }
               }
@@ -74,7 +74,7 @@ class SearchRequestsCountQueryAdapterTest {
                                     },
                                     "aggs": {
                                         "entrypoints": {
-                                                "terms": {"field":"entrypoint-id"}
+                                                "terms": {"field":"entrypoint-id.keyword"}
                                         }
                                     }
                                 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
@@ -35,7 +35,7 @@ class SearchRequestsCountQueryAdapterTest {
               {
                   "aggs": {
                       "entrypoints": {
-                              "terms": {"field":"entrypoint-id.keyword"}
+                              "terms": {"field":"entrypoint-id"}
                       }
                   }
               }
@@ -43,21 +43,21 @@ class SearchRequestsCountQueryAdapterTest {
 
     @Test
     void should_build_query_without_filter() {
-        var result = SearchRequestsCountQueryAdapter.adapt(null);
+        var result = SearchRequestsCountQueryAdapter.adapt(null, true);
 
         assertThatJson(result).isEqualTo(QUERY_WITHOUT_FILTER);
     }
 
     @Test
     void should_build_query_with_empty_filter() {
-        var result = SearchRequestsCountQueryAdapter.adapt(RequestsCountQuery.builder().build());
+        var result = SearchRequestsCountQueryAdapter.adapt(RequestsCountQuery.builder().build(), true);
 
         assertThatJson(result).isEqualTo(QUERY_WITHOUT_FILTER);
     }
 
     @Test
     void should_build_query_with_api_filter() {
-        var result = SearchRequestsCountQueryAdapter.adapt(RequestsCountQuery.builder().apiId("api-id").build());
+        var result = SearchRequestsCountQueryAdapter.adapt(RequestsCountQuery.builder().apiId("api-id").build(), true);
 
         assertThatJson(result)
             .isEqualTo(
@@ -74,11 +74,38 @@ class SearchRequestsCountQueryAdapterTest {
                                     },
                                     "aggs": {
                                         "entrypoints": {
-                                                "terms": {"field":"entrypoint-id.keyword"}
+                                                "terms": {"field":"entrypoint-id"}
                                         }
                                     }
                                 }
                              """
+            );
+    }
+
+    @Test
+    void should_adapt_the_query_according_when_entrypoint_id_not_keyword() {
+        var result = SearchRequestsCountQueryAdapter.adapt(RequestsCountQuery.builder().apiId("api-id").build(), false);
+
+        assertThatJson(result)
+            .isEqualTo(
+                """
+                        {
+                            "query":{
+                                "bool": {
+                                    "must": [
+                                        {
+                                            "term": {"api-id":"api-id"}
+                                        }
+                                    ]
+                                }
+                            },
+                            "aggs": {
+                                "entrypoints": {
+                                        "terms": {"field":"entrypoint-id.keyword"}
+                                }
+                            }
+                        }
+                     """
             );
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5102

## Description

Avoid error for user running APIM + Elasticsearch in ILM mode. Today if a user upgrade APIM from version 4.3.x to 4.4.x and call the new analytics endpoints an error occurs saying:
```
Unable to search: url[/dev_apim_master-v4-metrics/_search?ignore_unavailable=true] status[400] query[{"query":{"bool":{"must":[{"term":{"api-id":"0e6dab30-df20-437b-adab-30df20a37b43"}}]}},"aggs":{"entrypoints":{"terms":{"field":"entrypoint-id"}}}}] 
response[{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Fielddata is disabled on [entrypoint-id] in [dev_apim_master-v4-metrics-000008]. 
Text fields are not optimised for operations that require per-document field data like aggregations and sorting, 
so these operations are disabled by default. Please use a keyword field instead. 
```

From the official documentation here is a potential fix: https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html#before-enabling-fielddata

Here are screenshots with tests on my local ES & Kibana in ILM mode
![image](https://github.com/gravitee-io/gravitee-api-management/assets/25704259/d08efadc-bbcc-4750-8a91-882211b75d9f)

![image](https://github.com/gravitee-io/gravitee-api-management/assets/25704259/e73b9266-a886-4d55-9769-3bcf51ec4c5b)


## Linked PR:
https://github.com/gravitee-io/gravitee-common-elasticsearch/pull/206

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qxohuactnm.chromatic.com)
<!-- Storybook placeholder end -->
