### PR TITLE
fix(liquibase): drop not null constraint for environment_id keys table

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/05_add_environment_id.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/05_add_environment_id.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.4.0_add_missing_environment_id
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: ${gravitee_prefix}subscriptions
@@ -34,7 +35,3 @@ databaseChangeLog:
         - sql:
             dbms: 'postgresql,mssql'
             sql: UPDATE ${gravitee_prefix}keys SET environment_id = s.environment_id FROM ${gravitee_prefix}keys k, ${gravitee_prefix}key_subscriptions ks, ${gravitee_prefix}subscriptions s WHERE k.id = ks.key_id AND ks.subscription_id = s.id;
-        - addNotNullConstraint:
-            tableName: ${gravitee_prefix}keys
-            columnName: environment_id
-            columnDataType: VARCHAR(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_4/00_drop_not_null_constraint.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_4/00_drop_not_null_constraint.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.4.4_dropNotNullConstraint-keys-environment_id
+      author: GraviteeSource Team
+      changes:
+        - dropNotNullConstraint:
+            columnDataType: VARCHAR(64)
+            columnName: environment_id
+            tableName: ${gravitee_prefix}keys

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -189,3 +189,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_4_2/00_add_event_organizations.yml
   - include:
       - file: liquibase/changelogs/v4_4_2/01_federated_api_keys.yml
+  - include:
+      - file: liquibase/changelogs/v4_4_4/00_drop_not_null_constraint.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6055

## Description

Drop not null constraint from keys.environment_id. For security reasons we are not removing API keys from db on the API delete. Unused keys have null values on environment_id, because subscriptions are deleted already and we cannot set not null constraint

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

