### PR TITLE
fix(mongo-upgrader): make idempotent and consider prefix - 4.4.x

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/accessPoints/AccessPointsStatusAndUpdatedUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/accessPoints/AccessPointsStatusAndUpdatedUpgrader.java
@@ -17,7 +17,7 @@ package io.gravitee.repository.mongodb.management.upgrade.upgrader.accessPoints;
 
 import com.mongodb.client.model.Filters;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import io.gravitee.repository.mongodb.management.upgrade.upgrader.themes.ThemeTypeUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.environment.MissingEnvironmentUpgrader;
 import java.util.Date;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
@@ -25,19 +25,24 @@ import org.springframework.stereotype.Component;
 @Component
 public class AccessPointsStatusAndUpdatedUpgrader extends MongoUpgrader {
 
-    public static final int ACCESSPOINTS_STATUS_AND_UPDATED_UPGRADER_ORDER = ThemeTypeUpgrader.THEME_TYPE_UPGRADER_ORDER + 1;
+    public static final int ACCESSPOINTS_STATUS_AND_UPDATED_UPGRADER_ORDER =
+        MissingEnvironmentUpgrader.MISSING_ENVIRONMENT_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
 
     @Override
     public boolean upgrade() {
         var accessPointsStatusNullQuery = new Document("status", null);
 
-        template
-            .getCollection("access_points")
+        this.getCollection("access_points")
             .find(accessPointsStatusNullQuery)
             .forEach(accessPoint -> {
                 accessPoint.append("status", "CREATED");
                 accessPoint.append("updatedAt", new Date());
-                template.getCollection("access_points").replaceOne(Filters.eq("_id", accessPoint.getString("_id")), accessPoint);
+                this.getCollection("access_points").replaceOne(Filters.eq("_id", accessPoint.getString("_id")), accessPoint);
             });
 
         return true;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/MongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/common/MongoUpgrader.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.common;
 
+import com.mongodb.client.MongoCollection;
 import io.gravitee.node.api.upgrader.Upgrader;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -37,6 +39,10 @@ public abstract class MongoUpgrader implements Upgrader {
     @Autowired
     public void setEnvironment(Environment environment) {
         this.prefix = environment.getProperty("management.mongodb.prefix", "");
+    }
+
+    protected MongoCollection<Document> getCollection(String collectionName) {
+        return template.getCollection(buildCollectionName(collectionName));
     }
 
     protected String buildCollectionName(String collectionName) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/promotions/RemovePromotionAuthorPictureUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/promotions/RemovePromotionAuthorPictureUpgrader.java
@@ -29,8 +29,13 @@ public class RemovePromotionAuthorPictureUpgrader extends MongoUpgrader {
     public static final int REMOVE_PROMOTION_AUTHOR_PICTURE_UPGRADER_ORDER = 0;
 
     @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
     public boolean upgrade() {
-        var updateResult = template.getCollection("promotions").updateMany(new BsonDocument(), Updates.unset("author.picture"));
+        var updateResult = this.getCollection("promotions").updateMany(new BsonDocument(), Updates.unset("author.picture"));
         return updateResult.wasAcknowledged();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/themes/ThemeTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/themes/ThemeTypeUpgrader.java
@@ -32,15 +32,19 @@ public class ThemeTypeUpgrader extends MongoUpgrader {
     public static final int THEME_TYPE_UPGRADER_ORDER = PlanDefinitionVersionUpgrader.PLAN_DEFINITION_VERSION_UPGRADER_ORDER + 1;
 
     @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
     public boolean upgrade() {
         var themeTypeNullQuery = new Document("type", null);
 
-        template
-            .getCollection("themes")
+        this.getCollection("themes")
             .find(themeTypeNullQuery)
             .forEach(theme -> {
                 theme.append("type", "PORTAL");
-                template.getCollection("themes").replaceOne(Filters.eq("_id", theme.getString("_id")), theme);
+                this.getCollection("themes").replaceOne(Filters.eq("_id", theme.getString("_id")), theme);
             });
         return true;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.0.1</gravitee-integration-api.version>
-        <gravitee-node.version>5.18.1</gravitee-node.version>
+        <gravitee-node.version>5.18.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5530

## Description

Mongo upgraders have to use the prefix of tables if it exists.
In order to restart the upgraders, we need to set a version.
An update has been made on the upgrader fwk to allow upgrader versioning.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kziianazzq.chromatic.com)
<!-- Storybook placeholder end -->
