### PR TITLE
feat(porta-next): Update text for Last Updated in portal information …

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.html
@@ -43,7 +43,7 @@
 
       @if (api.updated_at) {
         <div>
-          <div i18n="@@apiDetailsLastUpdated" class="m3-body-large">Last updated</div>
+          <div i18n="@@apiDetailsLastUpdated" class="m3-body-large">API Last Updated</div>
           <div class="m3-body-medium">{{ api.updated_at | date }}</div>
         </div>
       }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-details/api-tab-details.component.spec.ts
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
 
 import { ApiTabDetailsComponent } from './api-tab-details.component';
 import { fakeApi } from '../../../../entities/api/api.fixtures';
+import { CategoriesService } from '../../../../services/categories.service';
+import { PageService } from '../../../../services/page.service';
 import { AppTestingModule } from '../../../../testing/app-testing.module';
 
 describe('ApiTabDetailsComponent', () => {
@@ -25,7 +30,11 @@ describe('ApiTabDetailsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApiTabDetailsComponent, AppTestingModule],
+      imports: [ApiTabDetailsComponent, AppTestingModule, HttpClientTestingModule],
+      providers: [
+        { provide: PageService, useValue: { listByApiId: () => of({ data: [] }), content: () => of({}) } },
+        { provide: CategoriesService, useValue: { categories: () => of({ data: [] }) } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiTabDetailsComponent);
@@ -36,5 +45,14 @@ describe('ApiTabDetailsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display "API Last Updated" if api.updated_at is present', () => {
+    component.api.updated_at = new Date();
+    fixture.detectChanges();
+    const lastUpdatedElement = fixture.debugElement
+      .queryAll(By.css('.m3-body-large'))
+      .find(el => el.nativeElement.textContent.includes('API Last Updated'));
+    expect(lastUpdatedElement).toBeDefined();
   });
 });


### PR DESCRIPTION
…card

## Issue

https://gravitee.atlassian.net/browse/APIM-6033

## Description

Update the label for “Last Updated” for an API to something clearer to represent that it is the last time the API was deployed, e.g. “API Last Updated.” It can be confusing for people that maybe the “Last Updated” refers to the docs page, when it does not. We should also check on whether this is configurable in the Labels section for portal.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<img width="1148" alt="Screenshot 2024-08-08 at 17 25 22" src="https://github.com/user-attachments/assets/e4c42a6b-1367-4f34-b43f-33b1336c4498">
