### PR TITLE
fix(portal-next): only show api key mode selection if shared api key enabled

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -42,6 +42,7 @@ import { CreateSubscription, Subscription } from '../../../entities/subscription
 import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
 import { ApiService } from '../../../services/api.service';
 import { ApplicationService } from '../../../services/application.service';
+import { ConfigService } from '../../../services/config.service';
 import { PageService } from '../../../services/page.service';
 import { PlanService } from '../../../services/plan.service';
 import { SubscriptionService } from '../../../services/subscription.service';
@@ -116,6 +117,7 @@ export class SubscribeToApiComponent implements OnInit {
 
   private currentApplicationsPage: BehaviorSubject<number> = new BehaviorSubject(1);
   private destroyRef = inject(DestroyRef);
+  private configuration = inject(ConfigService).configuration;
 
   constructor(
     private planService: PlanService,
@@ -144,7 +146,11 @@ export class SubscribeToApiComponent implements OnInit {
     this.checkoutData$ = this.api$.pipe(
       switchMap(api => this.handleCheckoutData$(api)),
       tap(({ api, applicationApiKeySubscriptions }) => {
-        this.showApiKeyModeSelection.set(api.definitionVersion !== 'FEDERATED' && applicationApiKeySubscriptions.length === 1);
+        this.showApiKeyModeSelection.set(
+          this.configuration.plan?.security?.sharedApiKey?.enabled === true &&
+            api.definitionVersion !== 'FEDERATED' &&
+            applicationApiKeySubscriptions.length === 1,
+        );
       }),
     );
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5445

## Description

Add business rule for when shared api key is enabled/disabled for the portal

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

