### PR TITLE
fix: make resource add work when api.resources props is undefined

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.spec.ts
@@ -101,7 +101,7 @@ describe('ApiResourcesComponent', () => {
   });
 
   it('should add a resource', async () => {
-    expectApiGetRequest(fakeApiV4({ id: API_ID, resources: [] }));
+    expectApiGetRequest(fakeApiV4({ id: API_ID, resources: undefined }));
     expectListResourcesRequest([fakeResourcePlugin({ id: 'cache', name: 'Cache' })]);
 
     // Open Add dialog

--- a/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
@@ -203,7 +203,7 @@ export class ApiResourcesComponent implements OnInit {
             switchMap((api) => {
               return this.apiService.update(api.id, {
                 ...api,
-                resources: [...api.resources, resourceToAdd],
+                resources: [...(api.resources ?? []), resourceToAdd],
               });
             }),
           ),
@@ -327,7 +327,7 @@ export class ApiResourcesComponent implements OnInit {
       .get(this.activatedRoute.snapshot.params.apiId)
       .pipe(
         switchMap((api) => {
-          const updatedResources = api.resources.map((resource, index) => {
+          const updatedResources = api.resources?.map((resource, index) => {
             if (index === apiResourceIndex) {
               return {
                 ...resource,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2364

## Description

Oups, 

make resource add work when api.resources props is undefined

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vauljtuief.chromatic.com)
<!-- Storybook placeholder end -->
