### PR TITLE
APIM-5750 OpenSSL is not available any more

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1406,6 +1406,12 @@
                     <version>${gravitee-secretprovider-hc-vault.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.secretprovider</groupId>
@@ -1413,6 +1419,12 @@
                     <version>${gravitee-secretprovider-kubernetes.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
@@ -133,6 +133,7 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
@@ -109,6 +109,7 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <classifier>${os.detected.classifier}</classifier>
+            <version>${netty-tcnative-boringssl-static.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -241,7 +241,7 @@
             <scope>compile</scope>
         </dependency>
 
-        <!-- Mapstruct + Lombok -->
+        <!-- Mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
@@ -362,27 +362,6 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
 
-        <!-- Netty native transport -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <classifier>linux-x86_64</classifier>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <classifier>${os.detected.classifier}</classifier>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-kqueue</artifactId>
-            <classifier>osx-x86_64</classifier>
-            <scope>runtime</scope>
-        </dependency>
-
         <!-- wiremock is late on jetty have to use its internal version to avoid classloading issues-->
         <dependency>
             <groupId>org.wiremock</groupId>
@@ -398,14 +377,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-            </extension>
-        </extensions>
-
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -119,7 +119,6 @@
             <includes>
                 <include>io.gravitee.*:*:jar</include>
             </includes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>
@@ -131,8 +130,9 @@
                 <exclude>com.graviteesource.*:*:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
+                <exclude>org.junit.jupiter:*:*</exclude>
+                <exclude>*:*:*:windows-x86_64</exclude>
             </excludes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -63,6 +63,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -71,6 +77,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -79,6 +91,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -87,6 +105,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -95,6 +119,102 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- logback -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Netty native transport: https://netty.io/wiki/native-transports.html-->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <classifier>osx-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <classifier>osx-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Netty tomcat native: https://netty.io/wiki/forked-tomcat-native.html -->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <classifier>linux-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <classifier>osx-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <classifier>osx-aarch_64</classifier>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -118,9 +118,8 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
-                <include>com.graviteesource.*:*:*</include>
+                <include>com.graviteesource.*:*:jar</include>
             </includes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>
@@ -132,8 +131,9 @@
                 <exclude>com.graviteesource.*:*:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
+                <exclude>org.junit.jupiter:*:*</exclude>
+                <exclude>*:*:*:windows-x86_64</exclude>
             </excludes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
@@ -66,11 +66,6 @@
             <artifactId>rxjava</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -196,9 +196,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
+            <scope>compile</scope>
         </dependency>
 
-        <!-- Mapstruct + Lombok -->
+        <!-- Mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -137,7 +137,6 @@
             <includes>
                 <include>io.gravitee.*:*:jar</include>
             </includes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>
@@ -151,9 +150,8 @@
                 <exclude>com.sun.mail:mailapi:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
+                <exclude>org.junit.jupiter:*:*</exclude>
             </excludes>
-            <!-- Used to not include transitive dependencies for runtime dependency (All plugins) -->
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -66,6 +66,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -74,6 +80,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -82,6 +94,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -90,6 +108,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -98,6 +122,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -106,6 +136,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -114,6 +150,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -122,6 +164,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -130,6 +178,12 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -138,6 +192,49 @@
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- logback -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-jackson</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback.contrib</groupId>
+            <artifactId>logback-json-core</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -136,8 +136,8 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
+                <include>com.graviteesource.*:*:jar</include>
             </includes>
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>
@@ -151,9 +151,8 @@
                 <exclude>com.sun.mail:mailapi:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
+                <exclude>org.junit.jupiter:*:*</exclude>
             </excludes>
-            <!-- Used to not include transitive dependencies for runtime dependency (All plugins) -->
-            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>
         </dependencySet>

--- a/pom.xml
+++ b/pom.xml
@@ -684,7 +684,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>${netty-tcnative-boringssl-static.version}</version>
-                <classifier>${os.detected.classifier}</classifier>
             </dependency>
 
             <dependency>
@@ -1088,6 +1087,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5750

## Description

The scope defined for the dependencies included in the bundle was forced to 'compile' instead of 'runtime', which excludes some dependencies, such as Netty native dependencies (transport or tcnative).

Additionally, BoringSSL was misconfigured and not always available depending on the architecture.

This PR attempts to address both issues.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-imcgmkyzsl.chromatic.com)
<!-- Storybook placeholder end -->
