### PR TITLE
fix: redis rate limit memory leak

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -288,6 +288,11 @@ ratelimit:
 #      path: ${gravitee.home}/security/redis-truststore.jks
 #      password: secret
 #      alias:
+#    operation:
+#      timeout: 10 # in milliseconds
+#    tcp:
+#      connectTimeout: 5000 # in milliseconds
+#      idleTimeout: 0 # in milliseconds
 
 # You must define the type of repository to use, when enabling distributed sync in clustering mode
 # because the gateway has to store data to share with other gateway instances.

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
@@ -30,10 +30,6 @@
 
 	<name>Gravitee.io APIM - Repository - Redis</name>
 
-	<properties>
-		<lettuce.version>6.1.5.RELEASE</lettuce.version>
-	</properties>
-
 	<dependencies>
 		<!-- Gravitee dependencies -->
 		<dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisNotConnectedException.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisNotConnectedException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.exception;
+
+import java.io.Serial;
+
+public class RedisNotConnectedException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 831794529058717663L;
+
+    public RedisNotConnectedException() {
+        super("Connection to Redis not available");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisOperationTimeoutException.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisOperationTimeoutException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.exception;
+
+import java.io.Serial;
+
+public class RedisOperationTimeoutException extends Exception {
+
+    @Serial
+    private static final long serialVersionUID = 1488201150127793681L;
+
+    public RedisOperationTimeoutException(int delayMs) {
+        super("Operation on Redis took more than " + delayMs + "ms");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
@@ -29,6 +29,7 @@ import io.vertx.redis.client.RedisRole;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
@@ -160,6 +161,13 @@ public class RedisConnectionFactory {
 
         // Set max waiting handlers high enough to manage high throughput since we are not using the pooled mode
         options.setMaxWaitingHandlers(1024);
+
+        // Enforce timeouts with default ones if not defined.
+        options
+            .getNetClientOptions()
+            .setConnectTimeout(readPropertyValue(propertyPrefix + "tcp.connectTimeout", int.class, 5000))
+            .setIdleTimeout(readPropertyValue(propertyPrefix + "tcp.idleTimeout", int.class, 0))
+            .setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
         return options;
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RateLimitRepositoryConfiguration.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.redis.vertx.RedisClient;
 import io.vertx.core.Vertx;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
 
@@ -45,7 +46,10 @@ public class RateLimitRepositoryConfiguration {
     }
 
     @Bean
-    public RedisRateLimitRepository redisRateLimitRepository(@Qualifier("redisRateLimitClient") RedisClient redisClient) {
-        return new RedisRateLimitRepository(redisClient);
+    public RedisRateLimitRepository redisRateLimitRepository(
+        @Qualifier("redisRateLimitClient") RedisClient redisClient,
+        @Value("${ratelimit.redis.operation.timeout:10}") int operationTimeout
+    ) {
+        return new RedisRateLimitRepository(redisClient, operationTimeout);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
@@ -17,6 +17,8 @@ package io.gravitee.repository.redis.ratelimit;
 
 import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
 
+import io.gravitee.repository.exception.RedisNotConnectedException;
+import io.gravitee.repository.exception.RedisOperationTimeoutException;
 import io.gravitee.repository.ratelimit.api.RateLimitRepository;
 import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.gravitee.repository.redis.vertx.RedisClient;
@@ -27,28 +29,38 @@ import io.vertx.redis.client.Response;
 import io.vertx.rxjava3.SingleHelper;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RedisRateLimitRepository.class);
     private static final String REDIS_KEY_PREFIX = "ratelimit:";
 
     private final RedisClient redisClient;
+    private final int operationTimeout;
+    private final AtomicLong operationFailureCounter;
 
-    public RedisRateLimitRepository(final RedisClient redisClient) {
+    public RedisRateLimitRepository(final RedisClient redisClient, int operationTimeout) {
         this.redisClient = redisClient;
+        this.operationTimeout = operationTimeout;
+        this.operationFailureCounter = new AtomicLong(0);
     }
 
     @Override
     public Single<RateLimit> incrementAndGet(String key, long weight, Supplier<RateLimit> supplier) {
+        if (!redisClient.isConnected()) {
+            // Fail fast in case the connection to Redis is not available.
+            return Single.error(new RedisNotConnectedException());
+        }
+
         final RateLimit newRate = supplier.get();
 
         return SingleHelper
@@ -61,7 +73,7 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
                                 convertToList(this.redisClient.scriptSha1(SCRIPT_RATELIMIT_KEY), REDIS_KEY_PREFIX + key, weight, newRate)
                             )
                         )
-                        .onFailure(t -> LOGGER.error("Failed to run rate-limit script on Redis {}", t.getMessage()))
+                        .onFailure(this::logOperationFailure)
                         .onComplete(asyncResultHandler)
             )
             .map(response -> {
@@ -79,7 +91,16 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
 
                 return newRate;
             })
-            .onErrorReturn(throwable -> newRate);
+            .timeout(operationTimeout, TimeUnit.MILLISECONDS, Single.error(new RedisOperationTimeoutException(operationTimeout)));
+    }
+
+    private void logOperationFailure(Throwable t) {
+        long failureCount = operationFailureCounter.getAndIncrement();
+        if (failureCount < 10) {
+            log.warn("Failed to run rate-limit script on Redis {}", t.getMessage());
+        } else if (failureCount % 10000 == 0) {
+            log.warn("Failed to run rate-limit script on Redis {} ({} times)", t.getMessage(), failureCount);
+        }
     }
 
     private List<String> convertToList(String scriptSha1, String key, long weight, RateLimit rate) {

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
@@ -78,7 +78,7 @@ public class RedisTestRepositoryConfiguration {
 
     @Bean
     public RedisRateLimitRepository redisRateLimitRepository(@Qualifier("redisRateLimitClient") RedisClient redisRateLimitClient) {
-        return new RedisRateLimitRepository(redisRateLimitClient);
+        return new RedisRateLimitRepository(redisRateLimitClient, 500);
     }
 
     @Bean

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
@@ -249,4 +249,16 @@ public class RedisConnectionFactoryTest {
         assertThat(options.getNetClientOptions()).isNotNull();
         assertThat(options.getNetClientOptions().isTrustAll()).isTrue();
     }
+
+    @Test
+    void shouldReturnRedisOptionsWithTCPTimeouts() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.tcp.connectTimeout", "1234");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.tcp.idleTimeout", "5678");
+
+        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+
+        assertThat(options.getNetClientOptions()).isNotNull();
+        assertThat(options.getNetClientOptions().getConnectTimeout()).isEqualTo(1234);
+        assertThat(options.getNetClientOptions().getIdleTimeout()).isEqualTo(5678);
+    }
 }

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -257,6 +257,15 @@ data:
               port: {{ .port }}
             {{- end }}
         {{- end }}
+        {{- if (not (empty (.Values.gateway.ratelimit.redis.operation))) }}
+        operation:
+          timeout: {{ .Values.gateway.ratelimit.redis.operation.timeout | default "10" }}
+        {{- end }}
+        {{- if (not (empty (.Values.gateway.ratelimit.redis.tcp))) }}
+        tcp:
+          connectTimeout: {{ .Values.gateway.ratelimit.redis.tcp.connectTimeout | default "5000" }}
+          idleTimeout: {{ .Values.gateway.ratelimit.redis.tcp.idleTimeout | default "0" }}
+        {{- end }}
       {{- end }}
 
     # Sharding tags configuration

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -135,3 +135,30 @@ tests:
                      *     path: \\${gravitee.home}/security/redis-truststore.jks\n
                      *     password: secret\n
                      *     alias: anotheralias\n"
+
+  - it: Set operation timeout, tcp connectTimeout and idleTimeout
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: redis
+      gateway:
+        ratelimit:
+          redis:
+            host: redis
+            port: 6379
+            ssl: false
+            operation:
+              timeout: 15
+            tcp:
+              connectTimeout: 10
+              idleTimeout: 5
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: " * redis:\n
+                     *   host: redis\n
+                     *   port: 6379\n
+                     *   operation:\n
+                     *     timeout: 15\n
+                     *   tcp:\n
+                     *     connectTimeout: 10\n"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -951,6 +951,11 @@ gateway:
     #         port: 26379
     #       - host: sentinel2
     #         port: 26379
+    #   operation:
+    #     timeout: 10 # in milliseconds
+    #   tcp:
+    #     connectTimeout: 5000 # in milliseconds
+    #     idleTimeout: 0 # in milliseconds
   management:
     http:
       # url: 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6281

## Description

- This PR attempts to fix several memory leak issues (and behavior leading to memory leak).
- Fix rate-limit probe to reflect the status of the Redis connectivity (no connection, operation timeout)
- Handle reconnection attempts with proper cleanup to avoid memory leak
- Allow tuning Redis TCP connection and idle timeout (connect timeout has been changed from 60000ms to 5000ms). They can be configured using respectively `ratelimit.redis.tcp.connectTimeout` (default to 5000ms) and `ratelimit.redis.tcp.idleTimeout` (default to 0ms means no idle)
- Add configurable operation timeout using `ratelimit.redis.operation.timeout` (default to 10ms) and propagate exception so the rate limit policy can apply the behavior when an error occurs.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kjpuphtbgw.chromatic.com)
<!-- Storybook placeholder end -->
