### PR TITLE
fix: don't use empty constructor on component

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
@@ -61,7 +61,6 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-@NoArgsConstructor
 public class ApiConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiConverter.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.times;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
@@ -54,13 +56,17 @@ import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SwaggerService;
 import io.gravitee.rest.api.service.VirtualHostService;
+import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.cockpit.model.DeploymentMode;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
+import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.converter.PageConverter;
 import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
 import java.util.ArrayList;
@@ -87,8 +93,10 @@ public class ApiServiceCockpitImplTest {
     private static final String ENVIRONMENT_ID = "environment#id";
     private static final String PAGE_ID = "page#id";
     private static final String SWAGGER_DEFINITION = "";
-    private final ApiConverter apiConverter = new ApiConverter();
     private final PageConverter pageConverter = new PageConverter();
+
+    @Mock
+    private ApiConverter apiConverter;
 
     @Mock
     private ApiService apiService;
@@ -130,6 +138,15 @@ public class ApiServiceCockpitImplTest {
 
     @Before
     public void setUp() throws Exception {
+        apiConverter =
+            new ApiConverter(
+                new ObjectMapper(),
+                mock(PlanService.class),
+                mock(FlowService.class),
+                mock(CategoryMapper.class),
+                mock(ParameterService.class),
+                mock(WorkflowService.class)
+            );
         service =
             new ApiServiceCockpitImpl(
                 new ObjectMapper(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
@@ -66,6 +66,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.V4EmulationEngineService;
 import io.gravitee.rest.api.service.VirtualHostService;
+import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
@@ -177,7 +178,9 @@ public class ApiService_CreateTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, mock(WorkflowService.class))
+    );
 
     @Spy
     private V4EmulationEngineService v4EmulationEngine = new V4EmulationEngineServiceImpl(YES.getLabel());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTest.java
@@ -126,7 +126,9 @@ public class ApiService_DeleteTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, mock(WorkflowService.class))
+    );
 
     private Api api;
     private PlanEntity planEntity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdAsMapTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdAsMapTest.java
@@ -34,6 +34,8 @@ import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
@@ -43,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -94,7 +97,9 @@ public class ApiService_FindByIdAsMapTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, mock(WorkflowService.class))
+    );
 
     @Test
     public void shouldFindByIdAsMap() throws TechnicalException {
@@ -116,7 +121,8 @@ public class ApiService_FindByIdAsMapTest {
             .thenAnswer(i -> getObjectMapper().convertValue(i.getArgument(0), Map.class));
         UserEntity userEntity = new UserEntity();
         userEntity.setId("user");
-        when(primaryOwnerService.getPrimaryOwner(any(), any())).thenReturn(new PrimaryOwnerEntity(userEntity));
+        PrimaryOwnerEntity primaryOwner = new PrimaryOwnerEntity(userEntity);
+        when(primaryOwnerService.getPrimaryOwner(any(), any())).thenReturn(primaryOwner);
         when(apiMetadataService.findAllByApi("api-id")).thenReturn(buildMetadatas());
 
         Map resultMap = apiService.findByIdAsMap("api-id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdTest.java
@@ -99,11 +99,16 @@ public class ApiService_FindByIdTest {
     @Mock
     private FlowService flowService;
 
+    @Mock
+    private WorkflowService workflowService;
+
     @Spy
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, workflowService)
+    );
 
     @Mock
     private RoleService roleService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
@@ -65,6 +65,7 @@ import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -136,11 +137,16 @@ public class ApiService_FindByUserTest {
     @Mock
     private FlowService flowService;
 
+    @Mock
+    private WorkflowService workflowService;
+
     @Spy
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, workflowService)
+    );
 
     @Mock
     private PrimaryOwnerService primaryOwnerService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_SearchTest.java
@@ -55,6 +55,7 @@ import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -135,7 +136,16 @@ public class ApiService_SearchTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(
+            objectMapper,
+            mock(PlanService.class),
+            mock(FlowService.class),
+            categoryMapper,
+            parameterService,
+            mock(WorkflowService.class)
+        )
+    );
 
     @Mock
     private SearchEngineService searchEngineService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
@@ -120,7 +120,9 @@ public class ApiService_StartTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, mock(WorkflowService.class))
+    );
 
     @Before
     public void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
@@ -117,7 +117,9 @@ public class ApiService_StopTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, mock(WorkflowService.class))
+    );
 
     @Mock
     private PrimaryOwnerService primaryOwnerService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -310,7 +310,9 @@ public class ApiService_UpdateTest {
     private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
 
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = Mockito.spy(
+        new ApiConverter(objectMapper, planService, flowService, categoryMapper, parameterService, workflowService)
+    );
 
     @Mock
     private ApiNotificationService apiNotificationService;
@@ -343,7 +345,6 @@ public class ApiService_UpdateTest {
     @Before
     public void setUp() {
         PropertyFilter apiMembershipTypeFilter = new ApiPermissionFilter();
-        apiConverter = spy(new ApiConverter());
         MockitoAnnotations.openMocks(this);
         objectMapper.setFilterProvider(
             new SimpleFilterProvider(Collections.singletonMap("apiMembershipTypeFilter", apiMembershipTypeFilter))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -127,7 +127,7 @@ public class ApiSearchService_SearchTest {
             new ApiSearchServiceImpl(
                 apiRepository,
                 apiMapper,
-                new GenericApiMapper(apiMapper, new ApiConverter()),
+                new GenericApiMapper(apiMapper, mock(ApiConverter.class)),
                 primaryOwnerService,
                 categoryService,
                 searchEngineService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -265,8 +265,8 @@ public class ApiServiceImplTest {
     @Mock
     private ApiQualityRuleRepository apiQualityRuleRepository;
 
-    @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    @Mock
+    private ApiConverter apiConverter;
 
     @Mock
     private PrimaryOwnerService primaryOwnerService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -178,9 +178,6 @@ public class ApiServiceImpl_findAllTest {
     @Mock
     private ApiQualityRuleRepository apiQualityRuleRepository;
 
-    @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
-
     @Mock
     private PrimaryOwnerService primaryOwnerService;
 
@@ -233,6 +230,16 @@ public class ApiServiceImpl_findAllTest {
             workflowService,
             new CategoryMapper(categoryService)
         );
+
+        ApiConverter apiConverter = new ApiConverter(
+            new ObjectMapper(),
+            mock(io.gravitee.rest.api.service.PlanService.class),
+            mock(io.gravitee.rest.api.service.configuration.flow.FlowService.class),
+            mock(CategoryMapper.class),
+            mock(ParameterService.class),
+            mock(WorkflowService.class)
+        );
+
         GenericApiMapper genericApiMapper = new GenericApiMapper(apiMapper, apiConverter);
         apiService =
             new ApiServiceImpl(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -133,8 +133,8 @@ public class ApiStateServiceImplTest {
     @Mock
     private ApiValidationService apiValidationService;
 
-    @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    @Mock
+    private ApiConverter apiConverter;
 
     @Mock
     private PlanSearchService planSearchService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -55,6 +55,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -84,7 +85,10 @@ public class ApiStateServiceImpl_DeployTest {
     private CategoryService categoryService;
 
     @Mock
-    private PlanService planService;
+    private PlanService planServiceV4;
+
+    @Mock
+    private io.gravitee.rest.api.service.PlanService planService;
 
     @Mock
     private EventService eventService;
@@ -93,7 +97,10 @@ public class ApiStateServiceImpl_DeployTest {
     private EventLatestRepository eventLatestRepository;
 
     @Mock
-    private FlowService flowService;
+    private FlowService flowServiceV4;
+
+    @Mock
+    private io.gravitee.rest.api.service.configuration.flow.FlowService flowService;
 
     @Mock
     private WorkflowService workflowService;
@@ -113,8 +120,18 @@ public class ApiStateServiceImpl_DeployTest {
     @Mock
     private ApiValidationService apiValidationService;
 
+    @Spy
+    private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
+
     @InjectMocks
-    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+    private ApiConverter apiConverter = new ApiConverter(
+        objectMapper,
+        planService,
+        flowService,
+        categoryMapper,
+        parameterService,
+        workflowService
+    );
 
     @Mock
     private PlanSearchService planSearchService;
@@ -146,8 +163,8 @@ public class ApiStateServiceImpl_DeployTest {
     public void setUp() {
         ApiMapper apiMapper = new ApiMapper(
             new ObjectMapper(),
-            planService,
-            flowService,
+            planServiceV4,
+            flowServiceV4,
             parameterService,
             workflowService,
             new CategoryMapper(categoryService)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5772

## Description

Fix regression introduced in 3c365d51543c24948a53c536198afe723a85a287.
We should not use a noArg constructor on component.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mosceitjfq.chromatic.com)
<!-- Storybook placeholder end -->
