### PR TITLE
feat(portal-next): show banner based upon backend settings

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -15,12 +15,19 @@
     limitations under the License.
 
 -->
-<app-banner>
-  <div class="welcome-banner-content">
-    <div class="m3-headline-large">{{ bannerTitle }}</div>
-    <div class="m3-title-small">{{ bannerSubtitle }}</div>
-  </div>
-</app-banner>
+@if (showBanner) {
+  <app-banner>
+    <div class="welcome-banner-content">
+      @if (bannerTitle) {
+        <div class="m3-headline-large">{{ bannerTitle }}</div>
+      }
+      @if (bannerSubtitle) {
+        <div class="m3-title-small">{{ bannerSubtitle }}</div>
+      }
+    </div>
+  </app-banner>
+}
+
 @if (filterList$ | async; as filterList) {
   <div class="catalog__filters">
     <app-api-filter

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -72,6 +72,7 @@ export class CatalogComponent {
   filterList$: Observable<Category[]> = of([]);
   loadingPage$ = new BehaviorSubject(true);
 
+  showBanner: boolean;
   bannerTitle: string;
   bannerSubtitle: string;
   selectedCategory: Category | undefined;
@@ -85,9 +86,9 @@ export class CatalogComponent {
     private router: Router,
     private configService: ConfigService,
   ) {
-    this.bannerTitle = this.configService.configuration?.portalNext?.bannerTitle ?? 'Welcome to Gravitee Developer Portal!';
-    this.bannerSubtitle =
-      this.configService.configuration?.portalNext?.bannerSubtitle ?? 'Discover powerful APIs to supercharge your projects.';
+    this.showBanner = this.configService.configuration?.portalNext?.banner?.enabled ?? false;
+    this.bannerTitle = this.configService.configuration?.portalNext?.banner?.title ?? '';
+    this.bannerSubtitle = this.configService.configuration?.portalNext?.banner?.subtitle ?? '';
     this.apiPaginator$ = this.loadApis$();
     this.filterList$ = this.loadCategories$();
   }

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -15,9 +15,12 @@
  */
 export class ConfigurationPortalNext {
   siteTitle?: string;
-  bannerTitle?: string;
-  bannerSubtitle?: string;
   access?: {
     enabled?: boolean;
+  };
+  banner?: {
+    enabled?: boolean;
+    title?: string;
+    subtitle?: string;
   };
 }

--- a/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/config.service.spec.ts
@@ -98,8 +98,11 @@ describe('ConfigService', () => {
       it('should load portal next configuration', done => {
         const portalNext: ConfigurationPortalNext = {
           siteTitle: 'a site title',
-          bannerTitle: 'a title',
-          bannerSubtitle: 'a subtitle',
+          banner: {
+            enabled: true,
+            title: 'a title',
+            subtitle: 'a subtitle',
+          },
         };
         service.loadConfiguration().subscribe(() => {
           expect(service.configuration.portalNext).toEqual(portalNext);

--- a/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
+++ b/gravitee-apim-portal-webui-next/src/testing/app-testing.module.ts
@@ -20,7 +20,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router } from '@angular/router';
 import { of } from 'rxjs/internal/observable/of';
 
-import { ConfigurationPortalNext } from '../entities/configuration/configuration-portal-next';
+import { Configuration } from '../entities/configuration/configuration';
 import { ConfigService } from '../services/config.service';
 
 export const TESTING_BASE_URL = 'http://localhost:8083/portal/environments/DEFAULT';
@@ -35,8 +35,16 @@ export class ConfigServiceStub {
     return TESTING_BASE_URL;
   }
 
-  get portalNext(): ConfigurationPortalNext {
-    return {};
+  get configuration(): Configuration {
+    return {
+      portalNext: {
+        banner: {
+          enabled: true,
+          title: 'Welcome to Gravitee Developer Portal!',
+          subtitle: 'Great subtitle',
+        },
+      },
+    };
   }
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5454

## Description

Show banner in Catalog page depending upon if it is enabled in the backend and with configured title + subtitle

Not shown:


![Screenshot 2024-07-31 at 17 45 23](https://github.com/user-attachments/assets/9906cdf5-27ee-417b-9997-347b22a1a37e)


Shown: 


![Screenshot 2024-07-31 at 17 48 04](https://github.com/user-attachments/assets/855e0b9c-faed-4f51-86a4-e1b13b68aa2d)


Backend implemented here: https://github.com/gravitee-io/gravitee-api-management/pull/8449

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

