### PR TITLE
fix: fix for displayed prompt with subscription validation status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
@@ -228,8 +228,12 @@ export class ApiSubscriptionEditComponent implements OnInit {
         takeUntil(this.unsubscribe$),
       )
       .subscribe(
-        (_) => {
-          this.snackBarService.success(`Subscription validated`);
+        (subscription) => {
+          if (subscription.status === 'ACCEPTED') {
+            this.snackBarService.success('Subscription validated');
+          } else {
+            this.snackBarService.error(`Subscription ${subscription.status.toLowerCase()}`);
+          }
           this.ngOnInit();
         },
         (err) => this.snackBarService.error(err.message),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4925

## Description

PR changes the content of the validation result prompt. 
Before the fix, each validation ended with the "Subscription validated" success snackbar. 
That might have been misleading if the subscription was for example rejected. 
Right now "Subscription validated" success snackbar is displayed only when the subscription is accepted.  
For every other scenario, we display an error snackbar with`Subscription + status` message.

<img width="2058" alt="Zrzut ekranu 2024-07-29 o 14 30 45" src="https://github.com/user-attachments/assets/fc3f25a5-22af-4c19-a60a-ea334c5e5b64">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-byjzfkjliy.chromatic.com)
<!-- Storybook placeholder end -->
