### PR TITLE
Apim 5455 add access controls to documentation v4 UI

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/createDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/createDocumentation.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Visibility } from './visibility';
+import { AccessControl } from './page';
 
 const CreateDocumentationTypeEnum = {
   MARKDOWN: 'MARKDOWN',
@@ -29,6 +30,8 @@ export interface BaseCreateDocumentation {
   order?: number;
   visibility?: Visibility;
   parentId?: string;
+  accessControls?: AccessControl[];
+  excludedAccessControls?: boolean;
 }
 
 export type CreateDocumentationFolder = BaseCreateDocumentation;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
@@ -15,12 +15,15 @@
  */
 import { Visibility } from './visibility';
 import { PageType } from './pageType';
+import { AccessControl } from './page';
 
 export interface BaseEditDocumentation {
   type?: PageType;
   name?: string;
   order?: number;
   visibility?: Visibility;
+  accessControls?: AccessControl[];
+  excludedAccessControls?: boolean;
 }
 
 export type EditDocumentationFolder = BaseEditDocumentation;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/page.ts
@@ -42,10 +42,17 @@ export interface Page {
   contentRevision?: Revision;
   hidden?: boolean;
   generalConditions?: boolean;
+  accessControls?: AccessControl[];
+  excludedAccessControls?: boolean;
 }
 
 export interface Breadcrumb {
   id: string;
   name: string;
   position: number;
+}
+
+export interface AccessControl {
+  referenceId?: string;
+  referenceType?: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -216,8 +216,8 @@ export class ApiV4MenuService implements ApiMenuService {
     if (this.permissionService.hasAnyMatching(['api-documentation-r'])) {
       tabs.push({
         displayName: 'Pages',
-        routerLink: 'v4/documentation',
-        routerLinkActiveOptions: { exact: true },
+        routerLink: 'v4/documentation/pages',
+        routerLinkActiveOptions: { exact: false },
       });
     }
 

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -822,37 +822,47 @@ const apisRoutes: Routes = [
         data: {
           docs: null,
         },
-        component: ApiDocumentationV4Component,
-      },
-      {
-        path: 'v4/documentation/new',
-        data: {
-          docs: null,
-          permissions: {
-            anyOf: ['api-documentation-c'],
+        children: [
+          {
+            path: '',
+            redirectTo: 'pages',
+            pathMatch: 'full',
           },
-        },
-        component: ApiDocumentationV4EditPageComponent,
-      },
-      {
-        path: 'v4/documentation/metadata',
-        data: {
-          docs: null,
-          permissions: {
-            anyOf: ['api-metadata-r'],
+          {
+            path: 'pages',
+            component: ApiDocumentationV4Component,
           },
-        },
-        component: ApiDocumentationV4MetadataComponent,
-      },
-      {
-        path: 'v4/documentation/:pageId',
-        data: {
-          docs: null,
-          permissions: {
-            anyOf: ['api-documentation-u', 'api-documentation-r'],
+          {
+            path: 'pages/new',
+            data: {
+              docs: null,
+              permissions: {
+                anyOf: ['api-documentation-c'],
+              },
+            },
+            component: ApiDocumentationV4EditPageComponent,
           },
-        },
-        component: ApiDocumentationV4EditPageComponent,
+          {
+            path: 'pages/:pageId',
+            data: {
+              docs: null,
+              permissions: {
+                anyOf: ['api-documentation-u', 'api-documentation-r'],
+              },
+            },
+            component: ApiDocumentationV4EditPageComponent,
+          },
+          {
+            path: 'metadata',
+            data: {
+              docs: null,
+              permissions: {
+                anyOf: ['api-metadata-r'],
+              },
+            },
+            component: ApiDocumentationV4MetadataComponent,
+          },
+        ],
       },
       {
         path: 'v4/policy-studio',

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
@@ -19,6 +19,7 @@ import { CommonModule, NgOptimizedImage } from '@angular/common';
 import {
   GioFormFilePickerModule,
   GioFormSelectionInlineModule,
+  GioFormSlideToggleModule,
   GioIconsModule,
   GioMonacoEditorModule,
 } from '@gravitee/ui-particles-angular';
@@ -36,6 +37,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterModule } from '@angular/router';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatSelect } from '@angular/material/select';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
 
 import { ApiDocumentationV4EmptyStateComponent } from './components/documentation-empty-state/api-documentation-v4-empty-state.component';
 import { ApiDocumentationV4ListNavigationHeaderComponent } from './components/documentation-list-navigation-header/api-documentation-v4-list-navigation-header.component';
@@ -106,6 +110,10 @@ import { GioApiMetadataListModule } from '../component/gio-api-metadata-list/gio
     GioAsyncApiModule,
     GioMetadataModule,
     GioApiMetadataListModule,
+    MatOption,
+    MatSelect,
+    GioFormSlideToggleModule,
+    MatSlideToggle,
   ],
 })
 export class ApiDocumentationV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -52,18 +52,40 @@
         <mat-step>
           <ng-template matStepLabel>Configure page</ng-template>
           <div class="stepper__content">
-            <form [formGroup]="stepOneForm">
+            <form [formGroup]="form.controls.stepOne" class="stepper__content__form">
               <mat-form-field>
                 <mat-label>Name</mat-label>
                 <input matInput formControlName="name" placeholder="Name" autofocus />
-                <mat-error *ngIf="stepOneForm.controls.name?.errors?.required">Name is required</mat-error>
-                <mat-error *ngIf="stepOneForm.controls.name?.errors?.unique">Name already exists in this folder</mat-error>
+                <mat-error *ngIf="form.controls.stepOne.controls.name?.errors?.required">Name is required</mat-error>
+                <mat-error *ngIf="form.controls.stepOne.controls.name?.errors?.unique">Name already exists in this folder</mat-error>
               </mat-form-field>
               <api-documentation-visibility formControlName="visibility"></api-documentation-visibility>
+              @if (form.controls.stepOne.controls.visibility.value === 'PRIVATE') {
+                <mat-form-field>
+                  <mat-label>Groups with permissions to view the page</mat-label>
+                  <mat-select formControlName="accessControlGroups" multiple>
+                    @for (group of groups; track group.id) {
+                      <mat-option [value]="group.id">{{ group.name }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+                <gio-form-slide-toggle>
+                  <b>Exclude the selected groups</b>
+                  <div>
+                    When selected, reverses the operation for the group permissions. Users belonging to any of the specified groups will NOT
+                    be able to view the page.
+                  </div>
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    formControlName="excludeGroups"
+                    aria-label="Exclude selected groups"
+                  ></mat-slide-toggle>
+                </gio-form-slide-toggle>
+              }
             </form>
           </div>
           <div class="stepper__actions">
-            <button mat-flat-button color="primary" matStepperNext [disabled]="stepOneForm.invalid">Next</button>
+            <button mat-flat-button color="primary" matStepperNext [disabled]="form.controls.stepOne.invalid">Next</button>
           </div>
         </mat-step>
         <mat-step *ngIf="mode === 'create'">
@@ -110,7 +132,7 @@
               [disabled]="isReadOnly"
               *ngIf="form.value?.source === 'IMPORT'"
             ></api-documentation-file-upload>
-            <mat-error *ngIf="stepOneForm.controls.content?.errors?.required">Page content cannot be empty</mat-error>
+            <mat-error *ngIf="form.controls.content.errors?.required">Page content cannot be empty</mat-error>
           </div>
           <div class="stepper__actions">
             <ng-container *ngIf="mode === 'create'">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.scss
@@ -55,6 +55,12 @@ $typography: map.get(gio.$mat-theme, typography);
     .mat-mdc-radio-group {
       width: 100%;
     }
+
+    &__form {
+      display: flex;
+      flex-flow: column;
+      gap: 14px;
+    }
   }
 
   &__actions {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.harness.ts
@@ -17,6 +17,8 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { GioFormSelectionInlineHarness } from '@gravitee/ui-particles-angular';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 import { ApiDocumentationV4VisibilityHarness } from '../components/api-documentation-v4-visibility/api-documentation-v4-visibility.harness';
 
@@ -27,6 +29,8 @@ export class ApiDocumentationV4EditPageHarness extends ComponentHarness {
   private deleteButtonLocator = this.locatorFor(MatButtonHarness.with({ text: 'Delete page' }));
   private nameInputLocator = this.locatorFor(MatInputHarness);
   private visibilityHarness = this.locatorFor(ApiDocumentationV4VisibilityHarness);
+  private selectAccessGroupsHarness = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="accessControlGroups"]' }));
+  private toggleExcludeGroups = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="excludeGroups"]' }));
   private sourceSelectionInlineHarness = this.locatorFor(GioFormSelectionInlineHarness.with({ selector: '.stepper__content__source' }));
 
   async getNextButton() {
@@ -60,6 +64,13 @@ export class ApiDocumentationV4EditPageHarness extends ComponentHarness {
 
   async visibilityIsDisabled(): Promise<boolean> {
     return this.visibilityHarness().then((harness) => harness.formIsDisabled());
+  }
+
+  async getAccessControlGroups(): Promise<MatSelectHarness | null> {
+    return this.selectAccessGroupsHarness().catch((_) => null);
+  }
+  async getExcludeGroups(): Promise<MatSlideToggleHarness | null> {
+    return this.toggleExcludeGroups().catch((_) => null);
   }
 
   async getSourceSelectionInlineHarnessHarness() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5455

## Description

Previous PR: https://github.com/gravitee-io/gravitee-api-management/pull/8140

When a page is private, the user can select which groups can see the page, as well as specify if the list of groups should be **excluded** from the page.

https://github.com/gravitee-io/gravitee-api-management/assets/42294616/a12c0eb5-e9eb-4839-b14f-d114c60fd365


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jqibznpbos.chromatic.com)
<!-- Storybook placeholder end -->
