### PR TITLE
fix(console): recreate configuration tab whenever httpConfig form group has changed

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/components/endpoint-http-config/endpoint-http-config.component.spec.ts
@@ -77,6 +77,7 @@ describe('ApiPropertiesComponent', () => {
       },
     };
     component.httpConfigFormGroup = EndpointHttpConfigComponent.getHttpConfigFormGroup(initialEndpointGroupV2, false);
+    component.ngOnChanges();
     fixture.detectChanges();
     endpointHttpConfigHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, EndpointHttpConfigHarness);
   });

--- a/gravitee-apim-console-webui/src/management/api/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/components/endpoint-http-config/endpoint-http-config.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, OnChanges, OnDestroy } from '@angular/core';
 import { asyncScheduler, merge, Subject } from 'rxjs';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { filter, startWith, takeUntil, map, observeOn } from 'rxjs/operators';
@@ -42,7 +42,7 @@ export interface EndpointHttpConfigValue {
   templateUrl: './endpoint-http-config.component.html',
   styleUrls: ['./endpoint-http-config.component.scss'],
 })
-export class EndpointHttpConfigComponent implements OnInit, OnDestroy {
+export class EndpointHttpConfigComponent implements OnDestroy, OnChanges {
   public static getHttpConfigFormGroup(endpointGroup: EndpointGroupV2 | EndpointV2, isReadonly: boolean): UntypedFormGroup {
     const httpClientOptions = new UntypedFormGroup({
       version: new UntypedFormControl({
@@ -196,7 +196,7 @@ export class EndpointHttpConfigComponent implements OnInit, OnDestroy {
 
   constructor(private readonly changeDetectorRef: ChangeDetectorRef) {}
 
-  ngOnInit(): void {
+  ngOnChanges(): void {
     if (!this.httpConfigFormGroup) {
       throw new Error('httpConfigFormGroup input is required');
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5351

## Description

recreate configuration tab whenever httpConfig form group has changed

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/7888/console](https://pr.team-apim.gravitee.dev/7888/console)
      Portal: [https://pr.team-apim.gravitee.dev/7888/portal](https://pr.team-apim.gravitee.dev/7888/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/7888/api/management](https://pr.team-apim.gravitee.dev/7888/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/7888](https://pr.team-apim.gravitee.dev/7888)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/7888](https://pr.gateway-v3.team-apim.gravitee.dev/7888)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-acvnsxhdtg.chromatic.com)
<!-- Storybook placeholder end -->
