### PR TITLE
fix(logging): Do not manipulate logging headers if header's value is …

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/transaction/TransactionPostProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/transaction/TransactionPostProcessor.java
@@ -65,12 +65,14 @@ public class TransactionPostProcessor implements Processor {
         String backendHeaderValue = responseHeaders.get(headerName);
 
         if (headerOverrideMode == TransactionHeaderOverrideMode.OVERRIDE) {
-            responseHeaders.set(headerName, requestHeaderValue);
+            if (requestHeaderValue != null) {
+                responseHeaders.set(headerName, requestHeaderValue);
+            }
         } else if (headerOverrideMode == TransactionHeaderOverrideMode.MERGE) {
             if (requestHeaderValue != null && !requestHeaderValue.equals(backendHeaderValue)) {
                 responseHeaders.add(headerName, requestHeaderValue);
             }
-        } else if (headerOverrideMode == TransactionHeaderOverrideMode.KEEP) {
+        } else if (headerOverrideMode == TransactionHeaderOverrideMode.KEEP && backendHeaderValue != null) {
             responseHeaders.set(headerName, backendHeaderValue);
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/transaction/TransactionPostProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/transaction/TransactionPostProcessorTest.java
@@ -112,6 +112,22 @@ class TransactionPostProcessorTest extends AbstractProcessorTest {
         assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("backend-request-id"));
     }
 
+    @Test
+    @DisplayName("Should override Transaction Id header's value but not Request Id header because empty, by the ones set by APIM")
+    void handleWithOverrideWithoutHeaderValue() {
+        instantiateTransactionPostProcessor(TransactionHeaderOverrideMode.OVERRIDE, TransactionHeaderOverrideMode.OVERRIDE);
+
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("backend-request-id"));
+    }
+
     private void instantiateTransactionPostProcessor(
         TransactionHeaderOverrideMode transactionOverrideMode,
         TransactionHeaderOverrideMode requestHeaderOverrideMode


### PR DESCRIPTION
…empty

## Issue

https://gravitee.atlassian.net/browse/APIM-4879

## Description

It may happen that an API owner is removing gravitee headers (such as X-Gravitee-Request-Id) using the transform-headers policy, which are required for logging (request only), in v4 mode.

This PR does not set the new header's value if the value is null (header has been removed by the policy)

