### PR TITLE
feat(console): open portal next settings from console

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -378,7 +378,7 @@
 
     @if (hasEnterpriseLicense$ | async; as hasEnterpriseLicense) {
       @if (hasEnterpriseLicense) {
-        <h2>New Portal</h2>
+        <h2>New Developer Portal</h2>
         <mat-card class="portal__form__card">
           <mat-card-content formGroupName="portalNext">
             <gio-banner-info>
@@ -393,10 +393,21 @@
                 aria-label="New Portal Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
-            @if (portalUrl && !!settings.portalNext?.access?.enabled) {
-              <div class="open-new-portal-button">
-                <a mat-raised-button [href]="portalUrl" target="_blank" color="primary" class="open-new-portal-button__content">
-                  <div>Open the New Developer Portal</div>
+            @if (!!settings.portalNext?.access?.enabled) {
+              <div class="new-developer-portal-actions">
+                @if (portalUrl) {
+                  <a mat-raised-button [href]="portalUrl" target="_blank" color="primary" class="new-developer-portal-actions__content">
+                    <div>Open Website</div>
+                    <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
+                  </a>
+                }
+                <a
+                  mat-stroked-button
+                  [routerLink]="[environmentRootRouterLink, '_portal']"
+                  target="_blank"
+                  class="new-developer-portal-actions__content"
+                >
+                  <div>Open Settings</div>
                   <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>
                 </a>
               </div>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
@@ -54,8 +54,10 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 }
-.open-new-portal-button {
+.new-developer-portal-actions {
   width: fit-content;
+  display: flex;
+  gap: 12px;
   &__content {
     display: flex;
     align-items: center;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -174,6 +174,7 @@ export class PortalSettingsComponent implements OnInit {
   ];
   hasEnterpriseLicense$: Observable<boolean> = of(false);
   portalUrl: string = undefined;
+  environmentRootRouterLink: string;
 
   constructor(
     private readonly portalSettingsService: PortalSettingsService,
@@ -187,6 +188,7 @@ export class PortalSettingsComponent implements OnInit {
   public ngOnInit() {
     this.isLoadingData = true;
     this.hasEnterpriseLicense$ = this.licenseService.getLicense$().pipe(map((license) => license.tier !== 'oss'));
+    this.environmentRootRouterLink = '/' + this.constants.org.currentEnv.id;
 
     combineLatest([this.portalSettingsService.get()])
       .pipe(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5453

## Description

Open the portal-next settings from the portal setting section in console.

<img width="798" alt="Screenshot 2024-07-23 at 11 24 49" src="https://github.com/user-attachments/assets/d333eb42-c2c8-41d6-b5f0-0790db895b9e">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bpvhzsyvyr.chromatic.com)
<!-- Storybook placeholder end -->
