### PR TITLE
feat: make repository prob cacheable, add health config

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/healthcheck/ManagementRepositoryProbe.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/healthcheck/ManagementRepositoryProbe.java
@@ -41,6 +41,11 @@ public class ManagementRepositoryProbe implements Probe {
     }
 
     @Override
+    public boolean isCacheable() {
+        return true;
+    }
+
+    @Override
     public CompletableFuture<Result> check() {
         try {
             // Search for an event to check repository connection

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -423,8 +423,11 @@ services:
         users:
           admin: adminadmin
 
-  # The thresholds to determine if a probe is healthy or not
 #  health:
+#    enabled: true
+#    delay: 5000
+#    unit: MILLISECONDS
+  # The thresholds to determine if a probe is healthy or not
 #    threshold:
 #      cpu: # Default is 80%
 #      memory: # Default is 80%

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/healthcheck/ManagementRepositoryProbe.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/healthcheck/ManagementRepositoryProbe.java
@@ -20,6 +20,7 @@ import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import java.util.concurrent.CompletableFuture;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -28,12 +29,18 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class ManagementRepositoryProbe implements Probe {
 
+    @Setter
     @Autowired
     private EventRepository eventRepository;
 
     @Override
     public String id() {
         return "management-repository";
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return true;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/healthcheck/ManagementRepositoryProbeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/healthcheck/ManagementRepositoryProbeTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.repository.healthcheck;
+package io.gravitee.rest.api.repository.healthcheck;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,11 +31,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ManagementRepositoryProbeTest {
 
     @Mock

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.0.0-alpha.14</gravitee-integration-api.version>
-        <gravitee-node.version>5.15.0</gravitee-node.version>
+        <gravitee-node.version>5.16.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
@@ -79,7 +79,7 @@
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-kubernetes.version>3.3.1</gravitee-kubernetes.version>
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
-        <gravitee-cloud-initializer.version>1.0.0-alpha.5</gravitee-cloud-initializer.version>
+        <gravitee-cloud-initializer.version>1.0.0-alpha.6</gravitee-cloud-initializer.version>
         <!-- Other dependencies version -->
         <angus-mail.version>2.0.1</angus-mail.version>
         <angus-activation.version>2.0.0</angus-activation.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-365

## Description

Mark the repository probe as cacheable so the node frameworks know there are and can avoid calling them too many times to reduce pressure on the repository. 
The PR also adds the default health config (commented) since it is now possible to fine-tune the frequency of the HC or completely disable it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-quiyquxnav.chromatic.com)
<!-- Storybook placeholder end -->
