### PR TITLE
fix: do not allow null federated value for api keys on 4.4 upgrade

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_2/01_federated_api_keys.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_2/01_federated_api_keys.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.4.2_federated_api_keys
+      author: GraviteeSource Team
+      changes:
+        - sql:
+            dbms: mssql
+            sql: update ${gravitee_prefix}keys set [federated] = 0 where [federated] is null;
+
+        - addNotNullConstraint:
+            tableName: ${gravitee_prefix}keys
+            columnName: federated
+            columnDataType: boolean

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -187,3 +187,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_4_0/06_update_access_points.yml
   - include:
       - file: liquibase/changelogs/v4_4_2/00_add_event_organizations.yml
+  - include:
+      - file: liquibase/changelogs/v4_4_2/01_federated_api_keys.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
@@ -26,6 +26,7 @@ import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Updates.push;
+import static com.mongodb.client.model.Updates.unset;
 
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.model.Sorts;
@@ -65,7 +66,7 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
             pipeline.add(match(eq("revoked", false)));
         }
         if (!filter.isIncludeFederated()) {
-            pipeline.add(match(eq("federated", false)));
+            pipeline.add(match(or(eq("federated", false), eq("federated", null))));
         }
 
         // set range query

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/FederatedIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/FederatedIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.keys;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("KeysFederatedIndexUpgrader")
+public class FederatedIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("keys")
+            .name("f1")
+            .key("federated", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/keys/ApiKeyFederatedUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/keys/ApiKeyFederatedUpgrader.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.keys;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.environment.MissingEnvironmentUpgrader;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+/**
+ * Initialize `environmentId` attribute on ApiKey, Plan and Subscriptions with the value found in the corresponding API.
+ */
+@Component
+public class ApiKeyFederatedUpgrader extends MongoUpgrader {
+
+    public static final int API_KEY_FEDERATED_UPGRADER_ORDER = MissingEnvironmentUpgrader.MISSING_ENVIRONMENT_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var unsetFederatedApiKeyQuery = new Document("federated", new Document("$exists", false));
+        var updateOperation = new Document("$set", new Document("federated", false));
+
+        return this.getCollection("keys").updateMany(unsetFederatedApiKeyQuery, updateOperation).wasAcknowledged();
+    }
+
+    @Override
+    public int getOrder() {
+        return API_KEY_FEDERATED_UPGRADER_ORDER;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5655

## Description

do not allow null federated value for api keys on 4.4 upgrade

Tested on:
Mongo ✅
Postgres ✅
MariaDB ✅
Mssql ✅
Mysql ✅

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

