### PR TITLE
Fix Federation default configuration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerCondition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerCondition.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.spring;
+
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.ConfigurationCondition;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class IntegrationControllerCondition implements ConfigurationCondition {
+
+    public static final String INTEGRATION_IDENTIFIER = "integration";
+
+    @Override
+    public boolean matches(ConditionContext conditionContext, AnnotatedTypeMetadata annotatedTypeMetadata) {
+        return conditionContext.getEnvironment().getProperty(INTEGRATION_IDENTIFIER + ".enabled", Boolean.class, false);
+    }
+
+    @Override
+    public ConfigurationPhase getConfigurationPhase() {
+        return ConfigurationPhase.REGISTER_BEAN;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.integration.controller.spring;
 
+import static io.gravitee.integration.controller.spring.IntegrationControllerCondition.INTEGRATION_IDENTIFIER;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
 import io.gravitee.apim.core.integration.use_case.UpdateAgentStatusUseCase;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
@@ -42,11 +43,13 @@ import io.gravitee.rest.api.service.TokenService;
 import io.vertx.rxjava3.core.Vertx;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 
 @Configuration
+@Conditional(IntegrationControllerCondition.class)
 public class IntegrationControllerConfiguration {
 
     @Bean("integrationWebsocketControllerAuthentication")
@@ -65,7 +68,7 @@ public class IntegrationControllerConfiguration {
 
     @Bean("integrationIdentifyConfiguration")
     public IdentifyConfiguration integrationPrefixConfiguration(final Environment environment) {
-        return new IdentifyConfiguration(environment, "integration");
+        return new IdentifyConfiguration(environment, INTEGRATION_IDENTIFIER);
     }
 
     @Bean("integrationControllerCommandHandlerFactory")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -170,6 +170,11 @@
 			<artifactId>gravitee-node-api</artifactId>
 		</dependency>
 
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-container</artifactId>
+        </dependency>
+
 		<dependency>
 			<groupId>io.gravitee.node.services</groupId>
 			<artifactId>gravitee-node-services-upgrader</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/integration/IntegrationAgentImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/integration/IntegrationAgentImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.integration;
 import static io.gravitee.apim.core.integration.model.IntegrationSubscription.apiKey;
 import static io.gravitee.apim.core.integration.model.IntegrationSubscription.oAuth;
 
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.integration.exception.IntegrationDiscoveryException;
 import io.gravitee.apim.core.integration.exception.IntegrationIngestionException;
 import io.gravitee.apim.core.integration.exception.IntegrationSubscriptionException;
@@ -50,6 +51,7 @@ import io.reactivex.rxjava3.core.Single;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -58,9 +60,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class IntegrationAgentImpl implements IntegrationAgent {
 
-    private final ExchangeController exchangeController;
+    private final Optional<ExchangeController> exchangeController;
 
-    public IntegrationAgentImpl(@Qualifier("integrationExchangeController") ExchangeController exchangeController) {
+    public IntegrationAgentImpl(@Qualifier("integrationExchangeController") Optional<ExchangeController> exchangeController) {
         this.exchangeController = exchangeController;
     }
 
@@ -179,29 +181,45 @@ public class IntegrationAgentImpl implements IntegrationAgent {
 
     private Single<IngestReply> sendIngestCommand(IngestCommand fetchCommand, String integrationId) {
         return exchangeController
-            .sendCommand(fetchCommand, integrationId)
-            .cast(IngestReply.class)
-            .onErrorReturn(throwable -> new IngestReply(fetchCommand.getId(), throwable.getMessage()));
+            .map(controller ->
+                controller
+                    .sendCommand(fetchCommand, integrationId)
+                    .cast(IngestReply.class)
+                    .onErrorReturn(throwable -> new IngestReply(fetchCommand.getId(), throwable.getMessage()))
+            )
+            .orElse(Single.error(new TechnicalDomainException("Federation feature not enabled")));
     }
 
     private Single<SubscribeReply> sendSubscribeCommand(SubscribeCommand subscribeCommand, String integrationId) {
         return exchangeController
-            .sendCommand(subscribeCommand, integrationId)
-            .cast(SubscribeReply.class)
-            .onErrorReturn(throwable -> new SubscribeReply(subscribeCommand.getId(), throwable.getMessage()));
+            .map(controller ->
+                controller
+                    .sendCommand(subscribeCommand, integrationId)
+                    .cast(SubscribeReply.class)
+                    .onErrorReturn(throwable -> new SubscribeReply(subscribeCommand.getId(), throwable.getMessage()))
+            )
+            .orElse(Single.error(new TechnicalDomainException("Federation feature not enabled")));
     }
 
     private Single<UnsubscribeReply> sendUnsubscribeCommand(UnsubscribeCommand command, String integrationId) {
         return exchangeController
-            .sendCommand(command, integrationId)
-            .cast(UnsubscribeReply.class)
-            .onErrorReturn(throwable -> new UnsubscribeReply(command.getId(), throwable.getMessage()));
+            .map(controller ->
+                controller
+                    .sendCommand(command, integrationId)
+                    .cast(UnsubscribeReply.class)
+                    .onErrorReturn(throwable -> new UnsubscribeReply(command.getId(), throwable.getMessage()))
+            )
+            .orElse(Single.error(new TechnicalDomainException("Federation feature not enabled")));
     }
 
     private Single<DiscoverReply> sendDiscoverCommand(DiscoverCommand command, String integrationId) {
         return exchangeController
-            .sendCommand(command, integrationId)
-            .cast(DiscoverReply.class)
-            .onErrorReturn(throwable -> new DiscoverReply(command.getId(), throwable.getMessage()));
+            .map(controller ->
+                controller
+                    .sendCommand(command, integrationId)
+                    .cast(DiscoverReply.class)
+                    .onErrorReturn(throwable -> new DiscoverReply(command.getId(), throwable.getMessage()))
+            )
+            .orElse(Single.error(new TechnicalDomainException("Federation feature not enabled")));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializerTest.java
@@ -16,10 +16,14 @@
 package io.gravitee.rest.api.service.impl.upgrade.initializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
 import io.gravitee.exchange.api.controller.ExchangeController;
+import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
 
 @ExtendWith(MockitoExtension.class)
 class IntegrationControllerInitializerTest {
@@ -34,16 +40,23 @@ class IntegrationControllerInitializerTest {
     @Mock
     ExchangeController exchangeController;
 
+    MockEnvironment environment = new MockEnvironment();
+
     IntegrationControllerInitializer initializer;
 
     @BeforeEach
     void setUp() {
-        initializer = new IntegrationControllerInitializer(exchangeController);
+        initializer =
+            new IntegrationControllerInitializer(
+                Optional.of(exchangeController),
+                Optional.of(new IdentifyConfiguration(environment, "integration"))
+            );
     }
 
     @Test
     @SneakyThrows
     void should_start_integration_controller() {
+        environment.setProperty("integration.enabled", "true");
         initializer.initialize();
 
         verify(exchangeController).start();
@@ -51,7 +64,25 @@ class IntegrationControllerInitializerTest {
 
     @Test
     @SneakyThrows
+    void should_not_start_integration_controller_by_default() {
+        initializer.initialize();
+
+        verify(exchangeController, never()).start();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_not_start_integration_controller_if_disabled() {
+        environment.setProperty("integration.enabled", "false");
+        initializer.initialize();
+
+        verify(exchangeController, never()).start();
+    }
+
+    @Test
+    @SneakyThrows
     void should_throw_when_integration_controller_starting_fails() {
+        environment.setProperty("integration.enabled", "true");
         when(exchangeController.start()).thenThrow(new Exception("error"));
 
         var throwable = Assertions.catchThrowable(() -> initializer.initialize());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -688,6 +688,7 @@ notifiers:
 
 # Integration
 integration:
+  enabled: false
   controller:
     ws:
       port: 8072

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.4.1
+
+- Add support for Federation:
+    - To enable the feature, change property `api.federation.enabled` to true 
+
 ### 4.4.0
 
 - Add support for multi-server installation

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -18,4 +18,5 @@ kubeVersion: ">=1.14.0-0"
 annotations:
   # List of changes for the release in artifacthub.io
   # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - Add support for Federation

--- a/helm/templates/api/api-ingress-federation-controller.yaml
+++ b/helm/templates/api/api-ingress-federation-controller.yaml
@@ -22,8 +22,9 @@ metadata:
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.api.federation.ingress.annotations }}
-    {{- include "common.ingress.annotations.render" (dict "annotations" .Values.api.federation.ingress.annotations "ingressClassName" .Values.api.federation.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
+    {{- $annotations := (merge .Values.api.federation.ingress.annotations .Values.api.ingress.management.annotations ) }}
+    {{- if $annotations }}
+    {{- include "common.ingress.annotations.render" (dict "annotations" $annotations "ingressClassName" .Values.api.federation.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.common .Values.common.annotations }}
     {{- range $key, $value := .Values.common.annotations }}
@@ -35,7 +36,11 @@ spec:
   ingressClassName: {{ .Values.api.federation.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-  {{- range $host := .Values.api.federation.ingress.hosts }}
+  {{- $hosts := .Values.api.ingress.management.hosts }}
+  {{- if .Values.api.federation.ingress.hosts -}}
+  {{- $hosts = .Values.api.federation.ingress.hosts }}
+  {{- end -}}
+  {{- range $host := $hosts }}
   - host: {{ $host | quote }}
     http:
       paths:
@@ -52,9 +57,13 @@ spec:
             servicePort: {{ $serviceAPIPort }}
           {{- end -}}
   {{- end -}}
-  {{- if .Values.api.federation.ingress.tls }}
+  {{- $tls := .Values.api.ingress.management.tls }}
+  {{- if .Values.api.federation.ingress.tls -}}
+  {{- $tls = .Values.api.federation.ingress.tls }}
+  {{- end -}}
+  {{- if $tls }}
   tls:
-{{ toYaml .Values.api.federation.ingress.tls | indent 4 }}
+{{ toYaml $tls | indent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -88,10 +88,6 @@ spec:
       {{- if .Values.api.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
-      {{- if .Values.api.federation.enabled -}}
-        {{- $plugins = concat $plugins .Values.cluster.plugins -}}
-      {{- end -}}
-
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
       {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.driver }}
       initContainers:
@@ -127,6 +123,12 @@ spec:
               value: "false"
             - name: GRAVITEE_CLOUD_ENABLED
               value: "false"
+            - name: GRAVITEE_INTEGRATION_ENABLED
+              value: "false"
+            - name: GRAVITEE_CLUSTER_TYPE
+              value: "standalone"
+            - name: GRAVITEE_CACHE_TYPE
+              value: "standalone"
             {{- if $plugins }}
             - name: GRAVITEE_PLUGINS_PATH_0
               value: '${gravitee.home}/plugins'
@@ -160,11 +162,6 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-management-api/config/gravitee.yml
               subPath: gravitee.yml
-          {{- if .Values.api.federation.enabled }}
-            - name: config
-              mountPath: /opt/graviteeio-management-api/config/hazelcast.xml
-              subPath: hazelcast.xml
-          {{- end }}
           {{- if .Values.api.logging.debug }}
             - name: config
               mountPath: /opt/graviteeio-management-api/config/logback.xml

--- a/helm/tests/api/configmap_test.yaml
+++ b/helm/tests/api/configmap_test.yaml
@@ -167,7 +167,7 @@ tests:
     template: api/api-configmap.yaml
     set:
       api:
-        integration:
+        federation:
           enabled: true
     asserts:
       - matchRegex:

--- a/helm/tests/api/deployment_cloud_test.yaml
+++ b/helm/tests/api/deployment_cloud_test.yaml
@@ -22,8 +22,8 @@ tests:
       - isAPIVersion:
           of: apps/v1
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: gravitee-cloud-certificates
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/cloud

--- a/helm/tests/api/deployment_cockpit_test.yaml
+++ b/helm/tests/api/deployment_cockpit_test.yaml
@@ -19,22 +19,22 @@ tests:
       - isAPIVersion:
           of: apps/v1
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: gravitee-cockpit-certificates
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/cockpit
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[0].name
           value: gravitee_cockpit_enabled
       - equal:
-          path: spec.template.spec.containers[0].env[2].value
+          path: spec.template.spec.containers[0].env[0].value
           value: "true"
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[5].name
           value: gravitee_cockpit_keystore_password
       - equal:
-          path: spec.template.spec.containers[0].env[7].value
+          path: spec.template.spec.containers[0].env[5].value
           value: "my_password"
 
   - it: Check cockpit deployment with keystore from secretKeyRef
@@ -56,22 +56,22 @@ tests:
       - isAPIVersion:
           of: apps/v1
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: gravitee-cockpit-certificates
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/cockpit
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[0].name
           value: gravitee_cockpit_enabled
       - equal:
-          path: spec.template.spec.containers[0].env[2].value
+          path: spec.template.spec.containers[0].env[0].value
           value: "true"
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[5].name
           value: gravitee_cockpit_keystore_password
       - equal:
-          path: spec.template.spec.containers[0].env[7].valueFrom
+          path: spec.template.spec.containers[0].env[5].valueFrom
           value:
             secretKeyRef:
               name: mysecret
@@ -96,22 +96,22 @@ tests:
       - isAPIVersion:
           of: apps/v1
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: gravitee-cockpit-certificates
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/cockpit
       - equal:
-          path: spec.template.spec.containers[0].env[2].name
+          path: spec.template.spec.containers[0].env[0].name
           value: gravitee_cockpit_enabled
       - equal:
-          path: spec.template.spec.containers[0].env[2].value
+          path: spec.template.spec.containers[0].env[0].value
           value: "true"
       - equal:
-          path: spec.template.spec.containers[0].env[7].name
+          path: spec.template.spec.containers[0].env[5].name
           value: gravitee_cockpit_keystore_password
       - equal:
-          path: spec.template.spec.containers[0].env[7].valueFrom
+          path: spec.template.spec.containers[0].env[5].valueFrom
           value:
             configMapKeyRef:
               name: special-config

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -6,8 +6,9 @@ tests:
   - it: Check Federation port is defined
     template: api/api-deployment.yaml
     set:
-      federation:
-        enabled: true
+      api:
+        federation:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -24,8 +25,9 @@ tests:
   - it: Check cluster plugins are downloaded
     template: api/api-deployment.yaml
     set:
-      federation:
-        enabled: true
+      api:
+        federation:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -21,29 +21,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env
           value:
-            - name: GRAVITEE_PLUGINS_PATH_0
-              value: ${gravitee.home}/plugins
-            - name: GRAVITEE_PLUGINS_PATH_1
-              value: ${gravitee.home}/plugins-ext
             - name: portal.entrypoint
               value: https://apim.example.com/
-      - equal:
-          path: spec.template.spec.initContainers
-          value:
-            - command:
-                - sh
-                - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-5.18.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-5.18.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-5.18.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-5.18.1.zip
-              env: [ ]
-              image: alpine:latest
-              imagePullPolicy: Always
-              name: get-plugins
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1001
-              volumeMounts:
-                - mountPath: /tmp/plugins
-                  name: graviteeio-apim-plugins
 
   - it: Check deployment with revisionHistoryLimit
     template: api/api-deployment.yaml
@@ -73,10 +52,10 @@ tests:
       - isKind:
           of: Deployment
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
 
   - it: Set containerPort with custom port if core service is enabled
@@ -99,8 +78,6 @@ tests:
           value:
             - name: http
               containerPort: 8083
-            - name: api-integration
-              containerPort: 8072
             - name: api-techapi
               containerPort: 20202
       - matchRegex:
@@ -124,8 +101,6 @@ tests:
           value:
             - name: http
               containerPort: 8083
-            - name: api-integration
-              containerPort: 8072
             - name: api-techapi
               containerPort: 18083
       - matchRegex:
@@ -233,8 +208,6 @@ tests:
           value: 
             - containerPort: 8083
               name: http
-            - containerPort: 8072
-              name: I-am-a-v-integration
             - containerPort: 18083
               name: I-am-a-techapi
             - containerPort: 18092

--- a/helm/tests/api/external_configuration.yaml
+++ b/helm/tests/api/external_configuration.yaml
@@ -121,7 +121,7 @@ tests:
       - hasDocuments:
           count: 1
       - equal:
-          path: spec.template.spec.containers[0].volumeMounts[2].name
+          path: spec.template.spec.containers[0].volumeMounts[1].name
           value: logback
       - equal:
           path: spec.template.spec.volumes[0].name

--- a/helm/tests/api/ingress_federationcontroller_test.yaml
+++ b/helm/tests/api/ingress_federationcontroller_test.yaml
@@ -2,10 +2,10 @@ suite: Test Management API - Federation Controller Ingress
 templates:
   - "api/api-ingress-federation-controller.yaml"
 tests:
-  - it: Check federation ingress enabled by default
+  - it: Check federation ingress disabled by default
     asserts:
       - hasDocuments:
-          count: 1
+          count: 0
 
   - it: Check federation disabled
     set:
@@ -30,6 +30,10 @@ tests:
           count: 0
 
   - it: Check default federation ingress
+    set:
+      api:
+        federation:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1

--- a/helm/tests/api/ingress_federationcontroller_test.yaml
+++ b/helm/tests/api/ingress_federationcontroller_test.yaml
@@ -47,6 +47,14 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /integration-controller(/.*)?
+      - equal:
+          path: metadata.annotations
+          value:
+            kubernetes.io/ingress.class: nginx
+            nginx.ingress.kubernetes.io/configuration-snippet: "etag on;\nproxy_pass_header ETag;\nproxy_pass_header if-match;\n"
+            nginx.ingress.kubernetes.io/proxy-read-timeout: 3600                                                                                                                                              │
+            nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+            nginx.ingress.kubernetes.io/rewrite-target: /$1
 
   - it: Check federation controller ingress with ingressClassName and kube < 1.18-0
     set:
@@ -127,3 +135,80 @@ tests:
       - equal:
           path: spec.rules[0].http.paths[0].path
           value: /test-federation-controller
+
+  - it: Check overridden hosts federation ingress
+    set:
+      api:
+        federation:
+          enabled: true
+          ingress:
+            hosts:
+              - host1.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.rules[0].host
+          value: host1.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /integration-controller(/.*)?
+
+  - it: Check management tls configuration by default
+    set:
+      api:
+        federation:
+          enabled: true
+        ingress:
+          management:
+            tls:
+              - hosts:
+                  - tls.example.com
+                secretName: api-custom-cert
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: tls.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: api-custom-cert
+
+  - it: Check overridden tls configuration
+    set:
+      api:
+        ingress:
+          management:
+            tls:
+              - hosts:
+                  - tls.example.com
+                secretName: api-custom-cert
+        federation:
+          enabled: true
+          ingress:
+            tls:
+              - hosts:
+                  - federation.example.com
+                secretName: federation-custom-cert
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: federation.example.com
+      - equal:
+          path: spec.tls[0].secretName
+          value: federation-custom-cert

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -87,6 +87,39 @@ tests:
             name: GRAVITEE_CLOUD_ENABLED
             value: "false"
 
+  - it: Check that federation have been disabled
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITEE_INTEGRATION_ENABLED
+            value: "false"
+
+  - it: Check that standalone mode is enabled
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITEE_CLUSTER_TYPE
+            value: "standalone"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GRAVITEE_CACHE_TYPE
+            value: "standalone"
+
   - it: Check if the helm hook annotations are present
     set:
       api:

--- a/helm/tests/api/service_integrationcontroller_test.yaml
+++ b/helm/tests/api/service_integrationcontroller_test.yaml
@@ -2,8 +2,25 @@ suite: Test Management API - Integration Controller Service
 templates:
   - "api/api-service.yaml"
 tests:
+  - it: Check federation service disabled by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - isAPIVersion:
+          of: v1
+      - notContains:
+          path: spec.ports
+          content:
+            name: api-integration-controller
+
   - it: Check default integration service
     template: api/api-service.yaml
+    set:
+      api:
+        federation:
+          enabled: true
     asserts:
       - hasDocuments:
           count: 1
@@ -27,6 +44,7 @@ tests:
     set:
       api:
         federation:
+          enabled: true
           service:
             externalPort: 8888
     asserts:

--- a/helm/tests/api/service_test.yaml
+++ b/helm/tests/api/service_test.yaml
@@ -89,11 +89,6 @@ tests:
               port: 42
               protocol: TCP
               targetPort: 18092
-            - name: I-am-a-very-long-name-Neque-porro-quisquam-est-qui-dolor-integration-controller
-              port: 72
-              protocol: TCP
-              targetPort: 8072
-
 
   - it: Deploy with NodePort and externalTrafficPolicy
     template: api/api-service.yaml

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -830,7 +830,7 @@ api:
   #      issuer: MY_ISSUER
 
   federation:
-    enabled: true
+    enabled: false
     port: 8072
     ingress:
       enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -837,8 +837,8 @@ api:
       ingressClassName: ""
       path: /integration-controller(/.*)?
       pathType: Prefix
-      hosts:
-        - apim.example.com
+#      hosts:
+#        - apim.example.com
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/proxy-read-timeout: 3600                                                                                                                                              │


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5539

## Description

Federation is disabled by default. 
Integration controller is started only when Federation is enabled and MAPI is not in upgrade mode
Update Helm chart to use by default the `management` ingress hosts and annotation to simplify Integration controller management

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cmicgeiewi.chromatic.com)
<!-- Storybook placeholder end -->
