### PR TITLE
fix: add a new index to improve events search for api synchronization

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdEnvsUpdatedAtIdTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/events/PropertiesApiIdEnvsUpdatedAtIdTypeIndexUpgrader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.events;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("EventsPropertiesApiIdEnvsUpdatedAtIdTypeIndexUpgrader")
+public class PropertiesApiIdEnvsUpdatedAtIdTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        // Warn: Mongodb doesn't support multikey index if more than one to-be-indexed field of a document is an array.
+        // Thus, it is not possible to index both 'environments' and 'organizations' fields as they are both arrays.
+        // We prefer index the 'environments' field as it may have more cardinalities than the 'organizations' one.
+        return Index
+            .builder()
+            .collection("events")
+            .name("pa1e1u1i1t1")
+            .key("properties.api_id", ascending())
+            .key("environments", ascending())
+            .key("updatedAt", descending())
+            .key("_id", descending())
+            .key("type", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/EventRepositoryTest.java
@@ -401,6 +401,21 @@ public class EventRepositoryTest extends AbstractManagementRepositoryTest {
         );
     }
 
+    @Test
+    public void shouldFindEventByTypeByApiAndEnvironment() throws Exception {
+        EventCriteria.EventCriteriaBuilder criteria = EventCriteria
+            .builder()
+            .types(List.of(EventType.PUBLISH_API, EventType.UNPUBLISH_API))
+            .property(Event.EventProperties.API_ID.getValue(), "api-1")
+            .from(0)
+            .to(0)
+            .environment("DEFAULT");
+        List<Event> events = eventRepository.search(criteria.build(), new PageableBuilder().pageSize(1).pageNumber(0).build()).getContent();
+
+        assertEquals(1L, events.size());
+        assertThat(events.stream().map(Event::getId)).contains("event02");
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownEvent() throws Exception {
         Event unknownEvent = new Event();


### PR DESCRIPTION
## Issue

N/A

## Description

Try to improve `ApiService.isSynchronized` and `ApiStateService.isSynchronized` by creating a new index.
This index has also been suggested by mongoAtlas
<img width="1116" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/13161768/c8981152-b382-4cee-b973-127833d7301b">
