### PR TITLE
fix: missing size 0 in v4 analytics queries

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapter.java
@@ -34,6 +34,7 @@ public class SearchAverageConnectionDurationQueryAdapter {
     public static String adapt(AverageConnectionDurationQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(AverageConnectionDurationQuery.builder().build()));
+        jsonContent.put("size", 0);
         jsonContent.put("query", esQuery);
         jsonContent.put("aggs", buildAverageMessagesPerRequestPerEntrypointAggregate(isEntrypointIdKeyword));
         return new JsonObject(jsonContent).encode();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapter.java
@@ -36,6 +36,7 @@ public class SearchAverageMessagesPerRequestQueryAdapter {
     public static String adapt(AverageMessagesPerRequestQuery query) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(AverageMessagesPerRequestQuery.builder().build()));
+        jsonContent.put("size", 0);
         jsonContent.put("query", esQuery);
         jsonContent.put("aggs", buildAverageMessagesPerRequestPerEntrypointAggregate());
         return new JsonObject(jsonContent).encode();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapter.java
@@ -28,6 +28,7 @@ public class SearchRequestsCountQueryAdapter {
 
     public static String adapt(RequestsCountQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
+        jsonContent.put("size", 0);
         var esQuery = buildElasticQuery(query);
         if (esQuery != null) {
             jsonContent.put("query", esQuery);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapter.java
@@ -33,6 +33,7 @@ public class SearchResponseStatusRangesQueryAdapter {
     public static String adapt(ResponseStatusRangesQuery query, boolean isEntrypointIdKeyword) {
         var jsonContent = new HashMap<String, Object>();
         var esQuery = buildElasticQuery(Optional.ofNullable(query).orElse(ResponseStatusRangesQuery.builder().build()));
+        jsonContent.put("size", 0);
         jsonContent.put("query", esQuery);
         jsonContent.put("aggs", buildResponseCountPerStatusCodeRangePerEntrypointAggregation(isEntrypointIdKeyword));
         return new JsonObject(jsonContent).encode();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageConnectionDurationQueryAdapterTest.java
@@ -32,6 +32,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
     public static final String QUERY_WITHOUT_FILTER =
         """
                  {
+                       "size": 0,
                        "query": {
                          "bool": {
                            "must": [
@@ -85,6 +86,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
             .isEqualTo(
                 """
                              {
+                               "size": 0,
                                "query": {
                                  "bool": {
                                    "must": [
@@ -128,6 +130,7 @@ class SearchAverageConnectionDurationQueryAdapterTest {
             .isEqualTo(
                 """
                              {
+                               "size": 0,
                                "query": {
                                  "bool": {
                                    "must": [

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchAverageMessagesPerRequestQueryAdapterTest.java
@@ -32,6 +32,7 @@ class SearchAverageMessagesPerRequestQueryAdapterTest {
     public static final String QUERY_WITHOUT_FILTER =
         """
                  {
+                       "size": 0,
                        "aggs": {
                          "entrypoints_agg": {
                            "aggs": {
@@ -96,6 +97,7 @@ class SearchAverageMessagesPerRequestQueryAdapterTest {
             .isEqualTo(
                 """
                              {
+                               "size": 0,
                                "query": {
                                  "bool": {
                                    "must": [

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestsCountQueryAdapterTest.java
@@ -33,6 +33,7 @@ class SearchRequestsCountQueryAdapterTest {
     public static final String QUERY_WITHOUT_FILTER =
         """
               {
+                  "size": 0,
                   "aggs": {
                       "entrypoints": {
                               "terms": {"field":"entrypoint-id"}
@@ -63,6 +64,7 @@ class SearchRequestsCountQueryAdapterTest {
             .isEqualTo(
                 """
                                 {
+                                    "size": 0,
                                     "query":{
                                         "bool": {
                                             "must": [
@@ -90,6 +92,7 @@ class SearchRequestsCountQueryAdapterTest {
             .isEqualTo(
                 """
                         {
+                            "size": 0,
                             "query":{
                                 "bool": {
                                     "must": [

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchResponseStatusRangesQueryAdapterTest.java
@@ -33,6 +33,7 @@ class SearchResponseStatusRangesQueryAdapterTest {
             .isEqualTo(
                 """
                             {
+                              "size": 0,
                               "query": {
                                 "term": {
                                   "api-id": "api-id"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5541

## Description

In order to improve analytics queries, we need to avoid returning the “hits” and only gather the aggregation data. To do that, we need to set the size parameter to 0 in our queries.
