### PR TITLE
fix(helm): make hazelcast cluster role and binding unique

### DIFF
--- a/helm/templates/api/api-rbac.yaml
+++ b/helm/templates/api/api-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "apim.serviceAccount" . }}-hazelcast-role
+  name: {{ .Release.Name }}-{{ template "apim.serviceAccount" . }}-hazelcast-role
 rules:
   - apiGroups:
       - ""
@@ -20,11 +20,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hazelcast-cluster-role-binding
+  name: {{ .Release.Name }}-{{ .Release.Name }}-hazelcast-crb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "apim.serviceAccount" . }}-hazelcast-role
+  name: {{ .Release.Name }}-{{ template "apim.serviceAccount" . }}-hazelcast-role
 subjects:
   - kind: ServiceAccount
     name: {{ template "apim.serviceAccount" . }}


### PR DESCRIPTION
## Description

ClusterRole and ClusterRoleBinding are not namespace scoped. They need to be unique in the whole cluster.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

