### PR TITLE
fix(portal): force angular sync when redoc is loaded

### DIFF
--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -54,7 +54,7 @@
     "messageformat": "2.3.0",
     "ngx-cookie-service": "17.0.0",
     "ngx-translate-messageformat-compiler": "6.5.0",
-    "redoc": "2.1.3",
+    "redoc": "2.1.5",
     "resize-observer-polyfill": "1.5.1",
     "rxjs": "6.5.5",
     "swagger-ui-dist": "5.10.3",

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -189,7 +189,9 @@ export class GvDocumentationComponent implements OnInit, AfterViewInit {
 
   selectPage(pageId: string) {
     const pageToDisplay = this._pages.find(page => page.id === pageId);
-    GvDocumentationComponent.reset(this.treeMenu?.nativeElement);
+    setTimeout(() => {
+      GvDocumentationComponent.reset(this.treeMenu?.nativeElement);
+    }, 0);
     this.currentPage = pageToDisplay;
     this.currentMenuItem = this.findMenuItem(this.menu, pageToDisplay);
   }

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, HostListener, Input, OnDestroy, ViewChild, OnInit } from '@angular/core';
+import { Component, HostListener, Input, OnDestroy, ViewChild, OnInit, ChangeDetectorRef } from '@angular/core';
 import { getCssVar } from '@gravitee/ui-components/src/lib/style';
 
 import { NotificationService } from '../../services/notification.service';
@@ -36,7 +36,7 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
 
   @Input() fragment: string;
 
-  constructor(private notificationService: NotificationService, private pageService: PageService) {}
+  constructor(private cd: ChangeDetectorRef, private notificationService: NotificationService, private pageService: PageService) {}
 
   /**
    * Redoc script is automatically loaded. See `angular.json` scripts section.
@@ -116,6 +116,7 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
       this.notificationService.error('gv-page.swagger.badFormat');
     }
     this.isLoaded = true;
+    this.cd.detectChanges();
     setTimeout(() => {
       const top = ScrollService.getHeaderHeight() + GvDocumentationComponent.PAGE_PADDING_TOP_BOTTOM;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5404

## Description

Angular is not aware that Redoc has already loaded the documentation, and in most cases, a loading icon remains on the UI until the user performs an action (e.g., scrolling).

fixed also documentation left sidebar to always display full content 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rwjwxdwaro.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7789/console](https://pr.team-apim.gravitee.dev/7789/console)
      Portal: [https://pr.team-apim.gravitee.dev/7789/portal](https://pr.team-apim.gravitee.dev/7789/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7789/api/management](https://pr.team-apim.gravitee.dev/7789/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7789](https://pr.team-apim.gravitee.dev/7789)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7789](https://pr.gateway-v3.team-apim.gravitee.dev/7789)

<!-- Environment placeholder end -->
