### PR TITLE
feat(service): User can import and publish a page from a remote URL

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapper.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.model.Page;
 import io.gravitee.rest.api.management.v2.rest.model.PageMedia;
 import io.gravitee.rest.api.management.v2.rest.model.PageSource;
 import io.gravitee.rest.api.management.v2.rest.model.Revision;
+import io.gravitee.rest.api.management.v2.rest.model.SourceConfiguration;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationAsyncApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateDocumentationMarkdown;
@@ -49,6 +50,7 @@ import org.mapstruct.factory.Mappers;
 @Mapper(uses = { ConfigurationSerializationMapper.class, DateMapper.class })
 public interface PageMapper {
     PageMapper INSTANCE = Mappers.getMapper(PageMapper.class);
+    ObjectMapper mapper = new GraviteeMapper();
 
     @Mapping(target = "source.configuration", qualifiedByName = "deserializeConfiguration")
     Page mapPage(io.gravitee.apim.core.documentation.model.Page page);
@@ -99,6 +101,10 @@ public interface PageMapper {
 
     @Mapping(target = "uploadDate", source = "createdAt")
     MediaEntity mapMedia(Media media);
+
+    @Mapping(target = "type", source = "type")
+    @Mapping(target = "configuration", qualifiedByName = "serializeConfiguration")
+    PageSource mapSourceConfigurationToPageSource(SourceConfiguration sourceConfiguration);
 
     io.gravitee.apim.core.documentation.model.Page map(
         io.gravitee.rest.api.management.v2.rest.model.CreateDocumentationMarkdown createDocumentationMarkdown
@@ -154,7 +160,6 @@ public interface PageMapper {
             return null;
         }
         if (configuration instanceof LinkedHashMap) {
-            ObjectMapper mapper = new GraviteeMapper();
             try {
                 return mapper.valueToTree(configuration);
             } catch (IllegalArgumentException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -6288,6 +6288,8 @@ components:
                           type: boolean
                           description: Page's homepage status.
                           example: true
+                      source:
+                        $ref: '#/components/schemas/SourceConfiguration'
             required:
                 - name
                 - type
@@ -6307,6 +6309,8 @@ components:
                           type: boolean
                           description: Page's homepage status.
                           example: true
+                      source:
+                        $ref: '#/components/schemas/SourceConfiguration'
             required:
                 - name
                 - type
@@ -6326,9 +6330,23 @@ components:
                           type: boolean
                           description: Page's homepage status.
                           example: true
+                      source:
+                        $ref: '#/components/schemas/SourceConfiguration'
             required:
                 - name
                 - type
+
+        SourceConfiguration:
+          type: object
+          description: Source configuration for fetching documentation content.
+          properties:
+            type:
+              type: string
+              description: Type of the source.
+              example: http-fetcher
+            configuration:
+              type: object
+              description: Configuration for the source.
 
         UpdateDocumentation:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PageMapperTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.gravitee.rest.api.management.v2.rest.model.SourceConfiguration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Sergii ILLICHEVSKYI (sergii.illichevskyi at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class PageMapperTest extends AbstractMapperTest {
+
+    private PageMapper pageMapper;
+
+    @BeforeEach
+    void setUp() {
+        pageMapper = PageMapper.INSTANCE;
+    }
+
+    @Test
+    void shouldMapSourceConfigurationToPageSource() throws Exception {
+        var sourceConfiguration = new SourceConfiguration();
+        sourceConfiguration.setType("http-fetcher");
+
+        Map<String, Object> configMap = new LinkedHashMap<>();
+        configMap.put("useSystemProxy", false);
+        configMap.put("autoFetch", false);
+        configMap.put("url", "https://apim-master-api.team-apim.gravitee.dev/management/openapi.yaml");
+        sourceConfiguration.setConfiguration(configMap);
+
+        var pageSource = pageMapper.mapSourceConfigurationToPageSource(sourceConfiguration);
+
+        assertNotNull(pageSource);
+        assertEquals("http-fetcher", pageSource.getType());
+
+        var expectedConfig =
+            """
+                {
+                  "useSystemProxy" : false,
+                  "autoFetch" : false,
+                  "url" : "https://apim-master-api.team-apim.gravitee.dev/management/openapi.yaml"
+                }""";
+        assertNotNull(pageSource.getConfiguration());
+        assertEquals(expectedConfig, pageSource.getConfiguration().toString());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3548

## Description

As an API publisher

I want to import documentation pages from a remote site like I can with a v2 API

so that I am getting the documentation outside of Gravitee where I am used to managing it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mbydzxavrj.chromatic.com)
<!-- Storybook placeholder end -->
