### PR TITLE
feat(console): User can add a home page for a v4 API: set homepage type

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.spec.ts
@@ -24,6 +24,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { set } from 'lodash';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
+import { By } from '@angular/platform-browser';
 
 import { ApiDocumentationV4Component } from './api-documentation-v4.component';
 import { ApiDocumentationV4Module } from './api-documentation-v4.module';
@@ -34,9 +35,7 @@ import { ApiDocumentationV4PagesListHarness } from './components/api-documentati
 import { ApiDocumentationV4PageTitleHarness } from './components/api-documentation-v4-page-title/api-documentation-v4-page-title.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { Breadcrumb, Page } from '../../../entities/management-api-v2/documentation/page';
-import { fakeFolder, fakeMarkdown } from '../../../entities/management-api-v2/documentation/page.fixture';
-import { ApiLifecycleState, fakeApiV4 } from '../../../entities/management-api-v2';
+import { Breadcrumb, Page, fakeFolder, fakeMarkdown, ApiLifecycleState, fakeApiV4 } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { PageType } from '../../../entities/page';
 import { Constants } from '../../../entities/Constants';
@@ -113,6 +112,45 @@ describe('ApiDocumentationV4', () => {
   afterEach(() => {
     httpTestingController.verify();
     jest.resetAllMocks();
+  });
+
+  describe('Custom section', () => {
+    it('should not include homepages in the custom pages (UI Test)', async () => {
+      const pages = [
+        fakeMarkdown({ id: 'page-1', name: 'Page 1', homepage: true }),
+        fakeMarkdown({ id: 'page-2', name: 'Page 2', homepage: false }),
+        fakeMarkdown({ id: 'page-3', name: 'Page 3', homepage: true }),
+        fakeMarkdown({ id: 'page-4', name: 'Page 4', homepage: false }),
+      ];
+      await init(pages, []);
+
+      fixture.detectChanges();
+
+      const pageElements = fixture.debugElement.queryAll(By.css('api-documentation-v4-pages-list'));
+      expect(pageElements.length).toBe(1);
+
+      const pageListComponent = pageElements[0].componentInstance;
+      expect(pageListComponent.pages.length).toBe(2);
+      expect(pageListComponent.pages[0].id).toBe('page-2');
+      expect(pageListComponent.pages[1].id).toBe('page-4');
+    });
+
+    it('should not show a homepage in the custom pages', async () => {
+      const pages = [
+        fakeMarkdown({ id: 'page-1', name: 'Page 1', homepage: true }),
+        fakeMarkdown({ id: 'page-2', name: 'Page 2', homepage: false }),
+      ];
+      await init(pages, []);
+
+      fixture.detectChanges();
+
+      const pageElements = fixture.debugElement.queryAll(By.css('api-documentation-v4-pages-list'));
+      expect(pageElements.length).toBe(1);
+
+      const pageListComponent = pageElements[0].componentInstance;
+      expect(pageListComponent.pages.length).toBe(1);
+      expect(pageListComponent.pages[0].id).toBe('page-2');
+    });
   });
 
   describe('API does not have pages', () => {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.component.ts
@@ -72,7 +72,7 @@ export class ApiDocumentationV4Component implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
       )
       .subscribe((res) => {
-        this.pages = res.pages;
+        this.pages = res.pages.filter((page) => !page.homepage);
         this.breadcrumbs = res.breadcrumb;
         this.isLoading = false;
       });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.spec.ts
@@ -24,6 +24,7 @@ import { BehaviorSubject } from 'rxjs';
 import { set } from 'lodash';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { By } from '@angular/platform-browser';
 
 import { ApiDocumentationV4DefaultPageComponent } from './api-documentation-v4-default-page.component';
 
@@ -33,7 +34,7 @@ import { ApiDocumentationV4EmptyStateHarness } from '../components/documentation
 import { PageType } from '../../../../entities/page';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { ApiDocumentationV4Module } from '../api-documentation-v4.module';
-import { ApiLifecycleState, Breadcrumb, fakeApiV4, Page } from '../../../../entities/management-api-v2';
+import { ApiLifecycleState, Breadcrumb, fakeApiV4, fakeMarkdown, Page } from '../../../../entities/management-api-v2';
 import { ApiDocumentationV4DefaultPageHarness } from '../components/documentation-home-page-header/api-documentation-v4-home-page-header.harness';
 
 describe('ApiDocumentationV4DefaultPageComponent', () => {
@@ -127,8 +128,27 @@ describe('ApiDocumentationV4DefaultPageComponent', () => {
 
       expect(routerNavigateSpy).toHaveBeenCalledWith(['.', 'homepage', 'new'], {
         relativeTo: expect.anything(),
-        queryParams: { parentId: 'ROOT', pageType: 'MARKDOWN' },
+        queryParams: { parentId: 'ROOT', pageType: 'MARKDOWN', homepage: true },
       });
+    });
+  });
+
+  describe('Homepage section', () => {
+    it('should only show current homepage', async () => {
+      const pages = [
+        fakeMarkdown({ id: 'page-1', name: 'Page 1', homepage: true }),
+        fakeMarkdown({ id: 'page-2', name: 'Page 2', homepage: false }),
+      ];
+      await init(pages, []);
+
+      fixture.detectChanges();
+
+      const pageElements = fixture.debugElement.queryAll(By.css('api-documentation-v4-pages-list'));
+      expect(pageElements.length).toBe(1);
+
+      const pageListComponent = pageElements[0].componentInstance;
+      expect(pageListComponent.pages.length).toBe(1);
+      expect(pageListComponent.pages[0].id).toBe('page-1');
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.ts
@@ -65,7 +65,7 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
         takeUntil(this.unsubscribe$),
       )
       .subscribe((res) => {
-        this.page = res.pages[0];
+        this.page = res.pages.find((p) => p.homepage === true);
         this.isLoading = false;
       });
   }
@@ -78,7 +78,7 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
   addPage(pageType: PageType) {
     this.router.navigate(['.', 'homepage', 'new'], {
       relativeTo: this.activatedRoute,
-      queryParams: { parentId: this.parentId, pageType },
+      queryParams: { parentId: this.parentId, pageType, homepage: true },
     });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.spec.ts
@@ -351,6 +351,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             parentId: 'ROOT',
             accessControls: [{ referenceId: 'group-1', referenceType: 'GROUP' }],
             excludedAccessControls: true,
+            homepage: false,
           });
         });
 
@@ -377,6 +378,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             parentId: 'ROOT',
             accessControls: [{ referenceId: 'group-1', referenceType: 'GROUP' }],
             excludedAccessControls: true,
+            homepage: false,
           });
 
           const publishReq = httpTestingController.expectOne({
@@ -541,6 +543,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             },
             accessControls: [],
             excludedAccessControls: false,
+            homepage: false,
           });
         });
 
@@ -573,6 +576,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             },
             accessControls: [],
             excludedAccessControls: false,
+            homepage: false,
           });
 
           const publishReq = httpTestingController.expectOne({
@@ -623,6 +627,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
             },
             accessControls: [],
             excludedAccessControls: false,
+            homepage: false,
           });
 
           const publishReq = httpTestingController.expectOne({
@@ -681,6 +686,7 @@ describe('ApiDocumentationV4EditPageComponent', () => {
           parentId: 'parent-folder-id',
           accessControls: [],
           excludedAccessControls: false,
+          homepage: false,
         });
       });
     });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-edit-page/api-documentation-v4-edit-page.component.ts
@@ -343,6 +343,7 @@ export class ApiDocumentationV4EditPageComponent implements OnInit, OnDestroy {
       type: this.pageType as CreateDocumentationType,
       name: formValue.stepOne.name,
       visibility: formValue.stepOne.visibility,
+      homepage: this.activatedRoute.snapshot.queryParams.homepage === 'true',
       content: formValue.content,
       parentId: this.activatedRoute.snapshot.queryParams.parentId || 'ROOT',
       accessControls: formValue.stepOne.accessControlGroups.map((referenceId) => ({ referenceId, referenceType: 'GROUP' })),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4337

## Description

As an API publisher
I want to add a home page to my v4 API
so that users in the portal can see the home page under the Details section when they find my API in the catalog.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<img width="1227" alt="Screenshot 2024-07-15 at 15 04 52" src="https://github.com/user-attachments/assets/a40ebee6-724f-4509-97b4-b8923745fb7a">





https://github.com/user-attachments/assets/db48779f-429e-4f94-8994-de088ac75340





<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tazctqomit.chromatic.com)
<!-- Storybook placeholder end -->
