### PR TITLE
fix: use node 5.21.0 to fix issue about cache manager

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-5.18.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-5.18.1.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-5.18.1.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-5.18.1.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-5.21.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-5.21.0.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-5.21.0.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-5.21.0.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -454,8 +454,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-5.18.1.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-5.18.1.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-5.21.0.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-5.21.0.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>2.1.0</gravitee-integration-api.version>
-        <gravitee-node.version>5.20.0</gravitee-node.version>
+        <gravitee-node.version>5.21.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>4.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-391

**Description**

Issues have been found on cache plugin where it wasn't properly terminated and it was joining the same hazelcast cluster.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tsnzbsrsql.chromatic.com)
<!-- Storybook placeholder end -->
