### PR TITLE
fix(console): show hint under mat-select in edit page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.html
@@ -64,11 +64,11 @@
                 <mat-form-field>
                   <mat-label>Groups with permissions to view the page</mat-label>
                   <mat-select formControlName="accessControlGroups" multiple>
-                    <mat-hint>If no groups are specified, all groups can view the page</mat-hint>
                     @for (group of groups; track group.id) {
                       <mat-option [value]="group.id">{{ group.name }}</mat-option>
                     }
                   </mat-select>
+                  <mat-hint>If no groups are specified, all groups can view the page</mat-hint>
                 </mat-form-field>
                 <gio-form-slide-toggle>
                   <gio-form-label>Exclude the selected groups</gio-form-label>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5821

## Description

Show hint for select groups in edit page:

![Screenshot 2024-07-12 at 17 34 33](https://github.com/user-attachments/assets/c544b2d5-f761-4a0d-a013-b231332b00d9)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ynslgyesrz.chromatic.com)
<!-- Storybook placeholder end -->
