### PR TITLE
Downgrade liquibase to 4.25.0

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <!-- Dependencies version -->
         <HikariCP.version>5.1.0</HikariCP.version>
-        <liquibase.version>4.28.0</liquibase.version>
+        <liquibase.version>4.25.0</liquibase.version>
         <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
         <mariaDB.version>3.4.0</mariaDB.version>
         <mssql-jdbc.version>12.7.0.jre11-preview</mssql-jdbc.version>


### PR DESCRIPTION
## Issue

Daily repository tests are failing with mysql & mariadb

## Description

This [commit](https://github.com/gravitee-io/gravitee-api-management/commit/c3bb9ec3afb3b90bd1f12ca7faf6d9790ab31a39) bumped versions of multiple libraries. In particular, liquibase has been updated from 4.21.1 to 4.28.0.

However, version 4.25.1 introduced a change regarding the type of a boolean column. (https://docs.liquibase.com/start/release-notes/liquibase-release-notes/liquibase-4.25.1.html) This commit fixes the tests by downgrading the library.

But a future commit will be done to adapt the code.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zcgwnoavjz.chromatic.com)
<!-- Storybook placeholder end -->
