### PR TITLE
[4.2.x] Add expand flag to get the primaryOwner while retrieving list of APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -131,6 +131,7 @@ public class ApisResource extends AbstractResource {
             GraviteeContext.getExecutionContext(),
             getAuthenticatedUser(),
             isAdmin(),
+            expands,
             paginationParam.toPageable()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -68,7 +68,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
-                - $ref: "#/components/parameters/apiExpandsParam"
+                - $ref: "#/components/parameters/apisSearchExpandsParam"
             tags:
                 - APIs
             summary: List APIs
@@ -145,7 +145,7 @@ paths:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
                 - $ref: "#/components/parameters/apiSortByParam"
-                - $ref: "#/components/parameters/apiExpandsParam"
+                - $ref: "#/components/parameters/apisGetExpandsParam"
             tags:
                 - APIs
             summary: Search APIs
@@ -5683,7 +5683,7 @@ components:
         ###############################
         # Other Query Parameters      #
         ###############################
-        apiExpandsParam:
+        apisSearchExpandsParam:
             name: expands
             in: query
             description: Expansion of data to return in APIs.
@@ -5693,6 +5693,17 @@ components:
                     type: string
                     enum:
                         - deploymentState
+        apisGetExpandsParam:
+          name: expands
+          in: query
+          description: Expansion of data to return in APIs.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - deploymentState
+                - primaryOwner
         from:
             name: from
             in: query

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
@@ -127,7 +128,15 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         var apiList = new ArrayList<GenericApiEntity>();
         apiList.add(returnedApi);
 
-        when(apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), eq(new PageableImpl(1, 10))))
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                isNull(),
+                eq(new PageableImpl(1, 10))
+            )
+        )
             .thenReturn(new Page<>(apiList, 1, apiList.size(), apiList.size()));
 
         final Response response = rootTarget().request().get();
@@ -197,7 +206,15 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         var apiList = new ArrayList<GenericApiEntity>();
         apiList.add(returnedApi);
 
-        when(apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), eq(new PageableImpl(1, 10))))
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                isNull(),
+                eq(new PageableImpl(1, 10))
+            )
+        )
             .thenReturn(new Page<>(apiList, 1, apiList.size(), apiList.size()));
 
         final Response response = rootTarget().request().get();
@@ -267,7 +284,15 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         var apiList = new ArrayList<GenericApiEntity>();
         apiList.add(returnedApi);
 
-        when(apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), eq(new PageableImpl(1, 10))))
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                isNull(),
+                eq(new PageableImpl(1, 10))
+            )
+        )
             .thenReturn(new Page<>(apiList, 1, apiList.size(), apiList.size()));
 
         final Response response = rootTarget().request().get();
@@ -331,7 +356,9 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         apiList.add(returnedApi1);
         apiList.add(returnedApi2);
 
-        when(apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), eq(new PageableImpl(1, 2))))
+        when(
+            apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), isNull(), eq(new PageableImpl(1, 2)))
+        )
             .thenReturn(new Page<>(apiList, 1, 2, 42));
 
         final Response response = rootTarget()
@@ -388,7 +415,15 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         apiList.add(returnedApi1);
         apiList.add(returnedApi2);
 
-        when(apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), eq(new PageableImpl(1, 2))))
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                eq(Set.of("deploymentState", "primaryOwner")),
+                eq(new PageableImpl(1, 2))
+            )
+        )
             .thenReturn(new Page<>(apiList, 1, 2, 42));
         when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), eq(returnedApi1))).thenReturn(true);
 
@@ -397,7 +432,7 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         final Response response = rootTarget()
             .queryParam(PaginationParam.PAGE_QUERY_PARAM_NAME, 1)
             .queryParam(PaginationParam.PER_PAGE_QUERY_PARAM_NAME, 2)
-            .queryParam("expands", "deploymentState")
+            .queryParam("expands", "deploymentState,primaryOwner")
             .request()
             .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
@@ -16,15 +16,14 @@
 package io.gravitee.rest.api.service.v4;
 
 import io.gravitee.common.data.domain.Page;
-import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.common.Pageable;
-import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -46,6 +45,14 @@ public interface ApiService {
     );
 
     void delete(final ExecutionContext executionContext, final String apiId, boolean closePlans);
+
+    Page<GenericApiEntity> findAll(
+        final ExecutionContext executionContext,
+        final String userId,
+        final boolean isAdmin,
+        final Set<String> expands,
+        final Pageable pageable
+    );
 
     Page<GenericApiEntity> findAll(
         final ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -163,6 +163,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private CategoryMapper categoryMapper;
 
     private static final String EMAIL_METADATA_VALUE = "${(api.primaryOwner.email)!''}";
+    private static final String EXPAND_PRIMARY_OWNER = "primaryOwner";
 
     public ApiServiceImpl(
         @Lazy final ApiRepository apiRepository,
@@ -675,6 +676,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final ExecutionContext executionContext,
         final String userId,
         final boolean isAdmin,
+        final Set<String> expands,
         final Pageable pageable
     ) {
         ApiCriteria.Builder criteria = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
@@ -700,13 +702,31 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         return apis
             .getContent()
             .stream()
-            .map(api -> genericApiMapper.toGenericApi(api, null))
+            .map(api -> {
+                PrimaryOwnerEntity primaryOwner = null;
+
+                if (expands != null && expands.contains(EXPAND_PRIMARY_OWNER)) {
+                    primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), api.getId());
+                }
+
+                return genericApiMapper.toGenericApi(api, primaryOwner);
+            })
             .collect(
                 Collectors.collectingAndThen(
                     Collectors.toList(),
                     apiEntityList -> new Page<>(apiEntityList, apis.getPageNumber(), (int) apis.getPageElements(), apis.getTotalElements())
                 )
             );
+    }
+
+    @Override
+    public Page<GenericApiEntity> findAll(
+        final ExecutionContext executionContext,
+        final String userId,
+        final boolean isAdmin,
+        final Pageable pageable
+    ) {
+        return this.findAll(executionContext, userId, isAdmin, Collections.emptySet(), pageable);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -18,8 +18,14 @@ package io.gravitee.rest.api.service.v4.impl;
 import static io.gravitee.rest.api.service.impl.promotion.PromotionServiceTest.USER_ID;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
@@ -31,17 +37,41 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
-import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.AlertService;
+import io.gravitee.rest.api.service.ApiMetadataService;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.ConnectorService;
+import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.GenericNotificationConfigService;
+import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.MediaService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.PolicyService;
+import io.gravitee.rest.api.service.PortalNotificationConfigService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.TopApiService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
-import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import io.gravitee.rest.api.service.v4.ApiNotificationService;
 import io.gravitee.rest.api.service.v4.ApiService;
+import io.gravitee.rest.api.service.v4.FlowService;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
+import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import io.gravitee.rest.api.service.v4.PropertiesService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
 import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
@@ -364,5 +394,41 @@ public class ApiServiceImpl_findAllTest {
         assertThat(apis.getPageElements()).isEqualTo(0);
 
         verify(apiRepository, never()).search(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_expand_primary_owner() {
+        var pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        var api1 = new Api();
+        api1.setId("API_1");
+
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                isNull(),
+                eq(pageable),
+                eq(new ApiFieldFilter.Builder().excludePicture().build())
+            )
+        )
+            .thenReturn(new Page<>(List.of(api1), 1, 1, 1));
+
+        when(primaryOwnerService.getPrimaryOwner(anyString(), anyString()))
+            .thenReturn(PrimaryOwnerEntity.builder().id("po-id").displayName("a PO").build());
+
+        final Page<GenericApiEntity> apis = apiService.findAll(
+            GraviteeContext.getExecutionContext(),
+            "UnitTests",
+            true,
+            Set.of("primaryOwner"),
+            new PageableImpl(1, 10)
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(1);
+        assertThat(apis.getContent().get(0))
+            .extracting(GenericApiEntity::getPrimaryOwner)
+            .isEqualTo(PrimaryOwnerEntity.builder().id("po-id").displayName("a PO").build());
+
+        verify(primaryOwnerService).getPrimaryOwner(anyString(), eq("API_1"));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4603

## Description

Cherry pick of https://github.com/gravitee-io/gravitee-api-management/pull/8128

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

