### PR TITLE
Handle ingesting over 600 APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.html
@@ -93,6 +93,21 @@
       </div>
     </mat-card-header>
 
+    <gio-banner-warning *ngIf="integration.pendingJob" class="pending-job-banner">
+      A discovery is in progress. The process should only take a few minutes to complete.
+      <div gioBannerAction>
+        <button
+          mat-raised-button
+          data-testid="refresh-button"
+          aria-label="Refresh"
+          [disabled]="isLoadingIntegration || isLoadingFederatedAPI"
+          (click)="refresh()"
+        >
+          Refresh
+        </button>
+      </div>
+    </gio-banner-warning>
+
     @if (federatedAPIs.length || isLoadingFederatedAPI) {
       <div class="card-table">
         <gio-table-wrapper

--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.scss
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.component.scss
@@ -171,3 +171,8 @@ gio-table-wrapper {
   height: 1px;
   background-color: mat.get-color-from-palette(gio.$mat-dove-palette, 'darker20');
 }
+
+.pending-job-banner {
+  margin-left: 16px;
+  margin-right: 16px;
+}

--- a/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.harness.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integration-overview/integration-overview.harness.ts
@@ -27,6 +27,7 @@ export class IntegrationOverviewHarness extends ComponentHarness {
     MatButtonHarness.with({ selector: '[data-testid=discover-button]' }),
   );
   private errorBannerLocator = this.locatorForOptional('gio-banner-error');
+  private jobPendingBanner = this.locatorForOptional('.pending-job-banner');
 
   public getTable = this.locatorForOptional(MatTableHarness);
   private getPaginationLocator = this.locatorForOptional(MatPaginatorHarness);
@@ -37,6 +38,10 @@ export class IntegrationOverviewHarness extends ComponentHarness {
 
   public getErrorBanner = async (): Promise<TestElement> => {
     return this.errorBannerLocator();
+  };
+
+  public getPendingJobBanner = async (): Promise<TestElement> => {
+    return this.jobPendingBanner();
   };
 
   public getSuccessBadge = async (): Promise<TestElement> => {

--- a/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
+++ b/gravitee-apim-console-webui/src/management/integrations/integrations.model.ts
@@ -35,6 +35,24 @@ export interface Integration {
   provider: string;
   description: string;
   owner?: string;
+  pendingJob?: IntegrationJob;
+}
+
+export interface IntegrationIngestionResponse {
+  status: IngestionStatus;
+  message?: string;
+}
+
+export interface IntegrationJob {
+  id: string;
+  status: IngestionStatus;
+  startedAt: string;
+}
+
+export enum IngestionStatus {
+  SUCCESS = 'SUCCESS',
+  PENDING = 'PENDING',
+  ERROR = 'ERROR',
 }
 
 export enum AgentStatus {

--- a/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/integrations.service.ts
@@ -24,6 +24,7 @@ import {
   DeletedFederatedAPIsResponse,
   FederatedAPIsResponse,
   Integration,
+  IntegrationIngestionResponse,
   IntegrationPreview,
   IntegrationResponse,
   UpdateIntegrationPayload,
@@ -75,8 +76,8 @@ export class IntegrationsService {
     return this.httpClient.delete<Integration>(`${this.url}/${id}`);
   }
 
-  public ingestIntegration(id: string) {
-    return this.httpClient.post(`${this.url}/${id}/_ingest`, null);
+  public ingestIntegration(id: string): Observable<IntegrationIngestionResponse> {
+    return this.httpClient.post<IntegrationIngestionResponse>(`${this.url}/${id}/_ingest`, null);
   }
 
   public previewIntegration(id: string): Observable<IntegrationPreview> {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IntegrationJobRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IntegrationJobRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.IntegrationJob;
+import java.util.Optional;
+
+public interface IntegrationJobRepository extends CrudRepository<IntegrationJob, String> {
+    Optional<IntegrationJob> findPendingJobFor(String integrationId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Integration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Integration.java
@@ -33,6 +33,7 @@ import lombok.With;
 @Data
 public class Integration {
 
+    @With
     private String id;
 
     private String name;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/IntegrationJob.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/IntegrationJob.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@Data
+public class IntegrationJob {
+
+    String id;
+    String sourceId;
+    String environmentId;
+    String initiatorId;
+
+    Date createdAt;
+    Date updatedAt;
+
+    String status;
+    String errorMessage;
+
+    Long upperLimit;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcIntegrationJobRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcIntegrationJobRepository.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.repository.management.model.IntegrationJob;
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JdbcIntegrationJobRepository extends JdbcAbstractCrudRepository<IntegrationJob, String> implements IntegrationJobRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcIntegrationJobRepository.class);
+
+    JdbcIntegrationJobRepository(@Value("${management.jdbc.prefix:}") String prefix) {
+        super(prefix, "integrationjobs");
+    }
+
+    @Override
+    public Optional<IntegrationJob> findPendingJobFor(String sourceId) throws TechnicalException {
+        LOGGER.debug("JdbcIntegrationJobRepository.findPendingJobFor({})", sourceId);
+        final List<IntegrationJob> jobs;
+        try {
+            jobs =
+                jdbcTemplate.query(
+                    getOrm().getSelectAllSql() + " where source_id = ? and status = 'PENDING'",
+                    getOrm().getRowMapper(),
+                    sourceId
+                );
+            return jobs.stream().findFirst();
+        } catch (final Exception ex) {
+            final String message = "Failed to find pending IntegrationJob for: " + sourceId;
+            LOGGER.error(message, ex);
+            throw new TechnicalException(message, ex);
+        }
+    }
+
+    @Override
+    protected String getId(IntegrationJob item) {
+        return item.getId();
+    }
+
+    @Override
+    protected JdbcObjectMapper<IntegrationJob> buildOrm() {
+        return JdbcObjectMapper
+            .builder(IntegrationJob.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("source_id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("initiator_Id", Types.NVARCHAR, String.class)
+            .addColumn("status", Types.NVARCHAR, String.class)
+            .addColumn("error_message", Types.NVARCHAR, String.class)
+            .addColumn("upper_limit", Types.INTEGER, Long.class)
+            .addColumn("created_at", Types.TIMESTAMP, Date.class)
+            .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/01_add_integration_jobs_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/01_add_integration_jobs_table.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.0_add_integration_jobs
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}integrationjobs
+            columns:
+              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: source_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: initiator_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: error_message, type: nvarchar(256), constraints: { nullable: true } }
+              - column: { name: status, type: nvarchar(32), constraints: { nullable: false } }
+              - column: { name: upper_limit, type: int, constraints: { nullable: false } }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
+              - column: { name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
+
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}integrationjobs
+            columnNames: id
+            tableName: ${gravitee_prefix}integrationjobs

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -191,3 +191,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_4_2/01_federated_api_keys.yml
   - include:
       - file: liquibase/changelogs/v4_5_0/00_integrations_nullable_agent_status.yml
+  - include:
+      - file: liquibase/changelogs/v4_5_0/01_add_integration_jobs_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -139,6 +139,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "flow_tags",
         "upgraders",
         "integrations",
+        "integrationjobs",
         "api_category_orders"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoIntegrationJobRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoIntegrationJobRepository.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.repository.management.model.IntegrationJob;
+import io.gravitee.repository.mongodb.management.internal.integrationjob.IntegrationJobMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class MongoIntegrationJobRepository implements IntegrationJobRepository {
+
+    @Autowired
+    private IntegrationJobMongoRepository internalRepository;
+
+    @Autowired
+    private GraviteeMapper mapper;
+
+    @Override
+    public Optional<IntegrationJob> findById(String s) throws TechnicalException {
+        log.debug("Find integrationJob by id [{}]", s);
+        Optional<IntegrationJob> result = internalRepository.findById(s).map(source -> mapper.map(source));
+        log.debug("Find integrationJob by id [{}] - DONE", s);
+        return result;
+    }
+
+    @Override
+    public IntegrationJob create(IntegrationJob job) throws TechnicalException {
+        log.debug("Create integrationJob [{}]", job.getId());
+        var created = internalRepository.insert(mapper.map(job));
+        log.debug("Create integrationJob [{}] - Done", created.getId());
+        return mapper.map(created);
+    }
+
+    @Override
+    public IntegrationJob update(IntegrationJob job) throws TechnicalException {
+        if (job == null) {
+            throw new IllegalStateException("IntegrationJob must not be null");
+        }
+
+        return internalRepository
+            .findById(job.getId())
+            .map(found -> {
+                log.debug("Update integrationJob [{}]", job.getId());
+                var updated = internalRepository.save(mapper.map(job));
+                log.debug("Update integrationJob [{}] - Done", updated.getId());
+                return mapper.map(updated);
+            })
+            .orElseThrow(() -> new IllegalStateException(String.format("No integration job found with id [%s]", job.getId())));
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        log.debug("Delete integration [{}]", id);
+        internalRepository.deleteById(id);
+        log.debug("Delete integration [{}] - Done", id);
+    }
+
+    @Override
+    public Set<IntegrationJob> findAll() throws TechnicalException {
+        return internalRepository.findAll().stream().map(source -> mapper.map(source)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<IntegrationJob> findPendingJobFor(String sourceId) {
+        return internalRepository.findPendingJobFor(sourceId).map(source -> mapper.map(source));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integrationjob/IntegrationJobMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integrationjob/IntegrationJobMongoRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.integrationjob;
+
+import io.gravitee.repository.mongodb.management.internal.model.IntegrationJobMongo;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IntegrationJobMongoRepository extends MongoRepository<IntegrationJobMongo, String> {
+    @Query("{ sourceId: ?0, status: 'PENDING' }")
+    Optional<IntegrationJobMongo> findPendingJobFor(String sourceId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IntegrationJobMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/IntegrationJobMongo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import java.util.Date;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}integrationjobs")
+public class IntegrationJobMongo extends Auditable {
+
+    @Id
+    private String id;
+
+    private String sourceId;
+    private String environmentId;
+    private String initiatorId;
+    private String status;
+    private String errorMessage;
+    private Long upperLimit;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -190,6 +190,11 @@ public interface GraviteeMapper {
 
     InvitationMongo map(Invitation toMap);
 
+    // IntegrationJob mapping
+    IntegrationJob map(IntegrationJobMongo source);
+
+    IntegrationJobMongo map(IntegrationJob source);
+
     // License mapping
     @Mapping(target = "referenceId", source = "id.referenceId")
     @Mapping(target = "referenceType", source = "id.referenceType")

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/integrations/SourceIdStatusIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/integrations/SourceIdStatusIndexUpgrader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.integrations;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("IntegrationJobsSourceIdStatusIndexUpgrader")
+public class SourceIdStatusIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("integrationjobs")
+            .name("sis1")
+            .key("sourceId", ascending())
+            .key("status", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -197,6 +197,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected IntegrationRepository integrationRepository;
 
     @Inject
+    protected IntegrationJobRepository integrationJobRepository;
+
+    @Inject
     protected ApiCategoryOrderRepository apiCategoryOrderRepository;
 
     protected void createModel(Object object) throws TechnicalException {
@@ -308,6 +311,8 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             accessPointRepository.create(accessPoint);
         } else if (object instanceof Integration integration) {
             integrationRepository.create(integration);
+        } else if (object instanceof IntegrationJob job) {
+            integrationJobRepository.create(job);
         } else if (object instanceof ApiCategoryOrder apiCategoryOrder) {
             apiCategoryOrderRepository.create(apiCategoryOrder);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IntegrationJobRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/IntegrationJobRepositoryTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.common.utils.UUID;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.IntegrationJob;
+import java.util.Date;
+import org.junit.Test;
+
+public class IntegrationJobRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/integrationjob-tests/";
+    }
+
+    // Create
+    @Test
+    public void should_create_a_job() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        var job = aJob(uuid, date);
+
+        var createdIntegration = integrationJobRepository.create(job);
+
+        assertThat(createdIntegration).isEqualTo(job);
+    }
+
+    // Find by id
+    @Test
+    public void should_get_job_by_id() throws TechnicalException {
+        var id = "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3";
+        var date = new Date(1470157767000L);
+        var expectedIntegration = aJob(id, date);
+
+        var result = integrationJobRepository.findById(id);
+
+        assertThat(result).hasValue(expectedIntegration);
+    }
+
+    @Test
+    public void should_return_empty_when_job_not_found() throws TechnicalException {
+        var integration = integrationJobRepository.findById("not-existing-id");
+
+        assertThat(integration).isNotPresent();
+    }
+
+    // Update
+    @Test
+    public void should_update_job() throws TechnicalException {
+        var id = "459a022c-e79c-4411-9a02-2ce79c141165";
+        var date = new Date(1470157767000L);
+        var updateDate = new Date(1712660289);
+
+        var toUpdate = aJob(id, date).toBuilder().status("ERROR").errorMessage("an error").updatedAt(updateDate).build();
+
+        var result = integrationJobRepository.update(toUpdate);
+        assertThat(result).isEqualTo(toUpdate);
+    }
+
+    @Test
+    public void should_throw_exception_when_job_to_update_not_found() {
+        var job = aJob("not-existing-id", new Date(1470157767000L));
+
+        assertThatThrownBy(() -> integrationJobRepository.update(job)).isInstanceOf(Exception.class);
+    }
+
+    // Delete
+    @Test
+    public void should_delete_a_job() throws TechnicalException {
+        var id = "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3";
+
+        integrationJobRepository.delete(id);
+
+        var result = integrationJobRepository.findById(id);
+        assertThat(result).isEmpty();
+    }
+
+    // Find pending job
+
+    @Test
+    public void should_return_pending_job_for_source_id() throws TechnicalException {
+        var result = integrationJobRepository.findPendingJobFor("source-id");
+
+        assertThat(result)
+            .hasValue(
+                IntegrationJob
+                    .builder()
+                    .id("f66274c9-3d8f-44c5-a274-c93d8fb4c5f3")
+                    .sourceId("source-id")
+                    .status("PENDING")
+                    .initiatorId("initiator-id")
+                    .upperLimit(100L)
+                    .environmentId("my-env")
+                    .createdAt(new Date(1470157767000L))
+                    .updatedAt(new Date(1470157767000L))
+                    .build()
+            );
+    }
+
+    @Test
+    public void should_return_empty_when_no_pending_job_found() throws TechnicalException {
+        assertThat(integrationJobRepository.findPendingJobFor("459a022c-e79c-4411-9a02-2ce79c141165")).isNotPresent();
+        assertThat(integrationJobRepository.findPendingJobFor("unknown")).isNotPresent();
+    }
+
+    private static IntegrationJob aJob(String uuid, Date date) {
+        return IntegrationJob
+            .builder()
+            .id(uuid)
+            .sourceId("source-id")
+            .status("PENDING")
+            .initiatorId("initiator-id")
+            .upperLimit(100L)
+            .environmentId("my-env")
+            .createdAt(date)
+            .updatedAt(date)
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/integrationjob-tests/integrationJobs.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/integrationjob-tests/integrationJobs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "cad107c9-27f2-40b2-9107-c927f2e0b2fc",
+    "sourceId": "integration1",
+    "environmentId": "my-env",
+    "initiatorId": "user-id",
+    "status": "PENDING",
+    "upperLimit": 100,
+    "createdAt": 1470157767000,
+    "updatedAt": 1470157767000
+  },
+  {
+    "id": "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3",
+    "sourceId": "source-id",
+    "environmentId": "my-env",
+    "initiatorId": "initiator-id",
+    "status": "PENDING",
+    "upperLimit": 100,
+    "createdAt": 1470157767000,
+    "updatedAt": 1470157767000
+  },
+  {
+    "id": "459a022c-e79c-4411-9a02-2ce79c141165",
+    "sourceId": "source-id",
+    "environmentId": "my-env",
+    "initiatorId": "user-id",
+    "status": "SUCCESS",
+    "upperLimit": 100,
+    "createdAt": 1470157767000,
+    "updatedAt": 1470157767000
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
@@ -16,11 +16,30 @@
 package io.gravitee.integration.controller.command;
 
 import io.gravitee.exchange.api.controller.ControllerCommandContext;
-import java.util.Set;
+import lombok.Data;
+import lombok.Setter;
 
-public record IntegrationCommandContext(boolean valid, String organizationId) implements ControllerCommandContext {
+@Data
+public final class IntegrationCommandContext implements ControllerCommandContext {
+
+    private final boolean valid;
+    private final String organizationId;
+
+    @Setter
+    private String integrationId;
+
+    public IntegrationCommandContext(boolean valid, String organizationId, String integrationId) {
+        this.valid = valid;
+        this.organizationId = organizationId;
+        this.integrationId = integrationId;
+    }
+
     public IntegrationCommandContext(boolean valid) {
-        this(valid, null);
+        this(valid, null, null);
+    }
+
+    public IntegrationCommandContext(boolean valid, String organizationId) {
+        this(valid, organizationId, null);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationControllerCommandHandlerFactory.java
@@ -16,12 +16,14 @@
 package io.gravitee.integration.controller.command;
 
 import io.gravitee.apim.core.integration.use_case.CheckIntegrationUseCase;
+import io.gravitee.apim.core.integration.use_case.IngestFederatedApisUseCase;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.controller.ControllerCommandContext;
 import io.gravitee.exchange.api.controller.ControllerCommandHandlersFactory;
 import io.gravitee.integration.controller.command.hello.HelloCommandHandler;
+import io.gravitee.integration.controller.command.ingest.IngestCommandHandler;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -29,11 +31,15 @@ import lombok.RequiredArgsConstructor;
 public class IntegrationControllerCommandHandlerFactory implements ControllerCommandHandlersFactory {
 
     private final CheckIntegrationUseCase checkIntegrationUseCase;
+    private final IngestFederatedApisUseCase ingestFederatedApisUseCase;
 
     @Override
     public List<CommandHandler<? extends Command<?>, ? extends Reply<?>>> buildCommandHandlers(
         final ControllerCommandContext controllerCommandContext
     ) {
-        return List.of(new HelloCommandHandler(checkIntegrationUseCase, (IntegrationCommandContext) controllerCommandContext));
+        return List.of(
+            new HelloCommandHandler(checkIntegrationUseCase, (IntegrationCommandContext) controllerCommandContext),
+            new IngestCommandHandler(ingestFederatedApisUseCase, (IntegrationCommandContext) controllerCommandContext)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
@@ -46,13 +46,14 @@ public class HelloCommandHandler implements CommandHandler<HelloCommand, HelloRe
                 HelloCommandPayload payload = command.getPayload();
                 var result = checkIntegrationUseCase.execute(
                     new CheckIntegrationUseCase.Input(
-                        integrationCommandContext.organizationId(),
+                        integrationCommandContext.getOrganizationId(),
                         payload.getTargetId(),
                         payload.getProvider()
                     )
                 );
 
                 if (result.success()) {
+                    integrationCommandContext.setIntegrationId(payload.getTargetId());
                     return new HelloReply(command.getId(), HelloReplyPayload.builder().targetId(payload.getTargetId()).build());
                 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/ingest/IngestCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/ingest/IngestCommandHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.controller.command.ingest;
+
+import io.gravitee.apim.core.integration.use_case.IngestFederatedApisUseCase;
+import io.gravitee.apim.infra.adapter.IntegrationAdapter;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.ingest.IngestCommand;
+import io.gravitee.integration.api.command.ingest.IngestReply;
+import io.gravitee.integration.api.command.ingest.IngestReplyPayload;
+import io.gravitee.integration.controller.command.IntegrationCommandContext;
+import io.reactivex.rxjava3.core.Single;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class IngestCommandHandler implements CommandHandler<IngestCommand, IngestReply> {
+
+    private final IngestFederatedApisUseCase ingestFederatedApisUseCase;
+    private final IntegrationCommandContext integrationCommandContext;
+
+    @Override
+    public String supportType() {
+        return IntegrationCommandType.INGEST.name();
+    }
+
+    @Override
+    public Single<IngestReply> handle(IngestCommand command) {
+        var payload = command.getPayload();
+        return ingestFederatedApisUseCase
+            .execute(
+                new IngestFederatedApisUseCase.Input(
+                    integrationCommandContext.getOrganizationId(),
+                    payload.ingestJobId(),
+                    payload
+                        .apis()
+                        .stream()
+                        .map(api -> IntegrationAdapter.INSTANCE.map(api, integrationCommandContext.getIntegrationId()))
+                        .toList(),
+                    payload.done()
+                )
+            )
+            .andThen(Single.just(new IngestReply(command.getId(), IngestReplyPayload.builder().build())))
+            .doOnError(throwable ->
+                log.error(
+                    "Unable to process ingest command payload for integration [{}]",
+                    integrationCommandContext.getIntegrationId(),
+                    throwable
+                )
+            )
+            .onErrorReturn(throwable -> new IngestReply(command.getId(), IngestReplyPayload.builder().build()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/spring/IntegrationControllerConfiguration.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.gravitee.apim.core.integration.use_case.CheckIntegrationUseCase;
+import io.gravitee.apim.core.integration.use_case.IngestFederatedApisUseCase;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.exchange.api.configuration.IdentifyConfiguration;
@@ -72,9 +73,10 @@ public class IntegrationControllerConfiguration {
 
     @Bean("integrationControllerCommandHandlerFactory")
     public IntegrationControllerCommandHandlerFactory integrationControllerCommandHandlerFactory(
-        final CheckIntegrationUseCase checkIntegrationUseCase
+        final CheckIntegrationUseCase checkIntegrationUseCase,
+        final IngestFederatedApisUseCase ingestFederatedApisUseCase
     ) {
-        return new IntegrationControllerCommandHandlerFactory(checkIntegrationUseCase);
+        return new IntegrationControllerCommandHandlerFactory(checkIntegrationUseCase, ingestFederatedApisUseCase);
     }
 
     @Bean("integrationExchangeController")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/command/hello/HelloCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/command/hello/HelloCommandHandlerTest.java
@@ -80,7 +80,8 @@ class HelloCommandHandlerTest {
     @BeforeEach
     void setUp() {
         var factory = new IntegrationControllerCommandHandlerFactory(
-            new CheckIntegrationUseCase(integrationCrudServiceInMemory, environmentCrudService)
+            new CheckIntegrationUseCase(integrationCrudServiceInMemory, environmentCrudService),
+            null
         );
 
         commandHandler =

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/IntegrationMapper.java
@@ -19,11 +19,14 @@ import static io.gravitee.apim.core.integration.use_case.DiscoveryUseCase.Output
 import static io.gravitee.apim.core.integration.use_case.DiscoveryUseCase.Output.State.UPDATE;
 
 import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
 import io.gravitee.apim.core.integration.model.IntegrationView;
 import io.gravitee.apim.core.integration.use_case.DiscoveryUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.CreateIntegration;
+import io.gravitee.rest.api.management.v2.rest.model.IngestionJob;
 import io.gravitee.rest.api.management.v2.rest.model.IngestionPreviewResponse;
 import io.gravitee.rest.api.management.v2.rest.model.IngestionPreviewResponseApisInner;
+import io.gravitee.rest.api.management.v2.rest.model.IngestionStatus;
 import java.util.List;
 import java.util.Set;
 import org.mapstruct.Mapper;
@@ -42,6 +45,8 @@ public interface IntegrationMapper {
 
     Integration map(CreateIntegration source);
 
+    IngestionJob map(IntegrationJob source);
+
     io.gravitee.rest.api.management.v2.rest.model.Integration map(Integration source);
 
     io.gravitee.rest.api.management.v2.rest.model.Integration map(IntegrationView source);
@@ -49,6 +54,8 @@ public interface IntegrationMapper {
     List<io.gravitee.rest.api.management.v2.rest.model.Integration> map(Set<Integration> source);
 
     Integration map(io.gravitee.rest.api.management.v2.rest.model.UpdateIntegration source);
+
+    IngestionStatus map(IntegrationJob.Status source);
 
     static IngestionPreviewResponse mapper(DiscoveryUseCase.Output preview) {
         return IngestionPreviewResponse

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/integration/IntegrationResource.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.core.integration.use_case.DeleteIntegrationUseCase;
 import io.gravitee.apim.core.integration.use_case.DiscoveryUseCase;
 import io.gravitee.apim.core.integration.use_case.GetIngestedApisUseCase;
 import io.gravitee.apim.core.integration.use_case.GetIntegrationUseCase;
-import io.gravitee.apim.core.integration.use_case.IngestIntegrationApisUseCase;
+import io.gravitee.apim.core.integration.use_case.StartIngestIntegrationApisUseCase;
 import io.gravitee.apim.core.integration.use_case.UpdateIntegrationUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
@@ -71,7 +71,7 @@ public class IntegrationResource extends AbstractResource {
     private UpdateIntegrationUseCase updateIntegrationUsecase;
 
     @Inject
-    private IngestIntegrationApisUseCase ingestIntegrationApisUseCase;
+    private StartIngestIntegrationApisUseCase startIngestIntegrationApisUseCase;
 
     @Inject
     private DiscoveryUseCase discoveryUseCase;
@@ -146,10 +146,10 @@ public class IntegrationResource extends AbstractResource {
 
         AuditInfo audit = getAuditInfo();
 
-        ingestIntegrationApisUseCase
-            .execute(new IngestIntegrationApisUseCase.Input(integrationId, audit))
+        startIngestIntegrationApisUseCase
+            .execute(new StartIngestIntegrationApisUseCase.Input(integrationId, audit))
             .subscribe(
-                () -> response.resume(IntegrationIngestionResponse.builder().status(IngestionStatus.SUCCESS).build()),
+                status -> response.resume(IntegrationIngestionResponse.builder().status(IngestionStatus.PENDING).build()),
                 response::resume
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3587,6 +3587,22 @@ components:
                     enum:
                         - CONNECTED
                         - DISCONNECTED
+                pendingJob:
+                    $ref: "#/components/schemas/IngestionJob"
+
+        IngestionJob:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Id of the ingestion job
+            startedAt:
+              type: string
+              format: date-time
+              description: The last datetime when the job was started.
+              example: 2023-05-25T12:40:46.184Z
+            status:
+              $ref: "#/components/schemas/IngestionStatus"
 
         IngestionPreviewResponse:
             type: object
@@ -3638,6 +3654,8 @@ components:
             example: SUCCESS
             enum:
                 - SUCCESS
+                - PENDING
+                - ERROR
 
         Links:
             description: List of links for pagination

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/crud_service/IntegrationJobCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/crud_service/IntegrationJobCrudService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.crud_service;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import java.util.Optional;
+
+public interface IntegrationJobCrudService {
+    IntegrationJob create(IntegrationJob job);
+
+    Optional<IntegrationJob> findById(String id);
+
+    IntegrationJob update(IntegrationJob job);
+
+    void delete(String id);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IngestStarted.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IngestStarted.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.model;
+
+/**
+ * Describe an Ingestion job that has started
+ * @param ingestJobId The job Id.
+ * @param total The total of APIs expected to be ingested.
+ */
+public record IngestStarted(String ingestJobId, long total) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationJob.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationJob.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.model;
+
+import io.gravitee.common.utils.TimeProvider;
+import java.time.ZonedDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.With;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class IntegrationJob {
+
+    String id;
+
+    /**
+     * The component id that triggers the job.
+     * For example, if the job is about ingesting Federated APIs from an external source, this id will be the id of the Integration.
+     */
+    @With
+    String sourceId;
+
+    /** The environment id where the job is executed */
+    String environmentId;
+
+    /** The user id that triggers the job */
+    String initiatorId;
+
+    ZonedDateTime createdAt;
+    ZonedDateTime updatedAt;
+
+    Status status;
+
+    /** The error message if the job failed */
+    String errorMessage;
+
+    /**
+     * The upper limit telling how many items can be processed by this job.
+     * For example, if the job is about ingesting Federated APIs from an external source, this limit will be the number of APIs to ingest.
+     */
+    Long upperLimit;
+
+    public enum Status {
+        PENDING,
+        SUCCESS,
+        ERROR,
+    }
+
+    public IntegrationJob complete() {
+        return toBuilder().status(Status.SUCCESS).updatedAt(TimeProvider.now()).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationView.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationView.java
@@ -36,12 +36,18 @@ public class IntegrationView extends Integration {
 
     AgentStatus agentStatus;
 
+    IntegrationJob pendingJob;
+
     public enum AgentStatus {
         CONNECTED,
         DISCONNECTED,
     }
 
     public IntegrationView(Integration integration, AgentStatus agentStatus) {
+        this(integration, agentStatus, null);
+    }
+
+    public IntegrationView(Integration integration, AgentStatus agentStatus, IntegrationJob pendingJob) {
         super(
             integration.getId(),
             integration.getName(),
@@ -52,6 +58,7 @@ public class IntegrationView extends Integration {
             integration.getUpdatedAt()
         );
         this.agentStatus = agentStatus;
+        this.pendingJob = pendingJob;
     }
 
     public Integration toIntegration() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/query_service/IntegrationJobQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/query_service/IntegrationJobQueryService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.query_service;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import java.util.Optional;
+
+public interface IntegrationJobQueryService {
+    Optional<IntegrationJob> findPendingJobFor(String integrationId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/service_provider/IntegrationAgent.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.integration.service_provider;
 
+import io.gravitee.apim.core.integration.model.IngestStarted;
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.integration.model.IntegrationApi;
 import io.gravitee.apim.core.integration.model.IntegrationSubscription;
@@ -33,6 +34,8 @@ public interface IntegrationAgent {
      * @return {@link Status} the Agent's status of the integration
      */
     Single<Status> getAgentStatusFor(String integrationId);
+
+    Single<IngestStarted> startIngest(String integrationId, String ingestJobId);
 
     Flowable<IntegrationApi> fetchAllApis(Integration integration);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/GetIntegrationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/GetIntegrationUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
 import io.gravitee.apim.core.integration.exception.IntegrationNotFoundException;
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.integration.model.IntegrationView;
+import io.gravitee.apim.core.integration.query_service.IntegrationJobQueryService;
 import io.gravitee.apim.core.integration.service_provider.IntegrationAgent;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import lombok.Builder;
@@ -34,15 +35,18 @@ import lombok.Builder;
 public class GetIntegrationUseCase {
 
     private final IntegrationCrudService integrationCrudService;
+    private final IntegrationJobQueryService integrationJobQueryService;
     private final LicenseDomainService licenseDomainService;
     private final IntegrationAgent integrationAgent;
 
     public GetIntegrationUseCase(
         IntegrationCrudService integrationCrudService,
+        IntegrationJobQueryService integrationJobQueryService,
         LicenseDomainService licenseDomainService,
         IntegrationAgent integrationAgent
     ) {
         this.integrationCrudService = integrationCrudService;
+        this.integrationJobQueryService = integrationJobQueryService;
         this.licenseDomainService = licenseDomainService;
         this.integrationAgent = integrationAgent;
     }
@@ -63,7 +67,9 @@ public class GetIntegrationUseCase {
             .map(status -> IntegrationView.AgentStatus.valueOf(status.name()))
             .blockingGet();
 
-        return new GetIntegrationUseCase.Output(new IntegrationView(integration, agentStatus));
+        var pendingJob = integrationJobQueryService.findPendingJobFor(integrationId);
+
+        return new GetIntegrationUseCase.Output(new IntegrationView(integration, agentStatus, pendingJob.orElse(null)));
     }
 
     @Builder

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCase.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.NotAllowedDomainException;
+import io.gravitee.apim.core.integration.crud_service.IntegrationCrudService;
+import io.gravitee.apim.core.integration.crud_service.IntegrationJobCrudService;
+import io.gravitee.apim.core.integration.exception.IntegrationNotFoundException;
+import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.apim.core.integration.service_provider.IntegrationAgent;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@Slf4j
+@RequiredArgsConstructor
+public class StartIngestIntegrationApisUseCase {
+
+    private final IntegrationCrudService integrationCrudService;
+    private final IntegrationJobCrudService integrationJobCrudService;
+    private final IntegrationAgent integrationAgent;
+    private final LicenseDomainService licenseDomainService;
+
+    public Single<IntegrationJob.Status> execute(Input input) {
+        var auditInfo = input.auditInfo;
+        var integrationId = input.integrationId;
+        var organizationId = auditInfo.organizationId();
+        var environmentId = auditInfo.environmentId();
+
+        if (!licenseDomainService.isFederationFeatureAllowed(organizationId)) {
+            return Single.error(NotAllowedDomainException.noLicenseForFederation());
+        }
+
+        return Single
+            .fromCallable(() ->
+                integrationCrudService
+                    .findById(integrationId)
+                    .filter(integration -> integration.getEnvironmentId().equals(environmentId))
+                    .orElseThrow(() -> new IntegrationNotFoundException(integrationId))
+            )
+            .flatMap(integration ->
+                integrationAgent
+                    .startIngest(integration.getId(), UuidString.generateRandom())
+                    .map(ingestStarted -> {
+                        log.info("Ingestion started for integration {}", integration.getId());
+
+                        if (ingestStarted.total() == 0) {
+                            log.info("No APIs to ingest for integration {}", integration.getId());
+                            return IntegrationJob.Status.SUCCESS;
+                        }
+
+                        integrationJobCrudService.create(
+                            newIngestJob(ingestStarted.ingestJobId(), integration, auditInfo.actor().userId(), ingestStarted.total())
+                        );
+
+                        return IntegrationJob.Status.PENDING;
+                    })
+            );
+    }
+
+    public IntegrationJob newIngestJob(String id, Integration integration, String initiatorId, Long total) {
+        var now = TimeProvider.now();
+        return IntegrationJob
+            .builder()
+            .id(id)
+            .sourceId(integration.getId())
+            .environmentId(integration.getEnvironmentId())
+            .initiatorId(initiatorId)
+            .status(IntegrationJob.Status.PENDING)
+            .upperLimit(total)
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+    }
+
+    public record Input(String integrationId, AuditInfo auditInfo) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/TriggerNotificationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/TriggerNotificationDomainService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.notification.domain_service;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
+import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
 import java.util.List;
 
 public interface TriggerNotificationDomainService {
@@ -26,4 +27,6 @@ public interface TriggerNotificationDomainService {
     void triggerApplicationNotification(String organizationId, final ApplicationHookContext context);
 
     void triggerApplicationNotification(String organizationId, final ApplicationHookContext context, List<Recipient> additionalRecipients);
+
+    void triggerPortalNotification(String organizationId, final PortalHookContext context);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/IntegrationNotificationTemplateData.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/IntegrationNotificationTemplateData.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@AllArgsConstructor
+@Data
+public class IntegrationNotificationTemplateData {
+
+    private String id;
+    private String name;
+    private String provider;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
@@ -21,4 +21,5 @@ public enum HookContextEntry {
     PLAN_ID,
     SUBSCRIPTION_ID,
     API_KEY,
+    INTEGRATION_ID,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/portal/FederatedApisIngestionCompleteHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/portal/FederatedApisIngestionCompleteHookContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.model.hook.portal;
+
+import io.gravitee.apim.core.notification.model.hook.HookContextEntry;
+import io.gravitee.rest.api.service.notification.PortalHook;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Context of the hook called when the ingestion of federated APIs is complete.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class FederatedApisIngestionCompleteHookContext extends PortalHookContext {
+
+    private final String integrationId;
+
+    public FederatedApisIngestionCompleteHookContext(String integrationId) {
+        super(PortalHook.FEDERATED_APIS_INGESTION_COMPLETE);
+        this.integrationId = integrationId;
+    }
+
+    @Override
+    protected Map<HookContextEntry, String> getChildProperties() {
+        return Map.ofEntries(Map.entry(HookContextEntry.INTEGRATION_ID, integrationId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/portal/PortalHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/portal/PortalHookContext.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.notification.model.hook.portal;
+
+import io.gravitee.apim.core.notification.model.hook.AbstractHookContext;
+import io.gravitee.apim.core.notification.model.hook.HookContextEntry;
+import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.PortalHook;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public abstract class PortalHookContext extends AbstractHookContext {
+
+    private final PortalHook hook;
+
+    public PortalHookContext(PortalHook hook) {
+        this.hook = hook;
+    }
+
+    public Map<HookContextEntry, String> getProperties() {
+        return new HashMap<>(getChildProperties());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationJobAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/IntegrationJobAdapter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface IntegrationJobAdapter {
+    IntegrationJobAdapter INSTANCE = Mappers.getMapper(IntegrationJobAdapter.class);
+
+    IntegrationJob toEntity(io.gravitee.repository.management.model.IntegrationJob source);
+
+    io.gravitee.repository.management.model.IntegrationJob toRepository(IntegrationJob source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/integration/IntegrationJobCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/integration/IntegrationJobCrudServiceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.integration;
+
+import io.gravitee.apim.core.integration.crud_service.IntegrationJobCrudService;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.apim.infra.adapter.IntegrationJobAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IntegrationJobCrudServiceImpl implements IntegrationJobCrudService {
+
+    private final IntegrationJobRepository integrationRepository;
+
+    public IntegrationJobCrudServiceImpl(@Lazy IntegrationJobRepository integrationJobRepository) {
+        this.integrationRepository = integrationJobRepository;
+    }
+
+    @Override
+    public IntegrationJob create(IntegrationJob job) {
+        try {
+            var created = integrationRepository.create(IntegrationJobAdapter.INSTANCE.toRepository(job));
+            return IntegrationJobAdapter.INSTANCE.toEntity(created);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when creating IntegrationJob for integration: " + job.getSourceId(), e);
+        }
+    }
+
+    @Override
+    public Optional<IntegrationJob> findById(String id) {
+        try {
+            return integrationRepository.findById(id).map(IntegrationJobAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find the IntegrationJob: " + id, e);
+        }
+    }
+
+    @Override
+    public IntegrationJob update(IntegrationJob job) {
+        try {
+            var updated = integrationRepository.update(IntegrationJobAdapter.INSTANCE.toRepository(job));
+            return IntegrationJobAdapter.INSTANCE.toEntity(updated);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurred when updating IntegrationJob: " + job.getId(), e);
+        }
+    }
+
+    @Override
+    public void delete(String id) {
+        try {
+            integrationRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when deleting IntegrationJob: " + id, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDoma
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
+import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
 import io.gravitee.apim.infra.notification.internal.TemplateDataFetcher;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -67,5 +68,11 @@ public class TriggerNotificationDomainServiceFacadeImpl implements TriggerNotifi
             notificationParameters,
             additionalRecipients
         );
+    }
+
+    @Override
+    public void triggerPortalNotification(String organizationId, PortalHookContext context) {
+        var notificationParameters = templateDataFetcher.fetchData(organizationId, context);
+        notifierService.trigger(new ExecutionContext(organizationId, null), context.getHook(), notificationParameters);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainServ
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.notification.model.ApiNotificationTemplateData;
 import io.gravitee.apim.core.notification.model.ApplicationNotificationTemplateData;
+import io.gravitee.apim.core.notification.model.IntegrationNotificationTemplateData;
 import io.gravitee.apim.core.notification.model.PlanNotificationTemplateData;
 import io.gravitee.apim.core.notification.model.PrimaryOwnerNotificationTemplateData;
 import io.gravitee.apim.core.notification.model.SubscriptionNotificationTemplateData;
@@ -30,6 +31,7 @@ import io.gravitee.apim.core.notification.model.hook.HookContextEntry;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.api.IntegrationRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -48,6 +50,7 @@ public class TemplateDataFetcher {
     private final ApplicationRepository applicationRepository;
     private final PlanRepository planRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final IntegrationRepository integrationRepository;
     private final ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
     private final ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService;
     private final ApiMetadataDecoderDomainService apiMetadataDecoderDomainService;
@@ -57,6 +60,7 @@ public class TemplateDataFetcher {
         @Lazy ApplicationRepository applicationRepository,
         @Lazy PlanRepository planRepository,
         @Lazy SubscriptionRepository subscriptionRepository,
+        @Lazy IntegrationRepository integrationRepository,
         ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService,
         ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService,
         ApiMetadataDecoderDomainService apiMetadataDecoderDomainService
@@ -65,6 +69,7 @@ public class TemplateDataFetcher {
         this.applicationRepository = applicationRepository;
         this.planRepository = planRepository;
         this.subscriptionRepository = subscriptionRepository;
+        this.integrationRepository = integrationRepository;
         this.apiPrimaryOwnerDomainService = apiPrimaryOwnerDomainService;
         this.applicationPrimaryOwnerDomainService = applicationPrimaryOwnerDomainService;
         this.apiMetadataDecoderDomainService = apiMetadataDecoderDomainService;
@@ -83,6 +88,7 @@ public class TemplateDataFetcher {
                         case APPLICATION_ID -> buildApplicationNotificationTemplateData(organizationId, entry.getValue());
                         case PLAN_ID -> buildPlanNotificationTemplateData(entry.getValue());
                         case SUBSCRIPTION_ID -> buildSubscriptionNotificationTemplateData(entry.getValue());
+                        case INTEGRATION_ID -> buildIntegrationNotificationTemplateData(entry.getValue());
                         case API_KEY -> Optional.of(entry.getValue());
                     }
                 )
@@ -98,6 +104,7 @@ public class TemplateDataFetcher {
             case APPLICATION_ID -> "application";
             case PLAN_ID -> "plan";
             case SUBSCRIPTION_ID -> "subscription";
+            case INTEGRATION_ID -> "integration";
             case API_KEY -> "apiKey";
         };
     }
@@ -207,6 +214,23 @@ public class TemplateDataFetcher {
                         .id(subscription.getId())
                         .reason(subscription.getReason())
                         .request(subscription.getRequest())
+                        .build()
+                );
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(e);
+        }
+    }
+
+    private Optional<IntegrationNotificationTemplateData> buildIntegrationNotificationTemplateData(String integrationId) {
+        try {
+            return integrationRepository
+                .findById(integrationId)
+                .map(subscription ->
+                    IntegrationNotificationTemplateData
+                        .builder()
+                        .id(subscription.getId())
+                        .name(subscription.getName())
+                        .provider(subscription.getProvider())
                         .build()
                 );
         } catch (TechnicalException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/integration/IntegrationJobQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/integration/IntegrationJobQueryServiceImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.integration;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.apim.core.integration.query_service.IntegrationJobQueryService;
+import io.gravitee.apim.infra.adapter.IntegrationJobAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class IntegrationJobQueryServiceImpl extends AbstractService implements IntegrationJobQueryService {
+
+    private final IntegrationJobRepository integrationJobRepository;
+
+    public IntegrationJobQueryServiceImpl(@Lazy IntegrationJobRepository integrationJobRepository) {
+        this.integrationJobRepository = integrationJobRepository;
+    }
+
+    @Override
+    public Optional<IntegrationJob> findPendingJobFor(String integrationId) {
+        try {
+            return integrationJobRepository.findPendingJobFor(integrationId).map(IntegrationJobAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurred while finding pending IntegrationJob for: " + integrationId, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -174,6 +174,11 @@ public class EmailNotificationBuilder {
             "New support Ticket by ${user.displayName}"
         ),
         PORTAL_GROUP_INVITATION(PortalHook.GROUP_INVITATION, "groupInvitationNotification.html", "New group invitation - ${group.name}"),
+        PORTAL_FEDERATED_APIS_INGESTION_COMPLETE(
+            PortalHook.FEDERATED_APIS_INGESTION_COMPLETE,
+            "federatedApisIngestionComplete.html",
+            "Federated APIs ingestion complete for Integration ${integration.name}"
+        ),
         TEMPLATES_FOR_ACTION_USER_REGISTRATION(
             ActionHook.USER_REGISTRATION,
             "userRegistration.html",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/PortalHook.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/PortalHook.java
@@ -30,6 +30,7 @@ public enum PortalHook implements Hook {
     USER_FIRST_LOGIN("First Login", "Triggered when an user log in for the first time", "USER"),
     PASSWORD_RESET("Password Reset", "Triggered when a password is reset", "USER"),
     NEW_SUPPORT_TICKET("New Support Ticket", "Triggered when a new support ticket is created", "SUPPORT"),
+    FEDERATED_APIS_INGESTION_COMPLETE("Ingestion complete", "Triggered when an ingestion has completed.", "FEDERATION"),
     GROUP_INVITATION("Group invitation", "Triggered when an user is invited in a group", "GROUP"),
     MESSAGE("Message", "Used when sending a custom message to an Environment Role", null, true);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationJobFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/IntegrationJobFixture.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.function.Supplier;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class IntegrationJobFixture {
+
+    public static final Supplier<IntegrationJob.IntegrationJobBuilder> BASE = () ->
+        IntegrationJob
+            .builder()
+            .id("job-id")
+            .sourceId("integration-id")
+            .initiatorId("initiator-id")
+            .environmentId("my-env")
+            .status(IntegrationJob.Status.PENDING)
+            .upperLimit(10L)
+            .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+            .updatedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()));
+
+    public static IntegrationJob aPendingIngestJob() {
+        return BASE.get().build();
+    }
+
+    public static IntegrationJob aSuccessJob() {
+        return BASE.get().status(IntegrationJob.Status.SUCCESS).build();
+    }
+
+    public static IntegrationJob anErrorJob() {
+        return BASE.get().status(IntegrationJob.Status.ERROR).errorMessage("Job failed").build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/IntegrationJobFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/IntegrationJobFixture.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.repository;
+
+import io.gravitee.repository.management.model.IntegrationJob;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Supplier;
+
+public class IntegrationJobFixture {
+
+    private IntegrationJobFixture() {}
+
+    public static final Supplier<IntegrationJob.IntegrationJobBuilder> BASE = () ->
+        IntegrationJob
+            .builder()
+            .id("job-id")
+            .sourceId("integration-id")
+            .environmentId("environment-id")
+            .initiatorId("initiator-id")
+            .status("PENDING")
+            .upperLimit(10L)
+            .createdAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+
+    public static IntegrationJob anIntegrationJob() {
+        return BASE.get().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationJobCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationJobCrudServiceInMemory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.integration.crud_service.IntegrationJobCrudService;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class IntegrationJobCrudServiceInMemory implements IntegrationJobCrudService, InMemoryAlternative<IntegrationJob> {
+
+    final ArrayList<IntegrationJob> storage = new ArrayList<>();
+
+    @Override
+    public IntegrationJob create(IntegrationJob integration) {
+        storage.add(integration);
+        return integration;
+    }
+
+    @Override
+    public Optional<IntegrationJob> findById(String id) {
+        return storage.stream().filter(item -> item.getId().equals(id)).findFirst();
+    }
+
+    @Override
+    public IntegrationJob update(IntegrationJob integration) {
+        OptionalInt index = this.findIndex(this.storage, i -> i.getId().equals(integration.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), integration);
+            return integration;
+        }
+
+        throw new IllegalStateException("IntegrationJob not found");
+    }
+
+    @Override
+    public void delete(String id) {
+        OptionalInt index = this.findIndex(this.storage, i -> i.getId().equals(id));
+        if (index.isPresent()) {
+            storage.remove(index.getAsInt());
+        }
+    }
+
+    @Override
+    public void initWith(List<IntegrationJob> items) {
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<IntegrationJob> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationJobQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/IntegrationJobQueryServiceInMemory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.apim.core.integration.query_service.IntegrationJobQueryService;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class IntegrationJobQueryServiceInMemory implements IntegrationJobQueryService, InMemoryAlternative<IntegrationJob> {
+
+    private final List<IntegrationJob> storage;
+
+    public IntegrationJobQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    public IntegrationJobQueryServiceInMemory(IntegrationJobCrudServiceInMemory integrationJobCrudServiceInMemory) {
+        storage = integrationJobCrudServiceInMemory.storage;
+    }
+
+    @Override
+    public Optional<IntegrationJob> findPendingJobFor(String integrationId) {
+        return storage
+            .stream()
+            .filter(integration -> integration.getSourceId().equals(integrationId))
+            .filter(integration -> integration.getStatus().equals(IntegrationJob.Status.PENDING))
+            .findFirst();
+    }
+
+    @Override
+    public void initWith(List<IntegrationJob> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<IntegrationJob> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/TriggerNotificationDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/TriggerNotificationDomainServiceInMemory.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDoma
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
+import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +34,7 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
 
     private final List<ApiHookContext> apiNotifications = new ArrayList<>();
     private final List<ApplicationNotification> applicationNotifications = new ArrayList<>();
+    private final List<PortalHookContext> portalNotifications = new ArrayList<>();
 
     @Override
     public void triggerApiNotification(String organizationId, ApiHookContext hookContext) {
@@ -54,6 +56,11 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
         additionalRecipients.forEach(recipient -> applicationNotifications.add(new ApplicationNotification(recipient, context)));
     }
 
+    @Override
+    public void triggerPortalNotification(String organizationId, PortalHookContext hookContext) {
+        portalNotifications.add(hookContext);
+    }
+
     public List<ApiHookContext> getApiNotifications() {
         return Collections.unmodifiableList(apiNotifications);
     }
@@ -62,8 +69,13 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
         return Collections.unmodifiableList(applicationNotifications);
     }
 
+    public List<PortalHookContext> getPortalNotifications() {
+        return Collections.unmodifiableList(portalNotifications);
+    }
+
     public void reset() {
         apiNotifications.clear();
         applicationNotifications.clear();
+        portalNotifications.clear();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -47,6 +47,8 @@ import inmemory.InstallationAccessQueryServiceInMemory;
 import inmemory.InstanceQueryServiceInMemory;
 import inmemory.IntegrationAgentInMemory;
 import inmemory.IntegrationCrudServiceInMemory;
+import inmemory.IntegrationJobCrudServiceInMemory;
+import inmemory.IntegrationJobQueryServiceInMemory;
 import inmemory.IntegrationQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
@@ -314,8 +316,20 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public IntegrationJobCrudServiceInMemory integrationJobCrudService() {
+        return new IntegrationJobCrudServiceInMemory();
+    }
+
+    @Bean
     public IntegrationQueryServiceInMemory integrationQueryService(IntegrationCrudServiceInMemory integrationCrudServiceInMemory) {
         return new IntegrationQueryServiceInMemory(integrationCrudServiceInMemory);
+    }
+
+    @Bean
+    public IntegrationJobQueryServiceInMemory integrationJobQueryService(
+        IntegrationJobCrudServiceInMemory integrationJobCrudServiceInMemory
+    ) {
+        return new IntegrationJobQueryServiceInMemory(integrationJobCrudServiceInMemory);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/StartIngestIntegrationApisUseCaseTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.integration.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.IntegrationFixture;
+import fixtures.core.model.LicenseFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.IntegrationAgentInMemory;
+import inmemory.IntegrationCrudServiceInMemory;
+import inmemory.IntegrationJobCrudServiceInMemory;
+import inmemory.LicenseCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.NotAllowedDomainException;
+import io.gravitee.apim.core.integration.exception.IntegrationNotFoundException;
+import io.gravitee.apim.core.integration.model.Integration;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StartIngestIntegrationApisUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String INTEGRATION_ID = "integration-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
+    IntegrationJobCrudServiceInMemory integrationJobCrudService = new IntegrationJobCrudServiceInMemory();
+
+    IntegrationAgentInMemory integrationAgent = new IntegrationAgentInMemory();
+    LicenseManager licenseManager = mock(LicenseManager.class);
+
+    private StartIngestIntegrationApisUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(seed -> seed != null ? seed : "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        useCase =
+            new StartIngestIntegrationApisUseCase(
+                integrationCrudService,
+                integrationJobCrudService,
+                integrationAgent,
+                new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager)
+            );
+
+        when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION_ID)).thenReturn(LicenseFixtures.anEnterpriseLicense());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(integrationCrudService, integrationJobCrudService).forEach(InMemoryAlternative::reset);
+        reset(licenseManager);
+    }
+
+    @Test
+    void should_create_a_job_and_return_pending_status_when_a_job_has_started() {
+        // Given
+        givenAnIntegration(IntegrationFixture.anIntegration(ENVIRONMENT_ID).withId(INTEGRATION_ID));
+        integrationAgent.configureApisNumberToIngest(INTEGRATION_ID, 10L);
+
+        // When
+        var result = useCase
+            .execute(new StartIngestIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .values();
+
+        // Then
+        assertThat(result).containsExactly(IntegrationJob.Status.PENDING);
+        assertThat(integrationJobCrudService.storage())
+            .contains(
+                IntegrationJob
+                    .builder()
+                    .id("generated-id")
+                    .sourceId(INTEGRATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .initiatorId(USER_ID)
+                    .status(IntegrationJob.Status.PENDING)
+                    .upperLimit(10L)
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_return_done_status_when_no_job_has_started_because_no_apis_to_ingest() {
+        // Given
+        givenAnIntegration(IntegrationFixture.anIntegration(ENVIRONMENT_ID).withId(INTEGRATION_ID));
+        integrationAgent.configureApisNumberToIngest(INTEGRATION_ID, 0L);
+
+        // When
+        var result = useCase
+            .execute(new StartIngestIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO))
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .values();
+
+        // Then
+        assertThat(integrationJobCrudService.storage()).isEmpty();
+        assertThat(result).containsExactly(IntegrationJob.Status.SUCCESS);
+    }
+
+    @Test
+    void should_throw_when_no_license_found() {
+        when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION_ID)).thenReturn(LicenseFixtures.anOssLicense());
+
+        useCase
+            .execute(new StartIngestIntegrationApisUseCase.Input(INTEGRATION_ID, AUDIT_INFO))
+            .test()
+            .assertError(NotAllowedDomainException.class);
+    }
+
+    @Test
+    void should_throw_when_no_integration_is_found() {
+        // When
+        var obs = useCase.execute(new StartIngestIntegrationApisUseCase.Input("unknown", AUDIT_INFO)).test();
+
+        // Then
+        obs.assertError(IntegrationNotFoundException.class);
+    }
+
+    private void givenAnIntegration(Integration integration) {
+        integrationCrudService.initWith(List.of(integration));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/integration/IntegrationJobCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/integration/IntegrationJobCrudServiceImplTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.IntegrationJobFixture;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class IntegrationJobCrudServiceImplTest {
+
+    IntegrationJobRepository repository;
+
+    IntegrationJobCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(IntegrationJobRepository.class);
+        service = new IntegrationJobCrudServiceImpl(repository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_job() {
+            //Given
+            var job = IntegrationJobFixture.aPendingIngestJob();
+            when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            //When
+            var created = service.create(job);
+
+            //Then
+            assertThat(created).isEqualTo(job);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            var job = IntegrationJobFixture.aPendingIngestJob();
+            when(repository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.create(job));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when creating IntegrationJob for integration: integration-id");
+        }
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        @SneakyThrows
+        void should_return_the_found_job() {
+            //Given
+            when(repository.findById(any()))
+                .thenAnswer(invocation ->
+                    Optional.of(
+                        fixtures.repository.IntegrationJobFixture.anIntegrationJob().toBuilder().id(invocation.getArgument(0)).build()
+                    )
+                );
+
+            //When
+            var result = service.findById("my-id");
+
+            //Then
+            assertThat(result)
+                .contains(IntegrationJobFixture.aPendingIngestJob().toBuilder().id("my-id").environmentId("environment-id").build());
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_when_not_found() {
+            //Given
+            when(repository.findById(any())).thenAnswer(invocation -> Optional.empty());
+
+            //When
+            var result = service.findById("my-id");
+
+            //Then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(repository.findById(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById("my-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurs while trying to find the IntegrationJob: my-id");
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @SneakyThrows
+        void should_update_integration() {
+            var job = IntegrationJobFixture
+                .aSuccessJob()
+                .toBuilder()
+                .updatedAt(Instant.parse("2020-02-04T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                .build();
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(job);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.IntegrationJob.class);
+            verify(repository).update(captor.capture());
+
+            assertThat(captor.getValue())
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    io.gravitee.repository.management.model.IntegrationJob
+                        .builder()
+                        .id("job-id")
+                        .sourceId("integration-id")
+                        .initiatorId("initiator-id")
+                        .environmentId("my-env")
+                        .status("SUCCESS")
+                        .upperLimit(10L)
+                        .createdAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
+                        .updatedAt(Date.from(Instant.parse("2020-02-04T20:22:02.00Z")))
+                        .build()
+                );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_updated_integration() {
+            //Given
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            //When
+            var toUpdate = IntegrationJobFixture.aPendingIngestJob();
+            var updated = service.update(toUpdate);
+
+            //Then
+            assertThat(updated).isEqualTo(toUpdate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            var job = IntegrationJobFixture.aSuccessJob();
+            when(repository.update(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.update(job));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurred when updating IntegrationJob: job-id");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_a_job() throws TechnicalException {
+            service.delete("job-id");
+            verify(repository).delete("job-id");
+        }
+
+        @Test
+        void should_throw_if_deletion_problem_occurs() throws TechnicalException {
+            doThrow(new TechnicalException()).when(repository).delete("job-id");
+            assertThatThrownBy(() -> service.delete("job-id"))
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when deleting IntegrationJob: job-id");
+            verify(repository).delete("job-id");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/integration/IntegrationJobQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/integration/IntegrationJobQueryServiceImplTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.repository.IntegrationJobFixture;
+import io.gravitee.apim.core.integration.model.IntegrationJob;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationJobRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IntegrationJobQueryServiceImplTest {
+
+    IntegrationJobRepository integrationRepository;
+
+    IntegrationJobQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        integrationRepository = mock(IntegrationJobRepository.class);
+        service = new IntegrationJobQueryServiceImpl(integrationRepository);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_pending_job_from_source_id() {
+        // Given
+        when(integrationRepository.findPendingJobFor(any()))
+            .thenAnswer(invocation ->
+                Optional.of(IntegrationJobFixture.anIntegrationJob().toBuilder().sourceId(invocation.getArgument(0)).build())
+            );
+
+        // When
+        var result = service.findPendingJobFor("integration-id");
+
+        //Then
+        assertThat(result)
+            .contains(
+                IntegrationJob
+                    .builder()
+                    .id("job-id")
+                    .sourceId("integration-id")
+                    .environmentId("environment-id")
+                    .initiatorId("initiator-id")
+                    .upperLimit(10L)
+                    .status(IntegrationJob.Status.PENDING)
+                    .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .updatedAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_throw_when_technical_exception_occurs() {
+        // Given
+        when(integrationRepository.findPendingJobFor(any())).thenThrow(TechnicalException.class);
+
+        // When
+        var throwable = catchThrowable(() -> service.findPendingJobFor("integration-id"));
+
+        // Then
+        assertThat(throwable)
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessage("An error occurred while finding pending IntegrationJob for: integration-id");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/federatedApisIngestionComplete.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/federatedApisIngestionComplete.html
@@ -1,0 +1,10 @@
+<html>
+	<body>
+		<header style="text-align: center;">
+			<#include "header.html" />
+		</header>
+		<div style="margin-top: 50px; color: #424e5a;">
+            <p>All Federated APIs of Integration <b>${integration.name}</b> have been ingested.</p>
+		</div>
+	</body>
+</html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/notifications/portal/PORTAL.FEDERATED_APIS_INGESTION_COMPLETE.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/notifications/portal/PORTAL.FEDERATED_APIS_INGESTION_COMPLETE.yml
@@ -1,0 +1,3 @@
+title: Federated APIs ingestion complete
+message: |
+  Ingestion for ${integration.name} completed ✅

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-expression-language.version>3.2.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
-        <gravitee-integration-api.version>1.1.0</gravitee-integration-api.version>
+        <gravitee-integration-api.version>2.0.0</gravitee-integration-api.version>
         <gravitee-node.version>5.20.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>4.1.0</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5759

## Description

Split Ingest use case in 2:
- `StartIngestIntegrationApisUseCase` executed by a call to `/integrations/{id}/_ingest`. This will start the ingest
- `IngestFederatedApisUseCase` executed when receiving `IngestCommand` from controller. This will create Federated APIs

A banner is shown when the ingestion is running

![image](https://github.com/user-attachments/assets/2fcdb6f0-e939-43eb-be95-d12049fedaf6)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sendroanah.chromatic.com)
<!-- Storybook placeholder end -->
