### PR TITLE
feat: introduce SharedPolicyGroupReactorFactoryManager to help select the proper factory based on criteria

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactory.java
@@ -22,5 +22,7 @@ import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup
  * @author GraviteeSource Team
  */
 public interface SharedPolicyGroupReactorFactory {
+    boolean canCreate(ReactableSharedPolicyGroup reactableSharedPolicyGroup);
+
     SharedPolicyGroupReactor create(ReactableSharedPolicyGroup reactableSharedPolicyGroup);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactoryManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactoryManager.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.sharedpolicygroup.reactor;
+
+import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.Reactable;
+import io.gravitee.gateway.reactor.handler.ReactorHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class SharedPolicyGroupReactorFactoryManager {
+
+    private final List<SharedPolicyGroupReactorFactory> sharedPolicyGroupReactorFactories;
+
+    // Inject embedded factories via spring configuration
+    public SharedPolicyGroupReactorFactoryManager(final List<SharedPolicyGroupReactorFactory> sharedPolicyGroupReactorFactories) {
+        this.sharedPolicyGroupReactorFactories = new ArrayList<>(sharedPolicyGroupReactorFactories);
+    }
+
+    /**
+     * Registers a {@link SharedPolicyGroupReactorFactory}. Useful for Reactor plugins.
+     * @param sharedPolicyGroupReactorFactory to register
+     */
+    public void register(SharedPolicyGroupReactorFactory sharedPolicyGroupReactorFactory) {
+        sharedPolicyGroupReactorFactories.add(sharedPolicyGroupReactorFactory);
+    }
+
+    public SharedPolicyGroupReactor create(final ReactableSharedPolicyGroup reactable) {
+        return sharedPolicyGroupReactorFactories
+            .stream()
+            .filter(reactorFactory -> reactorFactory.canCreate(reactable))
+            .map(reactorFactory -> reactorFactory.create(reactable))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No reactor found for reactable: " + reactable.getId()));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.handlers.sharedpolicygroup.reactor.impl;
 
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
@@ -46,6 +47,14 @@ public class DefaultSharedPolicyGroupReactorFactory implements SharedPolicyGroup
     private final PolicyClassLoaderFactory policyClassLoaderFactory;
     private final ComponentProvider componentProvider;
     private final io.gravitee.node.api.configuration.Configuration configuration;
+
+    @Override
+    public boolean canCreate(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
+        return (
+            SharedPolicyGroup.Phase.REQUEST.equals(reactableSharedPolicyGroup.getDefinition().getPhase()) ||
+            SharedPolicyGroup.Phase.RESPONSE.equals(reactableSharedPolicyGroup.getDefinition().getPhase())
+        );
+    }
 
     @Override
     public SharedPolicyGroupReactor create(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/registry/SharedPolicyGroupRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/registry/SharedPolicyGroupRegistry.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactor;
 import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactory;
+import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactoryManager;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class SharedPolicyGroupRegistry {
 
-    private final SharedPolicyGroupReactorFactory sharedPolicyGroupReactorFactory;
+    private final SharedPolicyGroupReactorFactoryManager sharedPolicyGroupReactorFactoryManager;
 
     @VisibleForTesting
     protected final Map<SharedPolicyGroupRegistryKey, SharedPolicyGroupReactor> registry = new HashMap<>();
@@ -39,7 +40,7 @@ public class SharedPolicyGroupRegistry {
 
     public void create(ReactableSharedPolicyGroup reactable) {
         try {
-            final SharedPolicyGroupReactor sharedPolicyGroupReactor = sharedPolicyGroupReactorFactory.create(reactable);
+            final SharedPolicyGroupReactor sharedPolicyGroupReactor = sharedPolicyGroupReactorFactoryManager.create(reactable);
             sharedPolicyGroupReactor.start();
             final SharedPolicyGroupReactor previousReactor = registry.put(
                 new SharedPolicyGroupRegistryKey(reactable.getId(), reactable.getEnvironmentId()),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/spring/SharedPolicyGroupConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/spring/SharedPolicyGroupConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.handlers.sharedpolicygroup.manager.impl.SharedPolicyG
 import io.gravitee.gateway.handlers.sharedpolicygroup.policy.SharedPolicyGroupPolicyFactory;
 import io.gravitee.gateway.handlers.sharedpolicygroup.policy.plugin.SharedPolicyGroupPolicyPlugin;
 import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactory;
+import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactoryManager;
 import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.impl.DefaultSharedPolicyGroupReactorFactory;
 import io.gravitee.gateway.handlers.sharedpolicygroup.registry.SharedPolicyGroupRegistry;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
@@ -35,6 +36,7 @@ import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.policy.PolicyClassLoaderFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -92,8 +94,10 @@ public class SharedPolicyGroupConfiguration {
     }
 
     @Bean
-    public SharedPolicyGroupRegistry sharedPolicyGroupRegistry(SharedPolicyGroupReactorFactory sharedPolicyGroupReactorFactory) {
-        return new SharedPolicyGroupRegistry(sharedPolicyGroupReactorFactory);
+    public SharedPolicyGroupRegistry sharedPolicyGroupRegistry(
+        SharedPolicyGroupReactorFactoryManager sharedPolicyGroupReactorFactoryManager
+    ) {
+        return new SharedPolicyGroupRegistry(sharedPolicyGroupReactorFactoryManager);
     }
 
     @Bean
@@ -104,5 +108,12 @@ public class SharedPolicyGroupConfiguration {
     @Bean
     public PolicyFactory sharedPolicyGroupPolicyFactory(final PolicyPluginFactory policyPluginFactory) {
         return new SharedPolicyGroupPolicyFactory(policyPluginFactory, new ExpressionLanguageConditionFilter<>());
+    }
+
+    @Bean
+    public SharedPolicyGroupReactorFactoryManager sharedPolicyGroupReactorFactoryManager(
+        List<SharedPolicyGroupReactorFactory> reactorFactories
+    ) {
+        return new SharedPolicyGroupReactorFactoryManager(reactorFactories);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactoryManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/SharedPolicyGroupReactorFactoryManagerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.sharedpolicygroup.reactor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
+import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
+import io.gravitee.gateway.reactive.policy.PolicyChain;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SharedPolicyGroupReactorFactoryManagerTest {
+
+    SharedPolicyGroupReactorFactoryManager cut;
+
+    @Test
+    void should_create_reactable_using_the_corresponding_factory() {
+        cut =
+            new SharedPolicyGroupReactorFactoryManager(
+                List.of(new FakeSharedPolicyGroupReactorFactory("fake-1"), new FakeSharedPolicyGroupReactorFactory("fake-2"))
+            );
+        final SharedPolicyGroupReactor expectedFake1 = cut.create(
+            new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-1").build())
+        );
+        assertThat(expectedFake1.id()).isEqualTo("fake-1");
+        final SharedPolicyGroupReactor expectedFake2 = cut.create(
+            new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-2").build())
+        );
+        assertThat(expectedFake2.id()).isEqualTo("fake-2");
+    }
+
+    @Test
+    void should_create_reactable_using_the_corresponding_factory_with_one_factory_registered_manually() {
+        cut = new SharedPolicyGroupReactorFactoryManager(List.of(new FakeSharedPolicyGroupReactorFactory("fake-1")));
+        final SharedPolicyGroupReactor expectedFake1 = cut.create(
+            new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-1").build())
+        );
+        assertThat(expectedFake1.id()).isEqualTo("fake-1");
+        cut.register(new FakeSharedPolicyGroupReactorFactory("fake-2"));
+        final SharedPolicyGroupReactor expectedFake2 = cut.create(
+            new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-2").build())
+        );
+        assertThat(expectedFake2.id()).isEqualTo("fake-2");
+    }
+
+    @Test
+    void should_throw_if_no_corresponding_factory() {
+        cut = new SharedPolicyGroupReactorFactoryManager(List.of());
+        assertThatThrownBy(() -> cut.create(new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-1").build())))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("No reactor found for reactable: fake-1");
+        cut.register(new FakeSharedPolicyGroupReactorFactory("fake-2"));
+        final SharedPolicyGroupReactor expectedFake2 = cut.create(
+            new ReactableSharedPolicyGroup(SharedPolicyGroup.builder().id("fake-2").build())
+        );
+        assertThat(expectedFake2.id()).isEqualTo("fake-2");
+    }
+
+    @AllArgsConstructor
+    static class FakeSharedPolicyGroupReactorFactory implements SharedPolicyGroupReactorFactory {
+
+        private final String supportId;
+
+        @Override
+        public boolean canCreate(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
+            return supportId.equals(reactableSharedPolicyGroup.getId());
+        }
+
+        @Override
+        public SharedPolicyGroupReactor create(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
+            return new SharedPolicyGroupReactor() {
+                @Override
+                public String id() {
+                    return supportId;
+                }
+
+                @Override
+                public ReactableSharedPolicyGroup reactableSharedPolicyGroup() {
+                    return null;
+                }
+
+                @Override
+                public PolicyChain policyChain() {
+                    return null;
+                }
+
+                @Override
+                public Lifecycle.State lifecycleState() {
+                    return null;
+                }
+
+                @Override
+                public SharedPolicyGroupReactor start() throws Exception {
+                    return null;
+                }
+
+                @Override
+                public SharedPolicyGroupReactor stop() throws Exception {
+                    return null;
+                }
+            };
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/registry/SharedPolicyGroupRegistryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/registry/SharedPolicyGroupRegistryTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactor;
-import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactory;
+import io.gravitee.gateway.handlers.sharedpolicygroup.reactor.SharedPolicyGroupReactorFactoryManager;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -45,7 +45,7 @@ class SharedPolicyGroupRegistryTest {
     public static final String ENV_ID = "envId";
 
     @Mock
-    private SharedPolicyGroupReactorFactory sharedPolicyGroupReactorFactory;
+    private SharedPolicyGroupReactorFactoryManager sharedPolicyGroupReactorFactoryManager;
 
     @Mock
     private SharedPolicyGroupReactor sharedPolicyGroupReactor;
@@ -54,13 +54,13 @@ class SharedPolicyGroupRegistryTest {
 
     @BeforeEach
     void setUp() {
-        cut = new SharedPolicyGroupRegistry(sharedPolicyGroupReactorFactory);
+        cut = new SharedPolicyGroupRegistry(sharedPolicyGroupReactorFactoryManager);
     }
 
     @SneakyThrows
     @Test
     void should_create_shared_policy_group_reactor() {
-        when(sharedPolicyGroupReactorFactory.create(any())).thenReturn(sharedPolicyGroupReactor);
+        when(sharedPolicyGroupReactorFactoryManager.create(any())).thenReturn(sharedPolicyGroupReactor);
         cut.create(ReactableSharedPolicyGroup.builder().id(ID).environmentId(ENV_ID).build());
         verify(sharedPolicyGroupReactor).start();
         assertThat(cut.get(ID, ENV_ID)).isSameAs(sharedPolicyGroupReactor);
@@ -69,7 +69,7 @@ class SharedPolicyGroupRegistryTest {
     @SneakyThrows
     @Test
     void should_create_shared_policy_group_reactor_and_stop_previous_one() {
-        when(sharedPolicyGroupReactorFactory.create(any())).thenReturn(sharedPolicyGroupReactor);
+        when(sharedPolicyGroupReactorFactoryManager.create(any())).thenReturn(sharedPolicyGroupReactor);
         final SharedPolicyGroupReactor previousReactor = mock(SharedPolicyGroupReactor.class);
         cut.registry.put(new SharedPolicyGroupRegistry.SharedPolicyGroupRegistryKey(ID, ENV_ID), previousReactor);
         cut.create(ReactableSharedPolicyGroup.builder().id(ID).environmentId(ENV_ID).build());


### PR DESCRIPTION



## Issue

https://gravitee.atlassian.net/browse/APIM-5625

## Description

As for APIs with the `ReactorFactoryManager`, we introduce the same kind of concept to allow the gateway to select the more convenient shared policy group reactor factory based on criteria. In a following PR, `message-reactor` will take benefit from it by being able to instantiate properly `SharedPolicyGroup` configured on `MESSAGE_REQUEST` or `MESSAGE_RESPONSE` phase

