### PR TITLE
refactor: refactor oai import use case

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -248,11 +248,8 @@ public class ApisResource extends AbstractResource {
                 .withDocumentation(Boolean.TRUE.equals(descriptor.getWithDocumentation()))
                 .build();
 
-            OAIToImportApiUseCase.Output output = oaiToImportApiUseCase.execute(
+            OAIToImportApiUseCase.Output importOutput = oaiToImportApiUseCase.execute(
                 new OAIToImportApiUseCase.Input(importSwaggerDescriptor, audit)
-            );
-            ImportApiDefinitionUseCase.Output importOutput = importApiDefinitionUseCase.execute(
-                new ImportApiDefinitionUseCase.Input(output.importDefinition(), audit)
             );
 
             boolean isSynchronized = apiStateDomainService.isSynchronized(importOutput.apiWithFlows(), audit);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ImportDefinitionCreateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ImportDefinitionCreateDomainService.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.model.NewApiMetadata;
+import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
+import io.gravitee.apim.core.api.model.import_definition.ApiMember;
+import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.documentation.domain_service.CreateApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.DocumentationValidationDomainService;
+import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
+import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.core.media.model.Media;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.core.metadata.model.MetadataId;
+import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
+import io.gravitee.apim.core.plan.model.PlanWithFlows;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@DomainService
+public class ImportDefinitionCreateDomainService {
+
+    private final ApiImportDomainService apiImportDomainService;
+    private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
+    private final CreateApiDomainService createApiDomainService;
+    private final ValidateApiDomainService validateApiDomainService;
+    private final ApiMetadataDomainService apiMetadataDomainService;
+    private final CreatePlanDomainService createPlanDomainService;
+    private final CreateApiDocumentationDomainService createApiDocumentationDomainService;
+    private final ApiIdsCalculatorDomainService apiIdsCalculatorDomainService;
+    private final MetadataCrudService metadataCrudService;
+    private final DocumentationValidationDomainService documentationValidationDomainService;
+
+    public ImportDefinitionCreateDomainService(
+        ApiImportDomainService apiImportDomainService,
+        ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
+        CreateApiDomainService createApiDomainService,
+        ValidateApiDomainService validateApiDomainService,
+        ApiMetadataDomainService apiMetadataDomainService,
+        CreatePlanDomainService createPlanDomainService,
+        CreateApiDocumentationDomainService createApiDocumentationDomainService,
+        ApiIdsCalculatorDomainService apiIdsCalculatorDomainService,
+        MetadataCrudService metadataCrudService,
+        DocumentationValidationDomainService documentationValidationDomainService
+    ) {
+        this.apiImportDomainService = apiImportDomainService;
+        this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
+        this.createApiDomainService = createApiDomainService;
+        this.validateApiDomainService = validateApiDomainService;
+        this.apiMetadataDomainService = apiMetadataDomainService;
+        this.createPlanDomainService = createPlanDomainService;
+        this.createApiDocumentationDomainService = createApiDocumentationDomainService;
+        this.apiIdsCalculatorDomainService = apiIdsCalculatorDomainService;
+        this.metadataCrudService = metadataCrudService;
+        this.documentationValidationDomainService = documentationValidationDomainService;
+    }
+
+    public ApiWithFlows create(AuditInfo auditInfo, ImportDefinition importDefinition) {
+        var environmentId = auditInfo.environmentId();
+        var organizationId = auditInfo.organizationId();
+        var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(organizationId, environmentId, auditInfo.actor().userId());
+        var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(environmentId, importDefinition);
+
+        var createdApi = createApiDomainService.create(
+            ApiModelFactory.fromApiExport(apiWithIds.getApiExport(), environmentId),
+            primaryOwner,
+            auditInfo,
+            api -> validateApiDomainService.validateAndSanitizeForCreation(api, primaryOwner, environmentId, organizationId)
+        );
+
+        createMetadata(importDefinition.getMetadata(), createdApi.getId(), auditInfo);
+        createPages(importDefinition.getPages(), createdApi.getId(), auditInfo);
+        createPlans(importDefinition.getPlans(), createdApi, auditInfo);
+        createMedias(importDefinition.getApiMedia(), createdApi.getId());
+        createMembers(importDefinition.getMembers(), createdApi.getId());
+        return createdApi;
+    }
+
+    private void createMetadata(Set<NewApiMetadata> metadataSet, String apiId, AuditInfo auditInfo) {
+        if (metadataSet != null) {
+            metadataSet
+                .stream()
+                .map(metadata -> metadata.toBuilder().apiId(apiId).build())
+                .forEach(metadata ->
+                    metadataCrudService
+                        .findById(
+                            MetadataId.builder().key(metadata.getKey()).referenceId(apiId).referenceType(Metadata.ReferenceType.API).build()
+                        )
+                        .ifPresentOrElse(
+                            existingMetadata ->
+                                apiMetadataDomainService.update(
+                                    existingMetadata.toBuilder().name(metadata.getName()).value(metadata.getValue()).build(),
+                                    auditInfo
+                                ),
+                            () -> apiMetadataDomainService.create(metadata, auditInfo)
+                        )
+                );
+        }
+    }
+
+    private void createPlans(Set<PlanWithFlows> plans, ApiWithFlows api, AuditInfo auditInfo) {
+        if (plans != null) {
+            plans
+                .stream()
+                .map(plan -> plan.toBuilder().apiId(api.getId()).build())
+                .forEach(plan -> createPlanDomainService.create(plan, plan.getFlows(), api.toApi(), auditInfo));
+        }
+    }
+
+    private void createPages(List<Page> pages, String apiId, AuditInfo auditInfo) {
+        if (pages != null) {
+            var now = Date.from(TimeProvider.now().toInstant());
+            pages
+                .stream()
+                .map(page -> {
+                    if (page.getParentId() != null) {
+                        validatePageParent(pages, page.getParentId());
+                    }
+                    return documentationValidationDomainService.validateAndSanitizeForCreation(
+                        page
+                            .toBuilder()
+                            .id(page.getId() == null ? UuidString.generateRandom() : page.getId())
+                            .referenceType(Page.ReferenceType.API)
+                            .referenceId(apiId)
+                            .createdAt(now)
+                            .updatedAt(now)
+                            .build(),
+                        auditInfo.organizationId(),
+                        false
+                    );
+                })
+                .forEach(page -> createApiDocumentationDomainService.createPage(page, auditInfo));
+        }
+    }
+
+    private void validatePageParent(List<Page> pages, String parentId) {
+        pages
+            .stream()
+            .filter(parent -> parentId.equals(parent.getId()))
+            .findFirst()
+            .ifPresent(parent -> {
+                if (!(parent.isFolder() || parent.isRoot())) {
+                    throw new InvalidPageParentException(parent.getId());
+                }
+            });
+    }
+
+    private void createMedias(List<Media> mediaList, String apiId) {
+        if (mediaList != null) {
+            apiImportDomainService.createPageAndMedia(mediaList, apiId);
+        }
+    }
+
+    private void createMembers(Set<ApiMember> members, String apiId) {
+        if (members != null) {
+            apiImportDomainService.createMembers(members, apiId);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCase.java
@@ -17,37 +17,14 @@ package io.gravitee.apim.core.api.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
-import io.gravitee.apim.core.api.domain_service.ApiIdsCalculatorDomainService;
-import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
-import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
-import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
-import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
-import io.gravitee.apim.core.api.model.NewApiMetadata;
-import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
-import io.gravitee.apim.core.api.model.import_definition.ApiMember;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.documentation.domain_service.CreateApiDocumentationDomainService;
-import io.gravitee.apim.core.documentation.domain_service.DocumentationValidationDomainService;
-import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
-import io.gravitee.apim.core.documentation.model.Page;
-import io.gravitee.apim.core.media.model.Media;
-import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
-import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
-import io.gravitee.apim.core.metadata.model.Metadata;
-import io.gravitee.apim.core.metadata.model.MetadataId;
-import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
-import io.gravitee.apim.core.plan.model.PlanWithFlows;
-import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 @UseCase
@@ -59,48 +36,21 @@ public class ImportApiDefinitionUseCase {
     public record Output(ApiWithFlows apiWithFlows) {}
 
     private final ApiCrudService apiCrudService;
-    private final ApiImportDomainService apiImportDomainService;
-    private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
-    private final CreateApiDomainService createApiDomainService;
-    private final ValidateApiDomainService validateApiDomainService;
-    private final ApiMetadataDomainService apiMetadataDomainService;
-    private final CreatePlanDomainService createPlanDomainService;
-    private final CreateApiDocumentationDomainService createApiDocumentationDomainService;
-    private final ApiIdsCalculatorDomainService apiIdsCalculatorDomainService;
-    private final MetadataCrudService metadataCrudService;
-    private final DocumentationValidationDomainService documentationValidationDomainService;
+    private final ImportDefinitionCreateDomainService importDefinitionCreateDomainService;
 
     public ImportApiDefinitionUseCase(
         ApiCrudService apiCrudService,
-        ApiImportDomainService apiImportDomainService,
-        ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
-        CreateApiDomainService createApiDomainService,
-        ValidateApiDomainService validateApiDomainService,
-        ApiMetadataDomainService apiMetadataDomainService,
-        CreatePlanDomainService createPlanDomainService,
-        CreateApiDocumentationDomainService createApiDocumentationDomainService,
-        ApiIdsCalculatorDomainService apiIdsCalculatorDomainService,
-        MetadataCrudService metadataCrudService,
-        DocumentationValidationDomainService documentationValidationDomainService
+        ImportDefinitionCreateDomainService importDefinitionCreateDomainService
     ) {
         this.apiCrudService = apiCrudService;
-        this.apiImportDomainService = apiImportDomainService;
-        this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
-        this.createApiDomainService = createApiDomainService;
-        this.validateApiDomainService = validateApiDomainService;
-        this.apiMetadataDomainService = apiMetadataDomainService;
-        this.createPlanDomainService = createPlanDomainService;
-        this.createApiDocumentationDomainService = createApiDocumentationDomainService;
-        this.apiIdsCalculatorDomainService = apiIdsCalculatorDomainService;
-        this.metadataCrudService = metadataCrudService;
-        this.documentationValidationDomainService = documentationValidationDomainService;
+        this.importDefinitionCreateDomainService = importDefinitionCreateDomainService;
     }
 
     public Output execute(Input input) {
         ensureIsV4Api(input.importDefinition().getApiExport());
         ensureApiDoesNotExist(input);
 
-        var createdApi = this.create(input);
+        var createdApi = importDefinitionCreateDomainService.create(input.auditInfo, input.importDefinition);
         return new Output(createdApi);
     }
 
@@ -114,112 +64,9 @@ public class ImportApiDefinitionUseCase {
         }
     }
 
-    private ApiWithFlows create(Input input) {
-        var auditInfo = input.auditInfo;
-        var environmentId = auditInfo.environmentId();
-        var organizationId = auditInfo.organizationId();
-        var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(organizationId, environmentId, auditInfo.actor().userId());
-        var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(environmentId, input.importDefinition);
-
-        var createdApi = createApiDomainService.create(
-            ApiModelFactory.fromApiExport(apiWithIds.getApiExport(), environmentId),
-            primaryOwner,
-            auditInfo,
-            api -> validateApiDomainService.validateAndSanitizeForCreation(api, primaryOwner, environmentId, organizationId)
-        );
-
-        createMetadata(input.importDefinition.getMetadata(), createdApi.getId(), auditInfo);
-        createPages(input.importDefinition.getPages(), createdApi.getId(), auditInfo);
-        createPlans(input.importDefinition.getPlans(), createdApi, auditInfo);
-        createMedias(input.importDefinition.getApiMedia(), createdApi.getId());
-        createMembers(input.importDefinition.getMembers(), createdApi.getId());
-        return createdApi;
-    }
-
     private void ensureIsV4Api(ApiExport api) {
         if (api.getDefinitionVersion() != DefinitionVersion.V4) {
             throw new ApiDefinitionVersionNotSupportedException(api.getDefinitionVersion().getLabel());
-        }
-    }
-
-    private void createMetadata(Set<NewApiMetadata> metadataSet, String apiId, AuditInfo auditInfo) {
-        if (metadataSet != null) {
-            metadataSet
-                .stream()
-                .map(metadata -> metadata.toBuilder().apiId(apiId).build())
-                .forEach(metadata ->
-                    metadataCrudService
-                        .findById(
-                            MetadataId.builder().key(metadata.getKey()).referenceId(apiId).referenceType(Metadata.ReferenceType.API).build()
-                        )
-                        .ifPresentOrElse(
-                            existingMetadata ->
-                                apiMetadataDomainService.update(
-                                    existingMetadata.toBuilder().name(metadata.getName()).value(metadata.getValue()).build(),
-                                    auditInfo
-                                ),
-                            () -> apiMetadataDomainService.create(metadata, auditInfo)
-                        )
-                );
-        }
-    }
-
-    private void createPlans(Set<PlanWithFlows> plans, ApiWithFlows api, AuditInfo auditInfo) {
-        if (plans != null) {
-            plans
-                .stream()
-                .map(plan -> plan.toBuilder().apiId(api.getId()).build())
-                .forEach(plan -> createPlanDomainService.create(plan, plan.getFlows(), api.toApi(), auditInfo));
-        }
-    }
-
-    private void createPages(List<Page> pages, String apiId, AuditInfo auditInfo) {
-        if (pages != null) {
-            var now = Date.from(TimeProvider.now().toInstant());
-            pages
-                .stream()
-                .map(page -> {
-                    if (page.getParentId() != null) {
-                        validatePageParent(pages, page.getParentId());
-                    }
-                    return documentationValidationDomainService.validateAndSanitizeForCreation(
-                        page
-                            .toBuilder()
-                            .id(page.getId() == null ? UuidString.generateRandom() : page.getId())
-                            .referenceType(Page.ReferenceType.API)
-                            .referenceId(apiId)
-                            .createdAt(now)
-                            .updatedAt(now)
-                            .build(),
-                        auditInfo.organizationId(),
-                        false
-                    );
-                })
-                .forEach(page -> createApiDocumentationDomainService.createPage(page, auditInfo));
-        }
-    }
-
-    private void validatePageParent(List<Page> pages, String parentId) {
-        pages
-            .stream()
-            .filter(parent -> parentId.equals(parent.getId()))
-            .findFirst()
-            .ifPresent(parent -> {
-                if (!(parent.isFolder() || parent.isRoot())) {
-                    throw new InvalidPageParentException(parent.getId());
-                }
-            });
-    }
-
-    private void createMedias(List<Media> mediaList, String apiId) {
-        if (mediaList != null) {
-            apiImportDomainService.createPageAndMedia(mediaList, apiId);
-        }
-    }
-
-    private void createMembers(Set<ApiMember> members, String apiId) {
-        if (members != null) {
-            apiImportDomainService.createMembers(members, apiId);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
@@ -16,7 +16,9 @@
 package io.gravitee.apim.core.api.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -37,23 +39,26 @@ public class OAIToImportApiUseCase {
 
     public record Input(ImportSwaggerDescriptorEntity importSwaggerDescriptor, AuditInfo auditInfo) {}
 
-    public record Output(ImportDefinition importDefinition) {}
+    public record Output(ApiWithFlows apiWithFlows) {}
 
     private final OAIDomainService oaiDomainService;
     private final GroupQueryService groupQueryService;
     private final TagQueryService tagsQueryService;
     private final EndpointConnectorPluginDomainService endpointConnectorPluginService;
+    private final ImportDefinitionCreateDomainService importDefinitionCreateDomainService;
 
     public OAIToImportApiUseCase(
         OAIDomainService oaiDomainService,
         GroupQueryService groupQueryService,
         TagQueryService tagsQueryService,
-        EndpointConnectorPluginDomainService endpointConnectorPluginService
+        EndpointConnectorPluginDomainService endpointConnectorPluginService,
+        ImportDefinitionCreateDomainService importDefinitionCreateDomainService
     ) {
         this.oaiDomainService = oaiDomainService;
         this.groupQueryService = groupQueryService;
         this.tagsQueryService = tagsQueryService;
         this.endpointConnectorPluginService = endpointConnectorPluginService;
+        this.importDefinitionCreateDomainService = importDefinitionCreateDomainService;
     }
 
     public Output execute(Input input) {
@@ -71,7 +76,8 @@ public class OAIToImportApiUseCase {
                 input.importSwaggerDescriptor.getPayload(),
                 importWithTags
             );
-            return new Output(importWithDocumentation);
+            final ApiWithFlows apiWithFlows = importDefinitionCreateDomainService.create(input.auditInfo, importWithDocumentation);
+            return new Output(apiWithFlows);
         }
 
         return null;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package initializers;
+
+import static org.mockito.Mockito.mock;
+
+import inmemory.ApiCategoryQueryServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.EntrypointPluginQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.IndexerInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.NoopSwaggerOpenApiResolver;
+import inmemory.NoopTemplateResolverDomainService;
+import inmemory.NotificationConfigCrudServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
+import inmemory.PageQueryServiceInMemory;
+import inmemory.PageRevisionCrudServiceInMemory;
+import inmemory.PageSourceDomainServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import inmemory.WorkflowCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIdsCalculatorDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
+import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.CreateApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.domain_service.DocumentationValidationDomainService;
+import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.metadata.crud_service.MetadataCrudService;
+import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.infra.domain_service.api.ApiImportDomainServiceLegacyWrapper;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import java.util.List;
+
+public class ImportDefinitionCreateDomainServiceTestInitializer {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
+    private final CreateApiDomainService createApiDomainService;
+    private final CreatePlanDomainService createPlanDomainService;
+    private final CreateApiDocumentationDomainService createApiDocumentationDomainService;
+    private final ApiIdsCalculatorDomainService apiIdsCalculatorDomainService;
+    private final DocumentationValidationDomainService documentationValidationDomainService;
+    private final ApiMetadataDomainService apiMetadataDomainService;
+
+    // Mocks
+    public final ApiImportDomainServiceLegacyWrapper apiImportDomainService = mock(ApiImportDomainServiceLegacyWrapper.class);
+    public final PolicyValidationDomainService policyValidationDomainService = mock(PolicyValidationDomainService.class);
+    public final ValidateApiDomainService validateApiDomainService = mock(ValidateApiDomainService.class);
+
+    // In Memory
+    public final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    public final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    public final ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    public final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    public final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    public final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    public final MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    public final ApiMetadataQueryServiceInMemory apiMetadataQueryServiceInMemory = new ApiMetadataQueryServiceInMemory(metadataCrudService);
+    public final IndexerInMemory indexer = new IndexerInMemory();
+    public final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    public final NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
+    public final WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
+    public final PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
+    public final PageQueryServiceInMemory pageQueryService = new PageQueryServiceInMemory();
+    public final PageRevisionCrudServiceInMemory pageRevisionCrudService = new PageRevisionCrudServiceInMemory();
+    public final PageSourceDomainServiceInMemory pageSourceDomainService = new PageSourceDomainServiceInMemory();
+    public final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+    public final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    public final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+
+    public ImportDefinitionCreateDomainServiceTestInitializer(ApiCrudServiceInMemory apiCrudService) {
+        var membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        apiPrimaryOwnerFactory =
+            new ApiPrimaryOwnerFactory(
+                groupQueryService,
+                membershipQueryService,
+                parametersQueryService,
+                roleQueryService,
+                userCrudService
+            );
+        var metadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
+        var auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditDomainService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
+        apiMetadataDomainService = new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryServiceInMemory, auditDomainService);
+        createApiDomainService =
+            new CreateApiDomainService(
+                apiCrudService,
+                auditDomainService,
+                new ApiIndexerDomainService(
+                    new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                    apiPrimaryOwnerDomainService,
+                    new ApiCategoryQueryServiceInMemory(),
+                    indexer
+                ),
+                apiMetadataDomainService,
+                apiPrimaryOwnerDomainService,
+                flowCrudService,
+                notificationConfigCrudService,
+                parametersQueryService,
+                workflowCrudService
+            );
+
+        var planValidatorService = new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService);
+        var flowValidationDomainService = new FlowValidationDomainService(
+            policyValidationDomainService,
+            new EntrypointPluginQueryServiceInMemory()
+        );
+        createPlanDomainService =
+            new CreatePlanDomainService(
+                planValidatorService,
+                flowValidationDomainService,
+                planCrudService,
+                flowCrudService,
+                auditDomainService
+            );
+
+        createApiDocumentationDomainService =
+            new CreateApiDocumentationDomainService(pageCrudService, pageRevisionCrudService, auditDomainService, indexer);
+        apiIdsCalculatorDomainService = new ApiIdsCalculatorDomainService(apiQueryService, pageQueryService, planQueryService);
+
+        documentationValidationDomainService =
+            new DocumentationValidationDomainService(
+                new HtmlSanitizerImpl(),
+                new NoopTemplateResolverDomainService(),
+                apiCrudService,
+                new NoopSwaggerOpenApiResolver(),
+                new ApiMetadataQueryServiceInMemory(),
+                new ApiPrimaryOwnerDomainService(
+                    new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
+                    groupQueryService,
+                    membershipCrudService,
+                    membershipQueryService,
+                    roleQueryService,
+                    userCrudService
+                ),
+                new ApiDocumentationDomainService(pageQueryService, planQueryService),
+                pageCrudService,
+                pageSourceDomainService
+            );
+        roleQueryService.initWith(
+            List.of(
+                Role
+                    .builder()
+                    .id("role-id")
+                    .scope(Role.Scope.API)
+                    .referenceType(Role.ReferenceType.ORGANIZATION)
+                    .referenceId(ORGANIZATION_ID)
+                    .name("PRIMARY_OWNER")
+                    .build()
+            )
+        );
+    }
+
+    public ImportDefinitionCreateDomainService initialize() {
+        return new ImportDefinitionCreateDomainService(
+            apiImportDomainService,
+            apiPrimaryOwnerFactory,
+            createApiDomainService,
+            validateApiDomainService,
+            apiMetadataDomainService,
+            createPlanDomainService,
+            createApiDocumentationDomainService,
+            apiIdsCalculatorDomainService,
+            metadataCrudService,
+            documentationValidationDomainService
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -63,6 +63,7 @@ import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.NewApiMetadata;
@@ -288,16 +289,18 @@ class ImportApiDefinitionUseCaseTest {
         useCase =
             new ImportApiDefinitionUseCase(
                 apiCrudService,
-                apiImportDomainService,
-                apiPrimaryOwnerFactory,
-                createApiDomainService,
-                validateApiDomainService,
-                apiMetadataDomainService,
-                createPlanDomainService,
-                createApiDocumentationDomainService,
-                apiIdsCalculatorDomainService,
-                metadataCrudService,
-                documentationValidationDomainService
+                new ImportDefinitionCreateDomainService(
+                    apiImportDomainService,
+                    apiPrimaryOwnerFactory,
+                    createApiDomainService,
+                    validateApiDomainService,
+                    apiMetadataDomainService,
+                    createPlanDomainService,
+                    createApiDocumentationDomainService,
+                    apiIdsCalculatorDomainService,
+                    metadataCrudService,
+                    documentationValidationDomainService
+                )
             );
 
         parametersQueryService.initWith(
@@ -667,7 +670,7 @@ class ImportApiDefinitionUseCaseTest {
             // Then
             var expectedApi = expectedApi();
             assertThat(apiCrudService.storage()).contains(expectedApi);
-            verify(apiImportDomainService, times(1)).createPageAndMedia(eq(mediaList), eq(API_ID));
+            verify(apiImportDomainService, times(1)).createPageAndMedia(mediaList, API_ID);
         }
 
         @Test
@@ -689,7 +692,7 @@ class ImportApiDefinitionUseCaseTest {
             // Then
             var expectedApi = expectedApi();
             assertThat(apiCrudService.storage()).contains(expectedApi);
-            verify(apiImportDomainService, times(1)).createMembers(eq(members), eq(API_ID));
+            verify(apiImportDomainService, times(1)).createMembers(members, API_ID);
         }
     }
 


### PR DESCRIPTION
## Description

- Externalize import logic in a dedicated domain service
- make Import api definition use case use this service
- [test] externalize the initialization of this service for reusability
- make OAI import service use this domain service and simplify the resource to only call one use case
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cmtjjrwjui.chromatic.com)
<!-- Storybook placeholder end -->
