### PR TITLE
fix(test-sdk): load PermissiveLicenseManager as a bootstrap class

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
@@ -41,6 +41,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 /**
  * This class allows to extend the {@link GatewayContainer} in order to override the {@link NodeFactory}
@@ -72,10 +73,28 @@ public class GatewayTestContainer extends GatewayContainer {
     }
 
     @Override
+    protected List<Class<?>> bootstrapClasses() {
+        List<Class<?>> classes = super.bootstrapClasses();
+        classes.add(GatewayTestNodeContainerConfiguration.class);
+        return classes;
+    }
+
+    @Override
     protected void startBootstrapComponents(AnnotationConfigApplicationContext ctx) {
         // Execute operations before starting bootstrap components (e.g.: the boot application context has been created).
         onBootApplicationContextCreated.accept(ctx);
         super.startBootstrapComponents(ctx);
+    }
+
+    @Configuration
+    public static class GatewayTestNodeContainerConfiguration {
+
+        // Force use of the PermissiveLicenseManager
+        @Primary
+        @Bean
+        public LicenseManager licenseManager() {
+            return new PermissiveLicenseManager();
+        }
     }
 
     @Configuration
@@ -159,11 +178,6 @@ public class GatewayTestContainer extends GatewayContainer {
         @Bean
         public MessageStorage messageStorage() {
             return new MessageStorage();
-        }
-
-        @Bean
-        public LicenseManager licenseManager() {
-            return new PermissiveLicenseManager();
         }
     }
 }


### PR DESCRIPTION
## Issue

Testing a plugin with a `feature` license flag in manifest was preventing the policy to load in the gateway container used by the SDK.

Problems come from the fact the `LicenseManager` bean has been configured under `annotatedClasses()` instead of `bootstrapClasses()` from node's `SpringBasedContainer`.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pkrfjwjmqq.chromatic.com)
<!-- Storybook placeholder end -->
