### PR TITLE
fix: fix NPE happening when updating index after deleting federated api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/search/model/IndexableApi.java
@@ -32,7 +32,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class IndexableApi implements Indexable {
 
-    private Api api;
+    @Builder.Default
+    private Api api = new Api(); // needs to be initialized because some setter requires it
 
     private PrimaryOwnerEntity primaryOwner;
 


### PR DESCRIPTION
## Description

A NPE was thrown while processing a DELETE command updating Lucene index after deleting a Federated API. 
This processing was instantiating an IndexableApi object and then set the id. Before this commit, setting the id was impossible because `api` attribute was null 🙈 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

