### PR TITLE
fix(mongo-upgrader): make idempotent and consider prefix - 4.2.x

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/MongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/MongoUpgrader.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.common;
 
+import com.mongodb.client.MongoCollection;
 import io.gravitee.node.api.upgrader.Upgrader;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -37,6 +39,10 @@ public abstract class MongoUpgrader implements Upgrader {
     @Autowired
     public void setEnvironment(Environment environment) {
         this.prefix = environment.getProperty("management.mongodb.prefix", "");
+    }
+
+    protected MongoCollection<Document> getCollection(String collectionName) {
+        return template.getCollection(buildCollectionName(collectionName));
     }
 
     protected String buildCollectionName(String collectionName) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/dashboards/DashboardTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/dashboards/DashboardTypeUpgrader.java
@@ -19,6 +19,7 @@ import static io.gravitee.repository.mongodb.management.upgrade.upgrader.promoti
 
 import com.mongodb.client.model.Filters;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import org.bson.Document;
 import org.springframework.stereotype.Component;
 
 /**
@@ -31,15 +32,21 @@ import org.springframework.stereotype.Component;
 public class DashboardTypeUpgrader extends MongoUpgrader {
 
     @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
     public boolean upgrade() {
+        var dashboardsTypeNotExistsQuery = new Document("type", new Document("$exists", false));
+
         // Because of DocumentDB which does not support latest aggregation APIs of MongoDB, we need to use this kind of update method.
-        template
-            .getCollection("dashboards")
-            .find()
+        this.getCollection("dashboards")
+            .find(dashboardsTypeNotExistsQuery)
             .forEach(dashboard -> {
                 dashboard.append("type", dashboard.getString("referenceType"));
                 dashboard.put("referenceType", "ENVIRONMENT");
-                template.getCollection("dashboards").replaceOne(Filters.eq("_id", dashboard.getString("_id")), dashboard);
+                this.getCollection("dashboards").replaceOne(Filters.eq("_id", dashboard.getString("_id")), dashboard);
             });
         return true;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/promotions/RemovePromotionAuthorPictureUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/promotions/RemovePromotionAuthorPictureUpgrader.java
@@ -29,8 +29,13 @@ public class RemovePromotionAuthorPictureUpgrader extends MongoUpgrader {
     public static final int REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER = 0;
 
     @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
     public boolean upgrade() {
-        var updateResult = template.getCollection("promotions").updateMany(new BsonDocument(), Updates.unset("author.picture"));
+        var updateResult = this.getCollection("promotions").updateMany(new BsonDocument(), Updates.unset("author.picture"));
         return updateResult.wasAcknowledged();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.4.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>4.8.6</gravitee-node.version>
+        <gravitee-node.version>4.8.7</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>2.2.2</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5530

## Description

Mongo upgraders have to use the prefix of tables if it exists.
In order to restart the upgraders, we need to set a version.
An update has been made on the upgrader fwk to allow upgrader versioning.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-afpepaadex.chromatic.com)
<!-- Storybook placeholder end -->
