### PR TITLE
fix: use crossid of shared policy group instead of id in policy studio

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupPolicyPlugin.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupPolicyPlugin.java
@@ -62,7 +62,7 @@ public class SharedPolicyGroupPolicyPlugin {
     public static SharedPolicyGroupPolicyPlugin fromSharedPolicyGroup(SharedPolicyGroup sharedPolicyGroup) {
         return SharedPolicyGroupPolicyPlugin
             .builder()
-            .id(sharedPolicyGroup.getId())
+            .id(sharedPolicyGroup.getCrossId())
             .name(sharedPolicyGroup.getName())
             .description(sharedPolicyGroup.getDescription())
             .apiType(sharedPolicyGroup.getApiType())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/GetSharedPolicyGroupPolicyPluginsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/GetSharedPolicyGroupPolicyPluginsUseCaseTest.java
@@ -51,7 +51,7 @@ class GetSharedPolicyGroupPolicyPluginsUseCaseTest {
 
         // Then
         assertEquals(result.sharedPolicyGroupPolicyList().size(), 1);
-        assertEquals(result.sharedPolicyGroupPolicyList().get(0).getId(), deployedSharedPolicyGroup.getId());
+        assertEquals(result.sharedPolicyGroupPolicyList().get(0).getId(), deployedSharedPolicyGroup.getCrossId());
         assertEquals(result.sharedPolicyGroupPolicyList().get(0).getName(), deployedSharedPolicyGroup.getName());
         assertEquals(result.sharedPolicyGroupPolicyList().get(0).getDescription(), deployedSharedPolicyGroup.getDescription());
         assertEquals(result.sharedPolicyGroupPolicyList().get(0).getApiType(), deployedSharedPolicyGroup.getApiType());


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-6318


