### PR TITLE
fix(tokens): Do not use service to retrieve token by value

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TokensResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TokensResource.java
@@ -97,8 +97,7 @@ public class TokensResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public void revokeToken(@PathParam("token") String tokenId) {
         // Check that token exists and belongs to user
-        Token tokenToRevoke = tokenService.findByToken(tokenId);
-        if (!tokenToRevoke.getReferenceId().equalsIgnoreCase(getAuthenticatedUserOrNull())) {
+        if (!tokenService.tokenExistsForUser(tokenId, getAuthenticatedUserOrNull())) {
             throw new TokenNotFoundException(tokenId);
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5481

## Description

findByToken is expecting the token's value and not its id, reason why we are getting a TokenNotFoundException.