### PR TITLE
fix(console): Audit log date range filter uses Moment instead of Date

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ts
+++ b/gravitee-apim-console-webui/src/app.module.ts
@@ -23,6 +23,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { setAngularJSGlobal, UpgradeModule } from '@angular/upgrade/static';
 import { GioPendoModule, GIO_PENDO_SETTINGS_TOKEN } from '@gravitee/ui-analytics';
 import { GioMatConfigModule } from '@gravitee/ui-particles-angular';
+import { MatMomentDateModule, provideMomentDateAdapter } from '@angular/material-moment-adapter';
 
 import { currentUserProvider, ajsScopeProvider } from './ajs-upgraded-providers';
 import { Constants } from './entities/Constants';
@@ -50,6 +51,8 @@ import { AuthModule } from './auth/auth.module';
     }),
     UpgradeModule,
 
+    MatMomentDateModule,
+
     AppRoutingModule,
     GioPendoModule.forRoot(),
     GioMatConfigModule,
@@ -75,6 +78,7 @@ import { AuthModule } from './auth/auth.module';
       provide: 'isFactory',
       useValue: true,
     },
+    provideMomentDateAdapter(undefined, { useUtc: true }),
   ],
 })
 export class AppModule implements DoBootstrap {

--- a/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.module.ts
+++ b/gravitee-apim-console-webui/src/components/gio-metadata/gio-metadata.module.ts
@@ -25,7 +25,6 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatMomentDateModule, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
 import { MatCardModule } from '@angular/material/card';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
@@ -47,7 +46,6 @@ import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper
     MatDialogModule,
     MatInputModule,
     MatIconModule,
-    MatMomentDateModule,
     MatSelectModule,
     MatSnackBarModule,
     MatSortModule,
@@ -57,6 +55,6 @@ import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper
     GioPermissionModule,
     GioTableWrapperModule,
   ],
-  providers: [{ provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],
+  providers: [],
 })
 export class GioMetadataModule {}

--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.html
@@ -118,7 +118,8 @@
 
       <!-- Row shown when there is no data -->
       <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
+        <td *ngIf="tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+        <td *ngIf="!tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
       </tr>
     </table>
   </gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.spec.ts
@@ -34,7 +34,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
 import { fakeMetadataPageAudit } from '../../../entities/audit/Audit.fixture';
 
-describe('EnvAuditComponent', () => {
+describe('ApiAuditListComponent', () => {
   let fixture: ComponentFixture<ApiAuditListComponent>;
   let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
@@ -103,10 +103,10 @@ describe('EnvAuditComponent', () => {
 
     const rangeSelect = await loader.getHarness(MatDateRangeInputHarness.with({ selector: '[formGroupName=range]' }));
     await (await rangeSelect.getStartInput()).setValue('4/11/2022');
-    expectGetApiAuditListRequest({ from: 986083200000 });
+    expectGetApiAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectGetApiAuditListRequest({ from: 1649635200000, to: 986083200000 });
+    expectGetApiAuditListRequest({ from: 1649635200000, to: 1650412800000 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.ts
@@ -43,6 +43,7 @@ interface ApiAuditData {
 })
 export class ApiAuditListComponent implements OnInit, OnDestroy {
   auditList: ApiAuditData[] = [];
+  tableIsLoading = false;
   auditForm: UntypedFormGroup;
   nbTotalAudit = 0;
 
@@ -104,6 +105,10 @@ export class ApiAuditListComponent implements OnInit, OnDestroy {
       .pipe(
         throttleTime(100),
         distinctUntilChanged(isEqual),
+        tap(() => {
+          this.auditList = [];
+          this.tableIsLoading = true;
+        }),
         switchMap(({ auditFilters, tableWrapper }) =>
           this.apiAuditService
             .getAudit(this.activatedRoute.snapshot.params.apiId, auditFilters, tableWrapper.pagination.index, tableWrapper.pagination.size)
@@ -127,6 +132,7 @@ export class ApiAuditListComponent implements OnInit, OnDestroy {
           patch: JSON.parse(audit.patch),
           displayPatch: false,
         }));
+        this.tableIsLoading = false;
       });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.module.ts
@@ -24,10 +24,9 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatNativeDateModule, MatOptionModule } from '@angular/material/core';
+import { MatOptionModule } from '@angular/material/core';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatMomentDateModule } from '@angular/material-moment-adapter';
 
 import { ApiAuditListComponent } from './api-audit-list.component';
 
@@ -50,8 +49,6 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     MatDatepickerModule,
     MatFormFieldModule,
     MatIconModule,
-    MatMomentDateModule,
-    MatNativeDateModule,
     MatOptionModule,
     MatSelectModule,
     MatSnackBarModule,

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/api-audit-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/api-audit-logs.component.html
@@ -25,13 +25,14 @@
 
       <api-audits-filter-form [events]="auditEvents$ | async" (filtersChange)="queryChange($event)"></api-audits-filter-form>
 
-      <ng-container *ngIf="apiAudits$ | async as auditsResponse">
+      @if (apiAudits$ | async; as auditsResponse) {
         <api-audits-table
+          [isLoading]="auditsResponse.isLoading"
           [audits]="auditsResponse.data"
           [pagination]="auditsResponse.pagination"
           (paginationChange)="paginationChange($event)"
         ></api-audits-table>
-      </ng-container>
+      }
     </div>
 
     <div class="events">

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.component.ts
@@ -18,6 +18,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { isEqual } from 'lodash';
+import { Moment } from 'moment';
 
 export interface ApiAuditFilter {
   events?: string[];
@@ -43,8 +44,8 @@ export class ApiAuditsFilterFormComponent implements OnInit, OnDestroy {
   protected filtersForm = new FormGroup({
     events: new FormControl<string[]>([]),
     range: new FormGroup({
-      start: new FormControl<Date>(null),
-      end: new FormControl<Date>(null),
+      start: new FormControl<Moment>(null),
+      end: new FormControl<Moment>(null),
     }),
   });
 
@@ -56,8 +57,8 @@ export class ApiAuditsFilterFormComponent implements OnInit, OnDestroy {
       .subscribe(({ events, range }) => {
         this.filtersChange.emit({
           events,
-          from: range?.start?.getTime() ?? null,
-          to: range?.end?.getTime() ?? null,
+          from: range?.start?.valueOf() ?? null,
+          to: range?.end?.valueOf() ?? null,
         });
       });
   }

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.module.ts
@@ -22,7 +22,6 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { GioFormTagsInputModule } from '@gravitee/ui-particles-angular';
-import { MatNativeDateModule } from '@angular/material/core';
 
 import { ApiAuditsFilterFormComponent } from './api-audits-filter-form.component';
 
@@ -34,7 +33,6 @@ import { ApiAuditsFilterFormComponent } from './api-audits-filter-form.component
     ReactiveFormsModule,
     MatButtonModule,
     MatDatepickerModule,
-    MatNativeDateModule,
     MatFormFieldModule,
     MatIconModule,
     MatSelectModule,

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-table/api-audits-table.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-table/api-audits-table.component.html
@@ -91,7 +91,8 @@
 
     <!-- Row shown when there is no data -->
     <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-      <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
+      <td *ngIf="isLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+      <td *ngIf="!isLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
     </tr>
   </table>
 </gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-table/api-audits-table.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-table/api-audits-table.component.ts
@@ -36,6 +36,9 @@ export class ApiAuditsTableComponent {
   @Input()
   public audits: Audit[];
 
+  @Input()
+  public isLoading: boolean;
+
   @Output()
   public paginationChange = new EventEmitter<Pagination>();
 

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.html
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.html
@@ -163,7 +163,8 @@
 
     <!-- Row shown when there is no data -->
     <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-      <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
+      <td *ngIf="tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+      <td *ngIf="!tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
     </tr>
   </table>
 </gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
@@ -122,10 +122,10 @@ describe('EnvAuditComponent', () => {
     // 3. Expect date range works and trigger new AuditListRequest
     const rangeSelect = await loader.getHarness(MatDateRangeInputHarness.with({ selector: '[formGroupName=range]' }));
     await (await rangeSelect.getStartInput()).setValue('4/11/2022');
-    expectAuditListRequest({ from: 986083200000 });
+    expectAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectAuditListRequest({ from: 1649635200000, to: 986083200000 });
+    expectAuditListRequest({ from: 1649635200000, to: 1650412800000 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
@@ -46,6 +46,7 @@ interface AuditDataTable {
 export class EnvAuditComponent implements OnInit, OnDestroy {
   public displayedColumns = ['date', 'user', 'referenceType', 'reference', 'event', 'targets', 'patch'];
   public filteredTableData: AuditDataTable[] = [];
+  public tableIsLoading = true;
   public nbTotalAudit = 0;
 
   public filtersForm = new FormGroup({
@@ -126,6 +127,10 @@ export class EnvAuditComponent implements OnInit, OnDestroy {
       .pipe(
         throttleTime(100),
         distinctUntilChanged(isEqual),
+        tap(() => {
+          this.filteredTableData = [];
+          this.tableIsLoading = true;
+        }),
         switchMap(({ auditFilters, tableWrapper }) =>
           this.auditService.list(auditFilters, tableWrapper.pagination.index, tableWrapper.pagination.size).pipe(
             catchError(() => {
@@ -149,6 +154,7 @@ export class EnvAuditComponent implements OnInit, OnDestroy {
           patch: JSON.parse(audit.patch),
           displayPatch: false,
         }));
+        this.tableIsLoading = false;
       });
   }
 

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.module.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.module.ts
@@ -24,7 +24,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { MatNativeDateModule } from '@angular/material/core';
 
 import { EnvAuditComponent } from './env-audit.component';
 
@@ -38,7 +37,6 @@ import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper
     MatFormFieldModule,
     MatSelectModule,
     MatDatepickerModule,
-    MatNativeDateModule,
     MatTableModule,
     MatButtonModule,
     MatCardModule,

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.html
@@ -180,7 +180,8 @@
 
     <!-- Row shown when there is no data -->
     <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-      <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
+      <td *ngIf="tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">Loading...</td>
+      <td *ngIf="!tableIsLoading" class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No audit</td>
     </tr>
   </table>
 </gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
@@ -140,10 +140,10 @@ describe('OrgSettingsAuditComponent', () => {
     // 2. Expect date range works and trigger new AuditListRequest
     const rangeSelect = await loader.getHarness(MatDateRangeInputHarness.with({ selector: '[formGroupName=range]' }));
     await (await rangeSelect.getStartInput()).setValue('4/11/2022');
-    expectAuditListRequest({ from: 986083200000 });
+    expectAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectAuditListRequest({ from: 1649635200000, to: 986083200000 });
+    expectAuditListRequest({ from: 1649635200000, to: 1650412800000 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
@@ -17,7 +17,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { isEqual, mapValues } from 'lodash';
 import { BehaviorSubject, EMPTY, forkJoin, Observable, Subject } from 'rxjs';
-import { catchError, distinctUntilChanged, shareReplay, switchMap, takeUntil, throttleTime } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, shareReplay, switchMap, takeUntil, tap, throttleTime } from 'rxjs/operators';
 
 import { Api } from '../../../entities/api';
 import { ApiService } from '../../../services-ngx/api.service';
@@ -138,7 +138,7 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.filtersForm.valueChanges
-      .pipe(distinctUntilChanged(isEqual), takeUntil(this.unsubscribe$))
+      .pipe(debounceTime(200), distinctUntilChanged(isEqual), takeUntil(this.unsubscribe$))
       .subscribe(({ event, referenceType, environmentId, applicationId, apiId, range }) => {
         this.filtersStream.next({
           tableWrapper: {
@@ -153,8 +153,8 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
             environmentId,
             applicationId,
             apiId,
-            from: range?.start?.getTime() ?? undefined,
-            to: range?.end?.getTime() ?? undefined,
+            from: range?.start?.valueOf() ?? undefined,
+            to: range?.end?.valueOf() ?? undefined,
           },
         });
       });

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
@@ -47,6 +47,7 @@ interface AuditDataTable {
 export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
   public displayedColumns = ['date', 'user', 'referenceType', 'reference', 'event', 'targets', 'patch'];
   public filteredTableData: AuditDataTable[] = [];
+  public tableIsLoading = true;
   public nbTotalAudit = 0;
 
   public filtersForm = new UntypedFormGroup({
@@ -163,6 +164,10 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
       .pipe(
         throttleTime(100),
         distinctUntilChanged(isEqual),
+        tap(() => {
+          this.filteredTableData = [];
+          this.tableIsLoading = true;
+        }),
         switchMap(({ auditFilters, tableWrapper }) =>
           this.auditService.listByOrganization(auditFilters, tableWrapper.pagination.index, tableWrapper.pagination.size).pipe(
             catchError(() => {
@@ -186,6 +191,7 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
           patch: JSON.parse(audit.patch),
           displayPatch: false,
         }));
+        this.tableIsLoading = false;
       });
   }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -34,7 +34,7 @@ import { MatBadgeModule } from '@angular/material/badge';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
+import { MatRippleModule } from '@angular/material/core';
 import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSortModule } from '@angular/material/sort';
@@ -124,7 +124,6 @@ import { GioUsersSelectorModule } from '../../shared/components/gio-users-select
     MatProgressBarModule,
     MatSortModule,
     MatDatepickerModule,
-    MatNativeDateModule,
     MatTabsModule,
 
     GioPermissionModule,

--- a/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
@@ -18,6 +18,7 @@ import { NgModule, NgZone } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { Router } from '@angular/router';
+import { MatMomentDateModule, provideMomentDateAdapter } from '@angular/material-moment-adapter';
 
 import { Constants } from '../../entities/Constants';
 
@@ -52,12 +53,18 @@ export const CONSTANTS_TESTING: Constants = {
 };
 
 @NgModule({
-  imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([{ path: '**', redirectTo: '' }]), MatIconTestingModule],
+  imports: [
+    HttpClientTestingModule,
+    RouterTestingModule.withRoutes([{ path: '**', redirectTo: '' }]),
+    MatIconTestingModule,
+    MatMomentDateModule,
+  ],
   providers: [
     {
       provide: Constants,
       useValue: CONSTANTS_TESTING,
     },
+    provideMomentDateAdapter(undefined, { useUtc: true }),
   ],
 })
 export class GioTestingModule {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5565

## Description

API Audit List uses a copy-paste date range picker from Environment Audit Log. Because we use both MatNativeDateModule and MatMomentDateModule, different ones are loaded in both components causing an error when reading date object from picker.

This PR is fixing issue with date range picker on API Audit List. Sorting out issue with multiple Mat???DateModule should be addressed in another technical issue.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sjjhredfou.chromatic.com)
<!-- Storybook placeholder end -->
