### PR TITLE
Apim 5453 mapi v2 get default theme

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Theme.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Theme.java
@@ -17,7 +17,10 @@ package io.gravitee.repository.management.model;
 
 import java.util.Date;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -26,9 +29,10 @@ import lombok.Setter;
  */
 @Setter
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Theme {
-
-    public Theme() {}
 
     public Theme(Theme cloned) {
         this.id = cloned.getId();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
@@ -34,7 +34,11 @@ public interface ThemeMapper {
     ThemePortal mapToThemePortal(Theme theme);
 
     @Mapping(source = "definitionPortalNext", target = "definition")
+    @Mapping(source = "definitionPortalNext.color.background.page", target = "definition.color.pageBackground")
+    @Mapping(source = "definitionPortalNext.color.background.card", target = "definition.color.cardBackground")
     ThemePortalNext mapToThemePortalNext(Theme theme);
+
+    List<io.gravitee.rest.api.management.v2.rest.model.Theme> map(List<Theme> themes);
 
     default io.gravitee.rest.api.management.v2.rest.model.Theme map(Theme theme) {
         if (ThemeType.PORTAL.equals(theme.getType())) {
@@ -45,6 +49,4 @@ public interface ThemeMapper {
         }
         return null;
     }
-
-    List<io.gravitee.rest.api.management.v2.rest.model.Theme> map(List<Theme> themes);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ThemeMapper.java
@@ -16,9 +16,9 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import io.gravitee.rest.api.management.v2.rest.model.ThemePortal;
 import io.gravitee.rest.api.management.v2.rest.model.ThemePortalNext;
-import io.gravitee.rest.api.management.v2.rest.model.ThemeType;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -28,7 +28,7 @@ import org.mapstruct.factory.Mappers;
 public interface ThemeMapper {
     ThemeMapper INSTANCE = Mappers.getMapper(ThemeMapper.class);
 
-    Theme.ThemeType map(ThemeType type);
+    ThemeType map(io.gravitee.rest.api.management.v2.rest.model.ThemeType type);
 
     @Mapping(source = "definitionPortal", target = "definition")
     ThemePortal mapToThemePortal(Theme theme);
@@ -37,10 +37,10 @@ public interface ThemeMapper {
     ThemePortalNext mapToThemePortalNext(Theme theme);
 
     default io.gravitee.rest.api.management.v2.rest.model.Theme map(Theme theme) {
-        if (Theme.ThemeType.PORTAL.equals(theme.getType())) {
+        if (ThemeType.PORTAL.equals(theme.getType())) {
             return new io.gravitee.rest.api.management.v2.rest.model.Theme(this.mapToThemePortal(theme));
         }
-        if (Theme.ThemeType.PORTAL_NEXT.equals(theme.getType())) {
+        if (ThemeType.PORTAL_NEXT.equals(theme.getType())) {
             return new io.gravitee.rest.api.management.v2.rest.model.Theme(this.mapToThemePortalNext(theme));
         }
         return null;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResource.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.ui;
 
-import io.gravitee.apim.core.theme.use_case.GetPortalThemesUseCase;
+import io.gravitee.apim.core.theme.use_case.GetThemesUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ThemeMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ThemeType;
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ThemesResource extends AbstractResource {
 
     @Inject
-    private GetPortalThemesUseCase getPortalThemesUseCase;
+    private GetThemesUseCase getPortalThemesUseCase;
 
     @GET
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = { RolePermissionAction.READ }) })
@@ -52,7 +52,7 @@ public class ThemesResource extends AbstractResource {
     ) {
         var result = getPortalThemesUseCase
             .execute(
-                GetPortalThemesUseCase.Input
+                GetThemesUseCase.Input
                     .builder()
                     .type(ThemeMapper.INSTANCE.map(type))
                     .enabled(enabled)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -127,6 +127,59 @@ paths:
             $ref: "#/components/responses/ThemesResponse"
           default:
             $ref: "#/components/responses/Error"
+
+    /environments/{envId}/ui/themes/_default:
+      servers:
+        - url: "{protocol}://{managementAPIHost}/management/v2/organizations/{orgId}"
+          description: APIM Management API v2 - Base URL to target specific organizations
+          variables:
+            protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                - https
+                - http
+            managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+            orgId:
+              description: The unique ID of your organization
+              default: DEFAULT
+        - url: "{protocol}://{managementAPIHost}/management/v2"
+          description: APIM Management API v2 - Default base URL
+          variables:
+            protocol:
+              description: The protocol you want to use to communicate with the mAPI
+              default: https
+              enum:
+                - https
+                - http
+            managementAPIHost:
+              description: The domain of the server hosting your Management API
+              default: localhost:8083
+      parameters:
+        - $ref: "#/components/parameters/envIdParam"
+      get:
+        tags:
+          - Management UI
+        parameters:
+          - $ref: "#/components/parameters/themeTypeParam"
+        summary: Get default theme
+        description: |
+          Get default theme for a given environment.
+          Only PORTAL_NEXT is currently supported.
+          
+          User must have the ENVIRONMENT_THEME[READ] permission.
+        operationId: getDefaultTheme
+        responses:
+          "200":
+            description: The default theme.
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Theme"
+          default:
+            $ref: "#/components/responses/Error"
 components:
     schemas:
         ConsoleCustomization:
@@ -351,6 +404,18 @@ components:
           type: object
           description: Theme definition used for Portal-Next
           properties:
+            color:
+              $ref: "#/components/schemas/PortalNextDefinitionColor"
+            font:
+              $ref: "#/components/schemas/PortalNextDefinitionFont"
+            customCss:
+              type: string
+              description: Custom CSS for Portal-Next
+
+        PortalNextDefinitionColor:
+          type: object
+          description: Theme definition used for Portal-Next
+          properties:
             primary:
               type: string
               description: Primary hex code color seed for Theme palette
@@ -367,22 +432,24 @@ components:
               type: string
               description: Error hex code color seed for Theme palette
               example: #e1f200
-            background:
+            pageBackground:
               type: string
               description: Background hex code color
               example: #e1f200
-            banner:
-              type: object
-              description: Banner customization
-              properties:
-                text:
-                  type: string
-                  description: Banner text hex code color
-                  example: #e1f200
-                background:
-                  type: string
-                  description: Banner background hex code color
-                  example: #e1f200
+            cardBackground:
+              type: string
+              description: Background hex code color
+              example: #e1f200
+
+        PortalNextDefinitionFont:
+          type: object
+          description: Theme definition used for Portal-Next
+          properties:
+            fontFamily:
+              type: string
+              description: Font-family used for Portal-Next
+              example: "Roboto"
+
         Theme:
           oneOf:
             - $ref: "#/components/schemas/ThemePortal"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/ui/ThemesResourceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import assertions.MAPIAssertions;
 import inmemory.ThemeQueryServiceInMemory;
 import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import io.gravitee.rest.api.management.v2.rest.model.Pagination;
 import io.gravitee.rest.api.management.v2.rest.model.ThemesResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
@@ -158,7 +159,7 @@ public class ThemesResourceTest extends AbstractResourceTest {
             .builder()
             .id(PORTAL_THEME_ID)
             .name(PORTAL_THEME_ID)
-            .type(Theme.ThemeType.PORTAL)
+            .type(ThemeType.PORTAL)
             .definitionPortal(portalDefinition)
             .createdAt(ZonedDateTime.now())
             .updatedAt(ZonedDateTime.now())
@@ -174,7 +175,7 @@ public class ThemesResourceTest extends AbstractResourceTest {
             .builder()
             .id(PORTAL_NEXT_THEME_ID)
             .name(PORTAL_NEXT_THEME_ID)
-            .type(Theme.ThemeType.PORTAL_NEXT)
+            .type(ThemeType.PORTAL_NEXT)
             .definitionPortalNext(portalDefinition)
             .createdAt(ZonedDateTime.now())
             .updatedAt(ZonedDateTime.now())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -82,6 +82,22 @@ public enum Key {
     PORTAL_NEXT_HOMEPAGE_BANNER_TITLE("portal.next.bannerTitle", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_HOMEPAGE_BANNER_SUBTITLE("portal.next.bannerSubtitle", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_ACCESS_ENABLED("portal.next.access.enabled", "false", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_COLOR_PRIMARY("portal.next.theme.color.primary", "#613CB0", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_COLOR_SECONDARY("portal.next.theme.color.secondary", "#958BA9", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_COLOR_TERTIARY("portal.next.theme.color.tertiary", "#B7818F", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_COLOR_ERROR("portal.next.theme.color.error", "#EC6152", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_COLOR_BACKGROUND_PAGE(
+        "portal.next.theme.color.background.page",
+        "#F7F8FD",
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
+    PORTAL_NEXT_THEME_COLOR_BACKGROUND_CARD(
+        "portal.next.theme.color.background.card",
+        "#FFFFFF",
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
+    PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "Roboto", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/theme/portalnext/ThemeDefinition.java
@@ -17,22 +17,51 @@ package io.gravitee.rest.api.model.theme.portalnext;
 
 import io.gravitee.rest.api.model.theme.portal.ThemeComponentDefinition;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ThemeDefinition {
 
-    private String primary;
-    private String secondary;
-    private String tertiary;
-    private String error;
-    private String background;
-    private Banner banner;
+    private String customCss;
+    private Font font;
+    private Color color;
 
     @Data
-    public static class Banner {
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Color {
 
-        private String background;
-        private String text;
+        private String primary;
+        private String secondary;
+        private String tertiary;
+        private String error;
+
+        private Background background;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Background {
+
+        private String page;
+        private String card;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Font {
+
+        private String fontFamily;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
@@ -19,7 +19,6 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.PictureEntity;
 import io.gravitee.rest.api.model.UrlPictureEntity;
-import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.portal.rest.mapper.ThemeMapper;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.rest.api.model.theme.ThemeType;
 import io.gravitee.rest.api.model.theme.portal.ThemeEntity;
 import io.gravitee.rest.api.portal.rest.model.ThemeResponse;
 import io.gravitee.rest.api.service.common.GraviteeContext;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/DefaultThemeDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/domain_service/DefaultThemeDomainService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
+import io.gravitee.apim.core.theme.exception.ThemeTypeNotSupportedException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class DefaultThemeDomainService {
+
+    private final ParametersDomainService parametersDomainService;
+
+    private static final List<Key> PORTAL_NEXT_THEME_KEYS = List.of(
+        Key.PORTAL_NEXT_THEME_COLOR_PRIMARY,
+        Key.PORTAL_NEXT_THEME_COLOR_SECONDARY,
+        Key.PORTAL_NEXT_THEME_COLOR_TERTIARY,
+        Key.PORTAL_NEXT_THEME_COLOR_ERROR,
+        Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_PAGE,
+        Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_CARD,
+        Key.PORTAL_NEXT_THEME_CUSTOM_CSS,
+        Key.PORTAL_NEXT_THEME_FONT_FAMILY
+    );
+
+    public Theme getDefaultTheme(ThemeType themeType, ExecutionContext executionContext) {
+        if (Objects.requireNonNull(themeType) == ThemeType.PORTAL_NEXT) {
+            return this.getPortalNextDefaultTheme(executionContext);
+        }
+
+        throw new ThemeTypeNotSupportedException(themeType.name());
+    }
+
+    private Theme getPortalNextDefaultTheme(ExecutionContext executionContext) {
+        Map<Key, String> parameters = parametersDomainService.getEnvironmentParameters(executionContext, PORTAL_NEXT_THEME_KEYS);
+
+        return Theme
+            .builder()
+            .type(ThemeType.PORTAL_NEXT)
+            .name("Default Portal Next Theme")
+            .referenceId(executionContext.getEnvironmentId())
+            .referenceType(Theme.ReferenceType.ENVIRONMENT)
+            .definitionPortalNext(
+                ThemeDefinition
+                    .builder()
+                    .color(
+                        ThemeDefinition.Color
+                            .builder()
+                            .primary(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY))
+                            .secondary(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_SECONDARY))
+                            .tertiary(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_TERTIARY))
+                            .error(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_ERROR))
+                            .background(
+                                ThemeDefinition.Background
+                                    .builder()
+                                    .card(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_CARD))
+                                    .page(parameters.get(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_PAGE))
+                                    .build()
+                            )
+                            .build()
+                    )
+                    .customCss(parameters.get(Key.PORTAL_NEXT_THEME_CUSTOM_CSS))
+                    .font(ThemeDefinition.Font.builder().fontFamily(parameters.get(Key.PORTAL_NEXT_THEME_FONT_FAMILY)).build())
+                    .build()
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/exception/ThemeTypeNotSupportedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/exception/ThemeTypeNotSupportedException.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.parameters.domain_service;
+package io.gravitee.apim.core.theme.exception;
 
-import io.gravitee.rest.api.model.parameters.Key;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.List;
-import java.util.Map;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 
-public interface ParametersDomainService {
-    Map<Key, String> getSystemParameters(List<Key> keys);
-    Map<Key, String> getEnvironmentParameters(ExecutionContext executionContext, List<Key> keys);
+public class ThemeTypeNotSupportedException extends ValidationDomainException {
+
+    public ThemeTypeNotSupportedException(String themeType) {
+        super("Theme type [" + themeType + "] is not supported");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
@@ -40,9 +40,4 @@ public class Theme {
     private String optionalLogo;
     private String favicon;
     private String backgroundImage;
-
-    public enum ThemeType {
-        PORTAL,
-        PORTAL_NEXT,
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/Theme.java
@@ -21,11 +21,13 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Theme {
 
     private String id;
     private String name;
+    private String referenceId;
+    private ReferenceType referenceType;
 
     private ThemeDefinition definitionPortal;
     private io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition definitionPortalNext;
@@ -40,4 +42,8 @@ public class Theme {
     private String optionalLogo;
     private String favicon;
     private String backgroundImage;
+
+    public enum ReferenceType {
+        ENVIRONMENT,
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/model/ThemeType.java
@@ -15,13 +15,7 @@
  */
 package io.gravitee.apim.core.theme.model;
 
-import lombok.Builder;
-import lombok.Data;
-
-@Data
-@Builder
-public class ThemeSearchCriteria {
-
-    private ThemeType type;
-    private Boolean enabled;
+public enum ThemeType {
+    PORTAL,
+    PORTAL_NEXT,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetDefaultThemeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetDefaultThemeUseCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.theme.domain_service.DefaultThemeDomainService;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetDefaultThemeUseCase {
+
+    private final DefaultThemeDomainService defaultThemeDomainService;
+
+    public Output execute(Input input) {
+        return new Output(this.defaultThemeDomainService.getDefaultTheme(input.type(), input.executionContext()));
+    }
+
+    @Builder
+    public record Input(ThemeType type, ExecutionContext executionContext) {}
+
+    public record Output(Theme result) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetThemesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/theme/use_case/GetThemesUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.theme.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.theme.model.Theme;
 import io.gravitee.apim.core.theme.model.ThemeSearchCriteria;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import io.gravitee.apim.core.theme.query_service.ThemeQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.PageableImpl;
@@ -26,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @UseCase
-public class GetPortalThemesUseCase {
+public class GetThemesUseCase {
 
     private final ThemeQueryService themeQueryService;
 
@@ -40,7 +41,7 @@ public class GetPortalThemesUseCase {
     }
 
     @Builder
-    public record Input(Theme.ThemeType type, Boolean enabled, int page, int size) {}
+    public record Input(ThemeType type, Boolean enabled, int page, int size) {}
 
     public record Output(Page<Theme> result) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
@@ -33,6 +33,11 @@ public class ThemeTypeNotSupportedException extends AbstractManagementException 
     private final String id;
     private final ThemeType type;
 
+    public ThemeTypeNotSupportedException(ThemeType type) {
+        this.type = type;
+        this.id = null;
+    }
+
     @Override
     public int getHttpStatusCode() {
         return HttpStatusCode.BAD_REQUEST_400;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ThemeTypeNotSupportedException.java
@@ -22,20 +22,25 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.theme.ThemeType;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-@AllArgsConstructor
 public class ThemeTypeNotSupportedException extends AbstractManagementException {
 
     private final String id;
-    private final ThemeType type;
+    private final String type;
 
-    public ThemeTypeNotSupportedException(ThemeType type) {
-        this.type = type;
+    public ThemeTypeNotSupportedException() {
         this.id = null;
+        this.type = null;
+    }
+
+    public ThemeTypeNotSupportedException(String id, ThemeType type) {
+        this.id = id;
+        this.type = type.name();
     }
 
     @Override
@@ -45,7 +50,7 @@ public class ThemeTypeNotSupportedException extends AbstractManagementException 
 
     @Override
     public String getMessage() {
-        return format("%s theme is currently not supported", type.name());
+        return format("[ %s ] theme is currently not supported", type);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ParametersDomainServiceInMemory.java
@@ -17,11 +17,14 @@ package inmemory;
 
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
 import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
 import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ParametersDomainServiceInMemory implements ParametersDomainService, InMemoryAlternative<Parameter> {
@@ -37,6 +40,22 @@ public class ParametersDomainServiceInMemory implements ParametersDomainService,
         return parameters
             .stream()
             .filter(parameter -> keys.contains(Key.findByKey(parameter.getKey())))
+            .collect(Collectors.toMap(parameter -> Key.findByKey(parameter.getKey()), Parameter::getValue));
+    }
+
+    @Override
+    public Map<Key, String> getEnvironmentParameters(ExecutionContext executionContext, List<Key> keys) {
+        if (keys.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return parameters
+            .stream()
+            .filter(parameter ->
+                keys.contains(Key.findByKey(parameter.getKey())) &&
+                Objects.equals(executionContext.getEnvironmentId(), parameter.getReferenceId()) &&
+                ParameterReferenceType.ENVIRONMENT.equals(parameter.getReferenceType())
+            )
             .collect(Collectors.toMap(parameter -> Key.findByKey(parameter.getKey()), Parameter::getValue));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/domain_service/DefaultThemeDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/domain_service/DefaultThemeDomainServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.*;
+import io.gravitee.apim.core.theme.exception.ThemeTypeNotSupportedException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class DefaultThemeDomainServiceTest {
+
+    private final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
+
+    private final ThemeDefinition EXPECTED_PORTAL_NEXT_THEME_DEFINITION = ThemeDefinition
+        .builder()
+        .color(
+            ThemeDefinition.Color
+                .builder()
+                .primary("#fff")
+                .secondary("#000")
+                .tertiary("#111")
+                .error("#222")
+                .background(ThemeDefinition.Background.builder().page("#333").card("#444").build())
+                .build()
+        )
+        .font(ThemeDefinition.Font.builder().fontFamily("Comic Sans").build())
+        .customCss(".style { }")
+        .build();
+
+    private final Theme EXPECTED_DEFAULT_PORTAL_NEXT_THEME = Theme
+        .builder()
+        .type(ThemeType.PORTAL_NEXT)
+        .referenceType(Theme.ReferenceType.ENVIRONMENT)
+        .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+        .name("Default Portal Next Theme")
+        .definitionPortalNext(EXPECTED_PORTAL_NEXT_THEME_DEFINITION)
+        .build();
+
+    ParametersDomainServiceInMemory parametersDomainService = new ParametersDomainServiceInMemory();
+    DefaultThemeDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        parametersDomainService.initWith(
+            List.of(
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getPrimary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_SECONDARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getSecondary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_TERTIARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getTertiary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_ERROR.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getError())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_PAGE.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getBackground().getPage())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_CARD.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getBackground().getCard())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_CUSTOM_CSS.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getCustomCss())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_FONT_FAMILY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getFont().getFontFamily())
+                    .build()
+            )
+        );
+
+        cut = new DefaultThemeDomainService(parametersDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(parametersDomainService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class GetDefaultTheme {
+
+        @Test
+        void should_return_portal_next_theme() {
+            var result = cut.getDefaultTheme(ThemeType.PORTAL_NEXT, EXECUTION_CONTEXT);
+            assertThat(result).isEqualTo(EXPECTED_DEFAULT_PORTAL_NEXT_THEME);
+        }
+
+        @Test
+        void should_throw_error_for_portal_theme() {
+            assertThatThrownBy(() -> cut.getDefaultTheme(ThemeType.PORTAL, EXECUTION_CONTEXT))
+                .isInstanceOf(ThemeTypeNotSupportedException.class);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetDefaultThemeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetDefaultThemeUseCaseTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.theme.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.InMemoryAlternative;
+import inmemory.ParametersDomainServiceInMemory;
+import io.gravitee.apim.core.theme.domain_service.DefaultThemeDomainService;
+import io.gravitee.apim.core.theme.exception.ThemeTypeNotSupportedException;
+import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class GetDefaultThemeUseCaseTest {
+
+    private final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
+
+    private final ThemeDefinition EXPECTED_PORTAL_NEXT_THEME_DEFINITION = ThemeDefinition
+        .builder()
+        .color(
+            ThemeDefinition.Color
+                .builder()
+                .primary("#fff")
+                .secondary("#000")
+                .tertiary("#111")
+                .error("#222")
+                .background(ThemeDefinition.Background.builder().page("#333").card("#444").build())
+                .build()
+        )
+        .font(ThemeDefinition.Font.builder().fontFamily("Comic Sans").build())
+        .customCss(".style { }")
+        .build();
+
+    private final Theme EXPECTED_DEFAULT_PORTAL_NEXT_THEME = Theme
+        .builder()
+        .type(ThemeType.PORTAL_NEXT)
+        .referenceType(Theme.ReferenceType.ENVIRONMENT)
+        .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+        .name("Default Portal Next Theme")
+        .definitionPortalNext(EXPECTED_PORTAL_NEXT_THEME_DEFINITION)
+        .build();
+
+    ParametersDomainServiceInMemory parametersDomainService = new ParametersDomainServiceInMemory();
+    GetDefaultThemeUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        parametersDomainService.initWith(
+            List.of(
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getPrimary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_SECONDARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getSecondary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_TERTIARY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getTertiary())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_ERROR.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getError())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_PAGE.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getBackground().getPage())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_COLOR_BACKGROUND_CARD.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getColor().getBackground().getCard())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_CUSTOM_CSS.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getCustomCss())
+                    .build(),
+                Parameter
+                    .builder()
+                    .referenceId(EXECUTION_CONTEXT.getEnvironmentId())
+                    .referenceType(ParameterReferenceType.ENVIRONMENT)
+                    .key(Key.PORTAL_NEXT_THEME_FONT_FAMILY.key())
+                    .value(EXPECTED_PORTAL_NEXT_THEME_DEFINITION.getFont().getFontFamily())
+                    .build()
+            )
+        );
+
+        cut = new GetDefaultThemeUseCase(new DefaultThemeDomainService(parametersDomainService));
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(parametersDomainService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_return_portal_next_theme() {
+        var result = cut.execute(new GetDefaultThemeUseCase.Input(ThemeType.PORTAL_NEXT, EXECUTION_CONTEXT));
+        assertThat(result).extracting(GetDefaultThemeUseCase.Output::result).isEqualTo(EXPECTED_DEFAULT_PORTAL_NEXT_THEME);
+    }
+
+    @Test
+    void should_throw_error_for_portal_theme() {
+        assertThatThrownBy(() -> cut.execute(new GetDefaultThemeUseCase.Input(ThemeType.PORTAL, EXECUTION_CONTEXT)))
+            .isInstanceOf(ThemeTypeNotSupportedException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetThemesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/theme/use_case/GetThemesUseCaseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.ThemeQueryServiceInMemory;
 import io.gravitee.apim.core.theme.model.Theme;
+import io.gravitee.apim.core.theme.model.ThemeType;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,14 +28,14 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class GetPortalThemesUseCaseTest {
+public class GetThemesUseCaseTest {
 
     public final ThemeQueryServiceInMemory themeQueryServiceInMemory = new ThemeQueryServiceInMemory();
-    private GetPortalThemesUseCase cut;
+    private GetThemesUseCase cut;
 
     @BeforeEach
     void setUp() {
-        cut = new GetPortalThemesUseCase(themeQueryServiceInMemory);
+        cut = new GetThemesUseCase(themeQueryServiceInMemory);
     }
 
     @AfterEach
@@ -44,20 +45,16 @@ public class GetPortalThemesUseCaseTest {
 
     @Test
     void should_return_empty_page() {
-        var result = cut
-            .execute(GetPortalThemesUseCase.Input.builder().page(1).size(10).enabled(false).type(Theme.ThemeType.PORTAL).build())
-            .result();
+        var result = cut.execute(GetThemesUseCase.Input.builder().page(1).size(10).enabled(false).type(ThemeType.PORTAL).build()).result();
 
         assertThat(result).hasFieldOrPropertyWithValue("content", List.of());
     }
 
     @Test
     void should_return_page_of_results() {
-        var portalTheme = Theme.builder().id("portal-id").type(Theme.ThemeType.PORTAL).enabled(true).build();
+        var portalTheme = Theme.builder().id("portal-id").type(ThemeType.PORTAL).enabled(true).build();
         themeQueryServiceInMemory.initWith(List.of(portalTheme));
-        var result = cut
-            .execute(GetPortalThemesUseCase.Input.builder().page(1).size(10).enabled(true).type(Theme.ThemeType.PORTAL).build())
-            .result();
+        var result = cut.execute(GetThemesUseCase.Input.builder().page(1).size(10).enabled(true).type(ThemeType.PORTAL).build()).result();
 
         assertThat(result).hasFieldOrPropertyWithValue("content", List.of(portalTheme));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/parameters/ParametersDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/parameters/ParametersDomainServiceImplTest.java
@@ -16,11 +16,20 @@
 package io.gravitee.apim.infra.domain_service.parameters;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -29,27 +38,91 @@ import org.springframework.mock.env.MockEnvironment;
 @ExtendWith(MockitoExtension.class)
 public class ParametersDomainServiceImplTest {
 
+    private ParameterService parameterService;
+    private MockEnvironment environment;
     private ParametersDomainServiceImpl cut;
 
     @BeforeEach
     void setUp() {
-        MockEnvironment environment = new MockEnvironment();
-        cut = new ParametersDomainServiceImpl(environment);
-        environment.setProperty(Key.CONSOLE_CUSTOMIZATION_TITLE.key(), "title");
-        environment.setProperty(Key.CONSOLE_CUSTOMIZATION_LOGO.key(), "logo");
+        parameterService = mock(ParameterService.class);
+        environment = new MockEnvironment();
+        cut = new ParametersDomainServiceImpl(environment, parameterService);
     }
 
-    @Test
-    void should_find_all_parameters() {
-        var result = cut.getSystemParameters(List.of(Key.CONSOLE_CUSTOMIZATION_TITLE, Key.CONSOLE_CUSTOMIZATION_LOGO));
-        Assertions.assertFalse(result.isEmpty());
-        assertThat(result.get(Key.CONSOLE_CUSTOMIZATION_TITLE)).isEqualTo("title");
-        assertThat(result.get(Key.CONSOLE_CUSTOMIZATION_LOGO)).isEqualTo("logo");
+    @Nested
+    class GetSystemParameters {
+
+        @BeforeEach
+        void setUp() {
+            environment.setProperty(Key.CONSOLE_CUSTOMIZATION_TITLE.key(), "title");
+            environment.setProperty(Key.CONSOLE_CUSTOMIZATION_LOGO.key(), "logo");
+        }
+
+        @Test
+        void should_find_all_parameters() {
+            var result = cut.getSystemParameters(List.of(Key.CONSOLE_CUSTOMIZATION_TITLE, Key.CONSOLE_CUSTOMIZATION_LOGO));
+            Assertions.assertFalse(result.isEmpty());
+            assertThat(result.get(Key.CONSOLE_CUSTOMIZATION_TITLE)).isEqualTo("title");
+            assertThat(result.get(Key.CONSOLE_CUSTOMIZATION_LOGO)).isEqualTo("logo");
+        }
+
+        @Test
+        void should_not_find_any_parameters() {
+            var result = cut.getSystemParameters(List.of(Key.CONSOLE_CUSTOMIZATION_THEME_MENUACTIVE));
+            Assertions.assertTrue(result.isEmpty());
+        }
     }
 
-    @Test
-    void should_not_find_any_parameters() {
-        var result = cut.getSystemParameters(List.of(Key.CONSOLE_CUSTOMIZATION_THEME_MENUACTIVE));
-        Assertions.assertTrue(result.isEmpty());
+    @Nested
+    class GetEnvironmentParameters {
+
+        private final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+
+        @Test
+        void should_find_parameters() {
+            var keyList = List.of(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY, Key.PORTAL_NEXT_THEME_COLOR_SECONDARY);
+            when(parameterService.findAll(eq(EXECUTION_CONTEXT), eq(keyList), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+                .thenReturn(
+                    Map.of(
+                        Key.PORTAL_NEXT_THEME_COLOR_PRIMARY.key(),
+                        List.of("primary-color"),
+                        Key.PORTAL_NEXT_THEME_COLOR_SECONDARY.key(),
+                        List.of("secondary-color")
+                    )
+                );
+
+            var result = cut.getEnvironmentParameters(EXECUTION_CONTEXT, keyList);
+            assertThat(result)
+                .isEqualTo(
+                    Map.of(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY, "primary-color", Key.PORTAL_NEXT_THEME_COLOR_SECONDARY, "secondary-color")
+                );
+        }
+
+        @Test
+        void should_not_return_parameters_without_value() {
+            var keyList = List.of(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY, Key.PORTAL_NEXT_THEME_COLOR_SECONDARY);
+            when(parameterService.findAll(eq(EXECUTION_CONTEXT), eq(keyList), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+                .thenReturn(
+                    Map.of(
+                        Key.PORTAL_NEXT_THEME_COLOR_PRIMARY.key(),
+                        List.of("primary-color"),
+                        Key.PORTAL_NEXT_THEME_COLOR_SECONDARY.key(),
+                        List.of()
+                    )
+                );
+
+            var result = cut.getEnvironmentParameters(EXECUTION_CONTEXT, keyList);
+            assertThat(result).isEqualTo(Map.of(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY, "primary-color"));
+        }
+
+        @Test
+        void should_not_find_any_parameters() {
+            var keyList = List.of(Key.PORTAL_NEXT_THEME_COLOR_PRIMARY, Key.PORTAL_NEXT_THEME_COLOR_SECONDARY);
+            when(parameterService.findAll(eq(EXECUTION_CONTEXT), eq(keyList), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+                .thenReturn(Map.of());
+
+            var result = cut.getEnvironmentParameters(EXECUTION_CONTEXT, keyList);
+            assertThat(result).isEqualTo(Map.of());
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
@@ -81,8 +81,10 @@ public class ThemeQueryServiceImplTest {
                 .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
-            var portalNextDefinition = new io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition();
-            portalNextDefinition.setPrimary("#fff");
+            var portalNextDefinition = io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition
+                .builder()
+                .color(io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition.Color.builder().primary("#fff").build())
+                .build();
             var portalNextTheme = io.gravitee.apim.core.theme.model.Theme
                 .builder()
                 .id(PORTAL_NEXT_THEME_ID)
@@ -194,7 +196,7 @@ public class ThemeQueryServiceImplTest {
         theme.setId(PORTAL_NEXT_THEME_ID);
         theme.setName(PORTAL_NEXT_THEME_ID);
         theme.setType(ThemeType.PORTAL_NEXT);
-        theme.setDefinition("{ \"primary\": \"#fff\" }");
+        theme.setDefinition("{ \"color\": { \"primary\": \"#fff\" } }");
         return theme;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/theme/ThemeQueryServiceImplTest.java
@@ -78,7 +78,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_THEME_ID)
                 .name(PORTAL_THEME_ID)
                 .definitionPortal(portalDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
             var portalNextDefinition = new io.gravitee.rest.api.model.theme.portalnext.ThemeDefinition();
@@ -88,7 +88,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_NEXT_THEME_ID)
                 .name(PORTAL_NEXT_THEME_ID)
                 .definitionPortalNext(portalNextDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL_NEXT)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL_NEXT)
                 .build();
 
             Assertions
@@ -113,7 +113,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_THEME_ID)
                 .name(PORTAL_THEME_ID)
                 .definitionPortal(portalDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
             Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
@@ -124,7 +124,7 @@ public class ThemeQueryServiceImplTest {
             var criteria = ThemeCriteria.builder().type(ThemeType.PORTAL).build();
             when(themeRepository.search(eq(criteria), any())).thenAnswer(invocation -> new Page<>(List.of(aPortalRepoTheme()), 0, 0, 0));
             var result = service.searchByCriteria(
-                ThemeSearchCriteria.builder().type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL).build(),
+                ThemeSearchCriteria.builder().type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL).build(),
                 new PageableImpl(1, 1)
             );
 
@@ -135,7 +135,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_THEME_ID)
                 .name(PORTAL_THEME_ID)
                 .definitionPortal(portalDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
             Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
@@ -154,7 +154,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_THEME_ID)
                 .name(PORTAL_THEME_ID)
                 .definitionPortal(portalDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
             Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));
@@ -173,7 +173,7 @@ public class ThemeQueryServiceImplTest {
                 .id(PORTAL_THEME_ID)
                 .name(PORTAL_THEME_ID)
                 .definitionPortal(portalDefinition)
-                .type(io.gravitee.apim.core.theme.model.Theme.ThemeType.PORTAL)
+                .type(io.gravitee.apim.core.theme.model.ThemeType.PORTAL)
                 .build();
 
             Assertions.assertThat(result).isNotNull().hasFieldOrPropertyWithValue("content", List.of(portalTheme));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5453

## Description

Get default portal-next theme. 
Returns:

![Screenshot 2024-07-19 at 10 27 27](https://github.com/user-attachments/assets/0693e704-7c50-44e2-b30f-a5d06ce07ecf)


Next PRs:
- MAPI-V2 + PAPI: Get current theme (for both portal + portal-next) -- [PR](https://github.com/gravitee-io/gravitee-api-management/pull/8441)
- MAPI-V2: Update theme (for both portal + portal-next)
- Portal-Next: Get theme values from back-end at start-up

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

