### PR TITLE
fix(management): repository query should not be limited to all tags when search for commands

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCommandRepository.java
@@ -257,7 +257,9 @@ public class JdbcCommandRepository extends JdbcAbstractCrudRepository<Command, S
             commands =
                 commands
                     .stream()
-                    .filter(command -> command.getTags() != null && command.getTags().containsAll(Arrays.asList(criteria.getTags())))
+                    .filter(command ->
+                        command.getTags() != null && command.getTags().stream().anyMatch(Arrays.asList(criteria.getTags())::contains)
+                    )
                     .collect(Collectors.toList());
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/message/CommandMongoRepositoryCustomImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/message/CommandMongoRepositoryCustomImpl.java
@@ -43,7 +43,7 @@ public class CommandMongoRepositoryCustomImpl implements CommandMongoRepositoryC
         }
 
         if (criteria.getTags() != null && criteria.getTags().length > 0) {
-            query.addCriteria(where("tags").all(Arrays.asList(criteria.getTags())));
+            query.addCriteria(where("tags").in(Arrays.asList(criteria.getTags())));
         }
 
         if (criteria.isNotExpired()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/CommandRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/CommandRepositoryTest.java
@@ -158,8 +158,14 @@ public class CommandRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull("not null", commands);
         assertFalse("not empty", commands.isEmpty());
-        assertEquals("result size", 1, commands.size());
-        assertEquals("contain 'search3'", "search3", commands.get(0).getId());
+        assertEquals("result size", 5, commands.size());
+        assertTrue(
+            "contain [msg-to-create, msg-to-update, search1, search2, search3]",
+            commands
+                .stream()
+                .map(Command::getId)
+                .allMatch(List.of("msg-to-create", "msg-to-update", "search1", "search2", "search3")::contains)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6336

## Description

repository query should not be limited to all tags when search for commands. 
e.g. when search for tags SUBSCRIPTION_FAILURE and EMAIL_TEMPLATE_UPDATE we we won't find anything, but we should be able to find when tag in db is only EMAIL_TEMPLATE_UPDATE 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

