### PR TITLE
Apim 5445 fix subscription button after T&C cancel

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -198,6 +198,7 @@ export class SubscribeToApiComponent implements OnInit {
       .pipe(
         switchMap(result => {
           if (!result.general_conditions_accepted && this.currentPlan()?.general_conditions) {
+            this.subscriptionInProgress.set(false);
             return EMPTY;
           }
           return this.subscriptionService.subscribe(result);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5445
https://gravitee.atlassian.net/browse/APIM-6224

## Description

Before, the subscription button stayed as disabled and `Subscribing....` if a user did not accept the Terms and Conditions dialog.

Fixed:

https://github.com/user-attachments/assets/98749706-5c09-41f0-995f-3e5c33dc7df7



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

