### PR TITLE
fix: bump avro-json dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <gravitee-policy-role-based-access-control.version>1.4.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.5.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>2.0.1</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>2.0.2</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>2.0.4</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.8</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>1.2.7</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>3.0.2</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5868

## Description

Bumps avro-json dependency to remove warning about Json to Avro transformation not being supported

## Additional context

Warning was removed in the policy in:
https://github.com/gravitee-io/gravitee-policy-transform-avro-json/pull/56
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mojmzzuxwb.chromatic.com)
<!-- Storybook placeholder end -->
