### PR TITLE
chore(ui): add yarn start alias for legacy frontends

### DIFF
--- a/gravitee-apim-portal-webui-next/README.md
+++ b/gravitee-apim-portal-webui-next/README.md
@@ -4,7 +4,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `yarn start` for a dev server. Navigate to `http://localhost:4101/`. The application will automatically reload if you change any of the source files.
+Run `yarn serve` for a dev server. Navigate to `http://localhost:4101/`. The application will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 

--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "start:apim-master": "BACKEND_ENV=apim-master-api.team-apim.gravitee.dev yarn start",
+    "serve": "ng serve",
+    "serve:apim-master": "BACKEND_ENV=apim-master-api.team-apim.gravitee.dev yarn serve",
     "build": "ng build",
     "build:prod": "NODE_OPTIONS=--max_old_space_size=8192 ng build --configuration production",
     "build:i18n": "yarn build:prod --localize",


### PR DESCRIPTION
## Description

Align portal-next to use `yarn serve` as our other front ends

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lttshrxwtn.chromatic.com)
<!-- Storybook placeholder end -->
