### PR TITLE
Portal & portal next : Customize order of APIs within a Category in the portal

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiCategoryOrderRepository.java
@@ -98,7 +98,7 @@ public class MongoApiCategoryOrderRepository implements ApiCategoryOrderReposito
 
     @Override
     public Optional<ApiCategoryOrder> findById(String apiId, String categoryId) {
-        LOGGER.error("Finding ApiCategoryOrder by ID [{}, {}]", apiId, categoryId);
+        LOGGER.debug("Finding ApiCategoryOrder by ID [{}, {}]", apiId, categoryId);
 
         return internalApiCategoryOrderRepo
             .findById(ApiCategoryOrderPkMongo.builder().categoryId(categoryId).apiId(apiId).build())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -24,6 +24,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiCategoryOrderQueryServiceInMemory;
+import inmemory.ApiCategoryQueryServiceInMemory;
+import inmemory.ApiKeyCrudServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.category.model.ApiCategoryOrder;
+import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.category.query_service.CategoryQueryService;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.CategoryEntity;
@@ -52,12 +62,25 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class ApisResourceTest extends AbstractResourceTest {
+
+    @Autowired
+    private CategoryQueryServiceInMemory categoryQueryServiceInMemory;
+
+    @Autowired
+    private ApiCategoryOrderQueryServiceInMemory apiCategoryOrderQueryServiceInMemory;
+
+    @Autowired
+    private ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainServiceInMemory;
+
+    @Autowired
+    private ApiQueryServiceInMemory apiQueryServiceInMemory;
 
     @Override
     protected String contextPath() {
@@ -67,6 +90,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     @Before
     public void init() {
         resetAllMocks();
+        prepareInMemoryServices();
 
         ApiEntity publishedApi1 = new ApiEntity();
         publishedApi1.setLifecycleState(ApiLifecycleState.PUBLISHED);
@@ -159,6 +183,79 @@ public class ApisResourceTest extends AbstractResourceTest {
             )
         )
             .thenReturn(true);
+    }
+
+    private void prepareInMemoryServices() {
+        categoryQueryServiceInMemory.reset();
+        apiCategoryOrderQueryServiceInMemory.reset();
+        apiAuthorizationDomainServiceInMemory.reset();
+        apiQueryServiceInMemory.reset();
+
+        final Category myCat = Category.builder().id("myCat").build();
+        categoryQueryServiceInMemory.initWith(List.of(myCat));
+        apiCategoryOrderQueryServiceInMemory.initWith(
+            List.of(
+                ApiCategoryOrder.builder().apiId("1").categoryId("myCat").build(),
+                ApiCategoryOrder.builder().apiId("3").categoryId("myCat").build(),
+                ApiCategoryOrder.builder().apiId("4").categoryId("myCat").build(),
+                ApiCategoryOrder.builder().apiId("5").categoryId("myCat").build(),
+                ApiCategoryOrder.builder().apiId("6").categoryId("myCat").build()
+            )
+        );
+        apiAuthorizationDomainServiceInMemory.initWith(
+            List.of(
+                Api
+                    .builder()
+                    .id("1")
+                    .name("1")
+                    .labels(List.of("label1", "label2"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api
+                    .builder()
+                    .id("3")
+                    .name("3")
+                    .labels(List.of("label1", "label2"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api
+                    .builder()
+                    .id("4")
+                    .name("4")
+                    .labels(List.of("label1", "label2", "label3"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api.builder().id("5").name("5").labels(List.of("label1")).apiLifecycleState(Api.ApiLifecycleState.PUBLISHED).build(),
+                Api.builder().id("6").name("6").apiLifecycleState(Api.ApiLifecycleState.PUBLISHED).build()
+            )
+        );
+        apiQueryServiceInMemory.initWith(
+            List.of(
+                Api
+                    .builder()
+                    .id("1")
+                    .name("1")
+                    .labels(List.of("label1", "label2"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api
+                    .builder()
+                    .id("3")
+                    .name("3")
+                    .labels(List.of("label1", "label2"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api
+                    .builder()
+                    .id("4")
+                    .name("4")
+                    .labels(List.of("label1", "label2", "label3"))
+                    .apiLifecycleState(Api.ApiLifecycleState.PUBLISHED)
+                    .build(),
+                Api.builder().id("5").name("5").labels(List.of("label1")).apiLifecycleState(Api.ApiLifecycleState.PUBLISHED).build(),
+                Api.builder().id("6").name("6").apiLifecycleState(Api.ApiLifecycleState.PUBLISHED).build()
+            )
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
@@ -57,7 +57,10 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
                         Objects.isNull(apiCriteria.getIntegrationId()) ||
                         Objects.equals(((IntegrationContext) api.getOriginContext()).getIntegrationId(), apiCriteria.getIntegrationId());
                     var matchesApiId = Objects.isNull(apiCriteria.getIds()) || apiCriteria.getIds().contains(api.getId());
-                    return matchesIntegrationId && matchesApiId;
+                    var matchesLifecycleState =
+                        Objects.isNull(apiCriteria.getLifecycleStates()) ||
+                        apiCriteria.getLifecycleStates().contains(api.getApiLifecycleState());
+                    return matchesIntegrationId && matchesApiId && matchesLifecycleState;
                 });
         }
         return this.storage().stream();


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-3754


## Description

- Portal Rest API -> sort API by categoryOrder on API search with category filter.
(if no category defined, no order)



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cwjjleyqpq.chromatic.com)
<!-- Storybook placeholder end -->
