### PR TITLE
ci: don't reuse the cache from another branch

### DIFF
--- a/.circleci/ci/src/commands/cmd-restore-maven-cache.ts
+++ b/.circleci/ci/src/commands/cmd-restore-maven-cache.ts
@@ -31,7 +31,6 @@ export class RestoreMavenJobCacheCommand {
           keys: [
             `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}`,
             `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}`,
-            `${config.cache.prefix}-<< parameters.jobName >>`,
           ],
         }),
       ],

--- a/.circleci/ci/src/commands/cmd-restore-maven-cache.ts
+++ b/.circleci/ci/src/commands/cmd-restore-maven-cache.ts
@@ -15,6 +15,7 @@
  */
 import { commands, parameters, reusable } from '@circleci/circleci-config-sdk';
 import { config } from '../config';
+import { CircleCIEnvironment } from '../pipelines';
 
 export class RestoreMavenJobCacheCommand {
   private static commandName = 'cmd-restore-maven-job-cache';
@@ -23,17 +24,19 @@ export class RestoreMavenJobCacheCommand {
     new parameters.CustomParameter('jobName', 'string', '', 'The job name'),
   ]);
 
-  public static get(): reusable.ReusableCommand {
+  public static get(environment: CircleCIEnvironment): reusable.ReusableCommand {
+    const keys = [
+      `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}`,
+      `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}`,
+    ];
+
+    if (environment.baseBranch !== environment.branch) {
+      keys.push(`${config.cache.prefix}-<< parameters.jobName >>-${environment.baseBranch}`);
+    }
+
     return new reusable.ReusableCommand(
       RestoreMavenJobCacheCommand.commandName,
-      [
-        new commands.cache.Restore({
-          keys: [
-            `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}`,
-            `${config.cache.prefix}-<< parameters.jobName >>-{{ .Branch }}`,
-          ],
-        }),
-      ],
+      [new commands.cache.Restore({ keys })],
       RestoreMavenJobCacheCommand.customParametersList,
       'Restore Maven cache for a dedicated job',
     );

--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -16,7 +16,7 @@
 const artifactoryUrl = 'https://odbxikk7vo-artifactory.services.clever-cloud.com';
 
 const cache = {
-  prefix: 'gravitee-api-management-v9',
+  prefix: 'gravitee-api-management-v10',
 };
 
 const dockerImages = {

--- a/.circleci/ci/src/index.ts
+++ b/.circleci/ci/src/index.ts
@@ -46,6 +46,7 @@ changed
   .then(
     (changes) =>
       ({
+        baseBranch: GIT_BASE_BRANCH,
         branch: CIRCLE_BRANCH,
         buildNum: CIRCLE_BUILD_NUM, // TODO merge this line with the next one when everything is working on the CI
         buildId: CIRCLE_BUILD_NUM,

--- a/.circleci/ci/src/jobs/backend/abstract-job-test.ts
+++ b/.circleci/ci/src/jobs/backend/abstract-job-test.ts
@@ -18,17 +18,19 @@ import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheC
 import { Executor } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Executors';
 import { config } from '../../config';
 import { JobOptionalProperties } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Job/types/Job.types';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export abstract class AbstractTestJob {
   protected static create(
     dynamicConfig: Config,
+    environment: CircleCIEnvironment,
     jobName: string,
     testStep: commands.Run,
     executor: Executor,
     pathsToPersist: string[],
     properties?: JobOptionalProperties,
   ) {
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-artifactory.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-artifactory.ts
@@ -24,7 +24,7 @@ export class BackendBuildAndPublishOnArtifactoryJob {
   private static jobName = 'job-backend-build-and-publish-artifactory';
 
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
-    const restoreMavenJobCacheCommand = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCommand = RestoreMavenJobCacheCommand.get(environment);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCommand);
 
     const prepareGpgCommand = PrepareGpgCmd.get(dynamicConfig);

--- a/.circleci/ci/src/jobs/backend/job-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-build-backend.ts
@@ -24,7 +24,7 @@ export class BuildBackendJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     const jobName = 'job-build';
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
+++ b/.circleci/ci/src/jobs/backend/job-community-build-backend.ts
@@ -17,12 +17,13 @@ import { commands, Config, Job, reusable } from '@circleci/circleci-config-sdk';
 import { OpenJdkExecutor } from '../../executors';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class CommunityBuildBackendJob {
-  public static create(dynamicConfig: Config): Job {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     const jobName = 'job-community-build';
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
+++ b/.circleci/ci/src/jobs/backend/job-nexus-staging.ts
@@ -26,7 +26,7 @@ export class NexusStagingJob {
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     dynamicConfig.importOrb(keeper);
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);
 
     const prepareGpgCmd = PrepareGpgCmd.get(dynamicConfig);

--- a/.circleci/ci/src/jobs/backend/job-publish.ts
+++ b/.circleci/ci/src/jobs/backend/job-publish.ts
@@ -18,12 +18,13 @@ import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/C
 import { config } from '../../config';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { OpenJdkExecutor } from '../../executors';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class PublishJob {
-  public static create(dynamicConfig: Config, target: 'nexus' | 'artifactory'): Job {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment, target: 'nexus' | 'artifactory'): Job {
     const jobName = `job-publish-on-${target}`;
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/backend/job-test-definition.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-definition.ts
@@ -17,11 +17,13 @@ import { commands, Config } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { OpenJdkExecutor } from '../../executors';
 import { AbstractTestJob } from './abstract-job-test';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestDefinitionJob extends AbstractTestJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-test-definition',
       new commands.Run({
         name: `Run definition tests`,

--- a/.circleci/ci/src/jobs/backend/job-test-gateway.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-gateway.ts
@@ -17,11 +17,13 @@ import { commands, Config } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { OpenJdkExecutor } from '../../executors';
 import { AbstractTestJob } from './abstract-job-test';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestGatewayJob extends AbstractTestJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-test-gateway',
       new commands.Run({
         name: `Run gateway tests`,

--- a/.circleci/ci/src/jobs/backend/job-test-integration.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-integration.ts
@@ -18,12 +18,13 @@ import { config } from '../../config';
 import { UbuntuExecutor } from '../../executors';
 import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestIntegrationJob {
   private static jobName = 'job-test-integration';
 
-  public static create(dynamicConfig: Config) {
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/backend/job-test-plugin.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-plugin.ts
@@ -17,11 +17,13 @@ import { commands, Config } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { AbstractTestJob } from './abstract-job-test';
 import { UbuntuExecutor } from '../../executors';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestPluginJob extends AbstractTestJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-test-plugin',
       new commands.Run({
         name: `Run plugin tests`,

--- a/.circleci/ci/src/jobs/backend/job-test-repository.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-repository.ts
@@ -17,11 +17,13 @@ import { commands, Config } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { AbstractTestJob } from './abstract-job-test';
 import { UbuntuExecutor } from '../../executors';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestRepositoryJob extends AbstractTestJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-test-repository',
       new commands.Run({
         name: `Run repository tests`,

--- a/.circleci/ci/src/jobs/backend/job-test-rest-api.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-rest-api.ts
@@ -17,11 +17,13 @@ import { commands, Config } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { OpenJdkExecutor } from '../../executors';
 import { AbstractTestJob } from './abstract-job-test';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class TestRestApiJob extends AbstractTestJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-test-rest-api',
       new commands.Run({
         name: `Run Rest API tests`,

--- a/.circleci/ci/src/jobs/backend/job-validate.ts
+++ b/.circleci/ci/src/jobs/backend/job-validate.ts
@@ -18,11 +18,12 @@ import { OpenJdkExecutor } from '../../executors';
 import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheCommand } from '../../commands';
 import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
 import { config } from '../../config';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class ValidateJob {
   private static jobName = 'job-validate';
-  public static create(dynamicConfig: Config): Job {
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/job-deploy-on-azure.ts
+++ b/.circleci/ci/src/jobs/job-deploy-on-azure.ts
@@ -28,7 +28,7 @@ export class DeployOnAzureJob {
 
     dynamicConfig.importOrb(orbs.keeper);
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
+++ b/.circleci/ci/src/jobs/job-sonarcloud-analysis.ts
@@ -40,7 +40,7 @@ export class SonarCloudAnalysisJob {
 
     const apimVersion = computeApimVersion(environment);
 
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/abstract-job-test-container.ts
@@ -18,16 +18,18 @@ import { NotifyOnFailureCommand, RestoreMavenJobCacheCommand, SaveMavenJobCacheC
 import { UbuntuExecutor } from '../../executors';
 import { Executor } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Executors';
 import { AnyParameterLiteral } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Parameters/types/CustomParameterLiterals.types';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export abstract class AbstractTestContainerJob {
   protected static create(
     dynamicConfig: Config,
+    environment: CircleCIEnvironment,
     jobName: string,
     parameters: parameters.CustomParametersList<AnyParameterLiteral>,
     testStep: commands.Run,
     executor: Executor = UbuntuExecutor.create(),
   ) {
-    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get();
+    const restoreMavenJobCacheCmd = RestoreMavenJobCacheCommand.get(environment);
     const saveMavenJobCacheCmd = SaveMavenJobCacheCommand.get();
     const notifyOnFailureCmd = NotifyOnFailureCommand.get(dynamicConfig);
     dynamicConfig.addReusableCommand(restoreMavenJobCacheCmd);

--- a/.circleci/ci/src/jobs/test-container/job-elastic-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-elastic-test-container.ts
@@ -16,11 +16,13 @@
 import { commands, Config, parameters } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { AbstractTestContainerJob } from './abstract-job-test-container';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class ElasticTestContainerJob extends AbstractTestContainerJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-elastic-test-container',
       new parameters.CustomParametersList([
         new parameters.CustomEnumParameter('engineType', ['elasticsearch', 'opensearch'], 'elasticsearch', 'Type of the search engine'),

--- a/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
@@ -17,11 +17,13 @@ import { commands, Config, parameters } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { UbuntuExecutor } from '../../executors';
 import { AbstractTestContainerJob } from './abstract-job-test-container';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class JdbcTestContainerJob extends AbstractTestContainerJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-jdbc-test-container',
       new parameters.CustomParametersList([
         new parameters.CustomParameter('jdbcType', 'string', '', 'Type and version of the database to test. Example: mariadb:10.5'),

--- a/.circleci/ci/src/jobs/test-container/job-mongo-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-mongo-test-container.ts
@@ -16,11 +16,13 @@
 import { commands, Config, parameters } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { AbstractTestContainerJob } from './abstract-job-test-container';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class MongoTestContainerJob extends AbstractTestContainerJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-mongo-test-container',
       new parameters.CustomParametersList([new parameters.CustomParameter('mongoVersion', 'string', '', 'Version of Mongo to test')]),
       new commands.Run({

--- a/.circleci/ci/src/jobs/test-container/job-redis-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-redis-test-container.ts
@@ -16,11 +16,13 @@
 import { commands, Config, parameters } from '@circleci/circleci-config-sdk';
 import { config } from '../../config';
 import { AbstractTestContainerJob } from './abstract-job-test-container';
+import { CircleCIEnvironment } from '../../pipelines';
 
 export class RedisTestContainerJob extends AbstractTestContainerJob {
-  public static create(dynamicConfig: Config) {
+  public static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     return super.create(
       dynamicConfig,
+      environment,
       'job-redis-test-container',
       new parameters.CustomParametersList([new parameters.CustomParameter('redisVersion', 'string', '', 'Version of Redis to test')]),
       new commands.Run({

--- a/.circleci/ci/src/pipelines/circleci-environment.ts
+++ b/.circleci/ci/src/pipelines/circleci-environment.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 export type CircleCIEnvironment = {
+  baseBranch: string;
   branch: string;
   buildNum: string;
   buildId: string;

--- a/.circleci/ci/src/pipelines/tests/pipeline-bridge-compatibility-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-bridge-compatibility-tests.spec.ts
@@ -20,6 +20,7 @@ describe('Run bridge compatibility tests', () => {
   it('should generate bridge compatibility tests pipeline', () => {
     const result = generateBridgeCompatibilityTestsConfig({
       action: 'bridge_compatibility_tests',
+      baseBranch: 'master',
       branch: 'master',
       sha1: '784ff35ca',
       changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-build-rpm-and-docker-images.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-build-rpm-and-docker-images.spec.ts
@@ -29,6 +29,7 @@ describe('Build RPM & Docker images workflow tests', () => {
     ({ graviteeioVersion, isDryRun, dockerTagAsLatest, expectedFileName }) => {
       const result = generateBuildRpmAndDockerImagesConfig({
         action: 'build_rpm_&_docker_images',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],
@@ -51,6 +52,7 @@ describe('Build RPM & Docker images workflow tests', () => {
     try {
       generateBuildRpmAndDockerImagesConfig({
         action: 'build_rpm_&_docker_images',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],
@@ -72,6 +74,7 @@ describe('Build RPM & Docker images workflow tests', () => {
     try {
       generateBuildRpmAndDockerImagesConfig({
         action: 'build_rpm_&_docker_images',
+        baseBranch: '',
         branch: '',
         sha1: '784ff35ca',
         changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -18,14 +18,14 @@ import { generateFullReleaseConfig } from '../pipeline-full-release';
 
 describe('Full release tests', () => {
   it.each`
-    branch     | isDryRun | dockerTagAsLatest | graviteeioVersion  | apimVersionPath                                           | expectedResult
-    ${'4.2.x'} | ${true}  | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-dry-run.yml'}
-    ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-no-dry-run.yml'}
-    ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-latest.yml'}
-    ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'release-4-2-0-alpha.yml'}
+    baseBranch | branch     | isDryRun | dockerTagAsLatest | graviteeioVersion  | apimVersionPath                                           | expectedResult
+    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-no-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${true}           | ${'4.2.0'}         | ${'./src/pipelines/tests/resources/common/pom.xml'}       | ${'release-4-2-0-latest.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${false}          | ${'4.2.0-alpha.1'} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'} | ${'release-4-2-0-alpha.yml'}
   `(
     'should build full release config on $branch with dry run $isDryRun, is latest $dockerTagAsLatest and version graviteeioVersion',
-    ({ branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {
+    ({ baseBranch, branch, isDryRun, dockerTagAsLatest, graviteeioVersion, apimVersionPath, expectedResult }) => {
       const result = generateFullReleaseConfig({
         action: 'release',
         sha1: '784ff35ca',
@@ -34,6 +34,7 @@ describe('Full release tests', () => {
         buildId: '1234',
         apimVersionPath,
         graviteeioVersion,
+        baseBranch,
         branch,
         isDryRun,
         dockerTagAsLatest,
@@ -56,6 +57,7 @@ describe('Full release tests', () => {
         buildId: '1234',
         graviteeioVersion: '4.1.0',
         branch: 'apim-1234-dev',
+        baseBranch: 'master',
         isDryRun: false,
         apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
       });

--- a/.circleci/ci/src/pipelines/tests/pipeline-nexus-staging.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-nexus-staging.spec.ts
@@ -20,6 +20,7 @@ describe('Nexus staging workflow tests', () => {
   it('should build nexus staging with no dry run', function () {
     const result = generateNexusStagingConfig({
       action: 'nexus_staging',
+      baseBranch: 'master',
       branch: 'master',
       sha1: '784ff35ca',
       changedFiles: [],
@@ -40,6 +41,7 @@ describe('Nexus staging workflow tests', () => {
     try {
       generateNexusStagingConfig({
         action: 'nexus_staging',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],
@@ -60,6 +62,7 @@ describe('Nexus staging workflow tests', () => {
     try {
       generateNexusStagingConfig({
         action: 'nexus_staging',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-package-bundle.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-package-bundle.spec.ts
@@ -26,6 +26,7 @@ describe('Package bundle workflow tests', () => {
   `('should build package bundle with $graviteeioVersion', ({ graviteeioVersion, isDryRun, expectedFileName }) => {
     const result = generatePackageBundleConfig({
       action: 'package_bundle',
+      baseBranch: 'master',
       branch: 'master',
       sha1: '784ff35ca',
       changedFiles: [],
@@ -46,6 +47,7 @@ describe('Package bundle workflow tests', () => {
     try {
       generatePackageBundleConfig({
         action: 'package_bundle',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-publish-docker-images.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-publish-docker-images.spec.ts
@@ -18,11 +18,11 @@ import { generatePublishDockerImagesConfig } from '../pipeline-publish-docker-im
 
 describe('Publish docker images tests', () => {
   it.each`
-    branch                     | isDryRun | expectedResult
-    ${'apim-1234-branch-name'} | ${true}  | ${'publish-docker-images-dry-run.yml'}
-    ${'master'}                | ${false} | ${'publish-docker-images-master.yml'}
-    ${'4.1.x'}                 | ${false} | ${'publish-docker-images-4-1-x.yml'}
-  `('should build publish docker image pipeline for $branch and dry run $isDryRun', ({ branch, isDryRun, expectedResult }) => {
+    baseBranch  | branch                     | isDryRun | expectedResult
+    ${'master'} | ${'apim-1234-branch-name'} | ${true}  | ${'publish-docker-images-dry-run.yml'}
+    ${'master'} | ${'master'}                | ${false} | ${'publish-docker-images-master.yml'}
+    ${'4.1.x'}  | ${'4.1.x'}                 | ${false} | ${'publish-docker-images-4-1-x.yml'}
+  `('should build publish docker image pipeline for $branch and dry run $isDryRun', ({ baseBranch, branch, isDryRun, expectedResult }) => {
     const result = generatePublishDockerImagesConfig({
       action: 'publish_docker_images',
       sha1: '784ff35ca',
@@ -31,6 +31,7 @@ describe('Publish docker images tests', () => {
       buildId: '1234',
       graviteeioVersion: '4.2.0',
       apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
+      baseBranch,
       branch,
       isDryRun,
     });

--- a/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
@@ -18,29 +18,30 @@ import { generatePullRequestsConfig } from '../pipeline-pull-requests';
 
 describe('Pull requests workflow tests', () => {
   it.each`
-    branchName                      | changedFiles                           | expectedFileName
-    ${'master'}                     | ${[]}                                  | ${'pull-requests-master.yml'}
-    ${'4.1.x'}                      | ${[]}                                  | ${'pull-requests-4-1-x.yml'}
-    ${'APIM-1234-run-e2e'}          | ${[]}                                  | ${'pull-requests-run-e2e.yml'}
-    ${'mergify/bp/4.0.x/pr-1234'}   | ${['pom.xml']}                         | ${'pull-requests-mergify.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['pom.xml']}                         | ${'pull-requests-custom-branch.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['helm']}                            | ${'pull-requests-custom-branch-helm-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-console-webui']}     | ${'pull-requests-custom-branch-console-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui']}      | ${'pull-requests-custom-branch-portal-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-definition']}        | ${'pull-requests-custom-branch-backend-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-repository']}        | ${'pull-requests-custom-branch-backend-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution']}      | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway']}           | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-integration-tests']} | ${'pull-requests-custom-branch-backend-integration-tests-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-plugin']}            | ${'pull-requests-custom-branch-backend-plugin-only.yml'}
-    ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-rest-api']}          | ${'pull-requests-custom-branch-backend-rest-api-only.yml'}
+    baseBranch  | branch                          | changedFiles                           | expectedFileName
+    ${'master'} | ${'master'}                     | ${['pom.xml']}                         | ${'pull-requests-master.yml'}
+    ${'4.1.x'}  | ${'4.1.x'}                      | ${['pom.xml']}                         | ${'pull-requests-4-1-x.yml'}
+    ${'4.0.x'}  | ${'mergify/bp/4.0.x/pr-1234'}   | ${['pom.xml']}                         | ${'pull-requests-mergify.yml'}
+    ${'master'} | ${'APIM-1234-run-e2e'}          | ${['pom.xml']}                         | ${'pull-requests-run-e2e.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['pom.xml']}                         | ${'pull-requests-custom-branch.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['helm']}                            | ${'pull-requests-custom-branch-helm-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-console-webui']}     | ${'pull-requests-custom-branch-console-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui']}      | ${'pull-requests-custom-branch-portal-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-definition']}        | ${'pull-requests-custom-branch-backend-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution']}      | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway']}           | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-integration-tests']} | ${'pull-requests-custom-branch-backend-integration-tests-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-plugin']}            | ${'pull-requests-custom-branch-backend-plugin-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-repository']}        | ${'pull-requests-custom-branch-backend-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-rest-api']}          | ${'pull-requests-custom-branch-backend-rest-api-only.yml'}
   `(
     'should generate pull-requests config for branch $branchName with changedFiles $changedFiles',
-    ({ branchName, changedFiles, expectedFileName }) => {
+    ({ baseBranch, branch, changedFiles, expectedFileName }) => {
       const result = generatePullRequestsConfig({
         action: 'pull_requests',
         apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
-        branch: branchName,
+        baseBranch,
+        branch,
         sha1: '784ff35ca',
         changedFiles: changedFiles,
         buildNum: '1234',

--- a/.circleci/ci/src/pipelines/tests/pipeline-release-helm.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release-helm.spec.ts
@@ -30,6 +30,7 @@ describe('Release helm charts tests', () => {
       buildId: '1234',
       graviteeioVersion: '4.2.0',
       apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+      baseBranch: 'master',
       branch: 'master',
       isDryRun,
     });

--- a/.circleci/ci/src/pipelines/tests/pipeline-release-notes-apim.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release-notes-apim.spec.ts
@@ -26,6 +26,7 @@ describe('Release notes apim workflow tests', () => {
     ({ graviteeioVersion, isDryRun, expectedFileName }) => {
       const result = generateReleaseNotesApimConfig({
         action: 'release_notes_apim',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],
@@ -47,6 +48,7 @@ describe('Release notes apim workflow tests', () => {
     try {
       generateReleaseNotesApimConfig({
         action: 'release_notes_apim',
+        baseBranch: 'master',
         branch: 'master',
         sha1: '784ff35ca',
         changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-release.spec.ts
@@ -18,13 +18,13 @@ import { generateReleaseConfig } from '../pipeline-release';
 
 describe('Release tests', () => {
   it.each`
-    branch     | isDryRun | apimVersionPath                                              | graviteeioVersion  | expectedResult
-    ${'4.2.x'} | ${true}  | ${'./src/pipelines/tests/resources/common/pom.xml'}          | ${'4.2.0'}         | ${'release-4-2-0-dry-run.yml'}
-    ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'4.2.0'}         | ${'release-4-2-0-snapshot.yml'}
-    ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'4.2.0-alpha.1'} | ${'release-4-2-0-alpha.yml'}
+    baseBranch | branch     | isDryRun | apimVersionPath                                              | graviteeioVersion  | expectedResult
+    ${'4.2.x'} | ${'4.2.x'} | ${true}  | ${'./src/pipelines/tests/resources/common/pom.xml'}          | ${'4.2.0'}         | ${'release-4-2-0-dry-run.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-snapshot.xml'} | ${'4.2.0'}         | ${'release-4-2-0-snapshot.yml'}
+    ${'4.2.x'} | ${'4.2.x'} | ${false} | ${'./src/pipelines/tests/resources/common/pom-alpha.xml'}    | ${'4.2.0-alpha.1'} | ${'release-4-2-0-alpha.yml'}
   `(
     'should build release config on $branch with dry run $isDryRun and graviteeio version $graviteeioVersion',
-    ({ branch, isDryRun, apimVersionPath, graviteeioVersion, expectedResult }) => {
+    ({ baseBranch, branch, isDryRun, apimVersionPath, graviteeioVersion, expectedResult }) => {
       const result = generateReleaseConfig({
         action: 'release',
         sha1: '784ff35ca',
@@ -32,6 +32,7 @@ describe('Release tests', () => {
         buildNum: '1234',
         buildId: '1234',
         graviteeioVersion,
+        baseBranch,
         branch,
         apimVersionPath,
         isDryRun,
@@ -53,6 +54,7 @@ describe('Release tests', () => {
         buildNum: '1234',
         buildId: '1234',
         graviteeioVersion: '4.1.0',
+        baseBranch: 'master',
         branch: 'apim-1234-dev',
         apimVersionPath: '/some/path',
         isDryRun: false,

--- a/.circleci/ci/src/pipelines/tests/pipeline-repositories-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-repositories-tests.spec.ts
@@ -20,6 +20,7 @@ describe('Run Repositories Tests', () => {
   it('should generate Repositories tests pipeline', () => {
     const result = generateRepositoriesTestsConfig({
       action: 'repositories_tests',
+      baseBranch: 'master',
       branch: 'master',
       sha1: '784ff35ca',
       changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/pipeline-run-e2e-tests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-run-e2e-tests.spec.ts
@@ -20,6 +20,7 @@ describe('Run e2e tests', () => {
   it('should generate Run e2e tests pipeline', () => {
     const result = generateRunE2ETestsConfig({
       action: 'run_e2e_tests',
+      baseBranch: 'master',
       branch: 'apim-xxx-test',
       sha1: '784ff35ca',
       changedFiles: [],

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -159,7 +159,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/nexus-staging/nexus-staging-no-dry-run.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -61,7 +61,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -204,7 +204,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -172,7 +172,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-dry-run.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -204,7 +204,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -256,7 +256,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -278,7 +278,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -322,7 +322,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -334,7 +334,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -348,7 +348,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -379,7 +379,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -411,7 +411,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -459,7 +459,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -491,7 +491,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -155,7 +155,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -199,7 +199,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -211,7 +211,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-integration:
     machine:
@@ -226,7 +226,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -156,7 +156,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -155,7 +155,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -199,7 +199,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -211,7 +211,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -225,7 +225,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -256,7 +256,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -288,7 +288,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -336,7 +336,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -368,7 +368,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -156,7 +156,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -204,7 +204,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -248,7 +248,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -260,7 +260,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -133,7 +133,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -155,7 +155,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -199,7 +199,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -211,7 +211,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -114,6 +114,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -112,9 +112,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -127,7 +127,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -314,7 +314,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -326,7 +326,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -114,7 +114,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -114,6 +114,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -114,7 +114,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -112,9 +112,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -127,7 +127,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -244,7 +244,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -256,7 +256,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-validate-workflow-status:
     docker:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -224,7 +224,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -246,7 +246,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -290,7 +290,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -302,7 +302,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -316,7 +316,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -347,7 +347,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -379,7 +379,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -427,7 +427,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -459,7 +459,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -256,7 +256,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -278,7 +278,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -322,7 +322,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -334,7 +334,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -348,7 +348,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -379,7 +379,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -411,7 +411,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -459,7 +459,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -491,7 +491,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-4.0.x
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-4.0.x
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -224,7 +224,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -246,7 +246,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -290,7 +290,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -302,7 +302,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -316,7 +316,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -347,7 +347,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -379,7 +379,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -427,7 +427,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -459,7 +459,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-4.0.x
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -224,7 +224,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build
@@ -246,7 +246,7 @@ jobs:
           jobName: job-test-definition
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run definition tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Ddefinition-modules -Dskip.validation=true -T 2C
@@ -290,7 +290,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+            - gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
       - keeper/env-export:
           secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
           var-name: SONAR_TOKEN
@@ -302,7 +302,7 @@ jobs:
       - save_cache:
           paths:
             - /opt/sonar-scanner/.sonar/cache
-          key: gravitee-api-management-v9-sonarcloud-analysis-<< parameters.cache_type >>
+          key: gravitee-api-management-v10-sonarcloud-analysis-<< parameters.cache_type >>
           when: always
   job-test-gateway:
     docker:
@@ -316,7 +316,7 @@ jobs:
           jobName: job-test-gateway
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run gateway tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dgateway-modules -Dskip.validation=true -T 2C
@@ -347,7 +347,7 @@ jobs:
           jobName: job-test-rest-api
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run Rest API tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -T 2C
@@ -379,7 +379,7 @@ jobs:
           jobName: job-test-integration
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run tests
           command: |-
@@ -427,7 +427,7 @@ jobs:
           jobName: job-test-plugin
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run plugin tests
           command: mvn --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
@@ -459,7 +459,7 @@ jobs:
           jobName: job-test-repository
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+            - gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
           name: Run repository tests
           command: mvn --fail-fast -s .gravitee.settings.xml verify --no-transfer-progress -Drepository-modules -Dskip.validation=true -T 2C

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -145,8 +145,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:
@@ -171,7 +171,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -147,7 +147,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-prepare-gpg:
     steps:

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -35,8 +35,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -49,7 +49,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -104,7 +104,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -35,9 +35,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>-master
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v10-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:
@@ -50,7 +50,7 @@ commands:
           name: Exclude all APIM artefacts from cache.
           command: rm -rf ~/.m2/repository/io/gravitee/apim
       - save_cache:
-          key: gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+          key: gravitee-api-management-v10-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
           paths:
             - ~/.m2
           when: always
@@ -172,7 +172,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2/repository/io/gravitee/apim
-          key: gravitee-api-management-v9-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+          key: gravitee-api-management-v10-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
           when: on_success
       - cmd-save-maven-job-cache:
           jobName: job-build

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -37,7 +37,6 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
-            - gravitee-api-management-v9-<< parameters.jobName >>
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/run-e2e-tests/run-e2e-tests.yml
@@ -37,6 +37,7 @@ commands:
           keys:
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
             - gravitee-api-management-v9-<< parameters.jobName >>-{{ .Branch }}
+            - gravitee-api-management-v9-<< parameters.jobName >>-master
     description: Restore Maven cache for a dedicated job
   cmd-save-maven-job-cache:
     parameters:

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -25,7 +25,7 @@ export class BridgeCompatibilityTestsWorkflow {
     const setupJob = SetupJob.create(dynamicConfig);
     dynamicConfig.addJob(setupJob);
 
-    const validateJob = ValidateJob.create(dynamicConfig);
+    const validateJob = ValidateJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(validateJob);
 
     const buildBackendJob = BuildBackendJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -89,7 +89,7 @@ export class PullRequestsWorkflow {
       const setupJob = SetupJob.create(dynamicConfig);
       dynamicConfig.addJob(setupJob);
 
-      const validateBackendJob = ValidateJob.create(dynamicConfig);
+      const validateBackendJob = ValidateJob.create(dynamicConfig, environment);
       dynamicConfig.addJob(validateBackendJob);
 
       const dangerJSJob = DangerJsJob.create(dynamicConfig);
@@ -118,7 +118,7 @@ export class PullRequestsWorkflow {
       );
 
       if (!filterJobs || shouldTestDefinition(environment.changedFiles)) {
-        const testDefinitionJob = TestDefinitionJob.create(dynamicConfig);
+        const testDefinitionJob = TestDefinitionJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testDefinitionJob);
 
         const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
@@ -142,7 +142,7 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestGateway(environment.changedFiles)) {
-        const testGatewayJob = TestGatewayJob.create(dynamicConfig);
+        const testGatewayJob = TestGatewayJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testGatewayJob);
 
         const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
@@ -166,7 +166,7 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestRestApi(environment.changedFiles)) {
-        const testRestApiJob = TestRestApiJob.create(dynamicConfig);
+        const testRestApiJob = TestRestApiJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testRestApiJob);
 
         const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
@@ -190,7 +190,7 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestIntegrationTests(environment.changedFiles)) {
-        const testIntegrationJob = TestIntegrationJob.create(dynamicConfig);
+        const testIntegrationJob = TestIntegrationJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testIntegrationJob);
 
         jobs.push(
@@ -203,7 +203,7 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestPlugin(environment.changedFiles)) {
-        const testPluginsJob = TestPluginJob.create(dynamicConfig);
+        const testPluginsJob = TestPluginJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testPluginsJob);
 
         const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
@@ -227,7 +227,7 @@ export class PullRequestsWorkflow {
       }
 
       if (!filterJobs || shouldTestRepository(environment.changedFiles)) {
-        const testRepositoryJob = TestRepositoryJob.create(dynamicConfig);
+        const testRepositoryJob = TestRepositoryJob.create(dynamicConfig, environment);
         dynamicConfig.addJob(testRepositoryJob);
 
         const sonarCloudAnalysisJob = SonarCloudAnalysisJob.create(dynamicConfig, environment);
@@ -416,16 +416,16 @@ export class PullRequestsWorkflow {
   }
 
   private static getMasterAndSupportJobs(dynamicConfig: Config, environment: CircleCIEnvironment): workflow.WorkflowJob[] {
-    const communityBuildJob = CommunityBuildBackendJob.create(dynamicConfig);
+    const communityBuildJob = CommunityBuildBackendJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(communityBuildJob);
 
     const snykApimChartsJob = SnykApimChartsJob.create(dynamicConfig, environment);
     dynamicConfig.addJob(snykApimChartsJob);
 
-    const publishOnArtifactoryJob = PublishJob.create(dynamicConfig, 'artifactory');
+    const publishOnArtifactoryJob = PublishJob.create(dynamicConfig, environment, 'artifactory');
     dynamicConfig.addJob(publishOnArtifactoryJob);
 
-    const publishOnNexusJob = PublishJob.create(dynamicConfig, 'nexus');
+    const publishOnNexusJob = PublishJob.create(dynamicConfig, environment, 'nexus');
     dynamicConfig.addJob(publishOnNexusJob);
 
     const releaseHelmDryRunJob = ReleaseHelmJob.create(dynamicConfig, environment);

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -23,11 +23,11 @@ export class RepositoriesTestsWorkflow {
   static create(dynamicConfig: Config, environment: CircleCIEnvironment) {
     const setupJob = SetupJob.create(dynamicConfig);
     const buildJob = BuildBackendJob.create(dynamicConfig, environment);
-    const jdbcTestContainerJob = JdbcTestContainerJob.create(dynamicConfig);
-    const mongoTestContainerJob = MongoTestContainerJob.create(dynamicConfig);
-    const elasticTestContainerJob = ElasticTestContainerJob.create(dynamicConfig);
-    const opensearchTestContainerJob = ElasticTestContainerJob.create(dynamicConfig);
-    const redisTestContainerJob = RedisTestContainerJob.create(dynamicConfig);
+    const jdbcTestContainerJob = JdbcTestContainerJob.create(dynamicConfig, environment);
+    const mongoTestContainerJob = MongoTestContainerJob.create(dynamicConfig, environment);
+    const elasticTestContainerJob = ElasticTestContainerJob.create(dynamicConfig, environment);
+    const opensearchTestContainerJob = ElasticTestContainerJob.create(dynamicConfig, environment);
+    const redisTestContainerJob = RedisTestContainerJob.create(dynamicConfig, environment);
 
     dynamicConfig.addJob(setupJob);
     dynamicConfig.addJob(buildJob);


### PR DESCRIPTION
## Issue

N/A

## Description

The cache used in circleCI jobs, when building APIM, keeps on growing.
This is due to the fact that jobs for a dedicated branch can reuse cache from other branches.

It's a good point when it's the first time you build you branch, but then a new cache is saved (bigger than the original one).

This PR stops this behaviour. The first build will have to download dependencies, but the cache in next builds will be smaller and faster to download.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aznmotmhqy.chromatic.com)
<!-- Storybook placeholder end -->
