### PR TITLE
fix(api): Do not check context-path for current API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
@@ -63,6 +63,9 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
   @Input()
   public pathsToIgnore: PathV4[] = [];
 
+  @Input()
+  public apiId?: string;
+
   public listeners: PathV4[] = [DEFAULT_LISTENER];
   public mainForm: FormGroup;
   public listenerFormArray = new FormArray(
@@ -262,7 +265,7 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
         if (contextPathsToIgnore.includes(contextPathValue)) {
           return of(null);
         }
-        return this.apiService.verify({ contextPath: contextPathValue });
+        return this.apiService.verify({ contextPath: contextPathValue }, this.apiId);
       });
 
       return zip(...pathValidations$).pipe(

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.component.ts
@@ -57,6 +57,9 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
   @Input()
   public domainRestrictions: string[] = [];
 
+  @Input()
+  public apiId?: string;
+
   public newListenerFormGroup(listener: PathV4): FormGroup {
     const { host, hostDomain } = extractDomainToHost(listener?.host, this.domainRestrictions);
 
@@ -140,7 +143,7 @@ export class GioFormListenersVirtualHostComponent extends GioFormListenersContex
         if (contextPathsToIgnore.includes(contextPathValue)) {
           return of(null);
         }
-        return this.apiService.verify({ host, contextPath: contextPathValue });
+        return this.apiService.verify({ host, contextPath: contextPathValue }, this.apiId);
       });
 
       return zip(...pathValidations$).pipe(

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -31,6 +31,7 @@
           *ngIf="!this.enableVirtualHost"
           [formControl]="pathsFormControl"
           [pathsToIgnore]="apiExistingPaths"
+          [apiId]="apiId"
         ></gio-form-listeners-context-path>
 
         <gio-form-listeners-virtual-host
@@ -38,6 +39,7 @@
           [formControl]="pathsFormControl"
           [pathsToIgnore]="apiExistingPaths"
           [domainRestrictions]="domainRestrictions"
+          [apiId]="apiId"
         ></gio-form-listeners-virtual-host>
       </div>
       <div class="entrypoints__footer" *ngIf="canUpdate">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4845

## Description

Do not check the context-path (+ virtual hosts) for the current API
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cpcufjbxdw.chromatic.com)
<!-- Storybook placeholder end -->
