### PR TITLE
fix(portal-next): show subscription list filter if no results + active filter

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
@@ -16,12 +16,7 @@
 
 -->
 @if (subscriptionsList$ | async; as subscriptions) {
-  @if (subscriptions.length === 0) {
-    <div class="api-tab-subscription__empty" id="no-subscriptions">
-      <header i18n="@@noSubscriptionAvailable" class="api-tab-subscription__empty-header">No subscription found</header>
-      <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
-    </div>
-  } @else {
+  @if (!!subscriptions.length || !!subscriptionsStatus.value) {
     <mat-form-field appearance="outline">
       <mat-label i18n="@@subscriptionStatusSelectLabel">Status</mat-label>
       <mat-select [formControl]="subscriptionsStatus" multiple id="api-tab-subscription__select">
@@ -30,6 +25,13 @@
         }
       </mat-select>
     </mat-form-field>
+  }
+  @if (subscriptions.length === 0) {
+    <div class="api-tab-subscription__empty" id="no-subscriptions">
+      <header i18n="@@noSubscriptionAvailable" class="api-tab-subscription__empty-header">No subscription found</header>
+      <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
+    </div>
+  } @else {
     <table mat-table [dataSource]="subscriptions" class="api-tab-subscriptions__table">
       <ng-container matColumnDef="application">
         <th mat-header-cell *matHeaderCellDef i18n="@@subscriptionTableColumnApplication" class="m3-title-medium">Application</th>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5876

## Description

Show filter when there are no results but there is a filter selected

https://github.com/user-attachments/assets/97010755-d5cc-4640-b48f-0bf9f130b8f0


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

