### PR TITLE
feat(console): User can import and publish a page from a remote URL

### DIFF
--- a/gravitee-apim-console-webui/src/entities/fetcher/fetcher.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/fetcher/fetcher.fixture.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FetcherListItem } from './fetcher';
+
+export function fakeFetcherListItem(attributes?: Partial<FetcherListItem>): FetcherListItem {
+  const base: FetcherListItem = {
+    id: 'id',
+    name: 'name',
+    description: 'description',
+    version: 'version',
+    schema:
+      '{"type": "object","title": "http","properties": {"url": {"title": "URL","description": "Url to the file you want to fetch","type": "string"}}}',
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/fetcher/fetcher.ts
+++ b/gravitee-apim-console-webui/src/entities/fetcher/fetcher.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface FetcherListItem {
+  id: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  schema: string;
+}

--- a/gravitee-apim-console-webui/src/entities/fetcher/index.ts
+++ b/gravitee-apim-console-webui/src/entities/fetcher/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './fetcher';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/createDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/createDocumentation.ts
@@ -15,6 +15,7 @@
  */
 import { Visibility } from './visibility';
 import { AccessControl } from './page';
+import { PageSource } from './pageSource';
 
 const CreateDocumentationTypeEnum = {
   MARKDOWN: 'MARKDOWN',
@@ -39,16 +40,19 @@ export type CreateDocumentationFolder = BaseCreateDocumentation;
 export interface CreateDocumentationMarkdown extends BaseCreateDocumentation {
   content?: string;
   homepage?: boolean;
+  source?: PageSource;
 }
 
 export interface CreateDocumentationSwagger extends BaseCreateDocumentation {
   content?: string;
   homepage?: boolean;
+  source?: PageSource;
 }
 
 export interface CreateDocumentationAsyncApi extends BaseCreateDocumentation {
   content?: string;
   homepage?: boolean;
+  source?: PageSource;
 }
 
 export type CreateDocumentation =

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
@@ -16,6 +16,7 @@
 import { Visibility } from './visibility';
 import { PageType } from './pageType';
 import { AccessControl } from './page';
+import { PageSource } from './pageSource';
 
 export interface BaseEditDocumentation {
   type?: PageType;
@@ -31,6 +32,19 @@ export type EditDocumentationFolder = BaseEditDocumentation;
 export interface EditDocumentationMarkdown extends BaseEditDocumentation {
   content?: string;
   homepage?: boolean;
+  source?: PageSource;
 }
 
-export type EditDocumentation = EditDocumentationFolder | EditDocumentationMarkdown;
+export interface EditDocumentationSwagger extends BaseEditDocumentation {
+  content?: string;
+  homepage?: boolean;
+  source?: PageSource;
+}
+
+export interface EditDocumentationAsyncApi extends BaseEditDocumentation {
+  content?: string;
+  homepage?: boolean;
+  source?: PageSource;
+}
+
+export type EditDocumentation = EditDocumentationFolder | EditDocumentationMarkdown | EditDocumentationSwagger | EditDocumentationAsyncApi;

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
@@ -18,6 +18,7 @@ import { MatCardModule } from '@angular/material/card';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import {
   GioFormFilePickerModule,
+  GioFormJsonSchemaModule,
   GioFormSelectionInlineModule,
   GioFormSlideToggleModule,
   GioIconsModule,
@@ -114,6 +115,7 @@ import { GioApiMetadataListModule } from '../component/gio-api-metadata-list/gio
     MatSelect,
     GioFormSlideToggleModule,
     MatSlideToggle,
+    GioFormJsonSchemaModule,
   ],
 })
 export class ApiDocumentationV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -104,10 +104,9 @@
                   <gio-card-content-title>Import from file</gio-card-content-title>
                 </gio-form-selection-inline-card-content>
               </gio-form-selection-inline-card>
-              <gio-form-selection-inline-card value="EXTERNAL" [disabled]="true">
+              <gio-form-selection-inline-card value="HTTP">
                 <gio-form-selection-inline-card-content icon="gio:language">
-                  <gio-card-content-title>Import from source (URL)</gio-card-content-title>
-                  <gio-card-content-subtitle><div class="gio-badge-primary">Coming soon</div></gio-card-content-subtitle>
+                  <gio-card-content-title>Import from URL</gio-card-content-title>
                 </gio-form-selection-inline-card-content>
               </gio-form-selection-inline-card>
             </gio-form-selection-inline>
@@ -132,6 +131,11 @@
               [disabled]="isReadOnly"
               *ngIf="form.value?.source === 'IMPORT'"
             ></api-documentation-file-upload>
+            @if (form.value?.source === 'HTTP') {
+              @if (schema$ | async; as schema) {
+                <gio-form-json-schema formControlName="sourceConfiguration" [jsonSchema]="schema"></gio-form-json-schema>
+              }
+            }
             <mat-error *ngIf="form.controls.content.errors?.required">Page content cannot be empty</mat-error>
           </div>
           <div class="stepper__actions">

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.harness.ts
@@ -32,6 +32,7 @@ export class ApiDocumentationV4EditPageHarness extends ComponentHarness {
   private selectAccessGroupsHarness = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="accessControlGroups"]' }));
   private toggleExcludeGroups = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="excludeGroups"]' }));
   private sourceSelectionInlineHarness = this.locatorFor(GioFormSelectionInlineHarness.with({ selector: '.stepper__content__source' }));
+  private httpUrlLocator = this.locatorFor(MatInputHarness.with({ selector: '[id*="url"]' }));
 
   async getNextButton() {
     return this.nextButtonLocator();
@@ -73,9 +74,14 @@ export class ApiDocumentationV4EditPageHarness extends ComponentHarness {
     return this.toggleExcludeGroups().catch((_) => null);
   }
 
-  async getSourceSelectionInlineHarnessHarness() {
+  async getSourceSelectionInlineHarness() {
     return await this.sourceSelectionInlineHarness();
   }
+
+  async getHttpUrlHarness() {
+    return await this.httpUrlLocator();
+  }
+
   async getSourceOptions() {
     return Promise.all(await this.sourceSelectionInlineHarness().then(async (radioGroup) => await radioGroup.getSelectionCards()));
   }

--- a/gravitee-apim-console-webui/src/services-ngx/fetcher.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/fetcher.service.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { FetcherService } from './fetcher.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { fakeFetcherListItem } from '../entities/fetcher/fetcher.fixture';
+
+describe('FetcherService', () => {
+  let httpTestingController: HttpTestingController;
+  let fetcherService: FetcherService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    fetcherService = TestBed.inject<FetcherService>(FetcherService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list FetcherListItem', () => {
+    it('should call the create endpoint', (done) => {
+      const id1 = 'id1';
+      const id2 = 'id2';
+      const schema1 =
+        '{"type": "object","title": "http","properties": {"url": {"title": "URL","description": "description1","type": "string"}}}';
+      const schema2 =
+        '{"type": "object","title": "http","properties": {"url": {"title": "URL","description": "description2","type": "string"}}}';
+
+      const fetcherListItem = [fakeFetcherListItem({ id: id1, schema: schema1 }), fakeFetcherListItem({ id: id2, schema: schema2 })];
+
+      fetcherService.getList().subscribe((fetcherListItem) => {
+        expect(fetcherListItem.length).toEqual(2);
+        expect(fetcherListItem[0].schema).toEqual(schema1);
+        expect(fetcherListItem[1].schema).toEqual(schema2);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/fetchers?expand=schema`,
+        method: 'GET',
+      });
+
+      req.flush(fetcherListItem);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/fetcher.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/fetcher.service.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { FetcherListItem } from '../entities/fetcher';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FetcherService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  getList(): Observable<FetcherListItem[]> {
+    return this.http.get<FetcherListItem[]>(`${this.constants.env.baseURL}/fetchers?expand=schema`);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3548

## Description

Front-end changes for 
As an API publisher

I want to import documentation pages from a remote site like I can with a v2 API

so that I am getting the documentation outside of Gravitee where I am used to managing it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zbcbeemzix.chromatic.com)
<!-- Storybook placeholder end -->

Create:

<img width="1594" alt="Screenshot 2024-07-04 at 17 52 22" src="https://github.com/gravitee-io/gravitee-api-management/assets/8080303/d20c34f5-41f0-4688-aef9-e59ed52180d5">


Update:
https://github.com/gravitee-io/gravitee-api-management/assets/8080303/eb632865-2578-4079-9618-9fa7c78374d3



<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/8236/console](https://pr.team-apim.gravitee.dev/8236/console)
      Portal: [https://pr.team-apim.gravitee.dev/8236/portal](https://pr.team-apim.gravitee.dev/8236/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/8236/api/management](https://pr.team-apim.gravitee.dev/8236/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/8236](https://pr.team-apim.gravitee.dev/8236)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/8236](https://pr.gateway-v3.team-apim.gravitee.dev/8236)

<!-- Environment placeholder end -->
