### PR TITLE
feat: allow to select mtls plan for a v4 API

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -145,6 +145,9 @@ export interface EnvSettings {
       jwt: {
         enabled: boolean;
       };
+      mtls: {
+        enabled: boolean;
+      };
     };
   };
   portal: {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
@@ -17,4 +17,4 @@
 /**
  * Plan security type.
  */
-export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT';
+export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT' | 'MTLS';

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -177,6 +177,9 @@ export function fakePortalSettings(attributes?: Partial<PortalSettings>): Portal
         push: {
           enabled: true,
         },
+        mtls: {
+          enabled: true,
+        },
       },
     },
     scheduler: {

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -160,6 +160,9 @@ export interface PortalSettingsPlan {
     push: {
       enabled: boolean;
     };
+    mtls: {
+      enabled: boolean;
+    };
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -63,7 +63,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
       selectionRule: new UntypedFormControl(),
     });
 
-    if (['KEY_LESS', 'PUSH'].includes(this.securityType.planFormType)) {
+    if (['KEY_LESS', 'PUSH', 'MTLS'].includes(this.securityType.planFormType)) {
       return;
     }
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -31,11 +31,7 @@
     ></plan-edit-general-step>
   </mat-step>
 
-  <mat-step
-    *ngIf="!isFederated && !['KEY_LESS', 'PUSH'].includes(planMenuItem.planFormType)"
-    state="secure"
-    [stepControl]="planForm.get('secure')"
-  >
+  <mat-step *ngIf="displaySecurityStep" state="secure" [stepControl]="planForm.get('secure')">
     <ng-template matStepperIcon="secure">
       <mat-icon svgIcon="gio:lock"></mat-icon>
     </ng-template>
@@ -43,7 +39,7 @@
     <plan-edit-secure-step matStepContent [api]="api" [securityType]="planMenuItem"></plan-edit-secure-step>
   </mat-step>
 
-  <mat-step *ngIf="mode === 'create'" state="restriction" [stepControl]="planForm.get('restriction')">
+  <mat-step *ngIf="displayRestrictionStep" state="restriction" [stepControl]="planForm.get('restriction')">
     <ng-template matStepperIcon="restriction">
       <mat-icon svgIcon="gio:shield-cross"></mat-icon>
     </ng-template>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -139,11 +139,15 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
   @Input()
   planStatus?: PlanStatus;
 
+  @Input({ required: true }) isTcpApi!: boolean;
+
   public isInit = false;
 
   public planForm = new UntypedFormGroup({});
   public initialPlanFormValue: unknown;
   public displaySubscriptionsSection = true;
+  public displayRestrictionStep: boolean;
+  public displaySecurityStep: boolean;
 
   @ViewChild(PlanEditGeneralStepComponent)
   private planEditGeneralStepComponent: PlanEditGeneralStepComponent;
@@ -191,6 +195,12 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     // Add default validator to the form control
     this.ngControl.control.setValidators(this.validate.bind(this));
     this.ngControl.control.updateValueAndValidity();
+
+    this.displayRestrictionStep = this.mode === 'create' && !this.isTcpApi;
+    this.displaySecurityStep =
+      !this.isFederated &&
+      !['KEY_LESS', 'PUSH'].includes(this.planMenuItem.planFormType) &&
+      !('MTLS' === this.planMenuItem.planFormType && this.isTcpApi);
 
     // When the parent form is touched, mark all the sub formGroup as touched
     const parentControl = this.ngControl.control.parent;
@@ -307,7 +317,7 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
           securityConfig: new UntypedFormControl({}),
           selectionRule: new UntypedFormControl(),
         }),
-      ...(this.mode === 'create' ? { restriction: this.planEditRestrictionStepComponent.restrictionForm } : {}),
+      ...(this.displayRestrictionStep ? { restriction: this.planEditRestrictionStepComponent.restrictionForm } : {}),
     });
 
     const value = planToInternalFormValue(this.controlValue, this.mode, this.isV2Api);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.html
@@ -17,7 +17,14 @@
 -->
 
 <form [formGroup]="form" (ngSubmit)="onAddPlan()">
-  <api-plan-form #apiPlanForm formControlName="plan" mode="create" [apiType]="apiType" [planMenuItem]="planMenuItem"></api-plan-form>
+  <api-plan-form
+    #apiPlanForm
+    formControlName="plan"
+    mode="create"
+    [isTcpApi]="isTcpApi"
+    [apiType]="apiType"
+    [planMenuItem]="planMenuItem"
+  ></api-plan-form>
 
   <div class="api-creation-v4__step__footer">
     <button mat-stroked-button type="button" *ngIf="apiPlanForm.hasPreviousStep() === false" (click)="onExitPlanCreation()">

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
@@ -39,6 +39,8 @@ export class Step4Security1PlansAddComponent implements OnInit {
   @Output()
   planChanges = new EventEmitter<CreatePlanV4>();
 
+  @Input() isTcpApi!: boolean;
+
   @Output()
   exitPlanCreation = new EventEmitter<void>();
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.html
@@ -37,6 +37,7 @@
     <step-4-security-1-plans-add
       [planMenuItem]="selectedPlanMenuItem"
       [apiType]="apiType"
+      [isTcpApi]="isTcpApi"
       (planChanges)="addPlan($event)"
       (exitPlanCreation)="onExitPlanCreation()"
     ></step-4-security-1-plans-add>
@@ -47,6 +48,7 @@
       [plan]="planToEdit"
       [planMenuItem]="selectedPlanMenuItem"
       [apiType]="apiType"
+      [isTcpApi]="isTcpApi"
       (planChanges)="editPlan($event)"
       (exitPlanCreation)="onExitPlanCreation()"
     ></step-4-security-1-plans-add>

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -35,6 +35,7 @@ export class Step4Security1PlansComponent implements OnInit {
 
   selectedPlanMenuItem: PlanMenuItemVM;
   public apiType: ApiType;
+  public isTcpApi: boolean;
 
   constructor(
     private readonly stepService: ApiCreationStepService,
@@ -52,6 +53,7 @@ export class Step4Security1PlansComponent implements OnInit {
     }
 
     this.apiType = currentStepPayload.type;
+    this.isTcpApi = currentStepPayload.hosts?.length > 0;
   }
 
   private computeDefaultApiPlans(currentStepPayload: ApiCreationPayload) {

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.html
@@ -28,6 +28,7 @@
       formControlName="plan"
       [mode]="mode"
       [api]="$any(api)"
+      [isTcpApi]="hasTcpListeners"
       [isFederated]="api.definitionVersion === 'FEDERATED'"
       [planMenuItem]="planMenuItem"
       [planStatus]="currentPlanStatus"

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -26,6 +26,7 @@ import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../..
 import { Api, CreatePlanV2, CreatePlanV4, Plan, PlanStatus } from '../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
+import { isApiV4 } from '../../../../util';
 
 @Component({
   selector: 'api-plan-edit',
@@ -46,6 +47,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
   @ViewChild('apiPlanForm')
   private apiPlanForm: ApiPlanFormComponent;
   public currentPlanStatus: PlanStatus;
+  public hasTcpListeners;
 
   constructor(
     private readonly router: Router,
@@ -65,6 +67,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
       .pipe(
         tap((api) => {
           this.api = api;
+          this.hasTcpListeners = isApiV4(api) && api.listeners.find((listener) => listener.type === 'TCP') != null;
           this.isReadOnly =
             !this.permissionService.hasAnyMatching(['api-plan-u']) ||
             this.api.definitionContext?.origin === 'KUBERNETES' ||

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
@@ -68,6 +68,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
         keyless: { enabled: true },
         customApiKey: { enabled: false },
         sharedApiKey: { enabled: false },
+        mtls: { enabled: false },
       },
     },
   };

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -112,6 +112,19 @@
             aria-label="Push plans ( only available for API V4 )"
           ></mat-slide-toggle>
         </gio-form-slide-toggle>
+        <gio-form-slide-toggle
+          formGroupName="mtls"
+          [matTooltip]="'Configuration provided by the system'"
+          [matTooltipDisabled]="!isReadonly('plan.security.mtls.enabled')"
+          class="portal__form__card__form-field"
+        >
+          <gio-form-label>mTLS plans ( only available for API V4 )</gio-form-label>
+          <mat-slide-toggle
+            formControlName="enabled"
+            gioFormSlideToggle
+            aria-label="mTLS plans ( only available for API V4 )"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
       </mat-card-content>
 
       <mat-card-content formGroupName="api">

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -55,6 +55,9 @@ interface PortalForm {
     push: FormGroup<{
       enabled: FormControl<boolean>;
     }>;
+    mtls: FormGroup<{
+      enabled: FormControl<boolean>;
+    }>;
   }>;
   api: FormGroup<{
     labelsDictionary: FormControl<string[]>;
@@ -263,6 +266,12 @@ export class PortalSettingsComponent implements OnInit {
           enabled: new FormControl({
             value: this.settings.plan.security.push.enabled,
             disabled: this.isReadonly('plan.security.push.enabled'),
+          }),
+        }),
+        mtls: new FormGroup({
+          enabled: new FormControl({
+            value: this.settings.plan.security.mtls.enabled,
+            disabled: this.isReadonly('plan.security.mtls.enabled'),
           }),
         }),
       }),

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
@@ -64,6 +64,9 @@ describe('ConstantsService', () => {
         push: {
           enabled: true,
         },
+        mtls: {
+          enabled: true,
+        },
       });
       const expectedPlanSecurityTypes = AVAILABLE_PLANS_FOR_MENU;
 
@@ -127,6 +130,9 @@ describe('ConstantsService', () => {
         push: {
           enabled: true,
         },
+        mtls: {
+          enabled: true,
+        },
       };
 
       beforeEach(async () => {
@@ -137,6 +143,10 @@ describe('ConstantsService', () => {
         const result = constantsService.getPlanMenuItems('V4', ['HTTP']);
 
         expect(result).toMatchObject([
+          {
+            planFormType: 'MTLS',
+            name: 'mTLS',
+          },
           {
             planFormType: 'OAUTH2',
             name: 'OAuth2',
@@ -159,7 +169,7 @@ describe('ConstantsService', () => {
         ]);
       });
 
-      it('should filter PUSH plan menu items when API definition version is V2', () => {
+      it('should filter PUSH plan and mTLS menu items when API definition version is V2', () => {
         const result = constantsService.getPlanMenuItems('V2', null);
 
         expect(result).toMatchObject([
@@ -202,10 +212,14 @@ describe('ConstantsService', () => {
         ]);
       });
 
-      it('should return only KEYLESS plan menu items when user has only TCP listeners types selected', () => {
+      it('should return only KEYLESS and mTLS plans menu items when user has only TCP listeners types selected', () => {
         const result = constantsService.getPlanMenuItems('V4', ['TCP']);
 
         expect(result).toMatchObject([
+          {
+            planFormType: 'MTLS',
+            name: 'mTLS',
+          },
           {
             planFormType: 'KEY_LESS',
             name: 'Keyless (public)',

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
@@ -28,6 +28,11 @@ export interface PlanMenuItemVM {
 }
 export const AVAILABLE_PLANS_FOR_MENU: PlanMenuItemVM[] = [
   {
+    planFormType: 'MTLS',
+    name: 'mTLS',
+    policy: 'mtls',
+  },
+  {
     planFormType: 'OAUTH2',
     name: 'OAuth2',
     policy: 'oauth2',
@@ -77,15 +82,21 @@ export class ConstantsService {
     const availablePlanMenuItems = this.getEnabledPlanMenuItems();
 
     if (definitionVersion === 'V4' && listenerTypes?.every((listenerType) => listenerType === 'TCP')) {
-      return availablePlanMenuItems.filter((p) => p.planFormType === 'KEY_LESS');
+      return availablePlanMenuItems.filter((p) => p.planFormType === 'KEY_LESS' || p.planFormType === 'MTLS');
     }
 
     if (definitionVersion === 'V4' && listenerTypes?.every((listenerType) => listenerType === 'SUBSCRIPTION')) {
       return availablePlanMenuItems.filter((planMenuItem) => planMenuItem.planFormType === 'PUSH');
     }
 
-    if (definitionVersion !== 'V4' || listenerTypes?.every((listenerType) => ['HTTP', 'TCP'].includes(listenerType))) {
+    if (definitionVersion === 'V4' && listenerTypes?.every((listenerType) => ['HTTP', 'TCP'].includes(listenerType))) {
       return availablePlanMenuItems.filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH');
+    }
+
+    if (definitionVersion !== 'V4') {
+      return availablePlanMenuItems
+        .filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH')
+        .filter((planMenuItem) => planMenuItem.planFormType !== 'MTLS');
     }
 
     return availablePlanMenuItems;

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -595,6 +595,19 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
+            <artifactId>gravitee-policy-mtls</artifactId>
+            <version>${gravitee-policy-mtls.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-oauth2</artifactId>
             <version>${gravitee-policy-oauth2.version}</version>
             <type>zip</type>

--- a/gravitee-apim-integration-tests/pom.xml
+++ b/gravitee-apim-integration-tests/pom.xml
@@ -353,6 +353,12 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.policy</groupId>
+            <artifactId>gravitee-policy-mtls</artifactId>
+            <version>${gravitee-policy-mtls.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-oauth2</artifactId>
             <version>${gravitee-policy-oauth2.version}</version>
             <scope>test</scope>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -268,6 +268,10 @@ public class Plan {
          * Plan which is using a JWT security authentication type for incoming HTTP requests.
          */
         JWT,
+        /**
+         * Plan which is using a MTLS security authentication type for incoming HTTP requests.
+         */
+        MTLS,
     }
 
     public enum PlanValidationType {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -111,7 +111,7 @@ public interface PlanMapper {
     @Mapping(target = "planDefinitionV4", source = "source", qualifiedByName = "mapToPlanDefinitionV4")
     io.gravitee.apim.core.plan.model.Plan map(CreatePlanV4 source);
 
-    @Mapping(target = "security", source = "security.type")
+    @Mapping(target = "security", source = "security.type", qualifiedByName = "toV2PlanSecurityType")
     @Mapping(target = "securityDefinition", source = "security.configuration", qualifiedByName = "serializeConfiguration")
     io.gravitee.rest.api.model.NewPlanEntity map(CreatePlanV2 plan);
 
@@ -165,6 +165,15 @@ public interface PlanMapper {
             return null;
         }
         return io.gravitee.rest.api.model.v4.plan.PlanSecurityType.valueOf(securityType.name()).getLabel();
+    }
+
+    @Named("toV2PlanSecurityType")
+    default io.gravitee.rest.api.model.PlanSecurityType toV2PlanSecurityType(PlanSecurityType securityType) {
+        // PlanSecurityType is a common enum containing MTLS plan. Such security type is not supported by V2, so it is ignored during mapping
+        if (Objects.isNull(securityType) || PlanSecurityType.MTLS.equals(securityType)) {
+            return null;
+        }
+        return io.gravitee.rest.api.model.PlanSecurityType.valueOf(securityType.name());
     }
 
     @Mapping(source = "planSecurity.type", target = "security.type", qualifiedByName = "mapToPlanSecurityType")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4002,6 +4002,7 @@ components:
                 - API_KEY
                 - OAUTH2
                 - JWT
+                - MTLS
         PlanStatus:
             type: string
             description: Plan status.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -174,6 +175,37 @@ public class PlanMapperTest {
         assertEquals(createPlanV2.getSelectionRule(), createPlanEntity.getSelectionRule());
 
         assertEquals(createPlanV2.getSecurity().getType().name(), createPlanEntity.getSecurity().name());
+        assertDefinitionEquals(createPlanV2.getSecurity().getConfiguration(), createPlanEntity.getSecurityDefinition());
+
+        assertEquals(createPlanEntity.getFlows().size(), createPlanV2.getFlows().size()); // Flow mapping is tested in FlowMapperTest
+    }
+
+    @Test
+    void should_map_CreatePlanV2_to_CreatePlanEntity_ignoring_mtls_plan_security_type() {
+        final var createPlanV2 = PlanFixtures.aCreatePlanV2();
+        // PlanSecurityType is a common enum containing MTLS plan. Such security type is not supported by V2, so it is ignored during mapping
+        createPlanV2.security(
+            io.gravitee.rest.api.management.v2.rest.model.PlanSecurity
+                .builder()
+                .type(io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType.MTLS)
+                .build()
+        );
+        final var createPlanEntity = planMapper.map(createPlanV2);
+
+        Assertions.assertNull(createPlanEntity.getId());
+        assertEquals(createPlanV2.getName(), createPlanEntity.getName());
+        assertEquals(createPlanV2.getDescription(), createPlanEntity.getDescription());
+        assertEquals(createPlanV2.getOrder(), createPlanEntity.getOrder());
+        assertEquals(createPlanV2.getCharacteristics(), createPlanEntity.getCharacteristics());
+        assertEquals(createPlanV2.getCommentMessage(), createPlanEntity.getCommentMessage());
+        assertEquals(createPlanV2.getCrossId(), createPlanEntity.getCrossId());
+        assertEquals(createPlanV2.getGeneralConditions(), createPlanEntity.getGeneralConditions());
+        assertEquals(new HashSet<>(createPlanV2.getTags()), createPlanEntity.getTags());
+        assertEquals(createPlanV2.getExcludedGroups(), createPlanEntity.getExcludedGroups());
+        assertEquals(createPlanV2.getValidation().name(), createPlanEntity.getValidation().name());
+        assertEquals(createPlanV2.getSelectionRule(), createPlanEntity.getSelectionRule());
+
+        assertNull(createPlanEntity.getSecurity());
         assertDefinitionEquals(createPlanV2.getSecurity().getConfiguration(), createPlanEntity.getSecurityDefinition());
 
         assertEquals(createPlanEntity.getFlows().size(), createPlanV2.getFlows().size()); // Flow mapping is tested in FlowMapperTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -131,6 +131,7 @@ public enum Key {
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
 
+    PLAN_SECURITY_MTLS_ENABLED("plan.security.mtls.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_JWT_ENABLED("plan.security.jwt.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_OAUTH2_ENABLED("plan.security.oauth2.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PLAN_SECURITY_APIKEY_ENABLED("plan.security.apikey.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
@@ -63,6 +63,9 @@ public class PlanSettings {
         @ParameterKey(Key.PLAN_SECURITY_PUSH_ENABLED)
         private Enabled push;
 
+        @ParameterKey(Key.PLAN_SECURITY_MTLS_ENABLED)
+        private Enabled mtls;
+
         public Enabled getApikey() {
             return apikey;
         }
@@ -101,6 +104,14 @@ public class PlanSettings {
 
         public void setJwt(Enabled jwt) {
             this.jwt = jwt;
+        }
+
+        public Enabled getMtls() {
+            return mtls;
+        }
+
+        public void setMtls(Enabled mtls) {
+            this.mtls = mtls;
         }
 
         public Enabled getSharedApiKey() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanSecurityType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanSecurityType.java
@@ -47,7 +47,12 @@ public enum PlanSecurityType {
     /**
      * Plan which is using a JWT security authentication type for incoming HTTP requests.
      */
-    JWT("jwt");
+    JWT("jwt"),
+
+    /**
+     * Plan which is using a mTLS security authentication type for incoming HTTP requests.
+     */
+    MTLS("mtls");
 
     private static final Map<String, PlanSecurityType> maps = Map.of(
         KEY_LESS.label,
@@ -57,7 +62,9 @@ public enum PlanSecurityType {
         OAUTH2.label,
         OAUTH2,
         JWT.label,
-        JWT
+        JWT,
+        MTLS.label,
+        MTLS
     );
 
     private final String label;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -155,6 +155,7 @@ public class ConfigurationMapper {
         configuration.setApikey(convert(security.getApikey()));
         configuration.setSharedApiKey(convert(security.getSharedApiKey()));
         configuration.setJwt(convert(security.getJwt()));
+        configuration.setMtls(convert(security.getMtls()));
         configuration.setKeyless(convert(security.getKeyless()));
         configuration.setOauth2(convert(security.getOauth2()));
         return configuration;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4840,6 +4840,8 @@ components:
           $ref: '#/components/schemas/Enabled'
         jwt:
           $ref: '#/components/schemas/Enabled'
+        mtls:
+          $ref: '#/components/schemas/Enabled'
     ConfigurationAnalytics:
       properties:
         clientTimeout:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4023,6 +4023,7 @@ components:
             - KEY_LESS
             - JWT
             - OAUTH2
+            - MTLS
         description:
           description: Description of the plan.
           type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -82,6 +82,9 @@
       },
       "jwt" : {
         "enabled" : true
+      },
+      "mtls" : {
+        "enabled" : true
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
@@ -100,6 +100,9 @@
       },
       "sharedApiKey" : {
         "enabled" : true
+      },
+      "mtls" : {
+        "enabled" : true
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
@@ -101,6 +101,7 @@ public class PlanValidatorDomainService {
                 case KEY_LESS -> Key.PLAN_SECURITY_KEYLESS_ENABLED;
                 case JWT -> Key.PLAN_SECURITY_JWT_ENABLED;
                 case OAUTH2 -> Key.PLAN_SECURITY_OAUTH2_ENABLED;
+                case MTLS -> Key.PLAN_SECURITY_MTLS_ENABLED;
             };
         if (
             !parametersQueryService.findAsBoolean(
@@ -113,7 +114,13 @@ public class PlanValidatorDomainService {
     }
 
     public void validatePlanSecurityAgainstEntrypoints(PlanSecurity planSecurity, List<ListenerType> listenerTypes) {
-        if (listenerTypes.contains(ListenerType.TCP) && !PlanSecurityType.KEY_LESS.getLabel().equals(planSecurity.getType())) {
+        if (
+            listenerTypes.contains(ListenerType.TCP) &&
+            !(
+                PlanSecurityType.KEY_LESS.getLabel().equals(planSecurity.getType()) ||
+                PlanSecurityType.MTLS.getLabel().equals(planSecurity.getType())
+            )
+        ) {
             throw new UnauthorizedPlanSecurityTypeException(planSecurity.getType());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -107,6 +107,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
     private static final List<PlanSecurityEntity> DEFAULT_SECURITY_LIST = Collections.unmodifiableList(
         Arrays.asList(
+            new PlanSecurityEntity("mtls", "mTLS", "mtls"),
             new PlanSecurityEntity("oauth2", "OAuth2", "oauth2"),
             new PlanSecurityEntity("jwt", "JWT", "'jwt'"),
             new PlanSecurityEntity("api_key", "API Key", "api-key"),

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,7 @@
         <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-message-filtering.version>1.1.3</gravitee-policy-message-filtering.version>
         <gravitee-policy-mock.version>1.13.5</gravitee-policy-mock.version>
+        <gravitee-policy-mtls.version>1.0.0-alpha.1</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>3.0.4</gravitee-policy-oauth2.version>
         <gravitee-policy-oas-validation.version>1.0.0-alpha.11</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3980

## Description

- Be able to create a MTLS plan for a V4 (Message or Proxy API) during API creation or directly in the plan section
- Display the plan sélection at subscription time in console and portal. Portal next not supported.
- Provide the ability to enable or disable mTLS plans from environment settings

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xmthbeagow.chromatic.com)
<!-- Storybook placeholder end -->
