### PR TITLE
fix(portal): do not render markdown if description does not exist

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pipes/markdown-description.pipe.ts
+++ b/gravitee-apim-portal-webui/src/app/pipes/markdown-description.pipe.ts
@@ -27,7 +27,7 @@ export class MarkdownDescriptionPipe implements PipeTransform {
   constructor(private configService: ConfigurationService, private markdown: MarkdownService, private sanitizer: DomSanitizer) {}
 
   transform(api: Api): Api {
-    return api
+    return api?.description
       ? {
           ...api,
           description: this.renderDescription(api.description),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5376

## Description

Avoid issue when api description is null.
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7769/console](https://pr.team-apim.gravitee.dev/7769/console)
      Portal: [https://pr.team-apim.gravitee.dev/7769/portal](https://pr.team-apim.gravitee.dev/7769/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7769/api/management](https://pr.team-apim.gravitee.dev/7769/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7769](https://pr.team-apim.gravitee.dev/7769)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7769](https://pr.gateway-v3.team-apim.gravitee.dev/7769)

<!-- Environment placeholder end -->
