### PR TITLE
APIM-3754: Add rest endpoints for api category order

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiCategoryOrderRepository.java
@@ -99,7 +99,10 @@ public class JdbcApiCategoryOrderRepository extends JdbcAbstractFindAllRepositor
                             .toString()
                     )
                 );
-        } catch (TechnicalException e) {
+        } catch (IllegalStateException e) {
+            LOGGER.error("Failed to update api category order", e);
+            throw new IllegalStateException("Failed to update api category order", e);
+        } catch (Exception e) {
             LOGGER.error("Failed to update api category order", e);
             throw new TechnicalException("Failed to update api category order", e);
         }
@@ -166,7 +169,8 @@ public class JdbcApiCategoryOrderRepository extends JdbcAbstractFindAllRepositor
         }
     }
 
-    private Optional<ApiCategoryOrder> findById(String apiId, String categoryId) throws TechnicalException {
+    @Override
+    public Optional<ApiCategoryOrder> findById(String apiId, String categoryId) {
         LOGGER.debug("JdbcApiCategoryOrderRepository.findById({}, {})", apiId, categoryId);
 
         try {
@@ -186,9 +190,8 @@ public class JdbcApiCategoryOrderRepository extends JdbcAbstractFindAllRepositor
             );
             return apiCategories.stream().findFirst();
         } catch (final Exception ex) {
-            final String error = "Failed to find ApiCategoryOrder by id";
-            LOGGER.error(error, ex);
-            throw new TechnicalException(error, ex);
+            LOGGER.error("Failed to find ApiCategoryOrder by id", ex);
+            return Optional.empty();
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
@@ -68,10 +68,7 @@ public class MongoApiCategoryOrderRepository implements ApiCategoryOrderReposito
             throw new IllegalStateException("ApiCategoryOrder must not be null for update");
         }
 
-        internalApiCategoryOrderRepo
-            .findById(
-                ApiCategoryOrderPkMongo.builder().categoryId(apiCategoryOrder.getCategoryId()).apiId(apiCategoryOrder.getApiId()).build()
-            )
+        this.findById(apiCategoryOrder.getApiId(), apiCategoryOrder.getCategoryId())
             .orElseThrow(() ->
                 new IllegalStateException(
                     String.format(
@@ -97,6 +94,15 @@ public class MongoApiCategoryOrderRepository implements ApiCategoryOrderReposito
             LOGGER.error("An error occurred when deleting ApiCategoryOrder [{}, {}]", apiId, categoryId, e);
             throw new TechnicalException("An error occurred when deleting ApiCategoryOrder", e);
         }
+    }
+
+    @Override
+    public Optional<ApiCategoryOrder> findById(String apiId, String categoryId) {
+        LOGGER.error("Finding ApiCategoryOrder by ID [{}, {}]", apiId, categoryId);
+
+        return internalApiCategoryOrderRepo
+            .findById(ApiCategoryOrderPkMongo.builder().categoryId(categoryId).apiId(apiId).build())
+            .map(apiCategoryOrderMongo -> mapper.map(apiCategoryOrderMongo));
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
@@ -51,6 +51,13 @@ public class ApiCategoryOrderRepositoryTest extends AbstractManagementRepository
     }
 
     @Test
+    public void shouldFindById() throws Exception {
+        final Optional<ApiCategoryOrder> optionalCategory = apiCategoryOrderRepository.findById("api-2", "category-2");
+        assertTrue(optionalCategory.isPresent());
+        assertEquals(ApiCategoryOrder.builder().apiId("api-2").categoryId("category-2").order(0).build(), optionalCategory.get());
+    }
+
+    @Test
     public void shouldFindAll() throws Exception {
         final Set<ApiCategoryOrder> optionalCategory = apiCategoryOrderRepository.findAll();
         assertTrue(optionalCategory.size() >= 3);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApi;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CategoryApiMapper {
+    CategoryApiMapper INSTANCE = Mappers.getMapper(CategoryApiMapper.class);
+
+    @Mapping(source = "api.id", target = "id")
+    @Mapping(source = "api.name", target = "name")
+    @Mapping(source = "api.description", target = "description")
+    @Mapping(source = "api.version", target = "apiVersion")
+    @Mapping(source = "api.definitionVersion", target = "definitionVersion")
+    @Mapping(source = "apiCategoryOrder.order", target = "order")
+    @Mapping(target = "accessPaths", expression = "java(computeAccessPaths(api))")
+    CategoryApi map(ApiCategoryOrder apiCategoryOrder, Api api);
+
+    @Named("computeAccessPaths")
+    default List<String> computeAccessPaths(Api api) {
+        if (Objects.isNull(api)) {
+            return List.of();
+        }
+
+        switch (api.getDefinitionVersion()) {
+            case V4 -> {
+                if (Objects.nonNull(api.getApiDefinitionV4()) && Objects.nonNull(api.getApiDefinitionV4().getListeners())) {
+                    Stream<String> tcpListenerHostsStream = api
+                        .getApiDefinitionV4()
+                        .getListeners()
+                        .stream()
+                        .filter(listener -> ListenerType.TCP.equals(listener.getType()))
+                        .map(TcpListener.class::cast)
+                        .flatMap(listener -> listener.getHosts().stream());
+
+                    Stream<String> httpListenerHostsStream = api
+                        .getApiDefinitionV4()
+                        .getListeners()
+                        .stream()
+                        .filter(listener -> ListenerType.HTTP.equals(listener.getType()))
+                        .map(HttpListener.class::cast)
+                        .filter(listener -> Objects.nonNull(listener.getPaths()))
+                        .flatMap(listener -> listener.getPaths().stream())
+                        .map(pathV4 -> Optional.ofNullable(pathV4.getHost()).orElse("") + Optional.ofNullable(pathV4.getPath()).orElse(""));
+
+                    return Stream.concat(tcpListenerHostsStream, httpListenerHostsStream).toList();
+                }
+            }
+            case V2 -> {
+                if (
+                    Objects.nonNull(api.getApiDefinition()) &&
+                    Objects.nonNull(api.getApiDefinition().getProxy()) &&
+                    Objects.nonNull(api.getApiDefinition().getProxy().getVirtualHosts())
+                ) {
+                    var virtualHosts = api.getApiDefinition().getProxy().getVirtualHosts();
+                    if (Objects.nonNull(virtualHosts)) {
+                        return virtualHosts
+                            .stream()
+                            .map(virtualHost ->
+                                Optional.ofNullable(virtualHost.getHost()).orElse("") +
+                                Optional.ofNullable(virtualHost.getPath()).orElse("")
+                            )
+                            .toList();
+                    }
+                }
+            }
+        }
+        return List.of();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoriesResource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category;
+
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+public class CategoriesResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("{categoryIdOrKey}")
+    public CategoryResource getCategoryResource() {
+        return resourceContext.getResource(CategoryResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryResource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category;
+
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.category.api.CategoryApisResource;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+public class CategoryResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("apis")
+    public CategoryApisResource getCategoryApisResource() {
+        return resourceContext.getResource(CategoryApisResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApiResource.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category.api;
+
+import io.gravitee.apim.core.category.use_case.UpdateCategoryApiOrderUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.CategoryApiMapper;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateCategoryApi;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import java.util.Objects;
+
+public class CategoryApiResource extends AbstractResource {
+
+    @PathParam("categoryIdOrKey")
+    String categoryIdOrKey;
+
+    @PathParam("apiId")
+    String apiId;
+
+    @Inject
+    UpdateCategoryApiOrderUseCase updateCategoryApiOrderUseCase;
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = { RolePermissionAction.UPDATE }) })
+    public Response updateCategoryApi(@Valid UpdateCategoryApi updateCategoryApi) {
+        if (Objects.isNull(updateCategoryApi)) {
+            throw new BadRequestException("Order cannot be null");
+        }
+
+        var result =
+            this.updateCategoryApiOrderUseCase.execute(
+                    new UpdateCategoryApiOrderUseCase.Input(
+                        GraviteeContext.getExecutionContext(),
+                        categoryIdOrKey,
+                        apiId,
+                        getAuthenticatedUser(),
+                        isAdmin(),
+                        updateCategoryApi.getOrder().intValue()
+                    )
+                )
+                .result();
+
+        return Response.ok().entity(CategoryApiMapper.INSTANCE.map(result.apiCategoryOrder(), result.api())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/category/api/CategoryApisResource.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category.api;
+
+import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.CategoryApiMapper;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApi;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApisResponse;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+public class CategoryApisResource extends AbstractResource {
+
+    @PathParam("categoryIdOrKey")
+    String categoryIdOrKey;
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private GetCategoryApisUseCase getCategoryApisUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = { RolePermissionAction.READ }) })
+    public Response getCategoryApisPage(@BeanParam @Valid PaginationParam paginationParam) {
+        var output = getCategoryApisUseCase.execute(
+            new GetCategoryApisUseCase.Input(GraviteeContext.getExecutionContext(), categoryIdOrKey, getAuthenticatedUser(), isAdmin())
+        );
+
+        List<CategoryApi> data = output
+            .results()
+            .stream()
+            .map(result -> CategoryApiMapper.INSTANCE.map(result.apiCategoryOrder(), result.api()))
+            .toList();
+
+        var paginationData = computePaginationData(data, paginationParam);
+
+        return Response
+            .ok()
+            .entity(
+                CategoryApisResponse
+                    .builder()
+                    .data(paginationData)
+                    .pagination(PaginationInfo.computePaginationInfo(output.results().size(), paginationData.size(), paginationParam))
+                    .build()
+            )
+            .build();
+    }
+
+    @Path("{apiId}")
+    public CategoryApiResource getCategoryApiResource() {
+        return resourceContext.getResource(CategoryApiResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/EnvironmentResource.java
@@ -21,6 +21,8 @@ import io.gravitee.rest.api.management.v2.rest.model.Environment;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApiMembersResource;
 import io.gravitee.rest.api.management.v2.rest.resource.api.ApisResource;
+import io.gravitee.rest.api.management.v2.rest.resource.category.CategoriesResource;
+import io.gravitee.rest.api.management.v2.rest.resource.category.CategoryResource;
 import io.gravitee.rest.api.management.v2.rest.resource.group.GroupsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.ui.ThemesResource;
 import io.gravitee.rest.api.service.EnvironmentService;
@@ -60,6 +62,11 @@ public class EnvironmentResource extends AbstractResource {
     @Path("/ui/themes")
     public ThemesResource getThemesResource() {
         return resourceContext.getResource(ThemesResource.class);
+    }
+
+    @Path("/categories")
+    public CategoriesResource getCategoriesResource() {
+        return resourceContext.getResource(CategoriesResource.class);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -64,6 +64,8 @@ tags:
       description: Everything about groups
     - name: Integration
       description: Everything about integration
+    - name: Categories
+      description: Everything about categories
 
 paths:
     # APIs
@@ -2270,6 +2272,53 @@ paths:
                                 $ref: "#/components/schemas/Page"
                 default:
                     $ref: "#/components/responses/Error"
+
+    # Categories
+
+    /environments/{envId}/categories/{categoryIdOrKey}/apis:
+      parameters:
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/categoryIdOrKeyParam"
+      get:
+        tags:
+          - Categories
+        parameters:
+          - $ref: "#/components/parameters/pageParam"
+          - $ref: "#/components/parameters/perPageParam"
+        description: Page of APIs within a Category
+        operationId: getCategoryApisPage
+        responses:
+          200:
+            $ref: "#/components/responses/CategoryApisResponse"
+          default:
+            $ref: "#/components/responses/Error"
+
+    /environments/{envId}/categories/{categoryIdOrKey}/apis/{apiId}:
+          parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/categoryIdOrKeyParam"
+            - $ref: "#/components/parameters/apiIdParam"
+          post:
+            tags:
+              - Categories
+            description: Update a specified API within a Category
+            operationId: updateCategoryApi
+            requestBody:
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/UpdateCategoryApi"
+              required: true
+            responses:
+              "200":
+                description: The updated CategoryApi
+                content:
+                  application/json:
+                    schema:
+                      $ref: "#/components/schemas/CategoryApi"
+              default:
+                $ref: "#/components/responses/Error"
+
 components:
     schemas:
         Analytics:
@@ -2918,6 +2967,45 @@ components:
             title: "UpdateApiFederated"
             allOf:
                 - $ref: "#/components/schemas/UpdateGenericApi"
+
+        CategoryApi:
+          type: object
+          description: API in a category
+          required:
+            - id
+            - name
+            - apiVersion
+            - definitionVersion
+            - order
+          allOf:
+            - $ref: "#/components/schemas/BaseApi"
+            - type: object
+              properties:
+                apiVersion:
+                  type: string
+                  description: API's version. It's a simple string only used in the portal.
+                  example: v1.0
+                definitionVersion:
+                  $ref: "#/components/schemas/DefinitionVersion"
+                order:
+                  type: number
+                  description: Order of the API in the Category list
+                accessPaths:
+                  type: array
+                  description: List of paths for accessing the API
+                  items:
+                    type: string
+                  example: [/context-path, /context-path-2]
+
+        UpdateCategoryApi:
+          type: object
+          description: Update an API within a Category
+          required:
+            - order
+          properties:
+            order:
+              type: number
+              description: New order for the specified API
 
         ApiDeployment:
             type: object
@@ -6473,6 +6561,13 @@ components:
             description: Id of a request.
             schema:
                 type: string
+        categoryIdOrKeyParam:
+          name: categoryIdOrKey
+          in: path
+          required: true
+          description: Id or Key of a category.
+          schema:
+            type: string
         groupIdParam:
             name: groupId
             in: path
@@ -7185,6 +7280,24 @@ components:
                                 description: Breadcrumb to the root folder. Only returned when parentId is specified.
                                 items:
                                     $ref: "#/components/schemas/Breadcrumb"
+
+        # Category
+        CategoryApisResponse:
+          description: Page of APIs within a Category
+          content:
+            application/json:
+              schema:
+                title: "CategoryApisResponse"
+                properties:
+                  data:
+                    description: List of APIs within a Category.
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CategoryApi"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+                  links:
+                    $ref: "#/components/schemas/Links"
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static assertions.MAPIAssertions.assertThat;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Proxy;
+import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApi;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+public class CategoryApiMapperTest {
+
+    private final CategoryApiMapper mapper = Mappers.getMapper(CategoryApiMapper.class);
+
+    private static final String API_ID = "api-id";
+    private static final String API_NAME = "api-name";
+    private static final String API_DESCRIPTION = "api-description";
+    private static final String API_VERSION = "99";
+    private static final String CAT_ID = "cat-id";
+
+    @Test
+    void should_map_v2_api_with_virtual_hosts() {
+        var virtualHost1 = new VirtualHost();
+        virtualHost1.setHost("host-1");
+        virtualHost1.setPath("/path-2");
+
+        var virtualHost2 = new VirtualHost();
+        virtualHost2.setHost(null);
+        virtualHost2.setPath("/great-path");
+
+        var definition = io.gravitee.definition.model.Api
+            .builder()
+            .definitionVersion(DefinitionVersion.V2)
+            .proxy(Proxy.builder().virtualHosts(List.of(virtualHost1, virtualHost2)).build())
+            .build();
+
+        var apiV2 = Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V2)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .apiDefinition(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV2);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V2)
+            .order(11)
+            .accessPaths(List.of("host-1/path-2", "/great-path"))
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void should_map_v2_api_without_virtual_hosts() {
+        var definition = io.gravitee.definition.model.Api
+            .builder()
+            .definitionVersion(DefinitionVersion.V2)
+            .proxy(Proxy.builder().virtualHosts(List.of()).build())
+            .build();
+
+        var apiV2 = Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V2)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .apiDefinition(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV2);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V2)
+            .order(11)
+            .accessPaths(List.of())
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void should_map_v4_api_with_tcp_listeners() {
+        var tcpListener = TcpListener.builder().hosts(List.of("one-host", "two-host")).build();
+
+        var definition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .listeners(List.of(tcpListener))
+            .build();
+
+        var apiV4 = Api
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionV4(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV4);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .order(11)
+            .accessPaths(List.of("one-host", "two-host"))
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void should_map_v4_api_with_http_listeners() {
+        var httpListener = HttpListener
+            .builder()
+            .paths(List.of(Path.builder().host("host-1").path("/path-2").build(), Path.builder().host(null).path("/great-path").build()))
+            .build();
+
+        var definition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .listeners(List.of(httpListener))
+            .build();
+
+        var apiV4 = Api
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionV4(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV4);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .order(11)
+            .accessPaths(List.of("host-1/path-2", "/great-path"))
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void should_map_v4_api_with_tcp_and_http_listeners() {
+        var tcpListener = TcpListener.builder().hosts(List.of("one-host", "two-host")).build();
+
+        var httpListener = HttpListener
+            .builder()
+            .paths(List.of(Path.builder().host("host-1").path("/path-2").build(), Path.builder().host(null).path("/great-path").build()))
+            .build();
+
+        var definition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .listeners(List.of(tcpListener, httpListener))
+            .build();
+
+        var apiV4 = Api
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionV4(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV4);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .order(11)
+            .accessPaths(List.of("one-host", "two-host", "host-1/path-2", "/great-path"))
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+
+    @Test
+    void should_map_v4_api_with_no_tcp_or_http_listeners() {
+        var definition = io.gravitee.definition.model.v4.Api
+            .builder()
+            .id(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .listeners(List.of())
+            .build();
+
+        var apiV4 = Api
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .description(API_DESCRIPTION)
+            .version(API_VERSION)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionV4(definition)
+            .build();
+
+        var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
+
+        var mappedResult = mapper.map(apiCategoryOrder, apiV4);
+
+        var expectedResult = CategoryApi
+            .builder()
+            .id(API_ID)
+            .name(API_NAME)
+            .apiVersion(API_VERSION)
+            .description(API_DESCRIPTION)
+            .definitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4)
+            .order(11)
+            .accessPaths(List.of())
+            .build();
+
+        assertThat(mappedResult).isNotNull().usingRecursiveAssertion().isEqualTo(expectedResult);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApiResourceTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import assertions.MAPIAssertions;
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.CategoryApiCrudServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.UpdateCategoryApiDomainServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApi;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateCategoryApi;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CategoryApiResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String CAT_ID = "cat-id";
+    private static final String API_ID = "cat-id";
+
+    @Autowired
+    ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService;
+
+    @Autowired
+    ApiQueryServiceInMemory apiQueryServiceInMemory;
+
+    @Autowired
+    CategoryApiCrudServiceInMemory categoryApiCrudServiceInMemory;
+
+    @Autowired
+    UpdateCategoryApiDomainServiceInMemory updateCategoryApiDomainServiceInMemory;
+
+    @Autowired
+    CategoryQueryServiceInMemory categoryQueryServiceInMemory;
+
+    @Autowired
+    ApiCrudServiceInMemory apiCrudServiceInMemory;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENV_ID + "/categories/" + CAT_ID + "/apis/" + API_ID;
+    }
+
+    @BeforeEach
+    void init() {
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENV_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        doReturn(environmentEntity).when(environmentService).findById(ENV_ID);
+        doReturn(environmentEntity).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENV_ID);
+
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        Stream
+            .of(
+                apiAuthorizationDomainService,
+                categoryQueryServiceInMemory,
+                apiQueryServiceInMemory,
+                categoryApiCrudServiceInMemory,
+                updateCategoryApiDomainServiceInMemory,
+                apiCrudService
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class UpdateCategoryApiOrder {
+
+        @Test
+        public void should_return_403_if_incorrect_permissions() {
+            when(
+                permissionService.hasPermission(
+                    eq(GraviteeContext.getExecutionContext()),
+                    eq(RolePermission.ENVIRONMENT_CATEGORY),
+                    eq(ENV_ID),
+                    eq(RolePermissionAction.UPDATE)
+                )
+            )
+                .thenReturn(false);
+
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(FORBIDDEN_403)
+                .asError()
+                .hasHttpStatus(FORBIDDEN_403)
+                .hasMessage("You do not have sufficient rights to access this resource");
+        }
+
+        @Test
+        public void should_return_400_if_missing_body() {
+            final Response response = rootTarget().request().post(Entity.json(null));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Order cannot be null");
+        }
+
+        @Test
+        public void should_return_400_if_order_not_specified() {
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().build()));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasHttpStatus(BAD_REQUEST_400)
+                .hasMessage("Validation error");
+        }
+
+        @Test
+        public void should_return_404_if_category_not_found() {
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(NOT_FOUND_404)
+                .asError()
+                .hasHttpStatus(NOT_FOUND_404)
+                .hasMessage("Category not found.");
+        }
+
+        @Test
+        public void should_return_404_if_api_not_found() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(NOT_FOUND_404)
+                .asError()
+                .hasHttpStatus(NOT_FOUND_404)
+                .hasMessage("Api not found.");
+        }
+
+        @Test
+        public void should_return_400_if_api_not_associated_to_category() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).definitionVersion(DefinitionVersion.V4).build()));
+
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(NOT_FOUND_404)
+                .asError()
+                .hasHttpStatus(NOT_FOUND_404)
+                .hasMessage("Api [cat-id] and Category [cat-id] not associated.");
+        }
+
+        @Test
+        public void should_return_changed_category_api() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+            apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).definitionVersion(DefinitionVersion.V4).build()));
+            var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(0).build();
+
+            categoryApiCrudServiceInMemory.initWith(List.of(apiCategoryOrder));
+            updateCategoryApiDomainServiceInMemory.initWith(categoryApiCrudServiceInMemory.storage());
+
+            final Response response = rootTarget().request().post(Entity.json(UpdateCategoryApi.builder().order(99).build()));
+
+            MAPIAssertions.assertThat(response).hasStatus(OK_200).asEntity(CategoryApi.class).isNotNull();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/category/CategoryApisResourceTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.category;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import assertions.MAPIAssertions;
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCategoryOrderQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.CategoryApisResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CategoryApisResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String CAT_ID = "cat-id";
+
+    @Autowired
+    ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService;
+
+    @Autowired
+    ApiCategoryOrderQueryServiceInMemory categoryApiQueryServiceInMemory;
+
+    @Autowired
+    ApiQueryServiceInMemory apiQueryServiceInMemory;
+
+    @Autowired
+    CategoryQueryServiceInMemory categoryQueryServiceInMemory;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENV_ID + "/categories/" + CAT_ID + "/apis";
+    }
+
+    @BeforeEach
+    void init() {
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENV_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        doReturn(environmentEntity).when(environmentService).findById(ENV_ID);
+        doReturn(environmentEntity).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENV_ID);
+
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        Stream
+            .of(apiAuthorizationDomainService, categoryApiQueryServiceInMemory, categoryQueryServiceInMemory, apiQueryServiceInMemory)
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class GetCategoryApis {
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            when(
+                permissionService.hasPermission(
+                    GraviteeContext.getExecutionContext(),
+                    RolePermission.ENVIRONMENT_CATEGORY,
+                    ENV_ID,
+                    RolePermissionAction.READ
+                )
+            )
+                .thenReturn(false);
+
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(FORBIDDEN_403)
+                .asError()
+                .hasHttpStatus(FORBIDDEN_403)
+                .hasMessage("You do not have sufficient rights to access this resource");
+        }
+
+        @Test
+        void should_throw_error_when_category_does_not_exist() {
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(NOT_FOUND_404)
+                .asError()
+                .hasHttpStatus(NOT_FOUND_404)
+                .hasMessage("Category not found.");
+        }
+
+        @Test
+        void should_return_empty_list_when_no_apis_in_category() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(CategoryApisResponse.class)
+                .hasFieldOrPropertyWithValue("data", List.of());
+        }
+
+        @Test
+        void should_return_page_of_results() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+            categoryApiQueryServiceInMemory.initWith(
+                List.of(
+                    ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                    ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(1).build()
+                )
+            );
+
+            apiQueryServiceInMemory.initWith(
+                List.of(
+                    Api.builder().id("api-1").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build(),
+                    Api.builder().id("api-2").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build()
+                )
+            );
+            final Response response = rootTarget().queryParam("page", 2).queryParam("perPage", 1).request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(CategoryApisResponse.class)
+                .extracting(CategoryApisResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).hasSize(1);
+                    assertThat(list.get(0)).hasFieldOrPropertyWithValue("id", "api-2").hasFieldOrPropertyWithValue("order", 1);
+                });
+        }
+
+        @Test
+        void should_return_all_results() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+            categoryApiQueryServiceInMemory.initWith(
+                List.of(
+                    ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                    ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(1).build()
+                )
+            );
+
+            apiQueryServiceInMemory.initWith(
+                List.of(
+                    Api.builder().id("api-1").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build(),
+                    Api.builder().id("api-2").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build()
+                )
+            );
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(CategoryApisResponse.class)
+                .extracting(CategoryApisResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).hasSize(2);
+                    assertThat(list.get(0)).hasFieldOrPropertyWithValue("id", "api-1").hasFieldOrPropertyWithValue("order", 0);
+                    assertThat(list.get(1)).hasFieldOrPropertyWithValue("id", "api-2").hasFieldOrPropertyWithValue("order", 1);
+                });
+        }
+
+        @Test
+        void should_order_results_by_category_api_order() {
+            categoryQueryServiceInMemory.initWith(List.of(Category.builder().id(CAT_ID).build()));
+            categoryApiQueryServiceInMemory.initWith(
+                List.of(
+                    ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(1).build(),
+                    ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(0).build()
+                )
+            );
+
+            apiQueryServiceInMemory.initWith(
+                List.of(
+                    Api.builder().id("api-1").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build(),
+                    Api.builder().id("api-2").definitionVersion(DefinitionVersion.V4).categories(Set.of(CAT_ID)).build()
+                )
+            );
+            final Response response = rootTarget().request().get();
+
+            MAPIAssertions
+                .assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(CategoryApisResponse.class)
+                .extracting(CategoryApisResponse::getData)
+                .satisfies(list -> {
+                    assertThat(list).hasSize(2);
+                    assertThat(list.get(0)).hasFieldOrPropertyWithValue("id", "api-2").hasFieldOrPropertyWithValue("order", 0);
+                    assertThat(list.get(1)).hasFieldOrPropertyWithValue("id", "api-1").hasFieldOrPropertyWithValue("order", 1);
+                });
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiAuthorizationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiAuthorizationDomainService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Set;
+
+public interface ApiAuthorizationDomainService {
+    Set<String> findIdsByUser(
+        ExecutionContext executionContext,
+        String userId,
+        ApiQueryCriteria apiQueryCriteria,
+        Sortable sortable,
+        boolean manageOnly
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiQueryCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiQueryCriteria.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import java.util.Collection;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ApiQueryCriteria {
+
+    private Collection<String> ids;
+    private String category;
+    private List<String> groups;
+    private String contextPath;
+    private String label;
+    private String state;
+    private Visibility visibility;
+    private String version;
+    private String name;
+    private String tag;
+    private String crossId;
+    private List<ApiLifecycleState> lifecycleStates;
+    private List<DefinitionVersion> definitionVersions;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/crud_service/CategoryApiCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/crud_service/CategoryApiCrudService.java
@@ -13,18 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.api;
+package io.gravitee.apim.core.category.crud_service;
 
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
 import java.util.Optional;
-import java.util.Set;
 
-public interface ApiCategoryOrderRepository extends FindAllRepository<ApiCategoryOrder> {
-    ApiCategoryOrder create(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
-    ApiCategoryOrder update(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
-    void delete(String apiId, String categoryId) throws TechnicalException;
+public interface CategoryApiCrudService {
     Optional<ApiCategoryOrder> findById(String apiId, String categoryId);
-    Set<ApiCategoryOrder> findAllByCategoryId(String categoryId);
-    Set<ApiCategoryOrder> findAllByApiId(String apiId);
+    ApiCategoryOrder get(String apiId, String categoryId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/domain_service/UpdateCategoryApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/domain_service/UpdateCategoryApiDomainService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.domain_service;
+
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+
+public interface UpdateCategoryApiDomainService {
+    void changeOrder(ApiCategoryOrder apiCategoryOrder, int newOrder);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/domain_service/ValidateCategoryDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/domain_service/ValidateCategoryDomainService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.category.exception.CategoryNotFoundException;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.category.query_service.CategoryQueryService;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@DomainService
+@AllArgsConstructor
+public class ValidateCategoryDomainService {
+
+    private CategoryQueryService categoryQueryService;
+
+    /**
+     * Get the id for a category
+     * If no key or id corresponds to categoryIdOrKey, then CategoryNotFoundException thrown.
+     *
+     * @param categoryIdOrKey -- Either the ID or Key of a Category
+     * @param environmentId -- The environmentId of a Category
+     * @return categoryId
+     */
+    public String validateCategoryIdOrKey(String categoryIdOrKey, String environmentId) {
+        if (Objects.isNull(categoryIdOrKey)) {
+            throw new CategoryNotFoundException(null);
+        }
+
+        return this.categoryQueryService.findById(categoryIdOrKey, environmentId)
+            .map(Category::getId)
+            .orElseThrow(() -> new CategoryNotFoundException(categoryIdOrKey));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/exception/ApiAndCategoryNotAssociatedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/exception/ApiAndCategoryNotAssociatedException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+public class ApiAndCategoryNotAssociatedException extends NotFoundDomainException {
+
+    public ApiAndCategoryNotAssociatedException(String apiId, String categoryId) {
+        super(String.format("Api [%s] and Category [%s] not associated.", apiId, categoryId));
+        this.setId(String.format("[%s, %s]", apiId, categoryId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/exception/CategoryNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+public class CategoryNotFoundException extends NotFoundDomainException {
+
+    public CategoryNotFoundException(String id) {
+        super("Category not found.", id);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/model/ApiCategoryOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/model/ApiCategoryOrder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ApiCategoryOrder {
+
+    private String apiId;
+    private String categoryId;
+    private int order;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/query_service/ApiCategoryOrderQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/query_service/ApiCategoryOrderQueryService.java
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.management.api;
+package io.gravitee.apim.core.category.query_service;
 
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.ApiCategoryOrder;
-import java.util.Optional;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
 import java.util.Set;
 
-public interface ApiCategoryOrderRepository extends FindAllRepository<ApiCategoryOrder> {
-    ApiCategoryOrder create(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
-    ApiCategoryOrder update(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
-    void delete(String apiId, String categoryId) throws TechnicalException;
-    Optional<ApiCategoryOrder> findById(String apiId, String categoryId);
+public interface ApiCategoryOrderQueryService {
     Set<ApiCategoryOrder> findAllByCategoryId(String categoryId);
-    Set<ApiCategoryOrder> findAllByApiId(String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/query_service/CategoryQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/query_service/CategoryQueryService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.query_service;
+
+import io.gravitee.apim.core.category.model.Category;
+import java.util.Optional;
+
+public interface CategoryQueryService {
+    Optional<Category> findById(String idOrKey, String environmentId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCase.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.category.domain_service.ValidateCategoryDomainService;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.query_service.ApiCategoryOrderQueryService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetCategoryApisUseCase {
+
+    private final ValidateCategoryDomainService validateCategoryDomainService;
+    private final ApiAuthorizationDomainService apiAuthorizationDomainService;
+    private final ApiCategoryOrderQueryService apiCategoryOrderQueryService;
+    private final ApiQueryService apiQueryService;
+
+    public Output execute(Input input) {
+        var categoryId = validateAndGetCategoryId(input.categoryIdOrKey(), input.executionContext().getEnvironmentId());
+
+        // Get api category orders by category id
+        var apiCategoryOrders = this.apiCategoryOrderQueryService.findAllByCategoryId(categoryId);
+
+        if (apiCategoryOrders.isEmpty()) {
+            return new Output(List.of());
+        }
+
+        var apiCategoryOrderApiIds = extractApiIds(apiCategoryOrders);
+
+        var apis =
+            this.getUserApisByCategoryAndApis(
+                    input.executionContext(),
+                    input.isAdmin(),
+                    input.currentUserId(),
+                    categoryId,
+                    apiCategoryOrderApiIds
+                )
+                .toList();
+
+        var results = mapToResult(apis, apiCategoryOrders).sorted(Comparator.comparingInt(o -> o.apiCategoryOrder.getOrder())).toList();
+
+        return new Output(results);
+    }
+
+    private static Stream<Result> mapToResult(List<Api> apis, Set<ApiCategoryOrder> apiCategoryOrders) {
+        final Map<String, ApiCategoryOrder> apiCategoryOrderByApi = apiCategoryOrders
+            .stream()
+            .collect(Collectors.toMap(ApiCategoryOrder::getApiId, Function.identity()));
+        return apis
+            .stream()
+            .map(api ->
+                Optional
+                    .ofNullable(apiCategoryOrderByApi.get(api.getId()))
+                    .map(apiCategoryOrder -> new Result(apiCategoryOrder, api))
+                    .orElse(null)
+            )
+            .filter(Objects::nonNull);
+    }
+
+    public record Input(ExecutionContext executionContext, String categoryIdOrKey, String currentUserId, boolean isAdmin) {}
+
+    public record Output(List<Result> results) {}
+
+    public record Result(ApiCategoryOrder apiCategoryOrder, Api api) {}
+
+    private Stream<Api> getUserApisByCategoryAndApis(
+        ExecutionContext executionContext,
+        boolean isAdmin,
+        String userId,
+        String categoryId,
+        List<String> apiIds
+    ) {
+        var apiSearchCriteria = ApiSearchCriteria.builder().category(categoryId);
+
+        if (isAdmin) {
+            apiSearchCriteria.ids(apiIds);
+        } else {
+            var apiIdsInUserScope =
+                this.apiAuthorizationDomainService.findIdsByUser(
+                        executionContext,
+                        userId,
+                        ApiQueryCriteria.builder().ids(apiIds).category(categoryId).build(),
+                        null,
+                        false
+                    );
+            apiSearchCriteria.ids(new ArrayList<>(apiIdsInUserScope));
+        }
+
+        return this.apiQueryService.search(apiSearchCriteria.build(), null, ApiFieldFilter.builder().pictureExcluded(true).build());
+    }
+
+    private static List<String> extractApiIds(Set<ApiCategoryOrder> apiCategoryOrders) {
+        return apiCategoryOrders.stream().map(ApiCategoryOrder::getApiId).toList();
+    }
+
+    private String validateAndGetCategoryId(String categoryIdOrKey, String environmentId) {
+        return this.validateCategoryDomainService.validateCategoryIdOrKey(categoryIdOrKey, environmentId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/UpdateCategoryApiOrderUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/category/use_case/UpdateCategoryApiOrderUseCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.apim.core.category.crud_service.CategoryApiCrudService;
+import io.gravitee.apim.core.category.domain_service.UpdateCategoryApiDomainService;
+import io.gravitee.apim.core.category.domain_service.ValidateCategoryDomainService;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateCategoryApiOrderUseCase {
+
+    private final ValidateCategoryDomainService validateCategoryDomainService;
+    private final ApiAuthorizationDomainService apiAuthorizationDomainService;
+    private final UpdateCategoryApiDomainService updateCategoryApiDomainService;
+    private final ApiCrudService apiCrudService;
+    private final CategoryApiCrudService categoryApiCrudService;
+
+    public Output execute(Input input) {
+        var categoryId = validateAndGetCategoryId(input.categoryIdOrKey(), input.executionContext().getEnvironmentId());
+
+        this.validateUserHasAccessToApi(input.executionContext(), input.userId(), input.isAdmin(), categoryId, input.apiId());
+
+        var apiCategoryOrder = validateAndGetApiCategoryAssociation(categoryId, input.apiId());
+
+        // Change order of api category order
+        this.updateCategoryApiDomainService.changeOrder(apiCategoryOrder, input.newOrder());
+
+        return new Output(
+            new Result(validateAndGetApiCategoryAssociation(categoryId, input.apiId()), this.apiCrudService.get(input.apiId()))
+        );
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String categoryIdOrKey,
+        String apiId,
+        String userId,
+        boolean isAdmin,
+        int newOrder
+    ) {}
+
+    public record Output(Result result) {}
+
+    public record Result(ApiCategoryOrder apiCategoryOrder, Api api) {}
+
+    private void validateUserHasAccessToApi(
+        ExecutionContext executionContext,
+        String userId,
+        boolean isAdmin,
+        String categoryId,
+        String apiId
+    ) {
+        if (!isAdmin) {
+            var apiIdsInUserScope =
+                this.apiAuthorizationDomainService.findIdsByUser(
+                        executionContext,
+                        userId,
+                        ApiQueryCriteria.builder().ids(List.of(apiId)).category(categoryId).build(),
+                        null,
+                        false
+                    );
+            if (apiIdsInUserScope.contains(apiId)) {
+                return;
+            }
+        } else if (this.apiCrudService.existsById(apiId)) {
+            return;
+        }
+
+        throw new ApiNotFoundException(apiId);
+    }
+
+    private String validateAndGetCategoryId(String categoryIdOrKey, String environmentId) {
+        return this.validateCategoryDomainService.validateCategoryIdOrKey(categoryIdOrKey, environmentId);
+    }
+
+    private ApiCategoryOrder validateAndGetApiCategoryAssociation(String categoryId, String apiId) {
+        return this.categoryApiCrudService.get(apiId, categoryId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiQueryCriteriaAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiQueryCriteriaAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.repository.management.model.Visibility;
+import io.gravitee.rest.api.model.api.ApiQuery;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApiQueryCriteriaAdapter {
+    ApiQueryCriteriaAdapter INSTANCE = Mappers.getMapper(ApiQueryCriteriaAdapter.class);
+
+    ApiQuery toRestModel(ApiQueryCriteria apiQueryCriteria);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/CategoryAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/CategoryAdapter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.rest.api.model.CategoryEntity;
+import java.util.Collection;
+import java.util.Set;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CategoryAdapter {
+    CategoryAdapter INSTANCE = Mappers.getMapper(CategoryAdapter.class);
+
+    Category toCoreModel(CategoryEntity categoryEntity);
+
+    ApiCategoryOrder toCoreModel(io.gravitee.repository.management.model.ApiCategoryOrder apiCategoryOrder);
+
+    Set<ApiCategoryOrder> toCoreModel(Collection<io.gravitee.repository.management.model.ApiCategoryOrder> apiCategoryOrders);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/category/CategoryApiCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/category/CategoryApiCrudServiceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.category;
+
+import io.gravitee.apim.core.category.crud_service.CategoryApiCrudService;
+import io.gravitee.apim.core.category.exception.ApiAndCategoryNotAssociatedException;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.infra.adapter.CategoryAdapter;
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
+import java.util.Objects;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryApiCrudServiceImpl implements CategoryApiCrudService {
+
+    private final ApiCategoryOrderRepository apiCategoryOrderRepository;
+
+    public CategoryApiCrudServiceImpl(@Lazy ApiCategoryOrderRepository apiCategoryOrderRepository) {
+        this.apiCategoryOrderRepository = apiCategoryOrderRepository;
+    }
+
+    @Override
+    public Optional<ApiCategoryOrder> findById(String apiId, String categoryId) {
+        if (Objects.isNull(apiId) || Objects.isNull(categoryId)) {
+            throw new ApiAndCategoryNotAssociatedException(apiId, categoryId);
+        }
+        return this.apiCategoryOrderRepository.findById(apiId, categoryId).map(CategoryAdapter.INSTANCE::toCoreModel);
+    }
+
+    @Override
+    public ApiCategoryOrder get(String apiId, String categoryId) {
+        return findById(apiId, categoryId).orElseThrow(() -> new ApiAndCategoryNotAssociatedException(apiId, categoryId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiAuthorizationDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiAuthorizationDomainServiceLegacyWrapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.apim.infra.adapter.ApiQueryCriteriaAdapter;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class ApiAuthorizationDomainServiceLegacyWrapper implements ApiAuthorizationDomainService {
+
+    private final ApiAuthorizationService delegate;
+
+    @Override
+    public Set<String> findIdsByUser(
+        ExecutionContext executionContext,
+        String userId,
+        ApiQueryCriteria apiQueryCriteria,
+        Sortable sortable,
+        boolean manageOnly
+    ) {
+        return this.delegate.findIdsByUser(
+                executionContext,
+                userId,
+                ApiQueryCriteriaAdapter.INSTANCE.toRestModel(apiQueryCriteria),
+                sortable,
+                manageOnly
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/category/UpdateCategoryApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/category/UpdateCategoryApiDomainServiceImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.category;
+
+import io.gravitee.apim.core.category.domain_service.UpdateCategoryApiDomainService;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.rest.api.service.v4.ApiCategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCategoryApiDomainServiceImpl implements UpdateCategoryApiDomainService {
+
+    private final ApiCategoryService delegate;
+
+    @Override
+    public void changeOrder(ApiCategoryOrder apiCategoryOrder, int newOrder) {
+        this.delegate.changeApiOrderInCategory(apiCategoryOrder.getApiId(), apiCategoryOrder.getCategoryId(), newOrder);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/category/ApiCategoryOrderQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/category/ApiCategoryOrderQueryServiceImpl.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.category;
+
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.query_service.ApiCategoryOrderQueryService;
+import io.gravitee.apim.infra.adapter.CategoryAdapter;
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
+import java.util.Set;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ApiCategoryOrderQueryServiceImpl implements ApiCategoryOrderQueryService {
+
+    private final ApiCategoryOrderRepository apiCategoryOrderRepository;
+
+    public ApiCategoryOrderQueryServiceImpl(@Lazy ApiCategoryOrderRepository apiCategoryOrderRepository) {
+        this.apiCategoryOrderRepository = apiCategoryOrderRepository;
+    }
+
+    @Override
+    public Set<ApiCategoryOrder> findAllByCategoryId(String categoryId) {
+        return CategoryAdapter.INSTANCE.toCoreModel(this.apiCategoryOrderRepository.findAllByCategoryId(categoryId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/category/CategoryQueryServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/category/CategoryQueryServiceLegacyWrapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.category;
+
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.category.query_service.CategoryQueryService;
+import io.gravitee.apim.infra.adapter.CategoryAdapter;
+import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class CategoryQueryServiceLegacyWrapper implements CategoryQueryService {
+
+    private final CategoryService categoryService;
+
+    @Override
+    public Optional<Category> findById(String idOrKey, String environmentId) {
+        try {
+            return Optional.of(CategoryAdapter.INSTANCE.toCoreModel(this.categoryService.findById(idOrKey, environmentId)));
+        } catch (CategoryNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiAuthorizationDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiAuthorizationDomainServiceInMemory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ApiAuthorizationDomainServiceInMemory implements ApiAuthorizationDomainService, InMemoryAlternative<Api> {
+
+    final List<Api> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<Api> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Api> storage() {
+        return storage;
+    }
+
+    @Override
+    public Set<String> findIdsByUser(
+        ExecutionContext executionContext,
+        String userId,
+        ApiQueryCriteria apiQueryCriteria,
+        Sortable sortable,
+        boolean manageOnly
+    ) {
+        return storage.stream().map(Api::getId).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCategoryOrderQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCategoryOrderQueryServiceInMemory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.query_service.ApiCategoryOrderQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ApiCategoryOrderQueryServiceInMemory implements ApiCategoryOrderQueryService, InMemoryAlternative<ApiCategoryOrder> {
+
+    private List<ApiCategoryOrder> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<ApiCategoryOrder> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ApiCategoryOrder> storage() {
+        return storage;
+    }
+
+    @Override
+    public Set<ApiCategoryOrder> findAllByCategoryId(String categoryId) {
+        return storage
+            .stream()
+            .filter(apiCategoryOrder -> Objects.equals(categoryId, apiCategoryOrder.getCategoryId()))
+            .collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryApiCrudServiceInMemory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.category.crud_service.CategoryApiCrudService;
+import io.gravitee.apim.core.category.exception.ApiAndCategoryNotAssociatedException;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class CategoryApiCrudServiceInMemory implements CategoryApiCrudService, InMemoryAlternative<ApiCategoryOrder> {
+
+    private final List<ApiCategoryOrder> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<ApiCategoryOrder> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ApiCategoryOrder> storage() {
+        return storage;
+    }
+
+    @Override
+    public Optional<ApiCategoryOrder> findById(String apiId, String categoryId) {
+        return storage
+            .stream()
+            .filter(apiCategoryOrder ->
+                Objects.equals(apiId, apiCategoryOrder.getApiId()) && Objects.equals(categoryId, apiCategoryOrder.getCategoryId())
+            )
+            .findFirst();
+    }
+
+    @Override
+    public ApiCategoryOrder get(String apiId, String categoryId) {
+        return this.findById(apiId, categoryId).orElseThrow(() -> new ApiAndCategoryNotAssociatedException(apiId, categoryId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryQueryServiceInMemory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.category.query_service.CategoryQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class CategoryQueryServiceInMemory implements CategoryQueryService, InMemoryAlternative<Category> {
+
+    private List<Category> storage = new ArrayList<>();
+
+    @Override
+    public void initWith(List<Category> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Category> storage() {
+        return storage;
+    }
+
+    @Override
+    public Optional<Category> findById(String idOrKey, String environmentId) {
+        return storage
+            .stream()
+            .filter(category -> Objects.equals(idOrKey, category.getId()) || (Objects.equals(idOrKey, category.getKey())))
+            .findFirst();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UpdateCategoryApiDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UpdateCategoryApiDomainServiceInMemory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.apim.core.category.crud_service.CategoryApiCrudService;
+import io.gravitee.apim.core.category.domain_service.UpdateCategoryApiDomainService;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.NoArgsConstructor;
+
+public class UpdateCategoryApiDomainServiceInMemory implements UpdateCategoryApiDomainService, InMemoryAlternative<ApiCategoryOrder> {
+
+    private final List<ApiCategoryOrder> storage;
+
+    public UpdateCategoryApiDomainServiceInMemory(CategoryApiCrudServiceInMemory categoryApiCrudService) {
+        this.storage = categoryApiCrudService.storage();
+    }
+
+    public UpdateCategoryApiDomainServiceInMemory() {
+        this.storage = new ArrayList<>();
+    }
+
+    @Override
+    public void initWith(List<ApiCategoryOrder> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ApiCategoryOrder> storage() {
+        return storage;
+    }
+
+    @Override
+    public void changeOrder(ApiCategoryOrder apiCategoryOrder, int newOrder) {
+        OptionalInt index =
+            this.findIndex(
+                    this.storage,
+                    apiCategoryOrder1 ->
+                        Objects.equals(apiCategoryOrder.getCategoryId(), apiCategoryOrder1.getCategoryId()) &&
+                        Objects.equals(apiCategoryOrder.getApiId(), apiCategoryOrder1.getApiId())
+                );
+        if (index.isPresent()) {
+            apiCategoryOrder.setOrder(newOrder);
+            storage.set(index.getAsInt(), apiCategoryOrder);
+            return;
+        }
+        throw new IllegalStateException("ApiCategoryOrder not found");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -16,7 +16,6 @@
 package inmemory.spring;
 
 import inmemory.*;
-import io.gravitee.apim.core.api.domain_service.ApiCRDExportDomainService;
 import io.gravitee.apim.infra.query_service.audit.AuditEventQueryServiceImpl;
 import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
@@ -278,5 +277,30 @@ public class InMemoryConfiguration {
     @Bean
     public TagQueryServiceInMemory tagQueryService() {
         return new TagQueryServiceInMemory();
+    }
+
+    @Bean
+    public ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService() {
+        return new ApiAuthorizationDomainServiceInMemory();
+    }
+
+    @Bean
+    public ApiCategoryOrderQueryServiceInMemory categoryApiQueryService() {
+        return new ApiCategoryOrderQueryServiceInMemory();
+    }
+
+    @Bean
+    public CategoryQueryServiceInMemory categoryQueryService() {
+        return new CategoryQueryServiceInMemory();
+    }
+
+    @Bean
+    public CategoryApiCrudServiceInMemory categoryApiCrudService() {
+        return new CategoryApiCrudServiceInMemory();
+    }
+
+    @Bean
+    public UpdateCategoryApiDomainServiceInMemory updateCategoryApiDomainService() {
+        return new UpdateCategoryApiDomainServiceInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/category/use_case/GetCategoryApisUseCaseTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.use_case;
+
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCategoryOrderQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.domain_service.ValidateCategoryDomainService;
+import io.gravitee.apim.core.category.exception.CategoryNotFoundException;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetCategoryApisUseCaseTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("ORG_ID", "ENV_ID");
+    private static final String CAT_ID = "cat-id";
+    private static final String USER_ID = "user-id";
+
+    ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService = new ApiAuthorizationDomainServiceInMemory();
+    ApiCategoryOrderQueryServiceInMemory apiCategoryOrderQueryService = new ApiCategoryOrderQueryServiceInMemory();
+    ApiQueryServiceInMemory apiQueryServiceInMemory = new ApiQueryServiceInMemory();
+    CategoryQueryServiceInMemory categoryQueryService = new CategoryQueryServiceInMemory();
+    ValidateCategoryDomainService validateCategoryDomainService;
+    GetCategoryApisUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        validateCategoryDomainService = new ValidateCategoryDomainService(categoryQueryService);
+        useCase =
+            new GetCategoryApisUseCase(
+                validateCategoryDomainService,
+                apiAuthorizationDomainService,
+                apiCategoryOrderQueryService,
+                apiQueryServiceInMemory
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(apiAuthorizationDomainService, apiCategoryOrderQueryService, apiQueryServiceInMemory, apiCategoryOrderQueryService)
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_throw_error_when_category_id_is_null() {
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, null, USER_ID, false))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(CategoryNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_error_when_category_id_not_found() {
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, false))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(CategoryNotFoundException.class);
+    }
+
+    @Test
+    void should_return_empty_lists_if_no_apis_found_in_category() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, false));
+
+        Assertions.assertThat(result).extracting("results").isEqualTo(List.of());
+    }
+
+    @Test
+    void should_search_with_restricted_api_ids_if_not_admin() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCategoryOrderQueryService.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(0).build()
+            )
+        );
+
+        var apiInUserScope = Api.builder().id("api-1").categories(Set.of(CAT_ID)).build();
+        apiAuthorizationDomainService.initWith(List.of(apiInUserScope));
+
+        apiQueryServiceInMemory.initWith(List.of(apiInUserScope, Api.builder().id("api-2").categories(Set.of(CAT_ID)).build()));
+
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, false));
+
+        Assertions
+            .assertThat(result)
+            .extracting("results")
+            .isEqualTo(
+                List.of(
+                    new GetCategoryApisUseCase.Result(
+                        ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                        apiInUserScope
+                    )
+                )
+            );
+    }
+
+    @Test
+    void should_search_with_all_api_ids_in_category_if_admin() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCategoryOrderQueryService.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(0).build()
+            )
+        );
+
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                Api.builder().id("api-1").categories(Set.of(CAT_ID)).build(),
+                Api.builder().id("api-2").categories(Set.of(CAT_ID)).build()
+            )
+        );
+
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, true));
+
+        Assertions.assertThat(result).extracting("results").isEqualTo(List.of(resultForApi("api-1", 0), resultForApi("api-2", 0)));
+    }
+
+    @Test
+    void should_return_empty_list_if_no_apis_in_scope_when_not_admin() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCategoryOrderQueryService.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(0).build()
+            )
+        );
+
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                Api.builder().id("api-1").categories(Set.of(CAT_ID)).build(),
+                Api.builder().id("api-2").categories(Set.of(CAT_ID)).build()
+            )
+        );
+
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, false));
+
+        Assertions.assertThat(result).extracting("results").isEqualTo(List.of());
+    }
+
+    @Test
+    void should_return_empty_lists_if_no_apis_found() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCategoryOrderQueryService.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-2").categoryId(CAT_ID).order(0).build()
+            )
+        );
+
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, true));
+
+        Assertions.assertThat(result).extracting("results").isEqualTo(List.of());
+    }
+
+    @Test
+    void should_return_category_api_list_and_api_list() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCategoryOrderQueryService.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("api-1").categoryId(CAT_ID).order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-2").categoryId("another-category").order(0).build(),
+                ApiCategoryOrder.builder().apiId("api-3").categoryId(CAT_ID).order(2).build(),
+                ApiCategoryOrder.builder().apiId("api-4").categoryId(CAT_ID).order(1).build(),
+                ApiCategoryOrder.builder().apiId("api-5").categoryId(CAT_ID).order(3).build()
+            )
+        );
+
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                Api.builder().id("api-1").categories(Set.of(CAT_ID)).build(),
+                Api.builder().id("api-3").categories(Set.of(CAT_ID)).build(),
+                Api.builder().id("api-4").categories(Set.of(CAT_ID)).build(),
+                Api.builder().id("api-5").categories(Set.of(CAT_ID)).build()
+            )
+        );
+
+        var result = useCase.execute(new GetCategoryApisUseCase.Input(EXECUTION_CONTEXT, CAT_ID, USER_ID, true));
+
+        Assertions
+            .assertThat(result)
+            .extracting("results")
+            .isEqualTo(List.of(resultForApi("api-1", 0), resultForApi("api-4", 1), resultForApi("api-3", 2), resultForApi("api-5", 3)));
+    }
+
+    private static GetCategoryApisUseCase.@NotNull Result resultForApi(String apiId, int order) {
+        return new GetCategoryApisUseCase.Result(
+            ApiCategoryOrder.builder().apiId(apiId).categoryId(CAT_ID).order(order).build(),
+            Api.builder().id(apiId).categories(Set.of(CAT_ID)).build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/category/use_case/UpdateCategoryApiOrderUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/category/use_case/UpdateCategoryApiOrderUseCaseTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.category.use_case;
+
+import static assertions.CoreAssertions.assertThat;
+
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.CategoryApiCrudServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.UpdateCategoryApiDomainServiceInMemory;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.domain_service.ValidateCategoryDomainService;
+import io.gravitee.apim.core.category.exception.ApiAndCategoryNotAssociatedException;
+import io.gravitee.apim.core.category.exception.CategoryNotFoundException;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UpdateCategoryApiOrderUseCaseTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("ORG_ID", "ENV_ID");
+    private static final String CAT_ID = "cat-id";
+    private static final String USER_ID = "user-id";
+    private static final String API_ID = "api-id";
+
+    ValidateCategoryDomainService validateCategoryDomainService;
+    ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService = new ApiAuthorizationDomainServiceInMemory();
+    UpdateCategoryApiDomainServiceInMemory updateCategoryApiDomainService;
+    CategoryQueryServiceInMemory categoryQueryService = new CategoryQueryServiceInMemory();
+    ApiCrudServiceInMemory apiCrudServiceInMemory = new ApiCrudServiceInMemory();
+    CategoryApiCrudServiceInMemory categoryApiCrudService = new CategoryApiCrudServiceInMemory();
+
+    UpdateCategoryApiOrderUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        updateCategoryApiDomainService = new UpdateCategoryApiDomainServiceInMemory(categoryApiCrudService);
+        validateCategoryDomainService = new ValidateCategoryDomainService(categoryQueryService);
+        useCase =
+            new UpdateCategoryApiOrderUseCase(
+                validateCategoryDomainService,
+                apiAuthorizationDomainService,
+                updateCategoryApiDomainService,
+                apiCrudServiceInMemory,
+                categoryApiCrudService
+            );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(
+                apiAuthorizationDomainService,
+                updateCategoryApiDomainService,
+                categoryQueryService,
+                apiCrudServiceInMemory,
+                categoryApiCrudService
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_throw_error_when_category_id_is_null() {
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, null, API_ID, USER_ID, false, 99))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(CategoryNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_error_when_category_id_not_found() {
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, CAT_ID, API_ID, USER_ID, false, 99))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(CategoryNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_error_if_api_not_in_user_scope() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, CAT_ID, API_ID, USER_ID, false, 99))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_error_if_admin_and_api_not_found() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, CAT_ID, API_ID, USER_ID, true, 99))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_error_if_api_category_order_not_found() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+        var throwable = Assertions.catchThrowable(() ->
+            useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, CAT_ID, API_ID, USER_ID, true, 99))
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(ApiAndCategoryNotAssociatedException.class);
+    }
+
+    @Test
+    void should_return_changed_api_category_order() {
+        categoryQueryService.initWith(List.of(Category.builder().id(CAT_ID).build()));
+        apiCrudServiceInMemory.initWith(List.of(Api.builder().id(API_ID).build()));
+        categoryApiCrudService.initWith(List.of(ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(0).build()));
+
+        var result = useCase.execute(new UpdateCategoryApiOrderUseCase.Input(EXECUTION_CONTEXT, CAT_ID, API_ID, USER_ID, true, 99));
+
+        assertThat(result)
+            .isNotNull()
+            .extracting(UpdateCategoryApiOrderUseCase.Output::result)
+            .extracting(UpdateCategoryApiOrderUseCase.Result::apiCategoryOrder)
+            .extracting(ApiCategoryOrder::getOrder)
+            .isEqualTo(99);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/category/CategoryApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/category/CategoryApiCrudServiceImplTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.category;
+
+import static assertions.CoreAssertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.category.exception.ApiAndCategoryNotAssociatedException;
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
+import io.gravitee.repository.management.model.ApiCategoryOrder;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class CategoryApiCrudServiceImplTest {
+
+    ApiCategoryOrderRepository apiCategoryOrderRepository;
+    CategoryApiCrudServiceImpl service;
+
+    private static final String API_ID = "api-id";
+    private static final String CAT_ID = "cat-id";
+
+    @BeforeEach
+    void setUp() {
+        apiCategoryOrderRepository = mock(ApiCategoryOrderRepository.class);
+        service = new CategoryApiCrudServiceImpl(apiCategoryOrderRepository);
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_get_existing_api_category_order() {
+            var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(99).build();
+
+            when(apiCategoryOrderRepository.findById(eq(API_ID), eq(CAT_ID))).thenReturn(Optional.of(apiCategoryOrder));
+
+            var result = service.get(API_ID, CAT_ID);
+
+            assertThat(result)
+                .isNotNull()
+                .satisfies(res -> {
+                    Assertions.assertEquals(API_ID, res.getApiId());
+                    Assertions.assertEquals(CAT_ID, res.getCategoryId());
+                    Assertions.assertEquals(99, res.getOrder());
+                });
+        }
+
+        @Test
+        void should_throw_exception_when_does_not_exist() {
+            when(apiCategoryOrderRepository.findById(eq(API_ID), eq(CAT_ID))).thenReturn(Optional.empty());
+
+            Assertions.assertThrows(ApiAndCategoryNotAssociatedException.class, () -> service.get(API_ID, CAT_ID));
+        }
+
+        @Test
+        void should_throw_exception_when_category_id_null() {
+            Assertions.assertThrows(ApiAndCategoryNotAssociatedException.class, () -> service.get(API_ID, null));
+        }
+
+        @Test
+        void should_throw_exception_when_api_id_null() {
+            Assertions.assertThrows(ApiAndCategoryNotAssociatedException.class, () -> service.get(null, CAT_ID));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiAuthorizationDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiAuthorizationDomainServiceLegacyWrapperTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.apim.core.api.model.ApiQueryCriteria;
+import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiAuthorizationDomainServiceLegacyWrapperTest {
+
+    private static final String API_ID = "api-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+
+    @Mock
+    ApiAuthorizationService apiAuthorizationService;
+
+    ApiAuthorizationDomainServiceLegacyWrapper service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiAuthorizationDomainServiceLegacyWrapper(apiAuthorizationService);
+    }
+
+    @Test
+    void should_call_legacy_service() {
+        service.findIdsByUser(
+            new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+            "user-id",
+            ApiQueryCriteria.builder().ids(List.of(API_ID)).build(),
+            null,
+            false
+        );
+
+        verify(apiAuthorizationService)
+            .findIdsByUser(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                "user-id",
+                ApiQuery.builder().ids(List.of(API_ID)).build(),
+                null,
+                false
+            );
+    }
+
+    @Test
+    void should_throw_when_validation_fails() {
+        doThrow(new RuntimeException("error")).when(apiAuthorizationService).findIdsByUser(any(), any(), any(), any(), anyBoolean());
+
+        var throwable = Assertions.catchThrowable(() ->
+            service.findIdsByUser(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                "user-id",
+                ApiQueryCriteria.builder().ids(List.of(API_ID)).build(),
+                null,
+                false
+            )
+        );
+
+        Assertions.assertThat(throwable).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/category/ApiCategoryOrderQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/category/ApiCategoryOrderQueryServiceImplTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.category;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
+import io.gravitee.repository.management.model.ApiCategoryOrder;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiCategoryOrderQueryServiceImplTest {
+
+    private static final String CAT_ID = "cat-id";
+
+    @Mock
+    ApiCategoryOrderRepository apiCategoryOrderRepository;
+
+    ApiCategoryOrderQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ApiCategoryOrderQueryServiceImpl(apiCategoryOrderRepository);
+    }
+
+    @Nested
+    class FindAllByCategoryId {
+
+        @Test
+        void should_return_list() {
+            when(apiCategoryOrderRepository.findAllByCategoryId(CAT_ID))
+                .thenReturn(
+                    Set.of(
+                        ApiCategoryOrder.builder().categoryId(CAT_ID).apiId("api-1").order(0).build(),
+                        ApiCategoryOrder.builder().categoryId(CAT_ID).apiId("api-2").order(1).build()
+                    )
+                );
+
+            var foundApiCategories = service.findAllByCategoryId(CAT_ID);
+
+            verify(apiCategoryOrderRepository, times(1)).findAllByCategoryId(CAT_ID);
+            Assertions
+                .assertThat(foundApiCategories)
+                .isNotNull()
+                .hasSize(2)
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    Set.of(
+                        io.gravitee.apim.core.category.model.ApiCategoryOrder.builder().categoryId(CAT_ID).apiId("api-1").order(0).build(),
+                        io.gravitee.apim.core.category.model.ApiCategoryOrder.builder().categoryId(CAT_ID).apiId("api-2").order(1).build()
+                    )
+                );
+        }
+
+        @Test
+        void should_return_empty_list() {
+            when(apiCategoryOrderRepository.findAllByCategoryId(CAT_ID)).thenReturn(Set.of());
+
+            var foundApiCategories = service.findAllByCategoryId(CAT_ID);
+
+            verify(apiCategoryOrderRepository, times(1)).findAllByCategoryId(CAT_ID);
+            Assertions.assertThat(foundApiCategories).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_validation_fails() {
+            doThrow(new RuntimeException("error")).when(apiCategoryOrderRepository).findAllByCategoryId(any());
+
+            var throwable = Assertions.catchThrowable(() -> service.findAllByCategoryId(CAT_ID));
+
+            Assertions.assertThat(throwable).isInstanceOf(RuntimeException.class);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/category/CategoryQueryServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/category/CategoryQueryServiceLegacyWrapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.category;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.rest.api.model.CategoryEntity;
+import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryQueryServiceLegacyWrapperTest {
+
+    private static final String CAT_ID = "cat-id";
+    private static final String CAT_KEY = "cat-key";
+    private static final String CAT_NAME = "cat-name";
+    private static final String ENVIRONMENT_ID = "environment-id";
+
+    @Mock
+    CategoryService categoryService;
+
+    CategoryQueryServiceLegacyWrapper service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CategoryQueryServiceLegacyWrapper(categoryService);
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        void should_return_category() {
+            when(categoryService.findById(CAT_ID, ENVIRONMENT_ID))
+                .thenReturn(CategoryEntity.builder().id(CAT_ID).key(CAT_KEY).name(CAT_NAME).build());
+
+            var optional = service.findById(CAT_ID, ENVIRONMENT_ID);
+
+            verify(categoryService, times(1)).findById(CAT_ID, ENVIRONMENT_ID);
+            Assertions.assertThat(optional).hasValue(Category.builder().id(CAT_ID).key(CAT_KEY).name(CAT_NAME).build());
+        }
+
+        @Test
+        void should_not_find_category() {
+            when(categoryService.findById(CAT_ID, ENVIRONMENT_ID)).thenThrow(new CategoryNotFoundException(CAT_ID));
+
+            var optional = service.findById(CAT_ID, ENVIRONMENT_ID);
+
+            verify(categoryService, times(1)).findById(CAT_ID, ENVIRONMENT_ID);
+            Assertions.assertThat(optional).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_other_error_occurs() {
+            when(categoryService.findById(any(), any())).thenThrow(new TechnicalManagementException(CAT_ID));
+
+            var throwable = Assertions.catchThrowable(() -> service.findById(CAT_ID, ENVIRONMENT_ID));
+
+            Assertions.assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3754
https://gravitee.atlassian.net/browse/APIM-5229

## Description

Create endpoints in `MAPI-v2`:
- Get list of APIs within a category via `/categories/:catIdOrKey/apis`
- Update the order of an API within a category via `POST /categories/:catIdOrKey/apis/:apiId`

Developer note: This would be a good one to test thoroughly locally before merging..........

Next PRs:
- Bring new changes to console: call new endpoint to get Apis + add arrows to change order
- Bring new changes to portal: add order to how Apis are listed
- Bring new changes to portal-next: add order to how Apis are listed

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xtphrvepxa.chromatic.com)
<!-- Storybook placeholder end -->
