### PR TITLE
fix: override queryParams when routing to logs

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/analytics/application-analytics.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/analytics/application-analytics.controller.ts
@@ -81,7 +81,12 @@ class ApplicationAnalyticsController {
 
   viewLogs() {
     // update the query parameter
-    this.ngRouter.navigate(['../', 'logs'], { relativeTo: this.activatedRoute });
+    this.ngRouter.navigate(['../', 'logs'], {
+      relativeTo: this.activatedRoute,
+      queryParams: {
+        ...this.activatedRoute.snapshot.queryParams,
+      },
+    });
   }
 }
 ApplicationAnalyticsController.$inject = ['ApplicationService', 'DashboardService', 'ngRouter'];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5245
gravitee-io/issues#9762

## Description

Override queryParams when routing to logs
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gkujtpinsv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7762/console](https://pr.team-apim.gravitee.dev/7762/console)
      Portal: [https://pr.team-apim.gravitee.dev/7762/portal](https://pr.team-apim.gravitee.dev/7762/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7762/api/management](https://pr.team-apim.gravitee.dev/7762/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7762](https://pr.team-apim.gravitee.dev/7762)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7762](https://pr.gateway-v3.team-apim.gravitee.dev/7762)

<!-- Environment placeholder end -->
