### PR TITLE
docs(readme): fix broken links in quick-setup/ README

### DIFF
--- a/docker/quick-setup/ee-with-alert-engine/README.md
+++ b/docker/quick-setup/ee-with-alert-engine/README.md
@@ -4,7 +4,7 @@ Here is a docker-compose to run APIM Enterprise Edition with Alert Engine
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/configure-alerts-and-notifications#configure-alerts
+> https://documentation.gravitee.io/apim/getting-started/configuration/notifications#configure-alerts
 ---
 
 ## How to run ?

--- a/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/README.md
+++ b/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/README.md
@@ -9,15 +9,16 @@ You can classically call your apis through your gateway, for example: `http://lo
 To test the **Bridge Server**, you can call, for example, `http://localhost:18092/_bridge/apis` to list all the apis directly from database.
 
 ---
-> For more information, please read this doc: https://documentation.gravitee.io/apim/getting-started/hybrid-deployment
-> and https://documentation.gravitee.io/apim/getting-started/configuration/configure-repositories/jdbc
+> For more information, please read this doc:
+> * https://documentation.gravitee.io/apim/getting-started/hybrid-deployment
+> * https://documentation.gravitee.io/apim/getting-started/configuration/repositories/jdbc
 ---
 
 ## Requirements
 
 You need to provide a JDBC driver for postgresql.
 Put it in a `.driver` folder
-You can download one here: https://jdbc.postgresql.org/download.html
+You can download one here: https://jdbc.postgresql.org/download/
 
 ## How to run ?
 

--- a/docker/quick-setup/https-gateway/README.md
+++ b/docker/quick-setup/https-gateway/README.md
@@ -4,8 +4,8 @@ Here is a docker-compose to run APIM with a secured gateway and test expression 
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/the-gravitee-api-gateway/environment-variables-system-properties-and-the-gravitee.yaml-file#enable-https-support
-> https://documentation.gravitee.io/apim/guides/gravitee-expression-language
+> * https://documentation.gravitee.io/apim/getting-started/configuration/apim-management-api/general-configuration#enable-https-support
+> * https://documentation.gravitee.io/apim/guides/gravitee-expression-language
 ---
 
 ## How to use ?

--- a/docker/quick-setup/keycloak/README.md
+++ b/docker/quick-setup/keycloak/README.md
@@ -4,7 +4,7 @@ Here is a docker-compose to run APIM with a Keycloak container available as an I
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/authentication-and-sso#keycloak-authentication
+> https://documentation.gravitee.io/apim/getting-started/configuration/authentication/custom-oauth2-openid-authorization-server#keycloak-authentication
 ---
 
 Keycloak UI is accessible here http://localhost:8081/auth
@@ -13,11 +13,11 @@ Keycloak UI is accessible here http://localhost:8081/auth
 
 ⚠️ You need a license file to be able to run Enterprise Edition of APIM. Do not forget to add your license file into `./.license`.
 
-In the Keycloak UI (https://documentation.gravitee.io/apim/getting-started/configuration/authentication-and-sso#create-a-keycloak-client):
+In the Keycloak UI ([create a Keycloak client](https://documentation.gravitee.io/apim/getting-started/configuration/authentication/custom-oauth2-openid-authorization-server#create-a-keycloak-client)):
 - Read how to create a new client for your application. (Already imported with `realm/realm-gio.json`)
 - Create a user in the "GIO" realm.
 
-You can read how to [configure the Identity provider following documentation](https://documentation.gravitee.io/apim/getting-started/configuration/authentication-and-sso#configure-keycloak-authentication-in-gravitee) but it's already configured with docker environment.
+You can read how to [configure the Identity provider following documentation](https://documentation.gravitee.io/apim/getting-started/configuration/authentication/custom-oauth2-openid-authorization-server#configure-keycloak-authentication-in-gravitee) but it's already configured with docker environment.
 
 ### How to test an api with `gravitee-resource-oauth2-provider-keycloak`
 

--- a/docker/quick-setup/mongodb/README.md
+++ b/docker/quick-setup/mongodb/README.md
@@ -4,7 +4,7 @@ Here is a docker-compose to run APIM with MongoDB as database.
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/configure-repositories/mongodb
+> https://documentation.gravitee.io/apim/getting-started/configuration/repositories/mongodb
 ---
 
 ## How to run ?

--- a/docker/quick-setup/opensearch/README.md
+++ b/docker/quick-setup/opensearch/README.md
@@ -4,7 +4,7 @@ Here is a docker-compose to run APIM with OpenSearch.
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/configure-repositories/elasticsearch
+> https://documentation.gravitee.io/apim/getting-started/configuration/repositories/elasticsearch
 ---
 
 ## How to run ?

--- a/docker/quick-setup/postgresql/README.md
+++ b/docker/quick-setup/postgresql/README.md
@@ -4,13 +4,13 @@ Here is a docker-compose to run APIM with PostgreSQL as database.
 
 ---
 > For more information, please read :
-> https://documentation.gravitee.io/apim/getting-started/configuration/configure-repositories/jdbc
+> https://documentation.gravitee.io/apim/getting-started/configuration/repositories/jdbc
 ---
 ## Requirements
 
 You need to provide a JDBC driver for postgresql.
 Put it in a `.driver` folder
-You can download one here: https://jdbc.postgresql.org/download.html
+You can download one here: https://jdbc.postgresql.org/download/
 
 ## How to run ?
 

--- a/docker/quick-setup/prometheus/README.md
+++ b/docker/quick-setup/prometheus/README.md
@@ -5,7 +5,8 @@ Here is a docker-compose to run APIM with one gateway and Prometheus scrapping e
 To test the **Prometheus scrapping endpoint**, you can call, for example, `http://localhost:18092/_node/metrics/prometheus` to see values.
 
 ---
-> For more information, please read this doc: https://documentation.gravitee.io/apim/getting-started/configuration/configure-apim-management-api/logging#expose-metrics-to-prometheus
+> For more information, please read this doc:
+> https://documentation.gravitee.io/apim/getting-started/configuration/apim-gateway/logging#expose-metrics-to-prometheus
 ---
 
 ## How to run ?

--- a/docker/quick-setup/redis-rate-limit/README.md
+++ b/docker/quick-setup/redis-rate-limit/README.md
@@ -5,7 +5,8 @@ Here is a docker-compose to run APIM with Redis as database for Rate Limiting
 You can classically call your apis through your gateway, for example: `http://localhost:8082/myapi`.
 
 ---
-> For more information, please read this doc: https://documentation.gravitee.io/apim/getting-started/configuration/configure-repositories/redis
+> For more information, please read this doc:
+> https://documentation.gravitee.io/apim/getting-started/configuration/repositories/redis
 ---
 
 ## Verify Rate Limit counters in Redis

--- a/docker/quick-setup/tags-internal-external/README.md
+++ b/docker/quick-setup/tags-internal-external/README.md
@@ -5,7 +5,8 @@ Here is a docker-compose to run APIM with two gateways:
  - One configured with sharding tag `external`. It will only sync APIs configured for this tag. To use this gateway, call your API with `http://localhost:8081/myapi`.
 
 ---
-> For more information, please read this doc: https://documentation.gravitee.io/apim/getting-started/configuration/the-gravitee-api-gateway/configure-sharding-tags-for-your-gravitee-api-gateways
+> For more information, please read this doc: 
+> https://documentation.gravitee.io/apim/getting-started/configuration/apim-gateway/sharding-tags#configure-sharding-tags-for-your-gravitee-api-gateways
 ---
 
 ## How to use ?


### PR DESCRIPTION
## Description

I've corrected the broken links in quick-setup's README.

They now redirect to the right sections of the documentation.

Hope this helps! 🙏