### PR TITLE
fix: allow users to define multiple DNS for the Management API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImpl.java
@@ -58,6 +58,12 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
     @Value("${installation.api.url:#{null}}")
     private String apiURL;
 
+    @Value("${installation.api.console.url:#{null}}")
+    private String consoleApiUrl;
+
+    @Value("${installation.api.portal.url:#{null}}")
+    private String portalApiUrl;
+
     @Value("${installation.api.proxyPath.management:${http.api.management.entrypoint:${http.api.entrypoint:/}management}}")
     private String managementProxyPath;
 
@@ -228,6 +234,8 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
         if (installationTypeDomainService.isMultiTenant()) {
             AccessPoint consoleAccessPoint = accessPointQueryService.getConsoleApiAccessPoint(organizationId);
             consoleAPIBaseUrl = buildHttpUrl(consoleAccessPoint);
+        } else if (StringUtils.isNotEmpty(consoleApiUrl)) {
+            consoleAPIBaseUrl = consoleApiUrl;
         } else {
             consoleAPIBaseUrl = apiURL;
         }
@@ -275,6 +283,8 @@ public class InstallationAccessQueryServiceImpl implements InstallationAccessQue
         if (installationTypeDomainService.isMultiTenant()) {
             AccessPoint consoleAccessPoint = accessPointQueryService.getPortalApiAccessPoint(environmentId);
             portalAPIBaseUrl = buildHttpUrl(consoleAccessPoint);
+        } else if (StringUtils.isNotEmpty(portalApiUrl)) {
+            portalAPIBaseUrl = portalApiUrl;
         } else {
             portalAPIBaseUrl = apiURL;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -319,7 +319,17 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                             reference.getId()
                         );
                         if (emailNotification != null) {
-                            emailService.sendAsyncEmailNotification(executionContext, emailNotification);
+                            try {
+                                emailService.sendAsyncEmailNotification(executionContext, emailNotification);
+                            } catch (Exception e) {
+                                LOGGER.error(
+                                    "An error occurs while trying to send email notification for {} {} {}",
+                                    reference.getType(),
+                                    reference.getId(),
+                                    userEntity.getId(),
+                                    e
+                                );
+                            }
                         }
                     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
@@ -55,7 +55,8 @@ class InstallationAccessQueryServiceImplTest {
         environment = new MockEnvironment();
         cut = new InstallationAccessQueryServiceImpl(environment, installationTypeDomainService, accessPointQueryService);
         setValue("cockpitEnabled", false);
-        setValue("apiURL", null);
+        setValue("consoleApiUrl", null);
+        setValue("portalApiUrl", null);
         setValue("managementProxyPath", "/management");
         setValue("portalProxyPath", "/portal");
     }
@@ -63,7 +64,7 @@ class InstallationAccessQueryServiceImplTest {
     @Test
     void should_throw_validation_error_when_api_url_is_malformed() {
         when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
-        setValue("apiURL", "wrong");
+        setValue("consoleApiUrl", "wrong");
 
         assertThatThrownBy(() -> cut.afterPropertiesSet())
             .isInstanceOf(InstallationAccessQueryServiceImpl.InvalidInstallationUrlException.class);
@@ -110,7 +111,8 @@ class InstallationAccessQueryServiceImplTest {
     @Test
     void should_use_api_url_when_installation_is_not_multi_tenant_and_console_and_portal_urls_are_not_defined() {
         when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
-        setValue("apiURL", "http://api.url");
+        setValue("consoleApiUrl", "http://api.url");
+        setValue("portalApiUrl", "http://api.url");
 
         cut.afterPropertiesSet();
         assertThat(cut.getConsoleAPIUrl(DEFAULT_ORGANIZATION_ID)).isEqualTo("http://api.url/management");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/installation/InstallationAccessQueryServiceImplTest.java
@@ -97,7 +97,18 @@ class InstallationAccessQueryServiceImplTest {
     }
 
     @Test
-    void should_use_api_url_when_installation_is_not_multi_tenant() {
+    void should_use_console_api_url_when_installation_is_not_multi_tenant_and_console_url_is_defined() {
+        when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
+        setValue("consoleApiUrl", "http://console.api.url");
+        setValue("portalApiUrl", "http://console.api.url");
+
+        cut.afterPropertiesSet();
+        assertThat(cut.getConsoleAPIUrl(DEFAULT_ORGANIZATION_ID)).isEqualTo("http://console.api.url/management");
+        assertThat(cut.getPortalAPIUrl(DEFAULT_ORGANIZATION_ID)).isEqualTo("http://console.api.url/portal");
+    }
+
+    @Test
+    void should_use_api_url_when_installation_is_not_multi_tenant_and_console_and_portal_urls_are_not_defined() {
         when(installationTypeDomainService.isMultiTenant()).thenReturn(false);
         setValue("apiURL", "http://api.url");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -588,6 +588,14 @@ notifiers:
 #  api:
 #    # Specify the URLs of Management API, mandatory if you want to connect it to Cockpit with a standalone installation
 #    url: http://localhost:8083
+#
+#    Specify the Management API management url of your installation, fallback on installation_api_url if not defined
+#    console:
+#      url: http://localhost:8083
+#    Specify the Management API portal url of your installation, fallback on installation_api_url if not defined
+#    portal:
+#      url: http://localhost:8083
+#
 #    proxyPath:
 #      management: ${http.api.management.entrypoint}
 #      portal: ${http.api.portal.entrypoint}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -591,10 +591,10 @@ notifiers:
 #
 #    Specify the Management API management url of your installation, fallback on installation_api_url if not defined
 #    console:
-#      url: http://localhost:8083
+#      url: ${installation.api.url}
 #    Specify the Management API portal url of your installation, fallback on installation_api_url if not defined
 #    portal:
-#      url: http://localhost:8083
+#      url: ${installation.api.url}
 #
 #    proxyPath:
 #      management: ${http.api.management.entrypoint}

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -104,6 +104,14 @@ data:
       {{ else }}
         url: {{ .Values.api.ingress.management.scheme }}://{{ index .Values.api.ingress.management.hosts 0 }}
       {{- end }}
+      {{- if and .Values.installation.api.console .Values.installation.api.console.url }}
+        console:
+          url: {{ .Values.installation.api.console.url }}
+      {{- end }}
+      {{- if and .Values.installation.api.portal .Values.installation.api.portal.url }}
+        portal:
+          url: {{ .Values.installation.api.portal.url }}
+      {{- end }}
         proxyPath:
           management: {{ regexFind "/[a-zA-Z0-9-\\/_.~]+" .Values.api.ingress.management.path }}
           portal: {{ regexFind "/[a-zA-Z0-9-\\/_.~]+" .Values.api.ingress.portal.path }}

--- a/helm/tests/api/configmap_test_installation.yaml
+++ b/helm/tests/api/configmap_test_installation.yaml
@@ -134,6 +134,30 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: "installation:[\\S\\s\\n]*api:[\\S\\s\\n]*url: https://mapi.example.com"
+  - it: Override installation.api.console.url
+    template: api/api-configmap.yaml
+    set:
+      installation:
+        type: standalone
+        api:
+          console:
+            url: https://mapi.example.com
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "installation:[\\S\\s\\n]*api:[\\S\\s\\n]*console:[\\S\\s\\n]*url: https://mapi.example.com"
+  - it: Override installation.api.portal.url
+    template: api/api-configmap.yaml
+    set:
+      installation:
+        type: standalone
+        api:
+          portal:
+            url: https://mapi.example.com
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "installation:[\\S\\s\\n]*api:[\\S\\s\\n]*portal:[\\S\\s\\n]*url: https://mapi.example.com"
 
   - it: Override api.ingress.[management/portal].ingess.path
     template: api/api-configmap.yaml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4814

## Description

The goal of this issue is to introduce a new configuration possibility for APIM standalone installations.
This is currently not easily possible, so in this PR we'll allow the users to dissociate the management and portal base url in the REST API.

Use Case 1:
You would like to have 2 REST APIs. The first one is linked to Cockpit and is aware of all the standalone configuration. The seconde one is only used for a public Portal. ( see https://github.com/gravitee-io/cloud-apim/blob/main/4-2-x-standalone-multi-mapi/values.yaml )

Use Case 2:
You would like to expose your REST API through multiple DNS. ( see https://github.com/gravitee-io/cloud-apim/blob/main/4-2-x-standalone-mapi-multi-host/values.yaml )

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-whylendagj.chromatic.com)
<!-- Storybook placeholder end -->
