### PR TITLE
fix(federation): in some case metadata can be null and we throw NPE

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/integration/IntegrationAgentImplTest.java
@@ -370,6 +370,26 @@ class IntegrationAgentImplTest {
                     return true;
                 });
         }
+
+        @Test
+        void should_throw_when_metadata_is_null() {
+            agent
+                .unsubscribe(
+                    INTEGRATION_ID,
+                    ApiDefinitionFixtures.aFederatedApi().toBuilder().id("gravitee-api-id").providerId("api-provider-id").build(),
+                    SubscriptionEntity.builder().id("subscription-id").build()
+                )
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+            var captor = ArgumentCaptor.forClass(Command.class);
+            Mockito.verify(controller).sendCommand(captor.capture(), Mockito.eq(INTEGRATION_ID));
+            assertThat(captor.getValue())
+                .isInstanceOf(UnsubscribeCommand.class)
+                .extracting(Command::getPayload)
+                .isEqualTo(new UnsubscribeCommandPayload("api-provider-id", new Subscription("subscription-id", null, null, Map.of())));
+        }
     }
 
     @NotNull


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5410

## Description

In some case metadata is null, we don't throw NPE in this case.
