### PR TITLE
fix: Message reporters lacking api name value

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractApiReactor.java
@@ -28,7 +28,6 @@ import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.invoker.Invoker;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
-import io.gravitee.gateway.reactive.core.v4.invoker.EndpointInvoker;
 import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactor.handler.Acceptor;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
@@ -129,6 +128,7 @@ public abstract class AbstractApiReactor extends AbstractLifecycleComponent<Reac
 
     protected void prepareCommonAttributes(MutableExecutionContext ctx) {
         ctx.setAttribute(ContextAttributes.ATTR_API, api.getId());
+        ctx.setAttribute(ContextAttributes.ATTR_API_NAME, api.getName());
         ctx.setAttribute(ContextAttributes.ATTR_API_DEPLOYED_AT, api.getDeployedAt().getTime());
         ctx.setAttribute(ContextAttributes.ATTR_ORGANIZATION, api.getOrganizationId());
         ctx.setAttribute(ContextAttributes.ATTR_ENVIRONMENT, api.getEnvironmentId());

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-exchange.version>1.7.5</gravitee-exchange.version>
         <gravitee-expression-language.version>3.2.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.5.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>2.1.0</gravitee-integration-api.version>
         <gravitee-node.version>5.21.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
@@ -284,7 +284,7 @@
         <gravitee-endpoint-azure-service-bus.version>0.1.0</gravitee-endpoint-azure-service-bus.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>3.1.0</gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>3.0.0</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>3.0.1</gravitee-reactor-message.version>
         <gravitee-repository-bridge.version>5.0.2</gravitee-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>1.0.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-policy-interops.version>1.0.0</gravitee-policy-interops.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6046

## Description

Added api name to execution context so that it is shown in message reporters

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
https://github.com/gravitee-io/gravitee-gateway-api/pull/230
https://github.com/gravitee-io/gravitee-reactor-message/pull/49
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ualrrjtdge.chromatic.com)
<!-- Storybook placeholder end -->
