### PR TITLE
chore: bump all dependencies

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -32,13 +32,13 @@
 
     <properties>
         <!-- Dependencies version -->
-        <HikariCP.version>5.0.0</HikariCP.version>
-        <liquibase.version>4.21.1</liquibase.version>
-        <liquibase-slf4j.version>4.0.0</liquibase-slf4j.version>
-        <mariaDB.version>2.7.12</mariaDB.version>
-        <mssql-jdbc.version>9.4.1.jre16</mssql-jdbc.version>
-        <mysql-connector-j.version>8.3.0</mysql-connector-j.version>
-        <postgresql.version>42.4.4</postgresql.version>
+        <HikariCP.version>5.1.0</HikariCP.version>
+        <liquibase.version>4.28.0</liquibase.version>
+        <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
+        <mariaDB.version>3.4.0</mariaDB.version>
+        <mssql-jdbc.version>12.7.0.jre11-preview</mssql-jdbc.version>
+        <mysql-connector-j.version>8.4.0</mysql-connector-j.version>
+        <postgresql.version>42.7.3</postgresql.version>
 
         <!-- Plugin configuration -->
         <default-database.jdbcType>postgresql</default-database.jdbcType>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -38,8 +38,8 @@
             But "You can use newer server versions unless your application uses functionality that is affected by changes in the MongoDB server"
             Meaning that we can use mongo server 6.0.x if we use basic functionalities.
         -->
-        <mongo.version>4.11.1</mongo.version>
-        <jna.version>5.11.0</jna.version>
+        <mongo.version>5.1.1</mongo.version>
+        <jna.version>5.14.0</jna.version>
     </properties>
 
     <dependencies>

--- a/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
@@ -66,12 +66,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/CustomUserFieldsRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/CustomUserFieldsRepositoryTest.java
@@ -16,9 +16,7 @@
 package io.gravitee.repository.management;
 
 import static io.gravitee.repository.management.model.CustomUserFieldReferenceType.ORGANIZATION;
-import static io.gravitee.repository.utils.DateUtils.compareDate;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.MetadataFormat;
@@ -39,35 +37,16 @@ public class CustomUserFieldsRepositoryTest extends AbstractManagementRepository
     @Test
     public void shouldFindById() throws Exception {
         final Optional<CustomUserField> optionalCustomUserField = customUserFieldsRepository.findById("string", "DEFAULT", ORGANIZATION);
-        assertNotNull(optionalCustomUserField);
-        assertTrue(optionalCustomUserField.isPresent());
-        assertEquals("FindById('string, default) : Invalid CustomUserField.key", "string", optionalCustomUserField.get().getKey());
-        assertEquals(
-            "FindById('string, default) : Invalid CustomUserField.refId",
-            "DEFAULT",
-            optionalCustomUserField.get().getReferenceId()
-        );
-        assertEquals(
-            "FindById('string, default) : Invalid CustomUserField.refType",
-            ORGANIZATION,
-            optionalCustomUserField.get().getReferenceType()
-        );
-        assertEquals("FindById('string, default) : Invalid CustomUserField.label", "String", optionalCustomUserField.get().getLabel());
-        assertFalse("FindById('string, default) : Invalid CustomUserField.required", optionalCustomUserField.get().isRequired());
-        assertTrue(
-            "FindById('string, default) : Invalid CustomUserField.createdAt",
-            compareDate(new Date(1486771200000L), optionalCustomUserField.get().getCreatedAt())
-        );
-        assertTrue(
-            "FindById('string, default) : Invalid CustomUserField.updatedAt",
-            compareDate(new Date(1486771200000L), optionalCustomUserField.get().getUpdatedAt())
-        );
-        assertNotNull("FindById('string, default) : Invalid CustomUserField.values", optionalCustomUserField.get().getValues());
-        assertThat(
-            "FindById('string, default) : Invalid CustomUserField.values",
-            optionalCustomUserField.get().getValues(),
-            containsInAnyOrder("test_values")
-        );
+        assertThat(optionalCustomUserField).isNotNull();
+        assertThat(optionalCustomUserField.isPresent()).isTrue();
+        assertThat(optionalCustomUserField.get().getKey()).isEqualTo("string");
+        assertThat(optionalCustomUserField.get().getReferenceId()).isEqualTo("DEFAULT");
+        assertThat(optionalCustomUserField.get().getReferenceType()).isEqualTo(ORGANIZATION);
+        assertThat(optionalCustomUserField.get().getLabel()).isEqualTo("String");
+        assertThat(optionalCustomUserField.get().isRequired()).isFalse();
+        assertThat(optionalCustomUserField.get().getCreatedAt()).isEqualTo(new Date(1486771200000L));
+        assertThat(optionalCustomUserField.get().getUpdatedAt()).isEqualTo(new Date(1486771200000L));
+        assertThat(optionalCustomUserField.get().getValues()).isNotNull().containsExactlyInAnyOrder("test_values");
     }
 
     @Test
@@ -76,12 +55,10 @@ public class CustomUserFieldsRepositoryTest extends AbstractManagementRepository
             "DEFAULT",
             ORGANIZATION
         );
-        assertNotNull("FindByRef(Default) Should return non null list ", customUserFields);
-        assertEquals("FindByRef(Default) Should return 4 elements", 4, customUserFields.size());
-        assertThat(
-            customUserFields.stream().map(CustomUserField::getKey).collect(Collectors.toList()),
-            containsInAnyOrder("string", "boolean", "updateKey", "deleteKey")
-        );
+        assertThat(customUserFields).isNotNull();
+        assertThat(customUserFields).size().isEqualTo(4);
+        assertThat(customUserFields.stream().map(CustomUserField::getKey).collect(Collectors.toList()))
+            .containsExactlyInAnyOrder("string", "boolean", "updateKey", "deleteKey");
     }
 
     @Test
@@ -107,29 +84,25 @@ public class CustomUserFieldsRepositoryTest extends AbstractManagementRepository
             ORGANIZATION
         );
 
-        assertNotNull("customUserFieldsRepository.create should return an CustomUserField", createdCustomUserField);
-        assertNotNull(beforeCreateBean);
-        assertFalse("customUserFieldsRepository should not found value before create", beforeCreateBean.isPresent());
-        assertNotNull(afterCreateBean);
-        assertTrue("customUserFieldsRepository should found value before create", afterCreateBean.isPresent());
+        assertThat(createdCustomUserField).isNotNull();
+        assertThat(beforeCreateBean).isNotNull();
+        assertThat(beforeCreateBean.isPresent()).isFalse();
+        assertThat(afterCreateBean).isNotNull();
+        assertThat(afterCreateBean.isPresent()).isTrue();
 
-        assertEquals("Invalid CustomUserField.key", newCufCustomUserField.getKey(), afterCreateBean.get().getKey());
-        assertEquals("Invalid CustomUserField.label", newCufCustomUserField.getLabel(), afterCreateBean.get().getLabel());
-        assertEquals("Invalid CustomUserField.format", newCufCustomUserField.getFormat(), afterCreateBean.get().getFormat());
-        assertEquals("Invalid CustomUserField.refId", newCufCustomUserField.getReferenceId(), afterCreateBean.get().getReferenceId());
-        assertEquals("Invalid CustomUserField.refType", newCufCustomUserField.getReferenceType(), afterCreateBean.get().getReferenceType());
-        assertEquals("Invalid CustomUserField.values", afterCreateBean.get().getValues().get(0), newCufCustomUserField.getValues().get(0));
+        assertThat(newCufCustomUserField.getKey()).isEqualTo(afterCreateBean.get().getKey());
+        assertThat(newCufCustomUserField.getLabel()).isEqualTo(afterCreateBean.get().getLabel());
+        assertThat(newCufCustomUserField.getFormat()).isEqualTo(afterCreateBean.get().getFormat());
+        assertThat(newCufCustomUserField.getReferenceId()).isEqualTo(afterCreateBean.get().getReferenceId());
+        assertThat(newCufCustomUserField.getReferenceType()).isEqualTo(afterCreateBean.get().getReferenceType());
+        assertThat(newCufCustomUserField.getValues().get(0)).isEqualTo(afterCreateBean.get().getValues().get(0));
 
-        assertEquals("Invalid CustomUserField.key", newCufCustomUserField.getKey(), createdCustomUserField.getKey());
-        assertEquals("Invalid CustomUserField.label", newCufCustomUserField.getLabel(), createdCustomUserField.getLabel());
-        assertEquals("Invalid CustomUserField.format", newCufCustomUserField.getFormat(), createdCustomUserField.getFormat());
-        assertEquals("Invalid CustomUserField.refId", newCufCustomUserField.getReferenceId(), createdCustomUserField.getReferenceId());
-        assertEquals(
-            "Invalid CustomUserField.refType",
-            newCufCustomUserField.getReferenceType(),
-            createdCustomUserField.getReferenceType()
-        );
-        assertEquals("Invalid CustomUserField.values", createdCustomUserField.getValues().get(0), newCufCustomUserField.getValues().get(0));
+        assertThat(newCufCustomUserField.getKey()).isEqualTo(createdCustomUserField.getKey());
+        assertThat(newCufCustomUserField.getLabel()).isEqualTo(createdCustomUserField.getLabel());
+        assertThat(newCufCustomUserField.getFormat()).isEqualTo(createdCustomUserField.getFormat());
+        assertThat(newCufCustomUserField.getReferenceId()).isEqualTo(createdCustomUserField.getReferenceId());
+        assertThat(newCufCustomUserField.getReferenceType()).isEqualTo(createdCustomUserField.getReferenceType());
+        assertThat(newCufCustomUserField.getValues().get(0)).isEqualTo(createdCustomUserField.getValues().get(0));
     }
 
     @Test
@@ -155,32 +128,25 @@ public class CustomUserFieldsRepositoryTest extends AbstractManagementRepository
             customUserField.getReferenceType()
         );
 
-        assertNotNull(customUserField);
-        assertNotNull(beforeUpdateBean);
-        assertTrue(beforeUpdateBean.isPresent());
-        assertNotNull(afterUpdateBean);
-        assertTrue(afterUpdateBean.isPresent());
-        assertNotNull(updatedCustomUserField);
+        assertThat(customUserField).isNotNull();
+        assertThat(beforeUpdateBean).isNotNull();
+        assertThat(beforeUpdateBean.isPresent()).isTrue();
+        assertThat(afterUpdateBean).isNotNull();
+        assertThat(afterUpdateBean.isPresent()).isTrue();
+        assertThat(updatedCustomUserField).isNotNull();
 
-        assertEquals("Invalid CustomUserField.key", customUserField.getKey(), afterUpdateBean.get().getKey());
-        assertEquals("Invalid CustomUserField.label", customUserField.getLabel(), afterUpdateBean.get().getLabel());
-        assertEquals("Invalid CustomUserField.format", customUserField.getFormat(), afterUpdateBean.get().getFormat());
-        assertEquals("Invalid CustomUserField.refId", customUserField.getReferenceId(), afterUpdateBean.get().getReferenceId());
-        assertEquals(
-            "Invalid CustomUserField.values.size = 1",
-            customUserField.getValues().size(),
-            afterUpdateBean.get().getValues().size()
-        );
+        assertThat(customUserField.getKey()).isEqualTo(afterUpdateBean.get().getKey());
+        assertThat(customUserField.getLabel()).isEqualTo(afterUpdateBean.get().getLabel());
+        assertThat(customUserField.getFormat()).isEqualTo(afterUpdateBean.get().getFormat());
+        assertThat(customUserField.getReferenceId()).isEqualTo(afterUpdateBean.get().getReferenceId());
+        assertThat(customUserField.getValues()).hasSameSizeAs(afterUpdateBean.get().getValues());
 
-        assertEquals("Invalid CustomUserField.key", customUserField.getKey(), afterUpdateBean.get().getKey());
-        assertEquals("Invalid CustomUserField.refId", beforeUpdateBean.get().getReferenceId(), afterUpdateBean.get().getReferenceId());
-        assertEquals("Invalid CustomUserField.format", beforeUpdateBean.get().getFormat(), afterUpdateBean.get().getFormat());
-        assertNotEquals("Invalid CustomUserField.label", beforeUpdateBean.get().getLabel(), afterUpdateBean.get().getLabel());
-        assertNotEquals("Invalid CustomUserField.required", beforeUpdateBean.get().isRequired(), afterUpdateBean.get().isRequired());
-        assertTrue(
-            "Invalid CustomUserField.values.empty",
-            beforeUpdateBean.get().getValues() == null || beforeUpdateBean.get().getValues().isEmpty()
-        );
+        assertThat(beforeUpdateBean.get().getKey()).isEqualTo(afterUpdateBean.get().getKey());
+        assertThat(beforeUpdateBean.get().getReferenceId()).isEqualTo(afterUpdateBean.get().getReferenceId());
+        assertThat(beforeUpdateBean.get().getFormat()).isEqualTo(afterUpdateBean.get().getFormat());
+        assertThat(beforeUpdateBean.get().getLabel()).isNotEqualTo(afterUpdateBean.get().getLabel());
+        assertThat(beforeUpdateBean.get().isRequired()).isNotEqualTo(afterUpdateBean.get().isRequired());
+        assertThat(beforeUpdateBean.get().getValues()).isNullOrEmpty();
     }
 
     @Test
@@ -189,9 +155,9 @@ public class CustomUserFieldsRepositoryTest extends AbstractManagementRepository
         customUserFieldsRepository.delete("deleteKey", "DEFAULT", ORGANIZATION);
         final Optional<CustomUserField> afterDelete = customUserFieldsRepository.findById("deleteKey", "DEFAULT", ORGANIZATION);
 
-        assertNotNull(beforeDelete);
-        assertTrue(beforeDelete.isPresent());
-        assertNotNull(afterDelete);
-        assertFalse(afterDelete.isPresent());
+        assertThat(beforeDelete).isNotNull();
+        assertThat(beforeDelete.isPresent()).isTrue();
+        assertThat(afterDelete).isNotNull();
+        assertThat(afterDelete.isPresent()).isFalse();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -33,7 +33,7 @@
 	<name>Gravitee.io APIM - Management API - Management - v2 - Rest API</name>
 
 	<properties>
-		<openapi-generator.version>6.5.0</openapi-generator.version>
+		<openapi-generator.version>6.6.0</openapi-generator.version>
 		<openapi.modelPackage>io.gravitee.rest.api.management.v2.rest.model</openapi.modelPackage>
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 	</properties>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/processor/SynchronizationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/processor/SynchronizationServiceTest.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.rest.api.service.processor;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doThrow;
@@ -65,7 +64,7 @@ public class SynchronizationServiceTest {
 
         List<Object> requiredFields = synchronizationService.getRequiredFieldsForComparison(ApiEntity.class, entity);
 
-        assertThat(requiredFields.size() == apiEntityRequiredFieldCount, is(true));
+        assertThat(requiredFields).hasSize(apiEntityRequiredFieldCount);
     }
 
     /**
@@ -97,7 +96,7 @@ public class SynchronizationServiceTest {
 
         boolean isSynchronized = synchronizationService.checkSynchronization(ApiEntity.class, deployedEntity, entityToDeploy);
 
-        assertThat(isSynchronized, is(true));
+        assertThat(isSynchronized).isTrue();
     }
 
     /**
@@ -131,7 +130,7 @@ public class SynchronizationServiceTest {
 
         boolean isSynchronized = synchronizationService.checkSynchronization(ApiEntity.class, deployedEntity, entityToDeploy);
 
-        assertThat(isSynchronized, is(false));
+        assertThat(isSynchronized).isFalse();
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.sanitizer;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 import org.assertj.core.api.BDDSoftAssertions;
@@ -25,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.rules.ErrorCollector;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -46,7 +46,7 @@
     </modules>
 
     <properties>
-        <jolt.version>0.1.5</jolt.version>
+        <jolt.version>0.1.8</jolt.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
@@ -27,7 +27,12 @@ import java.io.StringWriter;
 import java.util.*;
 import javax.wsdl.*;
 import javax.wsdl.extensions.schema.Schema;
-import org.apache.xmlbeans.*;
+import org.apache.xmlbeans.SchemaTypeSystem;
+import org.apache.xmlbeans.XmlBeans;
+import org.apache.xmlbeans.XmlCursor;
+import org.apache.xmlbeans.XmlException;
+import org.apache.xmlbeans.XmlObject;
+import org.apache.xmlbeans.XmlOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,15 +42,15 @@ public class SoapMessageBuilder {
     public static final String XMLSCHEMA = "http://www.w3.org/2001/XMLSchema";
     public static final String XSD_PREFIX = "xsd";
 
-    private final Map<Object, Object> namespaceMappings;
-    private final Map<Object, Object> prefixToNamespaces;
+    private final Map<String, String> namespaceMappings;
+    private final Map<String, String> prefixToNamespaces;
     private final XmlOptions options;
 
     private List<XmlObject> schemas = new ArrayList<>();
     private SchemaTypeSystem shemaTypeSystem;
     private boolean compiled = false;
 
-    public SoapMessageBuilder(Map<Object, Object> namespaceMappings) {
+    public SoapMessageBuilder(Map<String, String> namespaceMappings) {
         this.namespaceMappings = namespaceMappings;
         this.namespaceMappings.put(SampleXmlUtil.XSI_TYPE.getNamespaceURI(), SampleXmlUtil.XSI_TYPE.getPrefix());
         this.namespaceMappings.put(XMLSCHEMA, XSD_PREFIX);
@@ -56,7 +61,7 @@ public class SoapMessageBuilder {
 
         // provide prefixes used by the WSDL to keep naming consistency in SoapEnvelope message
         this.prefixToNamespaces = new HashMap();
-        for (Map.Entry entry : namespaceMappings.entrySet()) {
+        for (var entry : namespaceMappings.entrySet()) {
             this.prefixToNamespaces.put(entry.getValue(), entry.getKey());
         }
         this.options.setSaveSuggestedPrefixes(this.prefixToNamespaces);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/soap/AbstractSoapBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/soap/AbstractSoapBuilder.java
@@ -33,7 +33,7 @@ import org.apache.xmlbeans.impl.schema.BuiltinSchemaTypeSystem;
 public abstract class AbstractSoapBuilder {
 
     private SchemaTypeSystem shemaTypeSystem;
-    private Map<Object, Object> namespaceMappings;
+    private Map<String, String> namespaceMappings;
 
     protected SoapVersion version;
     protected BindingOperation bindingOperation;
@@ -59,7 +59,7 @@ public abstract class AbstractSoapBuilder {
         return this;
     }
 
-    public AbstractSoapBuilder withNamespaceMappings(Map<Object, Object> namespaceMappings) {
+    public AbstractSoapBuilder withNamespaceMappings(Map<String, String> namespaceMappings) {
         this.namespaceMappings = namespaceMappings;
         return this;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/SampleXmlUtil.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/SampleXmlUtil.java
@@ -17,8 +17,10 @@ package io.gravitee.rest.api.spec.converter.wsdl.utils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
@@ -32,21 +34,6 @@ import org.apache.xmlbeans.GDurationBuilder;
 import org.apache.xmlbeans.SchemaLocalElement;
 import org.apache.xmlbeans.SchemaParticle;
 import org.apache.xmlbeans.SchemaProperty;
-/*   Copyright 2004 The Apache Software Foundation
- *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 import org.apache.xmlbeans.SchemaType;
 import org.apache.xmlbeans.SimpleValue;
 import org.apache.xmlbeans.XmlAnySimpleType;
@@ -63,7 +50,6 @@ import org.apache.xmlbeans.XmlGYearMonth;
 import org.apache.xmlbeans.XmlInteger;
 import org.apache.xmlbeans.XmlObject;
 import org.apache.xmlbeans.XmlTime;
-import org.apache.xmlbeans.impl.util.Base64;
 import org.apache.xmlbeans.impl.util.HexBin;
 import org.apache.xmlbeans.soap.SOAPArrayType;
 import org.apache.xmlbeans.soap.SchemaWSDLArrayType;
@@ -182,15 +168,7 @@ public class SampleXmlUtil {
             case SchemaType.BTC_BOOLEAN:
                 return pick(2) == 0 ? "true" : "false";
             case SchemaType.BTC_BASE_64_BINARY:
-                {
-                    String result = null;
-                    try {
-                        result = new String(Base64.encode(formatToLength(pick(WORDS), sType).getBytes("utf-8")));
-                    } catch (java.io.UnsupportedEncodingException e) {
-                        /* Can't possibly happen */
-                    }
-                    return result;
-                }
+                return Base64.getEncoder().encodeToString(formatToLength(pick(WORDS), sType).getBytes(StandardCharsets.UTF_8));
             case SchemaType.BTC_HEX_BINARY:
                 return HexBin.encode(formatToLength(pick(WORDS), sType));
             case SchemaType.BTC_ANY_URI:

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
         <gatling-charts-highcharts.version>3.11.5</gatling-charts-highcharts.version>
         <gson.version>2.11.0</gson.version>
         <guava.version>33.2.1-jre</guava.version>
-        <hamcrest.version>2.2</hamcrest.version>
         <hazelcast.version>5.4.0</hazelcast.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <httpclient.version>4.5.14</httpclient.version>
@@ -932,12 +931,6 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>${hamcrest.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,22 +54,22 @@
              in gravitee-apim-gateway-tests-sdk and gravitee-apim-integration-tests
              along with the grpc libs to create test clients and servers -->
         <vertx.version>4.5.7</vertx.version>
-        <protobuf-java.version>3.24.0</protobuf-java.version>
+        <protobuf-java.version>4.27.2</protobuf-java.version>
         <grpc-java.version>1.50.2</grpc-java.version>
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
-        <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.0.35</gravitee-cockpit-api.version>
+        <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
+        <gravitee-cockpit-api.version>3.0.36</gravitee-cockpit-api.version>
         <gravitee-common.version>4.4.0</gravitee-common.version>
-        <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.6.1</gravitee-exchange.version>
         <gravitee-expression-language.version>3.1.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.0.1</gravitee-integration-api.version>
-        <gravitee-node.version>5.18.3</gravitee-node.version>
+        <gravitee-node.version>5.19.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>3.1.1</gravitee-plugin.version>
+        <gravitee-plugin.version>4.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.30.0</gravitee-reporter-api.version>
@@ -82,81 +82,81 @@
         <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
         <gravitee-cloud-initializer.version>1.0.0</gravitee-cloud-initializer.version>
         <!-- Other dependencies version -->
-        <angus-mail.version>2.0.1</angus-mail.version>
-        <angus-activation.version>2.0.0</angus-activation.version>
-        <asm.version>9.2</asm.version>
+        <angus-mail.version>2.0.3</angus-mail.version>
+        <angus-activation.version>2.0.2</angus-activation.version>
+        <asm.version>9.7</asm.version>
         <batik-transcoder.version>1.17</batik-transcoder.version>
-        <classgraph.version>4.8.138</classgraph.version>
-        <commons-io.version>2.11.0</commons-io.version>
+        <classgraph.version>4.8.174</classgraph.version>
+        <commons-io.version>2.16.1</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
-        <commons-pool2.version>2.11.1</commons-pool2.version>
-        <commons-text.version>1.10.0</commons-text.version>
-        <commons-email.version>1.5</commons-email.version>
-        <dozer.version>6.5.2</dozer.version>
-        <flexmark.version>0.62.2</flexmark.version>
-        <freemarker.version>2.3.31</freemarker.version>
-        <gatling-charts-highcharts.version>3.10.5</gatling-charts-highcharts.version>
-        <gson.version>2.8.9</gson.version>
-        <guava.version>32.1.3-jre</guava.version>
-        <hamcrest.version>1.3</hamcrest.version>
-        <hazelcast.version>5.3.5</hazelcast.version>
+        <commons-pool2.version>2.12.0</commons-pool2.version>
+        <commons-text.version>1.12.0</commons-text.version>
+        <commons-email.version>1.6.0</commons-email.version>
+        <dozer.version>7.0.0</dozer.version>
+        <flexmark.version>0.64.8</flexmark.version>
+        <freemarker.version>2.3.33</freemarker.version>
+        <gatling-charts-highcharts.version>3.11.5</gatling-charts-highcharts.version>
+        <gson.version>2.11.0</gson.version>
+        <guava.version>33.2.1-jre</guava.version>
+        <hamcrest.version>2.2</hamcrest.version>
+        <hazelcast.version>5.4.0</hazelcast.version>
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
-        <httpclient.version>4.5.13</httpclient.version>
-        <imageio.version>3.8.1</imageio.version>
-        <java-jwt.version>3.19.4</java-jwt.version>
-        <javassist.version>3.28.0-GA</javassist.version>
-        <jakarta.validation-api.version>3.0.2</jakarta.validation-api.version>
-        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
-        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <imageio.version>3.11.0</imageio.version>
+        <java-jwt.version>4.4.0</java-jwt.version>
+        <javassist.version>3.30.2-GA</javassist.version>
+        <jakarta.validation-api.version>3.1.0</jakarta.validation-api.version>
+        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
         <javax.inject.version>1</javax.inject.version>
-        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.activation-api.version>2.1.2</jakarta.activation-api.version>
-        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
+        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
+        <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <spring-data-mongodb.version>4.2.3</spring-data-mongodb.version>
+        <spring-data-mongodb.version>4.3.1</spring-data-mongodb.version>
 
         <!-- javax dependencies still required for compatibility or test -->
-        <jaxb-impl.version>4.0.4</jaxb-impl.version>
-        <jaxb-api.version>2.3.1</jaxb-api.version>
-        <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
+        <jaxb-impl.version>4.0.5</jaxb-impl.version>
+        <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
 
         <awaitility.version>4.2.1</awaitility.version>
-        <jmh.version>1.33</jmh.version>
+        <jmh.version>1.37</jmh.version>
         <jcstress.version>0.15</jcstress.version>
-        <jsonassert.version>1.5.0</jsonassert.version>
-        <json-unit.version>3.2.7</json-unit.version>
+        <jsonassert.version>1.5.3</jsonassert.version>
+        <json-unit.version>3.3.0</json-unit.version>
         <json-patch.version>1.13</json-patch.version>
         <json-path.version>2.9.0</json-path.version>
-        <json-smart.version>2.4.11</json-smart.version>
-        <jsoup.version>1.15.3</jsoup.version>
+        <json-smart.version>2.5.1</json-smart.version>
+        <jsoup.version>1.17.2</jsoup.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
-        <lucene.version>9.5.0</lucene.version>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <netty-tcnative-boringssl-static.version>2.0.62.Final</netty-tcnative-boringssl-static.version>
-        <nimbus-jose-jwt.version>9.37.2</nimbus-jose-jwt.version>
-        <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
-        <reactor-core.version>3.5.0</reactor-core.version>
-        <reactor-adapter.version>3.5.0</reactor-adapter.version>
+        <lucene.version>9.11.1</lucene.version>
+        <mapstruct.version>1.6.0.Beta2</mapstruct.version>
+        <netty-tcnative-boringssl-static.version>2.0.65.Final</netty-tcnative-boringssl-static.version>
+        <nimbus-jose-jwt.version>9.40</nimbus-jose-jwt.version>
+        <owasp-java-html-sanitizer.version>20240325.1</owasp-java-html-sanitizer.version>
+        <reactor-core.version>3.6.7</reactor-core.version>
+        <reactor-adapter.version>3.5.1</reactor-adapter.version>
         <slf4j2-mock.version>2.3.0</slf4j2-mock.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <swagger-jaxrs2.version>2.2.9</swagger-jaxrs2.version>
-        <swagger-core.version>2.2.20</swagger-core.version>
-        <swagger-parser.version>2.1.20</swagger-parser.version>
+        <swagger-jaxrs2.version>2.2.22</swagger-jaxrs2.version>
+        <swagger-core.version>2.2.22</swagger-core.version>
+        <swagger-parser.version>2.1.22</swagger-parser.version>
         <resilience4j-rxjava3.version>2.2.0</resilience4j-rxjava3.version>
         <!-- !! Transitive dependency !! need to remove when swagger parser will include a version higher than 1.7.12 -->
-        <rhino.version>1.7.14</rhino.version>
+        <rhino.version>1.7.15</rhino.version>
         <testcontainers.version>1.19.8</testcontainers.version>
-        <xmlbeans.version>3.1.0</xmlbeans.version>
-        <wiremock.version>3.0.4</wiremock.version>
+        <xmlbeans.version>5.2.1</xmlbeans.version>
+        <wiremock.version>3.8.0</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <!-- Plugins version -->
-        <gatling-maven-plugin.version>4.8.2</gatling-maven-plugin.version>
+        <gatling-maven-plugin.version>4.9.5</gatling-maven-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
-        <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
@@ -290,7 +290,7 @@
         <gravitee-policy-interops.version>1.0.0</gravitee-policy-interops.version>
 
         <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
-        <archunit-junit5.version>1.2.1</archunit-junit5.version>
+        <archunit-junit5.version>1.3.0</archunit-junit5.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

N/A

## Description

- Update properties with `mvn versions:update-properties`.
- 3 modifications:
  - openapi-generator introduced a breaking change in version 7. So keeping it at 6.6 for the moment
  - code adaptation in the SoapConverter part
  - remove hamcrest-library
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eeotfopdzf.chromatic.com)
<!-- Storybook placeholder end -->
