### PR TITLE
Apim 5403 fix category management

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiCategoryOrderRepository.java
@@ -17,13 +17,21 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.ApiCategoryOrder;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public interface ApiCategoryOrderRepository extends FindAllRepository<ApiCategoryOrder> {
     ApiCategoryOrder create(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
     ApiCategoryOrder update(ApiCategoryOrder apiCategoryOrder) throws TechnicalException;
-    void delete(String apiId, String categoryId) throws TechnicalException;
+
+    default void delete(String apiId, String categoryId) throws TechnicalException {
+        delete(apiId, List.of(categoryId));
+    }
+
+    void delete(String apiId, Collection<String> categoriesIds) throws TechnicalException;
+
     Optional<ApiCategoryOrder> findById(String apiId, String categoryId);
     Set<ApiCategoryOrder> findAllByCategoryId(String categoryId);
     Set<ApiCategoryOrder> findAllByApiId(String apiId);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -20,7 +20,6 @@ import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfigura
 import io.gravitee.repository.config.TestRepositoryInitializer;
 import java.sql.Connection;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import javax.sql.DataSource;
@@ -42,7 +41,7 @@ import org.springframework.stereotype.Component;
 public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcTestRepositoryInitializer.class);
-    private static final List<String> tablesToTruncate = Arrays.asList(
+    private static final List<String> tablesToTruncate = List.of(
         "apis",
         "keys",
         "key_subscriptions",
@@ -140,10 +139,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "integrations",
         "api_category_orders"
     );
-    private static final List<String> tablesToDrop = concatenate(
-        tablesToTruncate,
-        Arrays.asList("databasechangelog", "databasechangeloglock")
-    );
+    private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));
     private final DataSource dataSource;
     private final String prefix;
     private final String rateLimitPrefix;
@@ -163,7 +159,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
     }
 
     private static <T> List<T> concatenate(List<T> first, List<T> second) {
-        final List result = new ArrayList<>(first.size() + second.size());
+        final List<T> result = new ArrayList<>(first.size() + second.size());
         result.addAll(first);
         result.addAll(second);
         return result;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
@@ -18,17 +18,13 @@ package io.gravitee.repository.mongodb.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
 import io.gravitee.repository.management.model.ApiCategoryOrder;
-import io.gravitee.repository.management.model.Category;
 import io.gravitee.repository.mongodb.management.internal.api.ApiCategoryOrderMongoRepository;
-import io.gravitee.repository.mongodb.management.internal.model.ApiCategoryOrderMongo;
 import io.gravitee.repository.mongodb.management.internal.model.ApiCategoryOrderPkMongo;
-import io.gravitee.repository.mongodb.management.internal.model.CategoryMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,11 +83,15 @@ public class MongoApiCategoryOrderRepository implements ApiCategoryOrderReposito
     }
 
     @Override
-    public void delete(String apiId, String categoryId) throws TechnicalException {
+    public void delete(String apiId, Collection<String> categoriesIds) throws TechnicalException {
         try {
-            internalApiCategoryOrderRepo.deleteById(ApiCategoryOrderPkMongo.builder().categoryId(categoryId).apiId(apiId).build());
+            var toDelete = categoriesIds
+                .stream()
+                .map(categoryId -> ApiCategoryOrderPkMongo.builder().categoryId(categoryId).apiId(apiId).build())
+                .toList();
+            internalApiCategoryOrderRepo.deleteAllById(toDelete);
         } catch (Exception e) {
-            LOGGER.error("An error occurred when deleting ApiCategoryOrder [{}, {}]", apiId, categoryId, e);
+            LOGGER.error("An error occurred when deleting ApiCategoryOrder [{}, {}]", apiId, categoriesIds, e);
             throw new TechnicalException("An error occurred when deleting ApiCategoryOrder", e);
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -200,117 +200,116 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected ApiCategoryOrderRepository apiCategoryOrderRepository;
 
     protected void createModel(Object object) throws TechnicalException {
-        if (object instanceof Application) {
-            applicationRepository.create((Application) object);
-        } else if (object instanceof Api) {
-            apiRepository.create((Api) object);
-        } else if (object instanceof User) {
-            userRepository.create((User) object);
-        } else if (object instanceof Event) {
-            eventRepository.create((Event) object);
-        } else if (object instanceof ApiKey) {
-            final ApiKey apiKey = (ApiKey) object;
+        if (object instanceof Application application) {
+            applicationRepository.create(application);
+        } else if (object instanceof Api api) {
+            apiRepository.create(api);
+        } else if (object instanceof User user) {
+            userRepository.create(user);
+        } else if (object instanceof Event event) {
+            eventRepository.create(event);
+        } else if (object instanceof ApiKey apiKey) {
             apiKeyRepository.create(apiKey);
-        } else if (object instanceof Category) {
-            categoryRepository.create((Category) object);
-        } else if (object instanceof Group) {
-            groupRepository.create((Group) object);
-        } else if (object instanceof Membership) {
-            membershipRepository.create((Membership) object);
-        } else if (object instanceof Plan) {
-            planRepository.create((Plan) object);
-        } else if (object instanceof Tag) {
-            tagRepository.create((Tag) object);
-        } else if (object instanceof Page) {
-            pageRepository.create((Page) object);
-        } else if (object instanceof Subscription) {
-            subscriptionRepository.create((Subscription) object);
-        } else if (object instanceof Tenant) {
-            tenantRepository.create((Tenant) object);
-        } else if (object instanceof Metadata) {
-            metadataRepository.create((Metadata) object);
-        } else if (object instanceof Role) {
-            roleRepository.create((Role) object);
-        } else if (object instanceof Audit) {
-            auditRepository.create((Audit) object);
-        } else if (object instanceof Rating) {
-            ratingRepository.create((Rating) object);
-        } else if (object instanceof RatingAnswer) {
-            ratingAnswerRepository.create((RatingAnswer) object);
-        } else if (object instanceof PortalNotification) {
-            portalNotificationRepository.create((PortalNotification) object);
-        } else if (object instanceof PortalNotificationConfig) {
-            portalNotificationConfigRepository.create((PortalNotificationConfig) object);
-        } else if (object instanceof GenericNotificationConfig) {
-            genericNotificationConfigRepository.create((GenericNotificationConfig) object);
-        } else if (object instanceof Parameter) {
-            parameterRepository.create((Parameter) object);
-        } else if (object instanceof Dictionary) {
-            dictionaryRepository.create((Dictionary) object);
-        } else if (object instanceof ApiHeader) {
-            apiHeaderRepository.create((ApiHeader) object);
-        } else if (object instanceof Command) {
-            commandRepository.create((Command) object);
-        } else if (object instanceof IdentityProvider) {
-            identityProviderRepository.create((IdentityProvider) object);
-        } else if (object instanceof AlertTrigger) {
-            alertRepository.create((AlertTrigger) object);
-        } else if (object instanceof Entrypoint) {
-            entrypointRepository.create((Entrypoint) object);
-        } else if (object instanceof Invitation) {
-            invitationRepository.create((Invitation) object);
-        } else if (object instanceof ClientRegistrationProvider) {
-            clientRegistrationProviderRepository.create((ClientRegistrationProvider) object);
-        } else if (object instanceof Workflow) {
-            workflowRepository.create((Workflow) object);
-        } else if (object instanceof QualityRule) {
-            qualityRuleRepository.create((QualityRule) object);
-        } else if (object instanceof ApiQualityRule) {
-            apiQualityRuleRepository.create((ApiQualityRule) object);
-        } else if (object instanceof Dashboard) {
-            dashboardRepository.create((Dashboard) object);
-        } else if (object instanceof AlertEvent) {
-            alertEventRepository.create((AlertEvent) object);
-        } else if (object instanceof Environment) {
-            environmentRepository.create((Environment) object);
-        } else if (object instanceof Organization) {
-            organizationRepository.create((Organization) object);
-        } else if (object instanceof License) {
-            licenseRepository.create((License) object);
-        } else if (object instanceof Theme) {
-            themeRepository.create((Theme) object);
-        } else if (object instanceof IdentityProviderActivation) {
-            identityProviderActivationRepository.create((IdentityProviderActivation) object);
-        } else if (object instanceof Token) {
-            tokenRepository.create((Token) object);
-        } else if (object instanceof PageRevision) {
-            pageRevisionRepository.create((PageRevision) object);
-        } else if (object instanceof CustomUserField) {
-            customUserFieldsRepository.create((CustomUserField) object);
-        } else if (object instanceof NotificationTemplate) {
-            notificationTemplateRepository.create((NotificationTemplate) object);
-        } else if (object instanceof Ticket) {
-            ticketRepository.create((Ticket) object);
-        } else if (object instanceof Installation) {
-            installationRepository.create((Installation) object);
-        } else if (object instanceof Monitoring) {
+        } else if (object instanceof Category category) {
+            categoryRepository.create(category);
+        } else if (object instanceof Group group) {
+            groupRepository.create(group);
+        } else if (object instanceof Membership membership) {
+            membershipRepository.create(membership);
+        } else if (object instanceof Plan plan) {
+            planRepository.create(plan);
+        } else if (object instanceof Tag tag) {
+            tagRepository.create(tag);
+        } else if (object instanceof Page page) {
+            pageRepository.create(page);
+        } else if (object instanceof Subscription subscription) {
+            subscriptionRepository.create(subscription);
+        } else if (object instanceof Tenant tenant) {
+            tenantRepository.create(tenant);
+        } else if (object instanceof Metadata metadata) {
+            metadataRepository.create(metadata);
+        } else if (object instanceof Role role) {
+            roleRepository.create(role);
+        } else if (object instanceof Audit audit) {
+            auditRepository.create(audit);
+        } else if (object instanceof Rating rating) {
+            ratingRepository.create(rating);
+        } else if (object instanceof RatingAnswer ratingAnswer) {
+            ratingAnswerRepository.create(ratingAnswer);
+        } else if (object instanceof PortalNotification portalNotification) {
+            portalNotificationRepository.create(portalNotification);
+        } else if (object instanceof PortalNotificationConfig portalNotificationConfig) {
+            portalNotificationConfigRepository.create(portalNotificationConfig);
+        } else if (object instanceof GenericNotificationConfig genericNotificationConfig) {
+            genericNotificationConfigRepository.create(genericNotificationConfig);
+        } else if (object instanceof Parameter parameter) {
+            parameterRepository.create(parameter);
+        } else if (object instanceof Dictionary dictionary) {
+            dictionaryRepository.create(dictionary);
+        } else if (object instanceof ApiHeader apiHeader) {
+            apiHeaderRepository.create(apiHeader);
+        } else if (object instanceof Command command) {
+            commandRepository.create(command);
+        } else if (object instanceof IdentityProvider identityProvider) {
+            identityProviderRepository.create(identityProvider);
+        } else if (object instanceof AlertTrigger alertTrigger) {
+            alertRepository.create(alertTrigger);
+        } else if (object instanceof Entrypoint entrypoint) {
+            entrypointRepository.create(entrypoint);
+        } else if (object instanceof Invitation invitation) {
+            invitationRepository.create(invitation);
+        } else if (object instanceof ClientRegistrationProvider clientRegistrationProvider) {
+            clientRegistrationProviderRepository.create(clientRegistrationProvider);
+        } else if (object instanceof Workflow workflow) {
+            workflowRepository.create(workflow);
+        } else if (object instanceof QualityRule qualityRule) {
+            qualityRuleRepository.create(qualityRule);
+        } else if (object instanceof ApiQualityRule apiQualityRule) {
+            apiQualityRuleRepository.create(apiQualityRule);
+        } else if (object instanceof Dashboard apiQualityRule) {
+            dashboardRepository.create(apiQualityRule);
+        } else if (object instanceof AlertEvent alertEvent) {
+            alertEventRepository.create(alertEvent);
+        } else if (object instanceof Environment environment) {
+            environmentRepository.create(environment);
+        } else if (object instanceof Organization organization) {
+            organizationRepository.create(organization);
+        } else if (object instanceof License license) {
+            licenseRepository.create(license);
+        } else if (object instanceof Theme theme) {
+            themeRepository.create(theme);
+        } else if (object instanceof IdentityProviderActivation identityProviderActivation) {
+            identityProviderActivationRepository.create(identityProviderActivation);
+        } else if (object instanceof Token token) {
+            tokenRepository.create(token);
+        } else if (object instanceof PageRevision pageRevision) {
+            pageRevisionRepository.create(pageRevision);
+        } else if (object instanceof CustomUserField customUserField) {
+            customUserFieldsRepository.create(customUserField);
+        } else if (object instanceof NotificationTemplate notificationTemplate) {
+            notificationTemplateRepository.create(notificationTemplate);
+        } else if (object instanceof Ticket ticket) {
+            ticketRepository.create(ticket);
+        } else if (object instanceof Installation installation) {
+            installationRepository.create(installation);
+        } else if (object instanceof Monitoring monitoring) {
             try {
-                nodeMonitoringRepository.create((Monitoring) object).test().await(15, TimeUnit.SECONDS);
+                nodeMonitoringRepository.create(monitoring).test().await(15, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-        } else if (object instanceof Flow) {
-            flowRepository.create((Flow) object);
-        } else if (object instanceof Promotion) {
-            promotionRepository.create((Promotion) object);
-        } else if (object instanceof UpgradeRecord) {
-            upgraderRepository.create((UpgradeRecord) object);
-        } else if (object instanceof AccessPoint) {
-            accessPointRepository.create((AccessPoint) object);
-        } else if (object instanceof Integration) {
-            integrationRepository.create((Integration) object);
-        } else if (object instanceof ApiCategoryOrder) {
-            apiCategoryOrderRepository.create((ApiCategoryOrder) object);
+        } else if (object instanceof Flow flow) {
+            flowRepository.create(flow);
+        } else if (object instanceof Promotion promotion) {
+            promotionRepository.create(promotion);
+        } else if (object instanceof UpgradeRecord upgradeRecord) {
+            upgraderRepository.create(upgradeRecord);
+        } else if (object instanceof AccessPoint accessPoint) {
+            accessPointRepository.create(accessPoint);
+        } else if (object instanceof Integration integration) {
+            integrationRepository.create(integration);
+        } else if (object instanceof ApiCategoryOrder apiCategoryOrder) {
+            apiCategoryOrderRepository.create(apiCategoryOrder);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiCategoryOrderRepositoryTest.java
@@ -15,12 +15,9 @@
  */
 package io.gravitee.repository.management;
 
-import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static org.junit.Assert.*;
 
 import io.gravitee.repository.management.model.ApiCategoryOrder;
-import io.gravitee.repository.management.model.Category;
-import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -39,13 +36,13 @@ public class ApiCategoryOrderRepositoryTest extends AbstractManagementRepository
     }
 
     @Test
-    public void shouldFindAllByCategoryId() throws Exception {
+    public void shouldFindAllByCategoryId() {
         final Set<ApiCategoryOrder> optionalCategory = apiCategoryOrderRepository.findAllByCategoryId("category-1");
         assertEquals(2, optionalCategory.size());
     }
 
     @Test
-    public void shouldFindAllByApiId() throws Exception {
+    public void shouldFindAllByApiId() {
         final Set<ApiCategoryOrder> optionalCategory = apiCategoryOrderRepository.findAllByApiId("api-1");
         assertEquals(1, optionalCategory.size());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CategoryDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CategoryDomainService.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.api.domain_service;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.repository.exceptions.TechnicalException;
+import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -25,4 +27,6 @@ import java.util.Set;
 public interface CategoryDomainService {
     Set<String> toCategoryId(Api api, String environmentId);
     Set<String> toCategoryKey(Api api, String environmentId);
+
+    void updateOrderCategoriesOfApi(String apiId, Collection<String> categoryIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainService.java
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 public class ValidateFederatedApiDomainService {
 
     private final GroupValidationService groupValidationService;
-    private final CategoryDomainService categoryDomainService;
 
     public Api validateAndSanitizeForCreation(final Api api) {
         if (api.getDefinitionVersion() != DefinitionVersion.FEDERATED) {
@@ -47,8 +46,6 @@ public class ValidateFederatedApiDomainService {
             primaryOwnerEntity
         );
         updateApi.setGroups(groupIds);
-
-        updateApi.setCategories(categoryDomainService.toCategoryKey(updateApi, existingApi.getEnvironmentId()));
 
         var lifecycleState = ValidateApiLifecycleService.validateFederatedApiLifecycleState(
             existingApi.getApiLifecycleState(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPrimaryOwnerDomainService.java
@@ -37,8 +37,10 @@ import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @DomainService
+@RequiredArgsConstructor
 public class ApiPrimaryOwnerDomainService {
 
     private final AuditDomainService auditService;
@@ -47,22 +49,6 @@ public class ApiPrimaryOwnerDomainService {
     private final MembershipQueryService membershipQueryService;
     private final RoleQueryService roleQueryService;
     private final UserCrudService userCrudService;
-
-    public ApiPrimaryOwnerDomainService(
-        AuditDomainService auditDomainService,
-        GroupQueryService groupQueryService,
-        MembershipCrudService membershipCrudService,
-        MembershipQueryService membershipQueryService,
-        RoleQueryService roleQueryService,
-        UserCrudService userCrudService
-    ) {
-        this.auditService = auditDomainService;
-        this.groupQueryService = groupQueryService;
-        this.membershipCrudService = membershipCrudService;
-        this.membershipQueryService = membershipQueryService;
-        this.roleQueryService = roleQueryService;
-        this.userCrudService = userCrudService;
-    }
 
     public PrimaryOwnerEntity getApiPrimaryOwner(final String organizationId, String apiId) throws ApiPrimaryOwnerNotFoundException {
         return findPrimaryOwnerRole(organizationId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapterDecorator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapterDecorator.java
@@ -64,6 +64,7 @@ public abstract class ApiAdapterDecorator implements ApiAdapter {
     public FederatedApiEntity toFederatedApiEntity(Api source, PrimaryOwnerEntity primaryOwnerEntity) {
         var api = delegate.toFederatedApiEntity(source, primaryOwnerEntity);
         api.setOriginContext(toOriginContext(source));
+        api.setCategories(source.getCategories());
         return api;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CategoryDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CategoryDomainServiceImpl.java
@@ -17,20 +17,31 @@ package io.gravitee.apim.infra.domain_service.api;
 
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
+import io.gravitee.repository.management.model.ApiCategoryOrder;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
+import java.util.Collection;
 import java.util.Set;
-import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 /**
  * @author Sergii ILLICHEVSKYI (sergii.illichevskyi at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 @Service
-@AllArgsConstructor
 public class CategoryDomainServiceImpl implements CategoryDomainService {
 
     private final CategoryMapper categoryMapper;
+    private final ApiCategoryOrderRepository apiCategoryOrderRepository;
+
+    public CategoryDomainServiceImpl(CategoryMapper categoryMapper, @Lazy ApiCategoryOrderRepository apiCategoryOrderRepository) {
+        this.categoryMapper = categoryMapper;
+        this.apiCategoryOrderRepository = apiCategoryOrderRepository;
+    }
 
     @Override
     public Set<String> toCategoryId(Api api, String environmentId) {
@@ -40,5 +51,21 @@ public class CategoryDomainServiceImpl implements CategoryDomainService {
     @Override
     public Set<String> toCategoryKey(Api api, String environmentId) {
         return categoryMapper.toCategoryKey(environmentId, api.getCategories());
+    }
+
+    @Override
+    public void updateOrderCategoriesOfApi(String apiId, Collection<String> categoryIds) {
+        try {
+            var previousCategories = apiCategoryOrderRepository.findAllByApiId(apiId);
+            apiCategoryOrderRepository.delete(apiId, previousCategories.stream().map(ApiCategoryOrder::getCategoryId).toList());
+
+            int index = 0;
+            for (String categoryId : categoryIds) {
+                ApiCategoryOrder categoryOrder = ApiCategoryOrder.builder().categoryId(categoryId).apiId(apiId).order(index++).build();
+                apiCategoryOrderRepository.create(categoryOrder);
+            }
+        } catch (TechnicalException ex) {
+            log.error("Impossible to update order categories of API", ex);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.service.v4.impl;
 
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -28,7 +27,6 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.*;
-import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -132,7 +130,7 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     @Override
     public Set<GenericApiEntity> findGenericByEnvironmentAndIdIn(final ExecutionContext executionContext, final Set<String> apiIds) {
         if (apiIds.isEmpty()) {
-            return Collections.emptySet();
+            return Set.of();
         }
         ApiCriteria criteria = new ApiCriteria.Builder().ids(apiIds).environmentId(executionContext.getEnvironmentId()).build();
         List<Api> apisFound = apiRepository.search(criteria, ApiFieldFilter.allFields());
@@ -298,16 +296,16 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     }
 
     private List<String> getApiIdPageSubset(Collection<String> ids, Pageable pageable) {
-        Integer numberOfItems = ids.size();
-        Integer numberOfItemPerPage = pageable.getPageSize();
+        int numberOfItems = ids.size();
+        int numberOfItemPerPage = pageable.getPageSize();
 
         if (numberOfItemPerPage == 0 || numberOfItems <= 0) {
             return new ArrayList<>();
         }
 
-        Integer currentPage = pageable.getPageNumber();
+        int currentPage = pageable.getPageNumber();
 
-        Integer startIndex = (currentPage - 1) * numberOfItemPerPage;
+        int startIndex = (currentPage - 1) * numberOfItemPerPage;
 
         if (startIndex >= numberOfItems || currentPage < 1) {
             throw new PaginationInvalidException();
@@ -330,7 +328,7 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         }
         QueryBuilder<GenericApiEntity> searchEngineQueryBuilder = convert(apiQuery);
         if (excludeV4) {
-            searchEngineQueryBuilder.setExcludedFilters(Map.of(FIELD_DEFINITION_VERSION, Arrays.asList(DefinitionVersion.V4.getLabel())));
+            searchEngineQueryBuilder.setExcludedFilters(Map.of(FIELD_DEFINITION_VERSION, List.of(DefinitionVersion.V4.getLabel())));
         }
         Query<GenericApiEntity> searchEngineQuery = searchEngineQueryBuilder.build();
         if (isBlank(searchEngineQuery.getQuery())) {
@@ -430,7 +428,7 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
 
     private Set<GenericApiEntity> toGenericApis(final ExecutionContext executionContext, final List<Api> apis) {
         if (apis == null || apis.isEmpty()) {
-            return Collections.emptySet();
+            return Set.of();
         }
         //find primary owners usernames of each apis
         final List<String> apiIds = apis.stream().map(Api::getId).collect(toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -82,7 +82,6 @@ import io.gravitee.rest.api.service.TopApiService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
-import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeletableException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
@@ -422,7 +421,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                                 .getTags()
                                 .stream()
                                 .filter(tag -> !updateApiEntity.getTags().contains(tag))
-                                .collect(Collectors.toList());
+                                .toList();
                             throw new InvalidDataException(
                                 "Sharding tags " + missingTags + " used by plan '" + planToUpdate.getName() + "'"
                             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -20,7 +20,9 @@ import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.apim.infra.adapter.ApiAdapterDecorator;
+import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
@@ -31,12 +33,12 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.Visibility;
 import io.gravitee.repository.management.model.Workflow;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
-import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.context.IntegrationContext;
 import io.gravitee.rest.api.model.context.KubernetesContext;
 import io.gravitee.rest.api.model.context.OriginContext;
+import io.gravitee.rest.api.model.federation.FederatedApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -159,6 +161,11 @@ public class ApiMapper {
         return apiEntity;
     }
 
+    public FederatedApiEntity federatedToEntity(final Api api, final PrimaryOwnerEntity primaryOwner) {
+        api.setCategories(categoryMapper.toCategoryKey(api.getEnvironmentId(), api.getCategories()));
+        return ApiAdapter.INSTANCE.toFederatedApiEntity(api, PrimaryOwnerAdapter.INSTANCE.fromRestEntity(primaryOwner));
+    }
+
     public ApiEntity toEntity(
         final ExecutionContext executionContext,
         final Api api,
@@ -192,6 +199,15 @@ public class ApiMapper {
         }
 
         return apiEntity;
+    }
+
+    public FederatedApiEntity federatedToEntity(
+        final ExecutionContext executionContext,
+        final Api api,
+        final PrimaryOwnerEntity primaryOwner
+    ) {
+        api.setCategories(categoryMapper.toCategoryKey(executionContext.getEnvironmentId(), api.getCategories()));
+        return ApiAdapter.INSTANCE.toFederatedApiEntity(api, PrimaryOwnerAdapter.INSTANCE.fromRestEntity(primaryOwner));
     }
 
     public Api toRepository(final ExecutionContext executionContext, final NewApiEntity newApiEntity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UpdateCategoryApiDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UpdateCategoryApiDomainServiceInMemory.java
@@ -15,21 +15,12 @@
  */
 package inmemory;
 
-import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
-import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.ApiQueryCriteria;
-import io.gravitee.apim.core.category.crud_service.CategoryApiCrudService;
 import io.gravitee.apim.core.category.domain_service.UpdateCategoryApiDomainService;
 import io.gravitee.apim.core.category.model.ApiCategoryOrder;
-import io.gravitee.rest.api.model.common.Sortable;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
-import java.util.Set;
-import java.util.stream.Collectors;
-import lombok.NoArgsConstructor;
 
 public class UpdateCategoryApiDomainServiceInMemory implements UpdateCategoryApiDomainService, InMemoryAlternative<ApiCategoryOrder> {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateFederatedApiDomainServiceTest.java
@@ -17,7 +17,6 @@ package io.gravitee.apim.core.api.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.Mockito.mock;
 
 import fixtures.core.model.ApiFixtures;
 import inmemory.GroupQueryServiceInMemory;
@@ -38,12 +37,11 @@ class ValidateFederatedApiDomainServiceTest {
     private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
 
     ValidateFederatedApiDomainService service;
-    CategoryDomainService categoryDomainService = mock(CategoryDomainService.class);
 
     @BeforeEach
     void setUp() {
         var groupValidationService = new GroupValidationService(groupQueryService);
-        service = new ValidateFederatedApiDomainService(groupValidationService, categoryDomainService);
+        service = new ValidateFederatedApiDomainService(groupValidationService);
         groupQueryService.initWith(List.of(Group.builder().id("group-1").name("group-1").build()));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
@@ -47,6 +47,7 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
+import io.gravitee.repository.management.api.ApiCategoryOrderRepository;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
 import java.time.Clock;
@@ -86,7 +87,8 @@ class UpdateDynamicPropertiesUseCaseTest {
     private final UserCrudServiceInMemory userCrudServiceInMemory = new UserCrudServiceInMemory();
     private final ApiEventQueryServiceInMemory apiEventQueryServiceInMemory = new ApiEventQueryServiceInMemory();
     CategoryMapper categoryMapper = mock(CategoryMapper.class);
-    CategoryDomainService categoryDomainService = new CategoryDomainServiceImpl(categoryMapper);
+    ApiCategoryOrderRepository apiCategoryOrderRepository = mock(ApiCategoryOrderRepository.class);
+    CategoryDomainService categoryDomainService = new CategoryDomainServiceImpl(categoryMapper, apiCategoryOrderRepository);
 
     private ApiStateDomainService apiStateDomainService;
 
@@ -219,8 +221,8 @@ class UpdateDynamicPropertiesUseCaseTest {
     @Nested
     class WhenApiIsNotSynchronized {
 
-        private ArgumentCaptor<Api> apiCaptor = ArgumentCaptor.forClass(Api.class);
-        private ArgumentCaptor<AuditInfo> auditInfoCaptor = ArgumentCaptor.forClass(AuditInfo.class);
+        private final ArgumentCaptor<Api> apiCaptor = ArgumentCaptor.forClass(Api.class);
+        private final ArgumentCaptor<AuditInfo> auditInfoCaptor = ArgumentCaptor.forClass(AuditInfo.class);
 
         @BeforeEach
         void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
@@ -52,6 +52,7 @@ import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
+import io.gravitee.rest.api.service.v4.ApiCategoryService;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -78,6 +79,7 @@ class UpdateFederatedApiUseCaseTest {
     IndexerInMemory indexer = new IndexerInMemory();
     UpdateFederatedApiUseCase usecase;
     CategoryDomainService categoryDomainService = mock(CategoryDomainService.class);
+    ApiCategoryService apiCategoryService = mock(ApiCategoryService.class);
 
     @BeforeEach
     void setUp() {
@@ -121,14 +123,15 @@ class UpdateFederatedApiUseCaseTest {
             new UpdateFederatedApiUseCase(
                 apiCrudService,
                 apiPrimaryOwnerService,
-                new ValidateFederatedApiDomainService(new GroupValidationService(groupQueryService), categoryDomainService),
+                new ValidateFederatedApiDomainService(new GroupValidationService(groupQueryService)),
                 auditDomainService,
                 new ApiIndexerDomainService(
                     new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
                     apiPrimaryOwnerService,
                     new ApiCategoryQueryServiceInMemory(),
                     indexer
-                )
+                ),
+                categoryDomainService
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestIntegrationApisUseCaseTest.java
@@ -153,7 +153,7 @@ class IngestIntegrationApisUseCaseTest {
     PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
     PageRevisionCrudServiceInMemory pageRevisionCrudService = new PageRevisionCrudServiceInMemory();
 
-    ValidateFederatedApiDomainService validateFederatedApiDomainService = spy(new ValidateFederatedApiDomainService(null, null));
+    ValidateFederatedApiDomainService validateFederatedApiDomainService = spy(new ValidateFederatedApiDomainService(null));
     IngestIntegrationApisUseCase useCase;
 
     @BeforeAll

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiCategoryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiCategoryServiceImplTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -56,7 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -134,8 +133,8 @@ public class ApiCategoryServiceImplTest {
         @Test
         public void shouldThrownManagementExceptionWhenTechnicalExceptionOccurred() throws TechnicalException {
             when(apiRepository.listCategories(any())).thenThrow(new TechnicalException());
-            assertThatExceptionOfType(TechnicalManagementException.class)
-                .isThrownBy(() -> apiCategoryService.listCategories(List.of("api1"), "DEFAULT"));
+            var ex = catchException(() -> apiCategoryService.listCategories(List.of("api1"), "DEFAULT"));
+            assertThat(ex).isInstanceOf(TechnicalManagementException.class);
         }
     }
 
@@ -161,8 +160,8 @@ public class ApiCategoryServiceImplTest {
             verify(apiRepository, times(1)).update(firstOrphan);
             verify(apiRepository, times(1)).update(secondOrphan);
 
-            Assertions.assertEquals(0, firstOrphan.getCategories().size());
-            Assertions.assertEquals(1, secondOrphan.getCategories().size());
+            assertThat(firstOrphan.getCategories()).isEmpty();
+            assertThat(secondOrphan.getCategories()).hasSize(1);
 
             verify(apiCategoryOrderRepository, times(1)).delete(eq(firstOrphan.getId()), eq(categoryId));
             verify(apiCategoryOrderRepository, times(1)).delete(eq(secondOrphan.getId()), eq(categoryId));
@@ -210,8 +209,8 @@ public class ApiCategoryServiceImplTest {
                     any()
                 );
 
-            assertEquals(0, firstOrphan.getCategories().size());
-            assertEquals(1, secondOrphan.getCategories().size());
+            assertThat(firstOrphan.getCategories()).isEmpty();
+            assertThat(secondOrphan.getCategories()).hasSize(1);
         }
     }
 
@@ -252,7 +251,7 @@ public class ApiCategoryServiceImplTest {
             Map<String, Long> expectedCounts = Map.of(category1.getId(), 3L, category2.getId(), 2L, category3.getId(), 1L);
             Map<String, Long> counts = apiCategoryService.countApisPublishedGroupedByCategoriesForUser("user-1");
 
-            assertEquals(expectedCounts, counts);
+            assertThat(counts).isEqualTo(expectedCounts);
         }
     }
 
@@ -450,7 +449,7 @@ public class ApiCategoryServiceImplTest {
             apiCategoryService.updateApiCategories(API_ID, Set.of(CATEGORY_ID));
             verify(apiCategoryOrderRepository, never()).findAllByCategoryId(eq(CATEGORY_ID));
 
-            verify(apiCategoryOrderRepository, times(1)).delete(any(), any());
+            verify(apiCategoryOrderRepository, times(1)).delete(anyString(), anyString());
             verify(apiCategoryOrderRepository, times(1)).delete(eq(API_ID), eq(OTHER_CATEGORY));
 
             verify(apiCategoryOrderRepository, times(1)).update(any());
@@ -484,7 +483,7 @@ public class ApiCategoryServiceImplTest {
             apiCategoryService.updateApiCategories(API_ID, Set.of(CATEGORY_ID, YET_ANOTHER_CATEGORY));
             verify(apiCategoryOrderRepository, never()).findAllByCategoryId(eq(CATEGORY_ID));
 
-            verify(apiCategoryOrderRepository, times(1)).delete(any(), any());
+            verify(apiCategoryOrderRepository, times(1)).delete(anyString(), anyString());
             verify(apiCategoryOrderRepository, times(1)).delete(eq(API_ID), eq(OTHER_CATEGORY));
 
             verify(apiCategoryOrderRepository, times(1)).update(any());
@@ -501,7 +500,7 @@ public class ApiCategoryServiceImplTest {
             apiCategoryService.updateApiCategories(API_ID, null);
             verify(apiCategoryOrderRepository, never()).update(any());
             verify(apiCategoryOrderRepository, never()).create(any());
-            verify(apiCategoryOrderRepository, never()).delete(any(), any());
+            verify(apiCategoryOrderRepository, never()).delete(anyString(), anyString());
         }
     }
 
@@ -524,7 +523,7 @@ public class ApiCategoryServiceImplTest {
 
             apiCategoryService.deleteApiFromCategories(API_ID);
 
-            verify(apiCategoryOrderRepository, times(1)).delete(any(), any());
+            verify(apiCategoryOrderRepository, times(1)).delete(anyString(), anyString());
             verify(apiCategoryOrderRepository, times(1)).delete(eq(API_ID), eq(CATEGORY_ID));
 
             verify(apiCategoryOrderRepository, times(1)).update(any());
@@ -536,7 +535,7 @@ public class ApiCategoryServiceImplTest {
         void shouldDoNothingIfApiHadNoCategories() throws Exception {
             when(apiCategoryOrderRepository.findAllByApiId(eq(API_ID))).thenReturn(Set.of());
             apiCategoryService.deleteApiFromCategories(API_ID);
-            verify(apiCategoryOrderRepository, never()).delete(any(), any());
+            verify(apiCategoryOrderRepository, never()).delete(anyString(), anyString());
             verify(apiCategoryOrderRepository, never()).update(any());
         }
     }


### PR DESCRIPTION
**Issue** [APIM-5403](https://gravitee.atlassian.net/browse/APIM-5403)

## Description

[PR 7864](https://github.com/gravitee-io/gravitee-api-management/pull/7864) we have a bug with storage of categories by key instead of ids.



[APIM-5403]: https://gravitee.atlassian.net/browse/APIM-5403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mvzjznhcmg.chromatic.com)
<!-- Storybook placeholder end -->
