### PR TITLE
Fix event publisher on accesspoint crud

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/access_point/AccessPointCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/access_point/AccessPointCrudServiceImpl.java
@@ -144,6 +144,6 @@ public class AccessPointCrudServiceImpl extends TransactionalService implements 
         accessPointToDelete.setStatus(AccessPointStatus.DELETED);
         accessPointToDelete.setUpdatedAt(new Date());
         var updatedAccessPoint = accessPointRepository.update(accessPointToDelete);
-        eventManager.publishEvent(AccessPointEvent.DELETED, updatedAccessPoint);
+        eventManager.publishEvent(AccessPointEvent.DELETED, AccessPointAdapter.INSTANCE.toEntity(updatedAccessPoint));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/access_point/AccessPointCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/access_point/AccessPointCrudServiceImplTest.java
@@ -85,6 +85,8 @@ class AccessPointCrudServiceImplTest {
                 .status(AccessPointStatus.CREATED)
                 .build();
             when(accessPointRepository.findByCriteria(accessPointCriteria, null, null)).thenReturn(fetchedAccessPoints);
+            when(accessPointRepository.update(any(io.gravitee.repository.management.model.AccessPoint.class)))
+                .thenReturn(io.gravitee.repository.management.model.AccessPoint.builder().build());
 
             var dateBeforeDeletion = Instant.now().minusSeconds(1);
             service.deleteAccessPoints(referenceType, "ref-id");
@@ -98,7 +100,7 @@ class AccessPointCrudServiceImplTest {
                     assertThat(ap.getStatus()).isEqualTo(AccessPointStatus.DELETED);
                     assertThat(ap.getUpdatedAt()).isAfter(dateBeforeDeletion).isBefore(dateAfterDeletion);
                 });
-            verify(eventManager, times(2)).publishEvent(eq(AccessPointEvent.DELETED), any());
+            verify(eventManager, times(2)).publishEvent(eq(AccessPointEvent.DELETED), any(AccessPoint.class));
         }
     }
 


### PR DESCRIPTION

## Description

Currently we are facing the following exception when updating access points
```java
java.lang.ClassCastException: class io.gravitee.repository.management.model.AccessPoint cannot be cast to class io.gravitee.apim.core.access_point.model.AccessPoint (io.gravitee.repository.management.model.AccessPoint and io.gravitee.apim.core.access_point.model.AccessPoint are in unnamed module of loader java.net.URLClassLoader @f6f4d33)
	at io.gravitee.rest.api.security.cors.GraviteeCorsConfiguration$AccessPointEventListener.isReferenced(GraviteeCorsConfiguration.java:232)
	at io.gravitee.rest.api.security.cors.GraviteeCorsConfiguration$AccessPointEventListener.onEvent(GraviteeCorsConfiguration.java:213)
	at io.gravitee.common.event.impl.EventManagerImpl.lambda$publishEvent$1(EventManagerImpl.java:51)
```

