### PR TITLE
feat: simple implementation for scoring feature

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -32,6 +32,7 @@ export interface ConsoleSettings {
   licenseExpirationNotification?: ConsoleSettingsLicenseExpirationNotification;
   trialInstance?: ConsoleSettingsTrialInstance;
   federation?: ConsoleSettingsFederation;
+  scoring?: ConsoleSettingsScoring;
 }
 
 export interface ConsoleSettingsEmail {
@@ -180,5 +181,9 @@ export interface ConsoleSettingsTrialInstance {
 }
 
 export interface ConsoleSettingsFederation {
+  enabled?: boolean;
+}
+
+export interface ConsoleSettingsScoring {
   enabled?: boolean;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>io.gravitee.exchange</groupId>
             <artifactId>gravitee-exchange-api</artifactId>
-            <version>${gravitee-exchange.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.exchange</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -392,6 +392,8 @@ public enum Key {
     ALERT_ENGINE_ENABLED("alerts.alert-engine.enabled", "false", Set.of(SYSTEM)),
     FEDERATION_ENABLED("integration.enabled", "false", Set.of(SYSTEM)),
 
+    SCORING_ENABLED("scoring.enabled", "false", Set.of(SYSTEM)),
+
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
     TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
@@ -37,6 +37,7 @@ public class ConsoleConfigEntity {
     private LicenseExpirationNotification licenseExpirationNotification;
     private TrialInstance trialInstance;
     private Federation federation;
+    private Scoring scoring;
 
     public ConsoleConfigEntity() {
         super();
@@ -54,5 +55,6 @@ public class ConsoleConfigEntity {
         licenseExpirationNotification = new LicenseExpirationNotification();
         trialInstance = new TrialInstance();
         federation = new Federation();
+        scoring = new Scoring();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
@@ -47,6 +47,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
     private LicenseExpirationNotification licenseExpirationNotification;
     private TrialInstance trialInstance;
     private Federation federation;
+    private Scoring scoring;
 
     public ConsoleSettingsEntity() {
         super();
@@ -65,6 +66,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
         licenseExpirationNotification = new LicenseExpirationNotification();
         trialInstance = new TrialInstance();
         federation = new Federation();
+        scoring = new Scoring();
     }
 
     //Classes

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Scoring.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Scoring.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.model.annotations.ParameterKey;
+import io.gravitee.rest.api.model.parameters.Key;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Scoring {
+
+    @ParameterKey(Key.SCORING_ENABLED)
+    private Boolean enabled;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -76,6 +76,10 @@
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.exchange</groupId>
+            <artifactId>gravitee-exchange-api</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>io.gravitee.cockpit</groupId>
 			<artifactId>gravitee-cockpit-api</artifactId>
@@ -84,6 +88,10 @@
 			<groupId>io.gravitee.integration</groupId>
 			<artifactId>gravitee-integration-api</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>io.gravitee.scoring</groupId>
+            <artifactId>gravitee-scoring-api</artifactId>
+        </dependency>
 
 		<!-- Gravitee Dependencies -->
 		<dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/score/service_provider/ScoringProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/score/service_provider/ScoringProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.score.service_provider;
+
+import io.reactivex.rxjava3.core.Completable;
+
+public interface ScoringProvider {
+    Completable requestScore(String apiId, String organizationId, String environmentId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/score/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/score/use_case/ScoreApiRequestUseCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.apim.core.score.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.score.service_provider.ScoringProvider;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+
+@UseCase
+public class ScoreApiRequestUseCase {
+
+    private final ApiCrudService apiCrudService;
+    private final ScoringProvider scoreDomainService;
+
+    public ScoreApiRequestUseCase(ApiCrudService apiCrudService, ScoringProvider scoringProvider) {
+        this.apiCrudService = apiCrudService;
+        this.scoreDomainService = scoringProvider;
+    }
+
+    public Completable execute(Input input) {
+        return Maybe
+            .fromOptional(apiCrudService.findById(input.apiId()))
+            .switchIfEmpty(Single.error(new ApiNotFoundException(input.apiId())))
+            .flatMapCompletable(api -> this.scoreDomainService.requestScore(input.apiId(), input.envId(), input.orgId()));
+    }
+
+    public record Input(String apiId, String envId, String orgId) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/score/ScoringProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/score/ScoringProviderImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.score;
+
+import io.gravitee.apim.core.documentation.domain_service.ApiDocumentationDomainService;
+import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.score.service_provider.ScoringProvider;
+import io.gravitee.cockpit.api.CockpitConnector;
+import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestCommand;
+import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestCommandPayload;
+import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.scoring.api.model.ScoringRequest;
+import io.gravitee.scoring.api.model.asset.AssetType;
+import io.gravitee.scoring.api.model.asset.ContentType;
+import io.gravitee.scoring.api.model.asset.ScoreAsset;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ScoringProviderImpl implements ScoringProvider {
+
+    private final CockpitConnector cockpitConnector;
+    private final InstallationService installationService;
+    private final ApiDocumentationDomainService apiDocumentationDomainService;
+
+    public ScoringProviderImpl(
+        @Lazy CockpitConnector cockpitConnector,
+        InstallationService installationService,
+        ApiDocumentationDomainService apiDocumentationDomainService
+    ) {
+        this.cockpitConnector = cockpitConnector;
+        this.installationService = installationService;
+        this.apiDocumentationDomainService = apiDocumentationDomainService;
+    }
+
+    @Override
+    public Completable requestScore(String apiId, String organizationId, String environmentId) {
+        //Get OAS or Async API
+        List<Page> pages = apiDocumentationDomainService.getApiPages(apiId, null);
+        List<ScoreAsset> assets = pages
+            .stream()
+            .filter(page -> page.isAsyncApi() || page.isSwagger())
+            .map(page -> {
+                var assetType =
+                    switch (page.getType()) {
+                        case SWAGGER -> AssetType.OPEN_API;
+                        case ASYNCAPI -> AssetType.ASYNC_API;
+                        default -> throw new IllegalStateException("Unexpected value: " + page.getType());
+                    };
+                return new ScoreAsset(assetType, page.getName(), page.getContent(), extractContentType(page.getName()));
+            })
+            .toList();
+
+        ScoringRequestCommand command = new ScoringRequestCommand(
+            new ScoringRequestCommandPayload(
+                apiId,
+                environmentId,
+                organizationId,
+                installationService.get().getAdditionalInformation().get(InstallationService.COCKPIT_INSTALLATION_ID),
+                new ScoringRequest(assets)
+            )
+        );
+
+        return cockpitConnector
+            .sendCommand(command)
+            .onErrorReturn(error ->
+                new ScoringRequestReply(command.getId(), error.getMessage() != null ? error.getMessage() : error.toString())
+            )
+            .cast(ScoringRequestReply.class)
+            .flatMapCompletable(reply -> {
+                if (reply.getCommandStatus() == CommandStatus.ERROR) {
+                    return Completable.error(new TechnicalDomainException(reply.getErrorDetails()));
+                }
+                return Completable.complete();
+            });
+    }
+
+    private ContentType extractContentType(String pageName) {
+        if (pageName.endsWith(".json")) {
+            return ContentType.JSON;
+        } else if (pageName.endsWith(".yaml") || pageName.endsWith(".yml")) {
+            return ContentType.YAML;
+        }
+        throw new IllegalArgumentException("Unsupported content type for page: " + pageName);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/ScoringResponseCommandHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommand;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseReply;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.reactivex.rxjava3.core.Single;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class ScoringResponseCommandHandler implements CommandHandler<ScoringResponseCommand, ScoringResponseReply> {
+
+    @Override
+    public String supportType() {
+        return CockpitCommandType.SCORING_RESPONSE.name();
+    }
+
+    @Override
+    public Single<ScoringResponseReply> handle(ScoringResponseCommand command) {
+        var payload = command.getPayload();
+
+        log.info("received response [{}]", payload.result());
+
+        return Single.just(new ScoringResponseReply(command.getId(), CommandStatus.SUCCEEDED));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -486,6 +486,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getLicenseExpirationNotification(),
             consoleConfigEntity.getTrialInstance(),
             consoleConfigEntity.getFederation(),
+            consoleConfigEntity.getScoring(),
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringProviderInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringProviderInMemory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.score.service_provider.ScoringProvider;
+import io.reactivex.rxjava3.core.Completable;
+
+public class ScoringProviderInMemory implements ScoringProvider {
+
+    @Override
+    public Completable requestScore(String apiId, String organizationId, String environmentId) {
+        return Completable.complete();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -69,6 +69,7 @@ import inmemory.PrimaryOwnerDomainServiceInMemory;
 import inmemory.ResourcePluginCrudServiceInMemory;
 import inmemory.ResourcePluginQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
+import inmemory.ScoringProviderInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.TagQueryServiceInMemory;
@@ -425,5 +426,10 @@ public class InMemoryConfiguration {
     @Bean
     public ThemePortalNextAssetsDomainServiceInMemory themePortalNextAssetsDomainServiceInMemory() {
         return new ThemePortalNextAssetsDomainServiceInMemory();
+    }
+
+    @Bean
+    public ScoringProviderInMemory scoringProviderInMemory() {
+        return new ScoringProviderInMemory();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -712,3 +712,7 @@ api:
   properties:
     encryption:
       secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+
+# Scoring
+scoring:
+  enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.0.50</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>3.1.0</gravitee-cockpit-api.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
@@ -67,6 +67,7 @@
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.5.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
+        <gravitee-scoring-api.version>0.1.0</gravitee-scoring-api.version>
         <gravitee-node.version>6.3.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>4.1.0</gravitee-plugin.version>
@@ -323,6 +324,18 @@
                 <groupId>io.gravitee.integration</groupId>
                 <artifactId>gravitee-integration-api</artifactId>
                 <version>${gravitee-integration-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.scoring</groupId>
+                <artifactId>gravitee-scoring-api</artifactId>
+                <version>${gravitee-scoring-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.exchange</groupId>
+                <artifactId>gravitee-exchange-api</artifactId>
+                <version>${gravitee-exchange.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5164


## Description

[ADR](https://gravitee.slab.com/posts/api-scoring-ri6xqojg)

This PR allows us to confirm the wiring between APIM <> GraviteeCloud <> Spectral Scoring Service.

A new endpoint `.../apis/{apiId}/_score` has been implemented to manually trigger the scoring of an API. 
The use case dealing with that 
- will fetch all SWAGGER & ASYNCAPI pages of the API to create a `ScoringRequestCommand`
- sends the command through the GraviteeCloud connector and return

Once the Scoring is done, GraviteeCloud sends a `ScoringResponseCommand` containing the operation's result. For now, we only log the result.

## Additional context

Pre-requisite:
- https://github.com/gravitee-io/gravitee-scoring-api/pull/3
- https://github.com/gravitee-io/gravitee-cockpit-api/pull/199

Cockpit's PR: https://github.com/gravitee-io/gravitee-cockpit/pull/4798
Spectral Scoring Service: https://github.com/gravitee-io/spectral-scoring-service/pull/5
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aiplrajchy.chromatic.com)
<!-- Storybook placeholder end -->
