### PR TITLE
fix(console): fix for opening logs in new tab

### DIFF
--- a/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.controller.ts
@@ -122,19 +122,23 @@ class PlatformLogsController {
   }
 
   showLogDetails(log) {
-    this.ngRouter.navigate(['.', log.id], {
-      relativeTo: this.activatedRoute,
-      queryParams: {
-        timestamp: log.timestamp,
-        from: this.query.from,
-        to: this.query.to,
-        q: this.query.query,
-        page: this.query.page,
-        size: this.query.size,
-      },
-    });
+    return (
+      '/#!' +
+      this.ngRouter.createUrlTree(['.', log.id], {
+        relativeTo: this.activatedRoute,
+        queryParams: {
+          timestamp: log.timestamp,
+          from: this.query.from,
+          to: this.query.to,
+          q: this.query.query,
+          page: this.query.page,
+          size: this.query.size,
+        },
+      })
+    );
   }
 }
+
 PlatformLogsController.$inject = ['ApiService', 'AnalyticsService', 'Constants', 'ApplicationService', 'ngRouter', '$scope'];
 
 export default PlatformLogsController;

--- a/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.html
+++ b/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.html
@@ -71,7 +71,7 @@
                 ng-class="{'log-error': log.status >= 400}"
               >
                 <td md-cell nowrap>
-                  <a ng-click="$ctrl.showLogDetails(log)"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
+                  <a ng-href="{{$ctrl.showLogDetails(log)}}"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
                 </td>
                 <td md-cell nowrap><span class="gv-statuscode-{{log.status / 100 | number:0}}xx">{{log.status}}</span></td>
                 <td md-cell nowrap>{{$ctrl.logs.metadata[log.api].name}}</td>

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -149,18 +149,21 @@ class ApiAnalyticsLogsControllerAjs {
     });
   }
 
-  gotToLog(log: any) {
-    this.ngRouter.navigate(['.', log.id], {
-      relativeTo: this.activatedRoute,
-      queryParams: {
-        timestamp: log.timestamp,
-        from: this.query.from,
-        to: this.query.to,
-        q: this.query.query,
-        page: this.query.page,
-        size: this.query.size,
-      },
-    });
+  goToLog(log: any) {
+    return (
+      '/#!' +
+      this.ngRouter.createUrlTree(['.', log.id], {
+        relativeTo: this.activatedRoute,
+        queryParams: {
+          timestamp: log.timestamp,
+          from: this.query.from,
+          to: this.query.to,
+          q: this.query.query,
+          page: this.query.page,
+          size: this.query.size,
+        },
+      })
+    );
   }
 }
 ApiAnalyticsLogsControllerAjs.$inject = ['ApiService', '$scope', 'ngRouter', '$timeout', 'AnalyticsService', 'TenantService', '$q'];

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.html
@@ -82,7 +82,7 @@
               ng-class="{'log-error': log.status >= 400}"
             >
               <td md-cell nowrap>
-                <a ng-click="$ctrl.gotToLog(log)"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
+                <a ng-href="{{$ctrl.goToLog(log)}}"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
               </td>
               <td md-cell nowrap><span class="gv-statuscode-{{log.status / 100 | number:0}}xx">{{log.status}}</span></td>
               <td md-cell nowrap>{{$ctrl.getMetadata(log.application).name}}</td>

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
@@ -115,18 +115,21 @@ class ApplicationLogsController {
   }
 
   goToLog(log: any) {
-    this.ngRouter.navigate([log.id], {
-      relativeTo: this.activatedRoute,
-      queryParams: {
-        logId: log.id,
-        timestamp: log.timestamp,
-        from: this.query.from,
-        to: this.query.to,
-        q: this.query.query,
-        page: this.query.page,
-        size: this.query.size,
-      },
-    });
+    return (
+      '/#!' +
+      this.ngRouter.createUrlTree(['.', log.id], {
+        relativeTo: this.activatedRoute,
+        queryParams: {
+          logId: log.id,
+          timestamp: log.timestamp,
+          from: this.query.from,
+          to: this.query.to,
+          q: this.query.query,
+          page: this.query.page,
+          size: this.query.size,
+        },
+      })
+    );
   }
 }
 ApplicationLogsController.$inject = ['ApplicationService', '$scope', 'ngRouter'];

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.html
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.html
@@ -70,7 +70,7 @@
               ng-class="{'log-error': log.status >= 400}"
             >
               <td md-cell nowrap>
-                <a ng-click="$ctrl.goToLog(log)"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
+                <a ng-href="{{$ctrl.goToLog(log)}}"> {{log.timestamp | date:'yyyy-MM-dd HH:mm:ss.sss'}} </a>
               </td>
               <td md-cell nowrap><span class="gv-statuscode-{{log.status / 100 | number:0}}xx">{{log.status}}</span></td>
               <td md-cell nowrap>{{$ctrl.logs.metadata[log.api].name}}</td>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5253

## Description

Changing `ng-click` to `ng-href` to make way for user to open log in new tab.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zkjnapyomc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/8476/console](https://pr.team-apim.gravitee.dev/8476/console)
      Portal: [https://pr.team-apim.gravitee.dev/8476/portal](https://pr.team-apim.gravitee.dev/8476/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/8476/api/management](https://pr.team-apim.gravitee.dev/8476/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/8476](https://pr.team-apim.gravitee.dev/8476)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/8476](https://pr.gateway-v3.team-apim.gravitee.dev/8476)

<!-- Environment placeholder end -->
