### PR TITLE
avoid endpoint connectors icons to be cropped in api V4 creation flow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/api-creation-steps-common.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/api-creation-steps-common.component.scss
@@ -41,6 +41,11 @@ $typography: map.get(gio.$mat-theme, typography);
         margin-right: auto;
       }
     }
+
+    .gio-connector-list__option-centered {
+      display: flex;
+      align-items: center;
+    }
   }
 
   &__list-option {
@@ -55,8 +60,9 @@ $typography: map.get(gio.$mat-theme, typography);
   }
 
   &__icon {
-    height: 14px;
-    width: 14px;
+    height: 18px;
+    width: 18px;
+    margin-right: 4px;
   }
 
   &__form-container {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.html
@@ -41,11 +41,13 @@
         >
           <gio-connector-list-option-layout>
             <gio-connector-list-option-layout-title>
-              <mat-icon class="api-creation-v4__icon" [svgIcon]="endpoint.icon"></mat-icon>
-              {{ endpoint.name }}
-              <span class="gio-badge-primary api-creation-v4__badge">New</span>
-              <span class="gio-badge-accent api-creation-v4__badge" *ngIf="endpoint.isEnterprise">Enterprise</span>
-              <span class="gio-badge-warning api-creation-v4__badge" *ngIf="!endpoint.deployed">Not deployed</span>
+              <div class="gio-connector-list__option-centered">
+                <mat-icon class="api-creation-v4__icon" [svgIcon]="endpoint.icon"></mat-icon>
+                {{ endpoint.name }}
+                <span class="gio-badge-primary api-creation-v4__badge">New</span>
+                <span class="gio-badge-accent api-creation-v4__badge" *ngIf="endpoint.isEnterprise">Enterprise</span>
+                <span class="gio-badge-warning api-creation-v4__badge" *ngIf="!endpoint.deployed">Not deployed</span>
+              </div>
             </gio-connector-list-option-layout-title>
 
             <gio-connector-list-option-layout-body>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

avoid endpoint connectors icons to be cropped in api V4 creation flow

Before:
<img width="935" alt="Capture d’écran 2024-06-13 à 16 12 57" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/cfae29cc-d25a-4d35-9139-2648d335a630">

After:
<img width="928" alt="Capture d’écran 2024-06-13 à 16 11 51" src="https://github.com/gravitee-io/gravitee-api-management/assets/25704259/92c21255-210e-4ee7-a10d-4041aa1e9669">

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uwtmrszonk.chromatic.com)
<!-- Storybook placeholder end -->
