### PR TITLE
fix(console): change import openAPI wording

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4.component.html
@@ -68,7 +68,8 @@
       <div class="import__row">
         <h3>Options</h3>
         <gio-form-slide-toggle
-          ><gio-form-label>Add documentation pages</gio-form-label>Documentation pages use OpenAPI specifications.<mat-slide-toggle
+          ><gio-form-label>Create documentation page from spec</gio-form-label>This will add a documentation page for this API using the
+          OpenAPI spec used during the import. This page will be published automatically (you can change this later).<mat-slide-toggle
             gioFormSlideToggle
             formControlName="withDocumentation"
             aria-label="Toggle to create documentation page"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4328

## Description

Change import openAPI spec label and title

<img width="1021" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/47851994/88e75b8f-4e40-41df-ba3b-9f071defe285">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kejasvgzky.chromatic.com)
<!-- Storybook placeholder end -->
