### PR TITLE
feat: remove default to vhosts when have access points

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
@@ -156,7 +156,7 @@ describe('ApiCreationV4Component - HTTP Proxy', () => {
       }),
     );
 
-    it('should not allow to disable virtual host when domain restrictions are set', fakeAsync(async () => {
+    it('should allow to disable virtual host when domain restrictions are set', fakeAsync(async () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('PROXY');
       await stepperHelper.fillAndValidateStep2_1_EntrypointsList('PROXY', [
@@ -168,8 +168,7 @@ describe('ApiCreationV4Component - HTTP Proxy', () => {
       httpExpects.expectSchemaGetRequest(httpProxyEntrypoint);
       httpExpects.expectApiGetPortalSettings();
       httpExpects.expectVerifyContextPath();
-      expect(await entrypointsConfig.canSwitchListenerMode()).toEqual(false);
-      httpExpects.expectApiGetPortalSettings();
+      expect(await entrypointsConfig.canSwitchListenerMode()).toEqual(true);
     }));
   });
   describe('API Creation', () => {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
@@ -332,7 +332,7 @@ describe('ApiCreationV4Component - Message', () => {
       httpExpects.expectEndpointsGetRequest([]);
     }));
 
-    it('should not allow to disable virtual host when domain restrictions are set', fakeAsync(async () => {
+    it('should allow to disable virtual host when domain restrictions are set', fakeAsync(async () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('MESSAGE');
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
@@ -351,8 +351,7 @@ describe('ApiCreationV4Component - Message', () => {
       httpExpects.expectVerifyContextPath();
 
       const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
-      expect(await step21Harness.canSwitchListenerMode()).toEqual(false);
-      httpExpects.expectApiGetPortalSettings();
+      expect(await step21Harness.canSwitchListenerMode()).toEqual(true);
     }));
   });
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
@@ -30,13 +30,7 @@
         <div class="step-2-entrypoints-2-config__listeners-context__title">
           <span class="mat-body-strong">Entrypoints context</span>
 
-          <button
-            id="switchListenerType"
-            mat-button
-            type="button"
-            (click)="this.enableVirtualHost = !this.enableVirtualHost"
-            [disabled]="this.enableVirtualHost && this.domainRestrictions.length > 0"
-          >
+          <button id="switchListenerType" mat-button type="button" (click)="this.enableVirtualHost = !this.enableVirtualHost">
             <mat-icon [svgIcon]="enableVirtualHost ? 'gio:cancel' : 'gio:check'"></mat-icon>
             {{ enableVirtualHost ? 'Disable virtual hosts' : 'Enable virtual hosts' }}
           </button>

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -19,7 +19,7 @@ import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms
 import { forkJoin, Observable, Subject } from 'rxjs';
 import { GioFormJsonSchemaComponent, GioJsonSchema, GioLicenseService, License } from '@gravitee/ui-particles-angular';
 import { debounceTime, takeUntil, tap } from 'rxjs/operators';
-import { isEmpty, omitBy } from 'lodash';
+import { omitBy } from 'lodash';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { Step3Endpoints1ListComponent } from '../step-3-endpoints/step-3-endpoints-1-list.component';
@@ -74,8 +74,7 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
       .pipe(
         tap((restrictedDomain) => {
           this.domainRestrictions = restrictedDomain.map((value) => value.domain) || [];
-          this.enableVirtualHost =
-            !isEmpty(this.domainRestrictions) || paths.find((path) => path.host !== undefined || path.overrideAccess !== undefined) != null;
+          this.enableVirtualHost = paths.find((path) => path.host !== undefined || path.overrideAccess !== undefined) != null;
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -29,7 +29,7 @@
               mat-button
               type="button"
               (click)="switchEntrypointsMode()"
-              [disabled]="this.isReadOnly || (this.enableVirtualHost && this.domainRestrictions.length > 1)"
+              [disabled]="this.isReadOnly"
             >
               <mat-icon [svgIcon]="enableVirtualHost ? 'gio:cancel' : 'gio:check'"></mat-icon>
               {{ enableVirtualHost ? 'Disable virtual hosts' : 'Enable virtual hosts' }}

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -334,21 +334,21 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     });
 
     beforeEach(async () => {
-      await createComponent(RESTRICTED_DOMAINS, API, undefined, undefined, false);
+      await createComponent(RESTRICTED_DOMAINS, API, undefined, ['api-definition-u'], false);
     });
 
     afterEach(() => {
       expectApiPathVerify();
     });
 
-    it('should show virtual host and no disable button', async () => {
+    it('should show virtual host and disable button', async () => {
       const listeners = await loader.getHarness(GioFormListenersVirtualHostHarness).then((h) => h.getListenerRows());
       expect(listeners.length).toEqual(1);
       expect(await listeners[0].pathInput.getValue()).toEqual('/context-path');
 
       expect(await listeners[0].hostDomainSuffix.getText()).toEqual('host');
       const harness = await loader.getHarness(ApiEntrypointsV4GeneralHarness);
-      expect(await harness.canToggleListenerMode()).toEqual(false);
+      expect(await harness.canToggleListenerMode()).toEqual(true);
     });
 
     it('should save changes to virtual host', async () => {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.harness.ts
@@ -44,8 +44,8 @@ export class ApiEntrypointsV4GeneralHarness extends ComponentHarness {
 
   async canToggleListenerMode(): Promise<boolean> {
     return this.switchListenerModeLocator()
-      .then((btn) => !btn.isDisabled())
-      .catch((_) => false);
+      .then(async (btn) => btn != null && !(await btn.isDisabled()))
+      .catch(() => false);
   }
 
   async getToggleBtn(): Promise<MatButtonHarness> {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.html
@@ -19,14 +19,7 @@
   <mat-card-content>
     <form [formGroup]="formGroup" *ngIf="formGroup" (ngSubmit)="onSubmit()">
       <div class="title">
-        <button
-          *ngIf="
-            !this.isReadOnly && (!this.virtualHostModeEnabled || (this.virtualHostModeEnabled && this.domainRestrictions.length === 0))
-          "
-          (click)="switchEntrypointMode()"
-          mat-button
-          type="button"
-        >
+        <button *ngIf="!this.isReadOnly" (click)="switchEntrypointMode()" mat-button type="button">
           <ng-container *ngIf="!this.virtualHostModeEnabled"> <mat-icon svgIcon="gio:check"></mat-icon> Enable virtual hosts </ng-container>
           <ng-container *ngIf="this.virtualHostModeEnabled">
             <mat-icon svgIcon="gio:cancel"></mat-icon> Disable virtual hosts

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.spec.ts
@@ -438,14 +438,14 @@ describe('ApiProxyEntrypointsComponent', () => {
       ]);
     });
 
-    it('should not allow to switch to context-path mode', async () => {
+    it('should allow to switch to context-path mode', async () => {
       const api = fakeApiV2({ id: API_ID, proxy: { virtualHosts: [{ path: '/path-foo', host: 'host.io' }, { path: '/path-bar' }] } });
       expectApiGetRequest(api);
       expectApiGetPortalSettings();
       expectVerifyContextPath();
 
       const switchButton = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Disable virtual hosts' }));
-      expect(switchButton.length).toEqual(0);
+      expect(switchButton.length).toEqual(1);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints/api-entrypoints.component.ts
@@ -16,7 +16,7 @@
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
-import { get, isEmpty, isNil } from 'lodash';
+import { get, isNil } from 'lodash';
 import { combineLatest, EMPTY, Subject } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
@@ -172,7 +172,7 @@ export class ApiEntrypointsComponent implements OnInit, OnDestroy {
     this.pathsFormControl = this.formBuilder.control({ value: paths, disabled: this.isReadOnly }, Validators.required);
     this.formGroup.addControl('paths', this.pathsFormControl);
 
-    // virtual host mode is enabled if there are domain restrictions or if there is more than one virtual host or if the first virtual host has a host
-    this.virtualHostModeEnabled = !isEmpty(this.domainRestrictions) || !isNil(get(api, 'proxy.virtualHosts[0].host', null));
+    // virtual host mode is enabled if there is more than one virtual host or if the first virtual host has a host
+    this.virtualHostModeEnabled = !isNil(get(api, 'proxy.virtualHosts[0].host', null));
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -158,7 +158,7 @@
         *gioPermission="{ anyOf: ['api-definition-u'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="!canPromote || isKubernetesOrigin || api.definitionVersion === 'V4' || api.definitionVersion === 'V1'"
+        [disabled]="cannotPromote"
         data-testid="api_info_promote"
         (click)="promoteApi()"
       >

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -455,34 +455,6 @@ describe('ApiGeneralInfoComponent', () => {
         expect(apiQualityInfo).toBeTruthy();
       });
     });
-
-    describe('with multi-tenant installation', () => {
-      beforeEach(() => initComponent('multi-tenant'));
-
-      it('should not be able to promote api ', async () => {
-        const api = fakeApiV2({
-          id: API_ID,
-          name: '🐶 API',
-          apiVersion: '1.0.0',
-          labels: ['label1', 'label2'],
-          categories: ['category1'],
-          originContext: {
-            origin: 'KUBERNETES',
-          },
-        });
-        expectApiGetRequest(api);
-        expectCategoriesGetRequest([
-          { id: 'category1', name: 'Category 1', key: 'category1' },
-          { id: 'category2', name: 'Category 2', key: 'category2' },
-        ]);
-
-        // Wait image to be loaded (fakeAsync is not working with getBase64 🤷‍♂️)
-        await waitImageCheck();
-
-        const button = await loader.getHarness(MatButtonHarness.with({ text: /Promote/ }));
-        expect(await button.isDisabled()).toEqual(true);
-      });
-    });
   });
 
   describe('API V4', () => {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -83,7 +83,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
     canDeprecate: false,
     canDelete: false,
   };
-  public canPromote = false;
+  public cannotPromote = true;
   public canDisplayV4EmulationEngineToggle = false;
 
   public isQualityEnabled = false;
@@ -171,10 +171,11 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
             canDelete: !(api.state === 'STARTED' || api.lifecycleState === 'PUBLISHED'),
           };
           this.canDisplayV4EmulationEngineToggle = (api.definitionVersion != null && api.definitionVersion === 'V2') ?? false;
-          this.canPromote =
-            this.dangerActions.canChangeApiLifecycle &&
-            api.lifecycleState !== 'DEPRECATED' &&
-            this.constants.org.settings.management.installationType !== 'multi-tenant';
+          this.cannotPromote =
+            !(this.dangerActions.canChangeApiLifecycle && api.lifecycleState !== 'DEPRECATED') ||
+            this.isKubernetesOrigin ||
+            api.definitionVersion === 'V4' ||
+            api.definitionVersion === 'V1';
 
           this.apiDetailsForm = new UntypedFormGroup({
             name: new UntypedFormControl(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -188,8 +188,6 @@ public class VerifyApiPathDomainService {
             for (Path path : sanitizedPaths) {
                 if (path.hasHost()) {
                     checkDomainIsValid(path, restrictedDomains);
-                } else {
-                    path.setHost(restrictedDomains.get(0).getDomain());
                 }
             }
             if (!sanitizedPaths.isEmpty() && sanitizedPaths.stream().noneMatch(Path::isOverrideAccess)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainServiceTest.java
@@ -77,7 +77,7 @@ class VerifyApiPathDomainServiceTest {
 
     public static Stream<Arguments> sanitizeHostParams() {
         return Stream.of(
-            Arguments.of(null, "domain.com"),
+            Arguments.of(null, null),
             Arguments.of("domain.com:123", "domain.com:123"),
             Arguments.of("domain.net", "domain.net"),
             Arguments.of("sub.domain.com", "sub.domain.com"),
@@ -125,7 +125,7 @@ class VerifyApiPathDomainServiceTest {
 
     @ParameterizedTest
     @MethodSource("sanitizeHostParams")
-    public void should_set_domain_with_domain_restrictions(String host, String expectedHost) {
+    public void should_check_domain_restrictions_if_host_is_present(String host, String expectedHost) {
         givenExistingRestrictedDomains(ENVIRONMENT_ID, List.of("domain.com", "domain.net", "domain.com:123"));
 
         var res = service.checkAndSanitizeApiPaths(ENVIRONMENT_ID, "api-id", List.of(Path.builder().host(host).path("/path/").build()));
@@ -184,18 +184,6 @@ class VerifyApiPathDomainServiceTest {
             service.checkAndSanitizeApiPaths(ENVIRONMENT_ID, "api-id", List.of(Path.builder().path("/path/").build()))
         );
         assertThat(throwable).isInstanceOf(InvalidPathsException.class);
-    }
-
-    @Test
-    public void should_throw_exception_if_path_already_used_by_api_v2_with_default_host() {
-        givenExistingRestrictedDomains(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
-
-        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV2WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
-
-        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
-            service.checkAndSanitizeApiPaths(ENVIRONMENT_ID, "api-id", List.of(Path.builder().path("/path/").build()))
-        );
-        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(InvalidPathsException.class);
     }
 
     @Test
@@ -283,18 +271,6 @@ class VerifyApiPathDomainServiceTest {
         assertThat(res).hasSize(1);
         assertThat(res.get(0).getPath()).isEqualTo("/path/");
         assertThat(res.get(0).getHost()).isNullOrEmpty();
-    }
-
-    @Test
-    public void should_throw_exception_if_path_already_used_by_api_v4_with_default_host() {
-        givenExistingRestrictedDomains(ENVIRONMENT_ID, List.of("domain.com", "domain.net"));
-
-        givenExistingApis(ENVIRONMENT_ID, Stream.of(buildApiV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("domain.com", "/path/")))));
-
-        var pathAlreadyExistExceptionIfDefaultDomain = catchThrowable(() ->
-            service.checkAndSanitizeApiPaths(ENVIRONMENT_ID, "api-id", List.of(Path.builder().path("/path/").build()))
-        );
-        assertThat(pathAlreadyExistExceptionIfDefaultDomain).isInstanceOf(InvalidPathsException.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1764
https://gravitee.atlassian.net/browse/CJ-1748

## Description

After the re-work done around access points and how they are handled by the gateway (https://github.com/gravitee-io/gravitee-api-management/pull/7621 and https://github.com/gravitee-io/gravitee-api-management/pull/7809), this PR brings the following updates to the apim-console:
 - it removes default and restriction to vhosts when multi-tenancy with access points
 - it allows promotion of v2 APIs in a multi-tenant installations

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hbjpppbrqw.chromatic.com)
<!-- Storybook placeholder end -->
