### PR TITLE
fix(console): Date range picker sets end range at start of day

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.spec.ts
@@ -106,7 +106,7 @@ describe('ApiAuditListComponent', () => {
     expectGetApiAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectGetApiAuditListRequest({ from: 1649635200000, to: 1650412800000 });
+    expectGetApiAuditListRequest({ from: 1649635200000, to: 1650499199999 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-list/api-audit-list.component.ts
@@ -25,6 +25,7 @@ import { Moment } from 'moment';
 import { ApiAuditService } from '../../../services-ngx/api-audit.service';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { endOfDay } from '../../../util/date.util';
 
 interface ApiAuditData {
   id: string;
@@ -96,7 +97,7 @@ export class ApiAuditListComponent implements OnInit, OnDestroy {
             ...this.filtersStream.value.auditFilters,
             event,
             from: range?.start?.valueOf() ?? undefined,
-            to: range?.end?.valueOf() ?? undefined,
+            to: endOfDay(range?.end) ?? undefined,
           },
         });
       });

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/api-audit-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/api-audit-logs.component.spec.ts
@@ -96,7 +96,7 @@ describe('AuditLogsComponent', () => {
       await form.setDateRange({ start: '4/11/2022', end: '4/20/2022' });
 
       expectAuditListRequest({ from: 1649635200000 });
-      expectAuditListRequest({ from: 1649635200000, to: 1650412800000 });
+      expectAuditListRequest({ from: 1649635200000, to: 1650499199999 });
     });
 
     it('should reset filters and pagination', async () => {
@@ -126,7 +126,7 @@ describe('AuditLogsComponent', () => {
         fakeAuditResponse({ pagination: { page: 1, perPage: 10, pageCount: 3, pageItemsCount: 10, totalCount: 29 } }),
       );
       expectAuditListRequest(
-        { events: 'API_CREATED', from: 1649635200000, to: 1650412800000 },
+        { events: 'API_CREATED', from: 1649635200000, to: 1650499199999 },
         { page: 1, perPage: 10 },
         fakeAuditResponse({ pagination: { page: 1, perPage: 10, pageCount: 3, pageItemsCount: 10, totalCount: 29 } }),
       );
@@ -134,7 +134,7 @@ describe('AuditLogsComponent', () => {
       // navigate to 2nd page
       await paginator.goToNextPage();
       expectAuditListRequest(
-        { events: 'API_CREATED', from: 1649635200000, to: 1650412800000 },
+        { events: 'API_CREATED', from: 1649635200000, to: 1650499199999 },
         { page: 2, perPage: 10 },
         fakeAuditResponse({ pagination: { page: 2, perPage: 10, pageCount: 3, pageItemsCount: 10, totalCount: 29 } }),
       );

--- a/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-audit-logs/components/api-audits-filter-form/api-audits-filter-form.component.ts
@@ -20,6 +20,8 @@ import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 import { Moment } from 'moment';
 
+import { endOfDay } from '../../../../../util/date.util';
+
 export interface ApiAuditFilter {
   events?: string[];
   from?: number;
@@ -58,7 +60,7 @@ export class ApiAuditsFilterFormComponent implements OnInit, OnDestroy {
         this.filtersChange.emit({
           events,
           from: range?.start?.valueOf() ?? null,
-          to: range?.end?.valueOf() ?? null,
+          to: endOfDay(range?.end) ?? null,
         });
       });
   }

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
@@ -125,7 +125,7 @@ describe('EnvAuditComponent', () => {
     expectAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectAuditListRequest({ from: 1649635200000, to: 1650412800000 });
+    expectAuditListRequest({ from: 1649635200000, to: 1650499199999 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
@@ -25,6 +25,7 @@ import { ApplicationService } from '../../services-ngx/application.service';
 import { AuditService } from '../../services-ngx/audit.service';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { GioTableWrapperFilters } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { endOfDay } from '../../util/date.util';
 
 interface AuditDataTable {
   id: string;
@@ -118,7 +119,7 @@ export class EnvAuditComponent implements OnInit, OnDestroy {
             applicationId,
             apiId,
             from: range?.start?.valueOf() ?? undefined,
-            to: range?.end?.valueOf() ?? undefined,
+            to: endOfDay(range?.end) ?? undefined,
           },
         });
       });

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
@@ -143,7 +143,7 @@ describe('OrgSettingsAuditComponent', () => {
     expectAuditListRequest({ from: 1649635200000 });
 
     await (await rangeSelect.getEndInput()).setValue('4/20/2022');
-    expectAuditListRequest({ from: 1649635200000, to: 1650412800000 });
+    expectAuditListRequest({ from: 1649635200000, to: 1650499199999 });
   });
 
   it('should reset pagination on filter change', async () => {

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
@@ -26,6 +26,7 @@ import { AuditService } from '../../../services-ngx/audit.service';
 import { EnvironmentService } from '../../../services-ngx/environment.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { endOfDay } from '../../../util/date.util';
 
 interface AuditDataTable {
   id: string;
@@ -155,7 +156,7 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
             applicationId,
             apiId,
             from: range?.start?.valueOf() ?? undefined,
-            to: range?.end?.valueOf() ?? undefined,
+            to: endOfDay(range?.end) ?? undefined,
           },
         });
       });

--- a/gravitee-apim-console-webui/src/util/date.util.ts
+++ b/gravitee-apim-console-webui/src/util/date.util.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Moment } from 'moment';
+
+export function endOfDay(moment: Moment | undefined | null): undefined | number {
+  if (!moment) {
+    return undefined;
+  }
+
+  const endOfDay: Moment = moment.clone();
+  endOfDay.add(1, 'day');
+  endOfDay.subtract(1, 'millisecond');
+
+  return endOfDay.valueOf();
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6097
## Description

Change last date of range to last millisecond of day

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/8570/console](https://pr.team-apim.gravitee.dev/8570/console)
      Portal: [https://pr.team-apim.gravitee.dev/8570/portal](https://pr.team-apim.gravitee.dev/8570/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/8570/api/management](https://pr.team-apim.gravitee.dev/8570/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/8570](https://pr.team-apim.gravitee.dev/8570)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/8570](https://pr.gateway-v3.team-apim.gravitee.dev/8570)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rhanlkjmgy.chromatic.com)
<!-- Storybook placeholder end -->
