### PR TITLE
Fix license sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LicenseFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LicenseFetcher.java
@@ -17,12 +17,15 @@ package io.gravitee.gateway.services.sync.process.repository.fetcher;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.gateway.services.sync.process.repository.DefaultSyncManager;
+import io.gravitee.node.api.Node;
 import io.gravitee.repository.management.api.LicenseRepository;
 import io.gravitee.repository.management.api.search.LicenseCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.License;
 import io.reactivex.rxjava3.core.Flowable;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +41,16 @@ public class LicenseFetcher {
     @Accessors(fluent = true)
     private final int bulkItems;
 
+    private Set<String> organizations;
+
+    public LicenseFetcher(final LicenseRepository licenseRepository, final int bulkItems, final Node node) {
+        this.licenseRepository = licenseRepository;
+        this.bulkItems = bulkItems;
+        if (node.metadata().containsKey(Node.META_ORGANIZATIONS)) {
+            this.organizations = Set.copyOf((Set<String>) node.metadata().get(Node.META_ORGANIZATIONS));
+        }
+    }
+
     public Flowable<List<License>> fetchLatest(Long from, Long to) {
         return Flowable.generate(
             () ->
@@ -49,6 +62,7 @@ public class LicenseFetcher {
                         LicenseCriteria
                             .builder()
                             .referenceType(License.ReferenceType.ORGANIZATION)
+                            .referenceIds(organizations)
                             .from(from == null ? -1 : from - DefaultSyncManager.TIMEFRAME_DELAY)
                             .to(to == null ? -1 : to + DefaultSyncManager.TIMEFRAME_DELAY)
                             .build()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -126,9 +126,10 @@ public class RepositorySyncConfiguration {
     @Bean
     public LicenseFetcher licenseFetcher(
         LicenseRepository licenseRepository,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems,
+        Node node
     ) {
-        return new LicenseFetcher(licenseRepository, bulkItems);
+        return new LicenseFetcher(licenseRepository, bulkItems, node);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/DebugEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/DebugEventFetcherTest.java
@@ -91,7 +91,7 @@ class DebugEventFetcherTest {
     }
 
     @Test
-    void should_emit_on_error_when_repository_thrown_exception() throws TechnicalException {
+    void should_emit_on_error_when_repository_thrown_exception() {
         when(eventRepository.search(any())).thenThrow(new RuntimeException());
         cut.fetchLatest(null, null, Set.of()).test().assertError(RuntimeException.class);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/LicenseCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/LicenseCriteria.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management.api.search;
 
 import io.gravitee.repository.management.model.License;
+import java.util.Set;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -35,5 +36,5 @@ public class LicenseCriteria {
 
     private final License.ReferenceType referenceType;
 
-    private final String referenceId;
+    private final Set<String> referenceIds;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcLicenseRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcLicenseRepository.java
@@ -145,10 +145,10 @@ public class JdbcLicenseRepository extends JdbcAbstractPageableRepository<Licens
                 args.add(filter.getReferenceType().name());
             }
 
-            if (filter.getReferenceId() != null && !filter.getReferenceId().isEmpty()) {
+            if (filter.getReferenceIds() != null && !filter.getReferenceIds().isEmpty()) {
                 first = addClause(first, query);
-                query.append("reference_id = ?");
-                args.add(filter.getReferenceId());
+                query.append(" ( reference_id in ( ").append(getOrm().buildInClause(filter.getReferenceIds())).append(" ) )");
+                args.addAll(filter.getReferenceIds());
             }
 
             if (filter.getFrom() > 0) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management.internal.license;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.LicenseCriteria;
@@ -25,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom {
@@ -40,8 +42,8 @@ public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom 
             query.addCriteria(where("_id.referenceType").is(filter.getReferenceType().name()));
         }
 
-        if (filter.getReferenceId() != null && !filter.getReferenceId().isEmpty()) {
-            query.addCriteria(where("_id.referenceId").is(filter.getReferenceId()));
+        if (!isEmpty(filter.getReferenceIds())) {
+            query.addCriteria(where("_id.referenceId").in(filter.getReferenceIds()));
         }
 
         if (filter.getFrom() > 0 && filter.getTo() > 0) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/LicenseRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/LicenseRepositoryTest.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.License;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public class LicenseRepositoryTest extends AbstractManagementRepositoryTest {
@@ -123,7 +124,11 @@ public class LicenseRepositoryTest extends AbstractManagementRepositoryTest {
     public void shouldFindByReferenceTypeAndId() throws Exception {
         final Collection<License> licenses = licenseRepository
             .findByCriteria(
-                LicenseCriteria.builder().referenceType(License.ReferenceType.ORGANIZATION).referenceId("cockpitId-org-find-by-id").build(),
+                LicenseCriteria
+                    .builder()
+                    .referenceType(License.ReferenceType.ORGANIZATION)
+                    .referenceIds(Set.of("cockpitId-org-find-by-id"))
+                    .build(),
                 new PageableBuilder().pageSize(50).pageNumber(0).build()
             )
             .getContent();


### PR DESCRIPTION
## Description

When fetching licenses, the sync process doesn't filter on organization and can retrieve all license. The PR attempts to fix this issue.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

