### PR TITLE
Apim 5453 refactor portal next theme

### DIFF
--- a/gravitee-apim-portal-webui-next/src/index.html
+++ b/gravitee-apim-portal-webui-next/src/index.html
@@ -23,9 +23,15 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp"
       rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+      rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap" rel="stylesheet" />
     <!--    Define global when serving dev config with Vite for swagger-ui -->
     <script type="application/javascript">
       window.global ||= window;

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -23,7 +23,7 @@
 
 mat-card {
   --mdc-elevated-card-container-elevation: 0;
-  --mdc-outlined-card-container-color: #fff;
+  --mdc-outlined-card-container-color: #{theme.$card-background-color};
 }
 
 mat-form-field {

--- a/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
@@ -18,8 +18,9 @@
 Global variables
  */
 
-$font-family: var(--gio-app-font-family, (Roboto, sans-serif));
-$background-color: var(--gio-app-background-color, #f7f8fd);
+$font-family: var(--gio-app-font-family);
+$background-color: var(--gio-app-background-color);
+$card-background-color: var(--gio-app-card-background-color);
 $default-text-color: #1d192b;
 $paragraph-color: color-mix(in srgb, $default-text-color 75%, transparent);
 
@@ -32,5 +33,5 @@ $error-main-color: var(--gio-app-error-main-color);
 /**
 Component variables
  */
-$banner-background-color: var(--gio-banner-background-color, #eaddff);
-$banner-text-color: var(--gio-banner-text-color, #220f46);
+$banner-background-color: var(--mdc-list-list-item-leading-avatar-color);
+$banner-text-color: var(--mdc-outlined-text-field-focus-label-text-color);

--- a/gravitee-apim-portal-webui-next/src/services/theme.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/theme.service.spec.ts
@@ -13,19 +13,70 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { ThemeService } from './theme.service';
+import { Theme, ThemeService } from './theme.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('ThemeService', () => {
   let service: ThemeService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
     service = TestBed.inject(ThemeService);
+    httpTestingController = TestBed.inject(HttpTestingController);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('load theme', done => {
+    const themeResponse: Theme = {
+      definition: {
+        color: {
+          primary: '#000000',
+          secondary: '#111111',
+          tertiary: '#222222',
+          error: '#333333',
+          background: {
+            page: '#444444',
+            card: '#555555',
+          },
+        },
+        font: { fontFamily: '"Roboto", sans serif' },
+        customCss: 'app-root { background: blue; }',
+      },
+    };
+
+    service.loadTheme().subscribe({
+      next: _ => {
+        expect(document.documentElement.style.getPropertyValue('--gio-app-background-color')).toEqual(
+          themeResponse.definition.color?.background?.page,
+        );
+        expect(document.documentElement.style.getPropertyValue('--gio-app-card-background-color')).toEqual(
+          themeResponse.definition.color?.background?.card,
+        );
+        expect(document.documentElement.style.getPropertyValue('--gio-app-primary-main-color')).toEqual('hsl(0, 0%, 0%)');
+        expect(document.documentElement.style.getPropertyValue('--gio-app-secondary-main-color')).toEqual(
+          'hsl(0, 0%, 0.06666666666666667%)',
+        );
+        expect(document.documentElement.style.getPropertyValue('--gio-app-tertiary-main-color')).toEqual(
+          'hsl(0, 0%, 0.13333333333333333%)',
+        );
+        expect(document.documentElement.style.getPropertyValue('--gio-app-error-main-color')).toEqual('hsl(0, 0%, 0.2%)');
+        expect(document.documentElement.style.getPropertyValue('--gio-app-font-family')).toEqual(themeResponse.definition.font.fontFamily);
+        const style: HTMLStyleElement = document.getElementsByTagName('style')[0];
+        expect(style.innerText).toEqual(themeResponse.definition.customCss);
+        done();
+      },
+      error: _ => fail(),
+    });
+
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/theme?type=PORTAL_NEXT`).flush(themeResponse);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/theme.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/theme.service.ts
@@ -13,35 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { catchError, Observable, tap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
+import { ConfigService } from './config.service';
 import { hexToHSL } from '../app/helpers/hex-to-hsl';
 
-interface Theme {
-  primary?: string;
-  secondary?: string;
-  tertiary?: string;
-  error?: string;
-  background?: string;
-  banner?: {
-    background?: string;
-    textColor?: string;
+export interface Theme {
+  definition: {
+    color?: {
+      primary?: string;
+      secondary?: string;
+      tertiary?: string;
+      error?: string;
+      background?: {
+        card?: string;
+        page?: string;
+      };
+    };
+    font: {
+      fontFamily?: string;
+    };
+    customCss?: string;
   };
 }
 
-export const addHslToDocument = (propertyName: string, defaultHex: string, hex: string = '') => {
-  const { h, s, l } = hexToHSL(hex, defaultHex);
+export const addHslToDocument = (propertyName: string, hex: string = '') => {
+  if (!hex) {
+    return;
+  }
+  const { h, s, l } = hexToHSL(hex);
   document.documentElement.style.setProperty(propertyName, `hsl(${h}, ${s}%, ${l}%)`);
   document.documentElement.style.setProperty(`${propertyName}-h`, `${h}`);
   document.documentElement.style.setProperty(`${propertyName}-s`, `${s}%`);
   document.documentElement.style.setProperty(`${propertyName}-l`, `${l}%`);
 };
 
-export const addHexToDocument = (propertyName: string, hex?: string) => {
-  if (hex) {
-    document.documentElement.style.setProperty(propertyName, hex);
+export const addPropertyToDocument = (propertyName: string, value?: string) => {
+  if (value) {
+    document.documentElement.style.setProperty(propertyName, value);
   }
 };
 
@@ -49,24 +61,29 @@ export const addHexToDocument = (propertyName: string, hex?: string) => {
   providedIn: 'root',
 })
 export class ThemeService {
+  constructor(
+    private readonly http: HttpClient,
+    private configService: ConfigService,
+  ) {}
   loadTheme(): Observable<unknown> {
-    // TODO: Call backend to get dynamic theme values
-    return of({
-      primary: '#613CB0',
-      secondary: '#958BA9',
-      tertiary: '#B7818F',
-      error: '#EC6152',
-    }).pipe(
-      tap((theme: Theme) => {
-        addHexToDocument('--gio-app-background-color', theme.background);
-        addHexToDocument('--gio-banner-background-color', theme.banner?.background);
-        addHexToDocument('--gio-banner-text-color', theme.banner?.textColor);
+    return this.http.get<Theme>(`${this.configService.baseURL}/theme?type=PORTAL_NEXT`).pipe(
+      tap(({ definition }: Theme) => {
+        addPropertyToDocument('--gio-app-background-color', definition.color?.background?.page);
+        addPropertyToDocument('--gio-app-card-background-color', definition.color?.background?.card);
 
         // Convert to HSL in order to create palettes
-        addHslToDocument('--gio-app-primary-main-color', '#613CB0', theme.primary);
-        addHslToDocument('--gio-app-secondary-main-color', '#958BA9', theme.secondary);
-        addHslToDocument('--gio-app-tertiary-main-color', '#B7818F', theme.tertiary);
-        addHslToDocument('--gio-app-error-main-color', '#EC6152', theme.error);
+        addHslToDocument('--gio-app-primary-main-color', definition.color?.primary);
+        addHslToDocument('--gio-app-secondary-main-color', definition.color?.secondary);
+        addHslToDocument('--gio-app-tertiary-main-color', definition.color?.tertiary);
+        addHslToDocument('--gio-app-error-main-color', definition.color?.error);
+
+        addPropertyToDocument('--gio-app-font-family', definition.font.fontFamily);
+        if (definition.customCss) {
+          const style = document.createElement('style');
+          style.innerText = definition.customCss;
+          const body = document.body || document.getElementsByTagName('body')[0];
+          body.append(style);
+        }
       }),
       catchError(_ => of({})),
     );

--- a/gravitee-apim-portal-webui-next/src/stories/theme/theme.util.ts
+++ b/gravitee-apim-portal-webui-next/src/stories/theme/theme.util.ts
@@ -15,7 +15,7 @@
  */
 import { Args } from '@storybook/angular';
 
-import { addHexToDocument, addHslToDocument } from '../../services/theme.service';
+import { addPropertyToDocument, addHslToDocument } from '../../services/theme.service';
 
 const CUSTOMIZATION_ARGS = {
   primary: {
@@ -82,9 +82,9 @@ const computePalette = (config: CustomizationConfig) => {
 };
 
 const computeStyles = (theme: CustomizationConfig): void => {
-  addHexToDocument(CSS_VAR.background, theme.background);
-  addHexToDocument(CSS_VAR.bannerBackground, theme.bannerBackground);
-  addHexToDocument(CSS_VAR.bannerText, theme.bannerText);
+  addPropertyToDocument(CSS_VAR.background, theme.background);
+  addPropertyToDocument(CSS_VAR.bannerBackground, theme.bannerBackground);
+  addPropertyToDocument(CSS_VAR.bannerText, theme.bannerText);
 };
 
 const resetTheme = (): void => {

--- a/gravitee-apim-portal-webui-next/src/styles.scss
+++ b/gravitee-apim-portal-webui-next/src/styles.scss
@@ -27,6 +27,8 @@
 
 html {
   @include mat.all-component-themes(theme.$light-theme);
+
+  --mat-app-background-color: #{theme.$background-color};
 }
 
 body {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -500,7 +500,7 @@ components:
             fontFamily:
               type: string
               description: Font-family used for Portal-Next
-              example: "Roboto"
+              example: "\"Roboto\", sans-serif"
 
         Theme:
           oneOf:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -97,7 +97,7 @@ public enum Key {
         new HashSet<>(singletonList(ENVIRONMENT))
     ),
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
-    PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "Roboto", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5453

## Description

Refactor theme in portal-next to pick-up values from backend.

With new banner colors to be based upon the theme:

<img width="1080" alt="Screenshot 2024-07-24 at 12 29 12" src="https://github.com/user-attachments/assets/966b52d0-e87d-4609-a614-5bfb005e1dcf">

<img width="1075" alt="Screenshot 2024-07-24 at 12 29 27" src="https://github.com/user-attachments/assets/2c16234f-89cb-405b-bd2d-ce2bcc7ca806">


With custom CSS (yes it's ugly to show that the user can do lots of stuff 🙈 ):

- Used `'app-root { background: blue !important; div { background: red !important; } }'` for `customCss`:

<img width="1155" alt="Screenshot 2024-07-24 at 12 04 30" src="https://github.com/user-attachments/assets/2bfd9095-c461-4282-b917-6f86c16136d2">

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gebanweaxd.chromatic.com)
<!-- Storybook placeholder end -->
