### PR TITLE
fix: tests following node clean up

### DIFF
--- a/gravitee-apim-common/src/test/java/io/gravitee/apim/common/mapper/HttpClientOptionsMapperTest.java
+++ b/gravitee-apim-common/src/test/java/io/gravitee/apim/common/mapper/HttpClientOptionsMapperTest.java
@@ -44,8 +44,6 @@ class HttpClientOptionsMapperTest {
         assertThat(result.isPipelining()).isEqualTo(VertxHttpClientOptions.DEFAULT_PIPELINING);
         assertThat(result.getMaxConcurrentConnections()).isEqualTo(VertxHttpClientOptions.DEFAULT_MAX_CONCURRENT_CONNECTIONS);
         assertThat(result.isUseCompression()).isEqualTo(VertxHttpClientOptions.DEFAULT_USE_COMPRESSION);
-        assertThat(result.isPropagateClientAcceptEncoding()).isEqualTo(VertxHttpClientOptions.DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING);
-        assertThat(result.isFollowRedirects()).isEqualTo(VertxHttpClientOptions.DEFAULT_FOLLOW_REDIRECTS);
         assertThat(result.isClearTextUpgrade()).isEqualTo(VertxHttpClientOptions.DEFAULT_CLEAR_TEXT_UPGRADE);
         assertThat(result.getVersion()).isEqualTo(VertxHttpClientOptions.DEFAULT_PROTOCOL_VERSION);
     }
@@ -61,8 +59,6 @@ class HttpClientOptionsMapperTest {
             .pipelining(false)
             .maxConcurrentConnections(1)
             .useCompression(false)
-            .propagateClientAcceptEncoding(true)
-            .followRedirects(true)
             .clearTextUpgrade(false)
             .version(ProtocolVersion.HTTP_2)
             .build();
@@ -75,8 +71,6 @@ class HttpClientOptionsMapperTest {
         assertThat(result.isPipelining()).isFalse();
         assertThat(result.getMaxConcurrentConnections()).isOne();
         assertThat(result.isUseCompression()).isFalse();
-        assertThat(result.isPropagateClientAcceptEncoding()).isTrue();
-        assertThat(result.isFollowRedirects()).isTrue();
         assertThat(result.isClearTextUpgrade()).isFalse();
         assertThat(result.getVersion()).isEqualTo(VertxHttpProtocolVersion.HTTP_2);
     }

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -7,6 +7,12 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 
 - Add support for multi-server installation
 - Improve redis ratelimit configuration [issues/9726](https://github.com/gravitee-io/issues/issues/9726). Thanks [@gh0stsrc](https://github.com/gh0stsrc)
+- Add support for JWT authentication in HTTP repository (hybrid gateways 'bridge' client)
+- BREAKING CHANGE: 
+  - `gateway.management.http.trustall` is now `false` by default. Using a public CA or a well configured truststore should still work
+  - `gateway.management.http.username` (and `password`) have been removed to allow JWT auth to be configured. The following must be set from now on:
+    - `gateway.management.http.authentication.type` = `basic`
+    - & `gateway.management.http.authentication.basic.username` (and `password`) 
 
 ### 4.3.4
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.0.0-alpha.12</gravitee-integration-api.version>
-        <gravitee-node.version>5.14.4</gravitee-node.version>
+        <gravitee-node.version>5.14.7</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-364

## Description

With Node 5.14.7 some useless methods were removed from VertxHttpClientOptions, the mapper tests have been adapted accordingly

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xfiupjdxrt.chromatic.com)
<!-- Storybook placeholder end -->
