### PR TITLE
fix: implement new terms filter to avoid max clause count issues

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/AbstractQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/AbstractQuery.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.analytics.query;
 
 import io.gravitee.repository.analytics.query.response.Response;
+import java.util.List;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -28,6 +29,8 @@ public abstract class AbstractQuery<T extends Response> implements Query<T> {
     private TimeRangeFilter timeRangeFilter;
 
     private QueryFilter queryFilter;
+
+    private List<TermsFilter> termsFilters;
 
     public RootFilter root() {
         return rootFilter;
@@ -51,5 +54,13 @@ public abstract class AbstractQuery<T extends Response> implements Query<T> {
 
     void query(QueryFilter queryFilter) {
         this.queryFilter = queryFilter;
+    }
+
+    public List<TermsFilter> terms() {
+        return termsFilters;
+    }
+
+    void terms(List<TermsFilter> termsFilters) {
+        this.termsFilters = termsFilters;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/AbstractQueryBuilder.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/AbstractQueryBuilder.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.repository.analytics.query;
 
+import java.util.Map;
+import java.util.Set;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
@@ -48,6 +51,14 @@ public abstract class AbstractQueryBuilder<QB extends AbstractQueryBuilder, Q ex
     public QB root(String field, String id) {
         if (field != null && id != null) {
             this.query.root(new RootFilter(field, id));
+        }
+
+        return (QB) this;
+    }
+
+    public QB terms(Map<String, Set<String>> terms) {
+        if (terms != null && !terms.isEmpty()) {
+            this.query.terms(terms.keySet().stream().map(field -> new TermsFilter(field, terms.get(field))).toList());
         }
 
         return (QB) this;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/TermsFilter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/query/TermsFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.query;
+
+import java.util.Set;
+
+public class TermsFilter {
+
+    private final String field;
+
+    private final Set<String> values;
+
+    public TermsFilter(String filter, Set<String> values) {
+        this.field = filter;
+        this.values = values;
+    }
+
+    public String field() {
+        return this.field;
+    }
+
+    public Set<String> values() {
+        return this.values;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/count.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/count.ftl
@@ -2,6 +2,22 @@
   "query": {
     "bool": {
       "filter": [
+<#if query.terms()?has_content>
+        {
+          "bool": {
+            "should": [
+            <#list query.terms() as terms>
+              {
+                "terms": {
+                    "${terms.field()}": ["${terms.values()?join("\",\"")}"]
+                }
+              }
+                <#sep>,</#sep>
+            </#list>
+            ]
+          }
+        },
+</#if>
 <#if query.query()?has_content>
         {
           "query_string": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/dateHistogram.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/dateHistogram.ftl
@@ -3,6 +3,22 @@
   "query": {
     "bool": {
       "filter": [
+<#if query.terms()?has_content>
+        {
+          "bool": {
+            "should": [
+            <#list query.terms() as terms>
+              {
+                "terms": {
+                "${terms.field()}": ["${terms.values()?join("\",\"")}"]
+                }
+              }
+              <#sep>,</#sep>
+            </#list>
+            ]
+          }
+        },
+</#if>
 <#if query.query()?has_content>
         {
           "query_string": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/groupBy.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/groupBy.ftl
@@ -3,6 +3,22 @@
   "query": {
     "bool": {
       "filter": [
+<#if query.terms()?has_content>
+        {
+          "bool": {
+            "should": [
+            <#list query.terms() as terms>
+              {
+                "terms": {
+                  "${terms.field()}": ["${terms.values()?join("\",\"")}"]
+                }
+              }
+              <#sep>,</#sep>
+            </#list>
+            ]
+          }
+        },
+</#if>
 <#if query.query()?has_content>
         {
           "query_string": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/stats.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/analytics/stats.ftl
@@ -3,6 +3,22 @@
   "query": {
     "bool": {
       "filter": [
+<#if query.terms()?has_content>
+        {
+          "bool": {
+            "should": [
+            <#list query.terms() as terms>
+              {
+                "terms": {
+                  "${terms.field()}": ["${terms.values()?join("\",\"")}"]
+                }
+              }
+              <#sep>,</#sep>
+            </#list>
+            ]
+          }
+        },
+</#if>
 <#if query.query()?has_content>
         {
           "query_string": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/resources/freemarker/log/log.ftl
@@ -5,6 +5,22 @@
   "query": {
     "bool": {
       "filter": [
+        <#if query.terms()?has_content>
+        {
+          "bool": {
+          "should": [
+          <#list query.terms() as terms>
+            {
+              "terms": {
+                "${terms.field()}": ["${terms.values()?join("\",\"")}"]
+              }
+            }
+              <#sep>,</#sep>
+          </#list>
+          ]
+          }
+        },
+        </#if>
         <#if query.query()?has_content>
         {
           "query_string": {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchAnalyticsRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchAnalyticsRepositoryTest.java
@@ -30,6 +30,8 @@ import io.gravitee.repository.analytics.query.groupby.GroupByResponse;
 import io.gravitee.repository.analytics.query.groupby.GroupByResponse.Bucket;
 import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
 import io.gravitee.repository.analytics.query.stats.StatsResponse;
+import java.util.Map;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,7 +83,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         DateHistogramResponse response = analyticsRepository.query(
             dateHistogram()
                 .timeRange(lastDays(30), hours(1))
-                .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
                 .aggregation(AggregationType.AVG, "response-time")
                 .aggregation(AggregationType.AVG, "api-response-time")
                 .build()
@@ -97,7 +99,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         DateHistogramResponse response = analyticsRepository.query(
             dateHistogram()
                 .timeRange(lastDays(30), hours(1))
-                .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
                 .aggregation(AggregationType.AVG, "response-time")
                 .aggregation(AggregationType.FIELD, "application")
                 .build()
@@ -111,7 +113,11 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         Assert.assertNotNull(analyticsRepository);
 
         GroupByResponse response = analyticsRepository.query(
-            groupBy().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").field("application").build()
+            groupBy()
+                .timeRange(lastDays(60), hours(1))
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
+                .field("application")
+                .build()
         );
 
         Assert.assertNotNull(response);
@@ -124,7 +130,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         GroupByResponse response = analyticsRepository.query(
             groupBy()
                 .timeRange(lastDays(30), hours(1))
-                .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
                 .field("application")
                 .sort(SortBuilder.on("response-time", Order.DESC, SortType.AVG))
                 .build()
@@ -140,7 +146,7 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         GroupByResponse response = analyticsRepository.query(
             groupBy()
                 .timeRange(lastDays(30), hours(1))
-                .query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
                 .field("status")
                 .range(100, 199)
                 .range(200, 299)
@@ -171,11 +177,26 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         Assert.assertNotNull(analyticsRepository);
 
         CountResponse response = analyticsRepository.query(
-            count().timeRange(lastDays(30), hours(1)).query("api:4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1").build()
+            count().timeRange(lastDays(30), hours(1)).terms(Map.of("api", Set.of("4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1"))).build()
         );
 
         Assert.assertNotNull(response);
         Assert.assertEquals(3, response.getCount());
+    }
+
+    @Test
+    public void testCountWithTwoApis() throws Exception {
+        Assert.assertNotNull(analyticsRepository);
+
+        CountResponse response = analyticsRepository.query(
+            count()
+                .timeRange(lastDays(30), hours(1))
+                .terms(Map.of("api", Set.of("4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1", "e2c0ecd5-893a-458d-80ec-d5893ab58d12")))
+                .build()
+        );
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(4, response.getCount());
     }
 
     @Test
@@ -217,7 +238,11 @@ public class ElasticsearchAnalyticsRepositoryTest extends AbstractElasticsearchR
         Assert.assertNotNull(analyticsRepository);
 
         final StatsResponse response = analyticsRepository.query(
-            stats().timeRange(lastDays(30), hours(1)).query("api:4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1").field("response-time").build()
+            stats()
+                .timeRange(lastDays(30), hours(1))
+                .terms(Map.of("api", Set.of("4d8d6ca8-c2c7-4ab8-8d6c-a8c2c79ab8a1")))
+                .field("response-time")
+                .build()
         );
 
         Assert.assertNotNull(response);

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchLogRepositoryTest.java
@@ -23,6 +23,8 @@ import static org.junit.Assert.*;
 import io.gravitee.repository.analytics.query.tabular.TabularResponse;
 import io.gravitee.repository.elasticsearch.log.ElasticLogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
+import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -46,7 +48,12 @@ public class ElasticsearchLogRepositoryTest extends AbstractElasticsearchReposit
     @Test
     public void testTabular_withQuery() throws Exception {
         TabularResponse response = logRepository.query(
-            tabular().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").page(1).size(20).build()
+            tabular()
+                .timeRange(lastDays(60), hours(1))
+                .terms(Map.of("api", Set.of("be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab")))
+                .page(1)
+                .size(20)
+                .build()
         );
 
         assertNotNull(response);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -87,21 +87,20 @@ public class PlatformAnalyticsResource extends AbstractResource {
         analyticsParam.validate();
 
         // add filter by Apis or Applications
-        String fieldName;
-        Set<String> ids;
+        String termsField;
+        Set<String> termsValues;
 
         if ("application".equals(analyticsParam.getField())) {
-            fieldName = "application";
-            ids = findApplicationIds();
+            termsField = "application";
+            termsValues = findApplicationIds();
         } else {
-            fieldName = "api";
-            ids = findApiIds();
+            termsField = "api";
+            termsValues = findApiIds();
         }
 
-        if (ids.isEmpty()) {
+        if (termsValues.isEmpty()) {
             return Response.noContent().build();
         }
-        String extraFilter = getExtraFilter(fieldName, ids);
 
         if (analyticsParam.getQuery() != null) {
             analyticsParam.setQuery(analyticsParam.getQuery().replaceAll("\\?", "1"));
@@ -110,16 +109,16 @@ public class PlatformAnalyticsResource extends AbstractResource {
         Analytics analytics = null;
         switch (analyticsParam.getType()) {
             case DATE_HISTO:
-                analytics = executeDateHisto(analyticsParam, extraFilter);
+                analytics = executeDateHisto(analyticsParam, Map.of(termsField, termsValues));
                 break;
             case GROUP_BY:
-                analytics = executeGroupBy(analyticsParam, extraFilter);
+                analytics = executeGroupBy(analyticsParam, Map.of(termsField, termsValues));
                 break;
             case COUNT:
-                analytics = executeCount(analyticsParam, extraFilter);
+                analytics = executeCount(analyticsParam, Map.of(termsField, termsValues));
                 break;
             case STATS:
-                analytics = executeStats(analyticsParam, extraFilter);
+                analytics = executeStats(analyticsParam, Map.of(termsField, termsValues));
                 break;
         }
 
@@ -148,28 +147,28 @@ public class PlatformAnalyticsResource extends AbstractResource {
         return applicationService.findIdsByUserAndPermission(executionContext, getAuthenticatedUser(), null, APPLICATION_ANALYTICS, READ);
     }
 
-    private Analytics executeStats(AnalyticsParam analyticsParam, String extraFilter) {
+    private Analytics executeStats(AnalyticsParam analyticsParam, Map<String, Set<String>> terms) {
         final StatsQuery query = new StatsQuery();
         query.setFrom(analyticsParam.getFrom());
         query.setTo(analyticsParam.getTo());
         query.setInterval(analyticsParam.getInterval());
         query.setQuery(analyticsParam.getQuery());
         query.setField(analyticsParam.getField());
-        addExtraFilter(query, extraFilter);
+        query.setTerms(terms);
         return analyticsService.execute(query);
     }
 
-    private Analytics executeCount(AnalyticsParam analyticsParam, String extraFilter) {
+    private Analytics executeCount(AnalyticsParam analyticsParam, Map<String, Set<String>> terms) {
         CountQuery query = new CountQuery();
         query.setFrom(analyticsParam.getFrom());
         query.setTo(analyticsParam.getTo());
         query.setInterval(analyticsParam.getInterval());
         query.setQuery(analyticsParam.getQuery());
-        addExtraFilter(query, extraFilter);
+        query.setTerms(terms);
         return analyticsService.execute(query);
     }
 
-    private Analytics executeDateHisto(AnalyticsParam analyticsParam, String extraFilter) {
+    private Analytics executeDateHisto(AnalyticsParam analyticsParam, Map<String, Set<String>> terms) {
         DateHistogramQuery query = new DateHistogramQuery();
         query.setFrom(analyticsParam.getFrom());
         query.setTo(analyticsParam.getTo());
@@ -197,11 +196,11 @@ public class PlatformAnalyticsResource extends AbstractResource {
 
             query.setAggregations(aggregationList);
         }
-        addExtraFilter(query, extraFilter);
+        query.setTerms(terms);
         return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
     }
 
-    private Analytics executeGroupBy(AnalyticsParam analyticsParam, String extraFilter) {
+    private Analytics executeGroupBy(AnalyticsParam analyticsParam, Map<String, Set<String>> terms) {
         GroupByQuery query = new GroupByQuery();
         query.setFrom(analyticsParam.getFrom());
         query.setTo(analyticsParam.getTo());
@@ -223,24 +222,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
 
             query.setGroups(rangeMap);
         }
-        addExtraFilter(query, extraFilter);
+        query.setTerms(terms);
         return analyticsService.execute(GraviteeContext.getExecutionContext(), query);
-    }
-
-    private void addExtraFilter(AbstractQuery query, String extraFilter) {
-        if (query.getQuery() == null || query.getQuery().isEmpty()) {
-            query.setQuery(extraFilter);
-        } else if (extraFilter != null && !extraFilter.isEmpty()) {
-            query.setQuery(query.getQuery() + " AND " + extraFilter);
-        } else {
-            query.setQuery(query.getQuery());
-        }
-    }
-
-    private String getExtraFilter(String fieldName, Set<String> ids) {
-        if (ids != null && !ids.isEmpty()) {
-            return fieldName + ":(" + ids.stream().collect(Collectors.joining(" OR ")) + ")";
-        }
-        return null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
@@ -89,7 +89,12 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
             .findPlatform(
                 any(ExecutionContext.class),
                 argThat(query ->
-                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1) OR api:(api1))") &&
+                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    query.getTerms().size() == 2 &&
+                    query.getTerms().containsKey("application") &&
+                    query.getTerms().get("application").equals(Set.of("app1")) &&
+                    query.getTerms().containsKey("api") &&
+                    query.getTerms().get("api").equals(Set.of("api1")) &&
                     query.getPage() == 1 &&
                     query.getSize() == 10 &&
                     query.getFrom() == 0 &&
@@ -125,7 +130,10 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
             .findPlatform(
                 any(ExecutionContext.class),
                 argThat(query ->
-                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1))") &&
+                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    query.getTerms().size() == 1 &&
+                    query.getTerms().containsKey("application") &&
+                    query.getTerms().get("application").equals(Set.of("app1")) &&
                     query.getPage() == 1 &&
                     query.getSize() == 10 &&
                     query.getFrom() == 0 &&
@@ -162,7 +170,10 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
             .findPlatform(
                 any(ExecutionContext.class),
                 argThat(query ->
-                    Objects.equals(query.getQuery(), "(foo:bar) AND (api:(api1))") &&
+                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    query.getTerms().size() == 1 &&
+                    query.getTerms().containsKey("api") &&
+                    query.getTerms().get("api").equals(Set.of("api1")) &&
                     query.getPage() == 1 &&
                     query.getSize() == 10 &&
                     query.getFrom() == 0 &&

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
@@ -76,7 +76,12 @@ public class PlatformLogsResourceTest extends AbstractResourceTest {
             .findPlatform(
                 any(ExecutionContext.class),
                 argThat(query ->
-                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1) OR api:(api1))") &&
+                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    query.getTerms().size() == 2 &&
+                    query.getTerms().containsKey("application") &&
+                    query.getTerms().get("application").equals(Set.of("app1")) &&
+                    query.getTerms().containsKey("api") &&
+                    query.getTerms().get("api").equals(Set.of("api1")) &&
                     query.getPage() == 1 &&
                     query.getSize() == 10 &&
                     query.getFrom() == 0 &&

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/query/AbstractQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/query/AbstractQuery.java
@@ -15,11 +15,18 @@
  */
 package io.gravitee.rest.api.model.analytics.query;
 
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public abstract class AbstractQuery {
 
     private long from;
@@ -30,21 +37,18 @@ public abstract class AbstractQuery {
 
     private String query;
 
+    /**
+     * Warning if multiple terms filter are used, the logical operator used to combine them
+     * depend on the template
+     * @param terms a map containing terms filters (key is the field used for the terms filter
+     *              and value is a set of ids to filter on)
+     */
+    @Setter
+    private Map<String, Set<String>> terms;
+
     private String rootField;
 
     private String rootIdentifier;
-
-    public long getFrom() {
-        return from;
-    }
-
-    public void setFrom(long from) {
-        this.from = from;
-    }
-
-    public long getTo() {
-        return to;
-    }
 
     public void setTo(long to) {
         long now = System.currentTimeMillis();
@@ -52,37 +56,5 @@ public abstract class AbstractQuery {
             this.to = now;
         }
         this.to = to;
-    }
-
-    public long getInterval() {
-        return interval;
-    }
-
-    public void setInterval(long interval) {
-        this.interval = interval;
-    }
-
-    public String getQuery() {
-        return query;
-    }
-
-    public void setQuery(String query) {
-        this.query = query;
-    }
-
-    public String getRootField() {
-        return rootField;
-    }
-
-    public void setRootField(String rootField) {
-        this.rootField = rootField;
-    }
-
-    public String getRootIdentifier() {
-        return rootIdentifier;
-    }
-
-    public void setRootIdentifier(String rootIdentifier) {
-        this.rootIdentifier = rootIdentifier;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
@@ -33,7 +33,6 @@ import io.gravitee.repository.analytics.query.response.histogram.DateHistogramRe
 import io.gravitee.repository.analytics.query.stats.StatsResponse;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApplicationEntity;
-import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.TenantEntity;
 import io.gravitee.rest.api.model.TenantReferenceType;
 import io.gravitee.rest.api.model.analytics.Bucket;
@@ -51,7 +50,6 @@ import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApplicationService;
-import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.TenantService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.AnalyticsCalculateException;
@@ -129,6 +127,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                 QueryBuilders
                     .stats()
                     .query(query.getQuery())
+                    .terms(query.getTerms())
                     .timeRange(DateRangeBuilder.between(query.getFrom(), query.getTo()), IntervalBuilder.interval(query.getInterval()))
                     .root(query.getRootField(), query.getRootIdentifier())
                     .field(query.getField())
@@ -149,6 +148,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                 QueryBuilders
                     .count()
                     .query(query.getQuery())
+                    .terms(query.getTerms())
                     .timeRange(DateRangeBuilder.between(query.getFrom(), query.getTo()), IntervalBuilder.interval(query.getInterval()))
                     .root(query.getRootField(), query.getRootIdentifier())
                     .build()
@@ -167,6 +167,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             DateHistogramQueryBuilder queryBuilder = QueryBuilders
                 .dateHistogram()
                 .query(query.getQuery())
+                .terms(query.getTerms())
                 .timeRange(DateRangeBuilder.between(query.getFrom(), query.getTo()), IntervalBuilder.interval(query.getInterval()))
                 .root(query.getRootField(), query.getRootIdentifier());
 
@@ -193,6 +194,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             GroupByQueryBuilder queryBuilder = QueryBuilders
                 .groupBy()
                 .query(query.getQuery())
+                .terms(query.getTerms())
                 .timeRange(DateRangeBuilder.between(query.getFrom(), query.getTo()), IntervalBuilder.interval(query.getInterval()))
                 .root(query.getRootField(), query.getRootIdentifier())
                 .field(query.getField());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -281,6 +281,7 @@ public class LogsServiceImpl implements LogsService {
                     .page(query.getPage())
                     .size(query.getSize())
                     .query(query.getQuery())
+                    .terms(query.getTerms())
                     .sort(SortBuilder.on(field, query.isOrder() ? Order.ASC : Order.DESC, null))
                     .timeRange(DateRangeBuilder.between(query.getFrom(), query.getTo()), IntervalBuilder.interval(query.getInterval()))
                     //                            .root("application", application)


### PR DESCRIPTION
with elasticsearch analytics queries

## Issue

https://gravitee.atlassian.net/browse/APIM-5569

## Description

### Problem
When too many applications and/or APIs, the requests made to ES contain too many clauses (> 1024). We should use another way to build these requests to improve this.

Analytics queries to Elasticsearch are built with a filter using a query_string. The issue with this filter is that each element added to the query string is counted as a clause. 

Even if from Elasticsearch 8.0.0 indices.query.bool.max_clause_count has been deprecated and now rely on the size of the heap allocated and the number of search threads configured, we should avoid using a query_string for this.

### Solution
In order to avoid the query_string, the terms filter is a better option. It allows to pass a list of term to filter on and has better performance. Note that there is still a limit configured with this parameter [index.max_terms_count](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-terms-count) (default value is 65536).

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vkxgzsixbt.chromatic.com)
<!-- Storybook placeholder end -->
