### PR TITLE
Apim 5876 Portal next UI improvements

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-details.component.html
@@ -25,7 +25,7 @@
       </div>
       @if (plans$ | async; as plans) {
         <div class="api-details__header-button">
-          @if (!plans.length) {
+          @if (!plans.length && isAuthenticated()) {
             <div class="m3-body-medium on-surface-variant" i18n="@@apiDetailsNoPlans">No plans available</div>
           }
           <button

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
@@ -48,10 +48,10 @@
         </div>
       }
 
-      @if (api.categories?.length) {
+      @if (categories$ | async; as categories) {
         <div>
           <div i18n="@@apiDetailsCategories" class="m3-body-large">Categories</div>
-          <div class="m3-body-medium">{{ api.categories }}</div>
+          <div class="m3-body-medium">{{ categories }}</div>
         </div>
       }
     </mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.ts
@@ -23,6 +23,7 @@ import { PageComponent } from '../../../../components/page/page.component';
 import { MarkdownDescriptionPipe } from '../../../../components/pipe/markdown-description.pipe';
 import { Api } from '../../../../entities/api/api';
 import { Page } from '../../../../entities/page/page';
+import { CategoriesService } from '../../../../services/categories.service';
 import { PageService } from '../../../../services/page.service';
 
 interface HomepageData {
@@ -43,8 +44,12 @@ export class ApiTabDetailsComponent implements OnInit {
   @Input()
   pages!: Page[];
   homepageData$: Observable<HomepageData> = of();
+  categories$: Observable<string> = of('');
 
-  constructor(private pageService: PageService) {}
+  constructor(
+    private pageService: PageService,
+    private categoriesService: CategoriesService,
+  ) {}
 
   ngOnInit(): void {
     this.homepageData$ = this.pageService.listByApiId(this.api.id, true).pipe(
@@ -59,5 +64,19 @@ export class ApiTabDetailsComponent implements OnInit {
         }
       }),
     );
+
+    if (this.api.categories?.length) {
+      this.categories$ = this.categoriesService.categories().pipe(
+        map(({ data }) => {
+          if (!data.length || !this.api.categories) {
+            return '';
+          }
+          return this.api.categories
+            .map(c => data.find(category => category.id === c)?.name)
+            .filter(c => !!c)
+            .join(', ');
+        }),
+      );
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -15,8 +15,8 @@
     limitations under the License.
 
 -->
-<div class="subscriptions-details__navigate-back m3-title-small" i18n="@@subscriptionDetailsBackButton">
-  <mat-icon [routerLink]="['../']" class="subscriptions-details__arrow_backward">arrow_backward</mat-icon>
+<div class="subscriptions-details__navigate-back m3-title-small" i18n="@@subscriptionDetailsBackButton" [routerLink]="['../']">
+  <mat-icon class="subscriptions-details__arrow_backward">arrow_backward</mat-icon>
   Manage subscriptions
 </div>
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.scss
@@ -18,6 +18,7 @@
     display: flex;
     align-items: center;
     padding-left: 8px;
+    cursor: pointer;
     gap: 8px;
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
@@ -16,20 +16,20 @@
 
 -->
 @if (subscriptionsList$ | async; as subscriptions) {
-  <mat-form-field appearance="outline">
-    <mat-label i18n="@@subscriptionStatusSelectLabel">Status</mat-label>
-    <mat-select [formControl]="subscriptionsStatus" multiple id="api-tab-subscription__select">
-      @for (status of subscriptionStatusesList; track status) {
-        <mat-option [value]="status">{{ status | capitalizeFirst }}</mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
   @if (subscriptions.length === 0) {
     <div class="api-tab-subscription__empty" id="no-subscriptions">
       <header i18n="@@noSubscriptionAvailable" class="api-tab-subscription__empty-header">No subscription found</header>
       <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
     </div>
   } @else {
+    <mat-form-field appearance="outline">
+      <mat-label i18n="@@subscriptionStatusSelectLabel">Status</mat-label>
+      <mat-select [formControl]="subscriptionsStatus" multiple id="api-tab-subscription__select">
+        @for (status of subscriptionStatusesList; track status) {
+          <mat-option [value]="status">{{ status | capitalizeFirst }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
     <table mat-table [dataSource]="subscriptions" class="api-tab-subscriptions__table">
       <ng-container matColumnDef="application">
         <th mat-header-cell *matHeaderCellDef i18n="@@subscriptionTableColumnApplication" class="m3-title-medium">Application</th>
@@ -54,7 +54,11 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row class="api-tab-subscriptions__table-row" *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr
+        mat-row
+        class="api-tab-subscriptions__table-row"
+        *matRowDef="let subscription; columns: displayedColumns"
+        [routerLink]="['./', subscription.id]"></tr>
     </table>
   }
 } @else {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
@@ -30,5 +30,6 @@
 
   &-row {
     background: var(--mdc-outlined-card-container-color);
+    cursor: pointer;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.spec.ts
@@ -62,7 +62,7 @@ describe('SubscriptionsTableComponent', () => {
       const subscriptionTable = await harnessLoader.getHarness(MatTableHarness.with({ selector: '.api-tab-subscriptions__table' }));
       expect(subscriptionTable).toBeTruthy();
       expect(await subscriptionTable.getRows().then(value => value[0].getCellTextByColumnName())).toEqual({
-        application: 'Testapplication',
+        application: 'testApplication',
         expand: 'arrow_right',
         plan: '-',
         status: 'Rejected',

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.ts
@@ -69,11 +69,7 @@ export class SubscriptionsTableComponent implements OnInit {
   }
 
   retrieveMetadataName(id: string, metadata: SubscriptionMetadata) {
-    if (Object.hasOwn(metadata, id)) {
-      return this.capitalizeFirstPipe.transform(<string>metadata[id]['name']);
-    } else {
-      return '-';
-    }
+    return Object.hasOwn(metadata, id) ? <string>metadata[id]['name'] : '-';
   }
 
   private loadSubscriptions$(): Observable<Subscription[]> {

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-checkout/subscribe-to-api-checkout.component.scss
@@ -17,7 +17,7 @@
   &__container {
     display: flex;
     flex-direction: row;
-    padding: 32px 16px 0;
+    padding-top: 32px;
     gap: 32px;
 
     &__subscription-info {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5876

## Description

Clean up API Details screen:
- Remove "No plans available" when user is not authenticated
- Convert category ids => category names and add a space between items

![Screenshot 2024-07-12 at 17 11 48](https://github.com/user-attachments/assets/fa7a865d-1865-461a-8654-bba4a5d116b7)

Clean up Subscription screens:
- Make whole subscription row clickable to go to details
- No transform of Application name + Plan name in subscription list
- Do not show subscription status filter if no subscriptions exist
- Remove extra padding on the left of subscription details in checkout screen
- Make "Manage subscriptions" clickable in subscription details screen

https://github.com/user-attachments/assets/e3c55a4a-3064-4945-af8c-88c64aec8cc7

![Screenshot 2024-07-12 at 15 53 50](https://github.com/user-attachments/assets/e777e934-d84e-4980-a0f0-9b992ddd3422)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

