### PR TITLE
fix: do not override sync delay with default value

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -480,20 +480,20 @@ services:
   # and management UI
   sync:
     # Synchronization is done each 5 seconds
-    delay: 5000
-    unit: MILLISECONDS
-    repository:
-      enabled : true
-    distributed:
-      enabled : false # By enabling this mode, data synchronization process is distributed over clustered API gateways. You must configure distributed-sync repository.
-    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, API Keys, ...).
+#    delay: 5000
+#    unit: MILLISECONDS
+#    repository:
+#      enabled : true
+#    distributed:
+#      enabled: false # By enabling this mode, data synchronization process is distributed over clustered API gateways. You must configure distributed-sync repository.
+#    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, API Keys, ...).
 
      # [Alpha] Enable Kubernetes Synchronization
      # This sync service requires to install Gravitee Kubernetes Operator
 #    kubernetes:
 #      enabled: false
       # by default only the current namespace that the Gateway is running will be watched but you can watch "ALL" or a list
-      # of comma seprated namespaces "ns1,ns2,ns3" or an array of namespaces
+      # of comma separated namespaces "ns1,ns2,ns3" or an array of namespaces
 #      namespaces:
 #        - ALL
 #        - ns1

--- a/helm/README.md
+++ b/helm/README.md
@@ -504,7 +504,13 @@ By setting the value to `null` for `runAsUser` and `runAsGroup` it forces OpenSh
 Install `unittest` helm plugin
 
 ```shell
-helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11
+helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.11
+```
+
+Alternatively you can update the already installed plugin by running
+
+```shell
+helm plugin update unittest
 ```
 
 Update dependencies
@@ -515,5 +521,5 @@ helm dependency update
 Inside `helm/` directory, run:
 
 ```shell
-helm unittest -3 -f 'tests/**/*_test.yaml' .
+helm unittest -f 'tests/**/*_test.yaml' .
 ```

--- a/helm/tests/gateway/configmap_sync_test.yaml
+++ b/helm/tests/gateway/configmap_sync_test.yaml
@@ -1,0 +1,39 @@
+suite: Test Gateway default configmap - Sync Service
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Enable sync service by default
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: " *sync: \n
+                     *  enabled: true"
+  - it: Disable sync service
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          sync:
+            enabled: false
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: " *sync: \n
+                     *  enabled: false"
+  - it: Enable sync service and set `delay` and `unit`
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          sync:
+            enabled: true
+            delay: 10000
+            unit: MILLISECONDS
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: " *sync: \n
+                     *  delay: 10000\n
+                     *  enabled: true\n
+                     *  unit: MILLISECONDS"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1258,7 +1258,9 @@ gateway:
         #     password: ""
 
     sync:
-      cron: "*/5 * * * * *"
+      enabled: true
+      #delay: 5000
+      #unit: MILLISECONDS
 
   # handlers:
   #   request:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5499

## Description

The default value of 5s is defined at the code level but the `gravitee.yaml` and the helm values override it with the same value. This makes it impossible for the cloud-initializer to know if the end-user has changed this value explicitly and, consequently is never able to set the default value to 10s for the cloud.

This PR modifies both the `gravitee.yaml` and the helm chart to avoid redefining the value with the same default values. 
There is no breaking change to expect here.
