### PR TITLE
fix: remove only first and last wildcards

### DIFF
--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
@@ -284,7 +284,7 @@ class LogsFiltersController {
           this.filters['!_exists_'] = v;
           break;
         case 'body':
-          this.filters.body = v[0].replace(/\*/g, '');
+          this.filters.body = v[0].replace(/^\*(.*)\*$/g, '$1');
           break;
         case 'endpoint':
           this.filters.endpoint = v[0].replace(/\*|\\\\/g, '');


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3516
https://github.com/gravitee-io/issues/issues/9412

## Description

Remove only the wildcard characters added by the filter here: https://github.com/gravitee-io/gravitee-api-management/blob/4.0.x/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts#L340
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ivlshkbmxp.chromatic.com)
<!-- Storybook placeholder end -->
