### PR TITLE
fix: unable to update an API when federated APIs have been ingested

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -550,10 +550,11 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         if (!isEmpty(apiCriteria.getDefinitionVersion())) {
             List<DefinitionVersion> definitionVersionList = new ArrayList<>(apiCriteria.getDefinitionVersion());
 
+            var lookingForV2 = apiCriteria.getDefinitionVersion().stream().anyMatch(DefinitionVersion.V2::equals);
             boolean addNullClause = definitionVersionList.remove(null);
 
             StringBuilder clauseBuilder = new StringBuilder();
-            if (addNullClause) {
+            if (addNullClause || lookingForV2) {
                 if (definitionVersionList.isEmpty()) {
                     clauseBuilder.append("a.definition_version is null");
                 } else {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -274,6 +274,27 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         assertTrue(apis.stream().map(Api::getId).toList().containsAll(asList("api-to-delete", "api-to-update", "big-name")));
     }
 
+    @Test
+    public void shouldFindByDefinitionVersion() {
+        List<Api> v2Apis = apiRepository.search(
+            new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertThat(v2Apis).hasSize(10);
+
+        List<Api> v4Apis = apiRepository.search(
+            new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V4)).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertThat(v4Apis).hasSize(1);
+
+        List<Api> federatedApis = apiRepository.search(
+            new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.FEDERATED)).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertThat(federatedApis).hasSize(1);
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownApi() throws TechnicalException {
         Api unknownApi = new Api();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +129,11 @@ public class VerifyApiPathDomainService implements Validator<VerifyApiPathDomain
 
         apiSearchService
             .search(
-                ApiSearchCriteria.builder().environmentId(input.environmentId).build(),
+                ApiSearchCriteria
+                    .builder()
+                    .environmentId(input.environmentId)
+                    .definitionVersion(List.of(DefinitionVersion.V2, DefinitionVersion.V4))
+                    .build(),
                 null,
                 ApiFieldFilter.builder().pictureExcluded(true).build()
             )
@@ -198,11 +203,7 @@ public class VerifyApiPathDomainService implements Validator<VerifyApiPathDomain
     }
 
     private static List<Path> extractPaths(Api api) {
-        return Optional
-            .ofNullable(api.getDefinitionVersion())
-            .filter(definitionVersion -> definitionVersion != DefinitionVersion.FEDERATED)
-            .map(definitionVersion -> definitionVersion == DefinitionVersion.V4 ? getV4Paths(api) : getV2Paths(api))
-            .orElseGet(() -> getV2Paths(api));
+        return api.getDefinitionVersion() == DefinitionVersion.V4 ? getV4Paths(api) : getV2Paths(api);
     }
 
     private static List<Path> getV4Paths(Api api) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5921

## Description

The unicity check of an API Path where searching for all existing APIs
of an environment to ensure the path is not already used.
The commit 966ec66 introduces a bug
when trying to exclude Federated APIs.
This commit changes the behavior to only search for v2/v4 API as
Federated APIs don't have path, so there is no need to load them (and
because we can have a lot)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

