### PR TITLE
fix(logging): Set the logging condition to v2 apis when v4 mode is en…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configuration/api-logs-configuration.component.html
@@ -86,7 +86,7 @@
       <mat-form-field class="logging-card__conditionEL__form-field">
         <mat-label>Condition</mat-label>
         <input type="text" matInput aria-label="Logging configuration condition" formControlName="condition" />
-        <mat-hint> Support EL (e.g: &#123;#request.headers['Content-Type'][0] === 'application/json'&#125; )</mat-hint>
+        <mat-hint> Support EL (e.g: &#123;#request.headers['Content-Type'][0] == 'application/json'&#125; )</mat-hint>
       </mat-form-field>
     </mat-card-content>
   </mat-card>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
@@ -42,6 +42,8 @@ public class AnalyticsUtils {
         analytics.setEnabled(true);
         if (loggingV2 != null) {
             Logging logging = new Logging();
+            logging.setCondition(loggingV2.getCondition());
+
             if (loggingV2.getMode() != null) {
                 logging.getMode().setEntrypoint(loggingV2.getMode().isClientMode());
                 logging.getMode().setEndpoint(loggingV2.getMode().isProxyMode());

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/logging/LoggingV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/logging/LoggingV4EmulationIntegrationTest.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.apim.integration.tests.http.logging;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
@@ -172,6 +169,91 @@ class LoggingV4EmulationIntegrationTest extends AbstractGatewayTest {
                 assertThat(body).hasToString(mockResponseBody.toString());
                 return true;
             });
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    void should_notlog_invalidcondition(HttpClient httpClient, VertxTestContext context) throws Exception {
+        JsonObject mockResponseBody = new JsonObject().put("response", "body");
+        wiremock.stubFor(get("/endpoint").willReturn(badRequest()));
+
+        AtomicReference<String> requestHostAndPortRef = new AtomicReference<>();
+        JsonObject requestBody = new JsonObject().put("field", "of the pelennor");
+
+        subject
+            .doOnNext(log -> {
+                final String transactionAndRequestId = wiremock
+                    .getAllServeEvents()
+                    .get(0)
+                    .getRequest()
+                    .getHeaders()
+                    .getHeader("X-Gravitee-Transaction-Id")
+                    .firstValue();
+
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(log.getClientRequest().getBody()).isEqualTo(requestBody.toString());
+                    soft.assertThat(log.getClientRequest().getUri()).isEqualTo("/test");
+                    soft
+                        .assertThat(log.getClientRequest().getHeaders().toSingleValueMap())
+                        .contains(
+                            entry("host", requestHostAndPortRef.get()),
+                            entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                            entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                            entry("content-length", String.valueOf(requestBody.toString().length()))
+                        );
+                });
+
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(log.getProxyRequest().getBody()).isEqualTo(requestBody.toString());
+                    soft.assertThat(log.getProxyRequest().getUri()).isEqualTo("http://localhost:" + wiremock.port() + "/endpoint");
+                    soft
+                        .assertThat(log.getProxyRequest().getHeaders().toSingleValueMap())
+                        .contains(
+                            entry("Host", "localhost:" + wiremock.port()),
+                            entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                            entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                            entry("content-length", String.valueOf(requestBody.toString().length()))
+                        );
+                });
+
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(log.getProxyResponse().getBody()).isBlank();
+                    soft.assertThat(log.getProxyResponse().getStatus()).isEqualTo(400);
+                    soft
+                        .assertThat(log.getProxyResponse().getHeaders().toSingleValueMap())
+                        .doesNotContainKeys("X-Gravitee-Transaction-Id", "X-Gravitee-Request-Id");
+                });
+
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(log.getClientResponse().getBody()).isBlank();
+                    soft.assertThat(log.getClientResponse().getStatus()).isEqualTo(400);
+                    soft
+                        .assertThat(log.getClientResponse().getHeaders().toSingleValueMap())
+                        .contains(
+                            entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                            entry("X-Gravitee-Request-Id", transactionAndRequestId)
+                        );
+                });
+            })
+            .doOnNext(m -> context.completeNow())
+            .doOnError(context::failNow)
+            .subscribe();
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> {
+                request.setHost("127.0.0.1");
+                requestHostAndPortRef.set(request.getHost() + ":" + request.getPort());
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete();
 
         wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
     }


### PR DESCRIPTION
…abled

## Issue

https://gravitee.atlassian.net/browse/APIM-5226

## Description

When logging is enabled with a condition for v2 APIs, running v4 mode, the condition was not properly set.
It's working well for v4 APIs or for v2 APIs without v4 mode

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zwtlohdrrr.chromatic.com)
<!-- Storybook placeholder end -->
