### PR TITLE
Apim 4915 add link to api and app in user details

### DIFF
--- a/gravitee-apim-console-webui/src/entities/user/userMembership.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/user/userMembership.fixture.ts
@@ -44,11 +44,13 @@ export function fakeUserMembership<T extends 'application' | 'api' | string = st
           visibility: 'PUBLIC',
           name: '\uD83D\uDC82‍♀️Planets API Validator',
           version: '1.0',
+          environmentId: 'DEFAULT',
         },
         'aee23b1e-34b1-4551-a23b-1e34b165516a': {
           visibility: 'PUBLIC',
           name: '\uD83E\uDE90 Planets',
           version: '1.0',
+          environmentId: 'DEFAULT',
         },
       },
     };
@@ -74,6 +76,7 @@ export function fakeUserMembership<T extends 'application' | 'api' | string = st
       metadata: {
         '00783aa6-d0db-45d1-b83a-a6d0db05d1e1': {
           name: 'Default application',
+          environmentId: 'DEFAULT',
         },
       },
     };
@@ -98,6 +101,7 @@ export function fakeUserMembership<T extends 'application' | 'api' | string = st
     metadata: {
       '00783aa6-d0db-45d1-b83a-a6d0db05d1e1': {
         name: 'Default application',
+        environmentId: 'DEFAULT',
       },
     },
   };

--- a/gravitee-apim-console-webui/src/entities/user/userMembership.ts
+++ b/gravitee-apim-console-webui/src/entities/user/userMembership.ts
@@ -35,6 +35,7 @@ export type UserMembershipMetadataApplication = Record<
   string,
   {
     name: string;
+    environmentId: string;
   }
 >;
 
@@ -42,6 +43,7 @@ export type UserMembershipMetadataApi = Record<
   string,
   {
     name: string;
+    environmentId: string;
     version?: string;
     visibility?: 'PUBLIC' | 'PRIVATE';
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.html
@@ -215,7 +215,7 @@
         >
           <!-- Position Name -->
           <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef id="name" mat-sort-header>Name</th>
+            <th mat-header-cell *matHeaderCellDef id="group-name" mat-sort-header>Name</th>
             <td mat-cell *matCellDef="let group">
               {{ group.name }}
 
@@ -265,7 +265,7 @@
 
           <!-- Delete Column -->
           <ng-container matColumnDef="delete">
-            <th mat-header-cell *matHeaderCellDef id="roles" width="5%">Delete</th>
+            <th mat-header-cell *matHeaderCellDef id="delete-user-group" width="5%">Delete</th>
             <td mat-cell *matCellDef="let group">
               <button
                 *gioPermission="{ anyOf: ['organization-user-d'] }"
@@ -310,9 +310,15 @@
         <table mat-table [dataSource]="apisTableDS" matSort aria-label="APIs table">
           <!-- Name Column -->
           <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef id="name" mat-sort-header>Name</th>
+            <th mat-header-cell *matHeaderCellDef id="api-name" mat-sort-header>Name</th>
             <td mat-cell *matCellDef="let api">
-              {{ api.name }}
+              @if (api.environmentId && api.id) {
+                <a [routerLink]="['/', api.environmentId, 'apis', api.id]">
+                  {{ api.name }}
+                </a>
+              } @else {
+                {{ api.name }}
+              }
             </td>
           </ng-container>
 
@@ -366,9 +372,15 @@
         >
           <!-- Name Column -->
           <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef id="name">Name</th>
-            <td mat-cell *matCellDef="let group">
-              {{ group.name }}
+            <th mat-header-cell *matHeaderCellDef id="app-name">Name</th>
+            <td mat-cell *matCellDef="let application">
+              @if (application.environmentId && application.id) {
+                <a [routerLink]="['/', application.environmentId, 'applications', application.id]">
+                  {{ application.name }}
+                </a>
+              } @else {
+                {{ application.name }}
+              }
             </td>
           </ng-container>
 
@@ -403,7 +415,7 @@
         <table class="org-settings-user-detail__tokens__card__table" mat-table [dataSource]="tokensTableDS" aria-label="Tokens table">
           <!-- Name Column -->
           <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef id="name">Name</th>
+            <th mat-header-cell *matHeaderCellDef id="token-name">Name</th>
             <td mat-cell *matCellDef="let token">
               {{ token.name }}
             </td>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -29,6 +29,7 @@ import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
 
 import { OrgSettingsUserDetailComponent } from './org-settings-user-detail.component';
 
@@ -432,8 +433,8 @@ describe('OrgSettingsUserDetailComponent', () => {
       'api',
       fakeUserMembership('api', {
         metadata: {
-          apiAlphaId: { name: 'API Alpha', version: '1.0.0', visibility: 'PUBLIC' },
-          apiBetaId: { name: 'API Beta', version: '42.0.0', visibility: 'PRIVATE' },
+          apiAlphaId: { name: 'API Alpha', version: '1.0.0', visibility: 'PUBLIC', environmentId: 'DEFAULT' },
+          apiBetaId: { name: 'API Beta', version: '42.0.0', visibility: 'PRIVATE', environmentId: 'DEFAULT' },
         },
       }),
     );
@@ -465,8 +466,8 @@ describe('OrgSettingsUserDetailComponent', () => {
       'application',
       fakeUserMembership('application', {
         metadata: {
-          appFoxId: { name: 'Application Fox' },
-          appDogId: { name: 'Application Dog' },
+          appFoxId: { name: 'Application Fox', environmentId: 'DEFAULT' },
+          appDogId: { name: 'Application Dog', environmentId: 'DEFAULT' },
         },
       }),
     );
@@ -494,8 +495,8 @@ describe('OrgSettingsUserDetailComponent', () => {
       'application',
       fakeUserMembership('application', {
         metadata: {
-          appFoxId: { name: 'Application Fox' },
-          appDogId: { name: 'Application Dog' },
+          appFoxId: { name: 'Application Fox', environmentId: 'DEFAULT' },
+          appDogId: { name: 'Application Dog', environmentId: 'DEFAULT' },
         },
       }),
     );
@@ -655,6 +656,60 @@ describe('OrgSettingsUserDetailComponent', () => {
     ]);
     expectUserMembershipGetRequest(user.id, 'api');
     expectUserMembershipGetRequest(user.id, 'application');
+  });
+
+  it('should have application name link', async () => {
+    const user = fakeUser({
+      id: 'userId',
+      source: 'gravitee',
+      status: 'ACTIVE',
+    });
+    expectUserTokensGetRequest(user);
+    expectUserGetRequest(user);
+    expectEnvironmentListRequest();
+    expectUserGroupsGetRequest(user.id);
+    expectUserMembershipGetRequest(user.id, 'api');
+    expectUserMembershipGetRequest(
+      user.id,
+      'application',
+      fakeUserMembership('application', {
+        metadata: {
+          appFoxId: { name: 'Application Fox', environmentId: 'DEFAULT' },
+          appDogId: { name: 'Application Dog', environmentId: 'DEFAULT' },
+        },
+      }),
+    );
+    expectRolesListRequest('ORGANIZATION');
+
+    const clickableName = fixture.debugElement.query(By.css('a[href="/DEFAULT/applications/appFoxId"]'));
+    expect(clickableName).toBeTruthy();
+  });
+
+  it('should display api name link', async () => {
+    const user = fakeUser({
+      id: 'userId',
+      source: 'gravitee',
+      status: 'ACTIVE',
+    });
+    expectUserTokensGetRequest(user);
+    expectUserGetRequest(user);
+    expectEnvironmentListRequest();
+    expectUserGroupsGetRequest(user.id);
+    expectUserMembershipGetRequest(
+      user.id,
+      'api',
+      fakeUserMembership('api', {
+        metadata: {
+          apiAlphaId: { name: 'API Alpha', version: '1.0.0', visibility: 'PUBLIC', environmentId: 'DEFAULT' },
+          apiBetaId: { name: 'API Beta', version: '42.0.0', visibility: 'PRIVATE', environmentId: 'DEFAULT' },
+        },
+      }),
+    );
+    expectUserMembershipGetRequest(user.id, 'application');
+    expectRolesListRequest('ORGANIZATION');
+
+    const clickableName = fixture.debugElement.query(By.css('a[href="/DEFAULT/apis/apiAlphaId"]'));
+    expect(clickableName).toBeTruthy();
   });
 
   function expectUserTokensGetRequest(user: User = fakeUser({ id: 'userId' }), tokens: Token[] = []) {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -70,11 +70,13 @@ interface ApiDS {
   id: string;
   version: string;
   visibility: string;
+  environmentId: string;
 }
 
 interface ApplicationDS {
   id: string;
   name: string;
+  environmentId: string;
 }
 
 interface TokenDS {
@@ -188,6 +190,7 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
           name: apiMetadata.name,
           version: apiMetadata.version,
           visibility: apiMetadata.visibility,
+          environmentId: apiMetadata.environmentId,
         }));
         this.initialTableDS['apisTableDS'] = this.apisTableDS;
         this.tablesUnpaginatedLength['apisTableDS'] = this.apisTableDS.length;
@@ -200,6 +203,7 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
         this.applicationsTableDS = Object.entries(metadata).map(([applicationId, applicationMetadata]: [string, any]) => ({
           id: applicationId,
           name: applicationMetadata.name,
+          environmentId: applicationMetadata.environmentId,
         }));
         this.initialTableDS['applicationsTableDS'] = this.applicationsTableDS;
         this.tablesUnpaginatedLength['applicationsTableDS'] = this.applicationsTableDS.length;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -911,12 +911,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                         metadata.put(api.getId(), "name", api.getName());
                         metadata.put(api.getId(), "version", api.getVersion());
                         metadata.put(api.getId(), "visibility", api.getVisibility());
+                        metadata.put(api.getId(), "environmentId", api.getEnvironmentId());
                     });
             } else if (type.equals(MembershipReferenceType.APPLICATION)) {
                 applicationRepository
                     .findByIds(memberships.stream().map(UserMembership::getReference).collect(Collectors.toList()))
                     .forEach(application -> {
                         metadata.put(application.getId(), "name", application.getName());
+                        metadata.put(application.getId(), "environmentId", application.getEnvironmentId());
                     });
             }
             return metadata;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Sets;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.repository.management.model.MembershipMemberType;
+import io.gravitee.repository.management.model.Visibility;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UserMembership;
+import io.gravitee.rest.api.model.pagedresult.Metadata;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+public class MembershipService_FindUserMembershipMetadataTest {
+
+    private static final String USER_MEMBERSHIP_REFERENCE = "ref-id";
+    private static UserMembership USER_MEMBERSHIP;
+
+    private MembershipService membershipService;
+
+    @Mock
+    private MembershipRepository mockMembershipRepository;
+
+    @Mock
+    private ApiRepository mockApiRepository;
+
+    @Mock
+    private ApplicationRepository mockApplicationRepository;
+
+    @Mock
+    private GroupService mockGroupService;
+
+    @Mock
+    private RoleService mockRoleService;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        membershipService =
+            new MembershipServiceImpl(
+                null,
+                null,
+                mockApplicationRepository,
+                null,
+                null,
+                null,
+                mockMembershipRepository,
+                mockRoleService,
+                null,
+                null,
+                null,
+                null,
+                mockApiRepository,
+                mockGroupService,
+                null,
+                null
+            );
+        USER_MEMBERSHIP = new UserMembership();
+        USER_MEMBERSHIP.setReference(USER_MEMBERSHIP_REFERENCE);
+    }
+
+    @ParameterizedTest
+    @MethodSource({ "emptyMetadataInputs" })
+    void shouldBeEmpty(List<UserMembership> memberships, MembershipReferenceType type) {
+        var result = membershipService.findUserMembershipMetadata(memberships, type);
+        assertThat(result).isNotNull().satisfies(res -> assertThat(res.toMap()).isEmpty());
+    }
+
+    static Stream<Arguments> emptyMetadataInputs() {
+        var validUserMembership = new UserMembership();
+        validUserMembership.setReference(USER_MEMBERSHIP_REFERENCE);
+        var validUserMembershipList = List.of(validUserMembership);
+
+        return Stream.of(
+            Arguments.of(null, MembershipReferenceType.API),
+            Arguments.of(new ArrayList<UserMembership>(), MembershipReferenceType.API),
+            Arguments.of(validUserMembershipList, null),
+            Arguments.of(validUserMembershipList, MembershipReferenceType.ENVIRONMENT),
+            Arguments.of(validUserMembershipList, MembershipReferenceType.PLATFORM),
+            Arguments.of(validUserMembershipList, MembershipReferenceType.ORGANIZATION),
+            Arguments.of(validUserMembershipList, MembershipReferenceType.API),
+            Arguments.of(validUserMembershipList, MembershipReferenceType.APPLICATION)
+        );
+    }
+
+    @Test
+    void shouldReturnApiMetadata() {
+        when(mockApiRepository.search(eq(new ApiCriteria.Builder().ids(List.of(USER_MEMBERSHIP_REFERENCE)).build()), any(), any()))
+            .thenReturn(
+                Stream.of(
+                    Api
+                        .builder()
+                        .id(USER_MEMBERSHIP_REFERENCE)
+                        .name("api-name")
+                        .version("v11")
+                        .visibility(Visibility.PUBLIC)
+                        .environmentId("env-id")
+                        .build()
+                )
+            );
+        var result = membershipService.findUserMembershipMetadata(List.of(USER_MEMBERSHIP), MembershipReferenceType.API);
+        assertThat(result)
+            .isNotNull()
+            .satisfies(res ->
+                assertThat(res.toMap())
+                    .isNotEmpty()
+                    .extractingByKey(USER_MEMBERSHIP_REFERENCE)
+                    .hasFieldOrPropertyWithValue("name", "api-name")
+                    .hasFieldOrPropertyWithValue("version", "v11")
+                    .hasFieldOrPropertyWithValue("visibility", Visibility.PUBLIC)
+                    .hasFieldOrPropertyWithValue("environmentId", "env-id")
+            );
+    }
+
+    @Test
+    void shouldReturnApplicationMetadata() throws TechnicalException {
+        when(mockApplicationRepository.findByIds(eq(List.of(USER_MEMBERSHIP_REFERENCE))))
+            .thenReturn(
+                Set.of(Application.builder().id(USER_MEMBERSHIP_REFERENCE).name("application-name").environmentId("env-id").build())
+            );
+        var result = membershipService.findUserMembershipMetadata(List.of(USER_MEMBERSHIP), MembershipReferenceType.APPLICATION);
+        assertThat(result)
+            .isNotNull()
+            .satisfies(res ->
+                assertThat(res.toMap())
+                    .isNotEmpty()
+                    .extractingByKey(USER_MEMBERSHIP_REFERENCE)
+                    .hasFieldOrPropertyWithValue("name", "application-name")
+                    .hasFieldOrPropertyWithValue("environmentId", "env-id")
+            );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4915

## Description

Allow user to click the name of an API or Application in the User Details view in order to navigate to the specified page.


https://github.com/gravitee-io/gravitee-api-management/assets/42294616/2dd9c412-ff39-49f9-a169-70fabd4ad695



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jikenpdxja.chromatic.com)
<!-- Storybook placeholder end -->
