### PR TITLE
fix: avoid memory leak on successive api redeploy

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -130,6 +130,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
     protected AnalyticsContext analyticsContext;
     private List<ApiService> services;
     private final boolean validateSubscriptionEnabled;
+    private List<Acceptor<?>> acceptors;
 
     public DefaultApiReactor(
         final Api api,
@@ -378,11 +379,13 @@ public class DefaultApiReactor extends AbstractApiReactor {
 
     @Override
     public List<Acceptor<?>> acceptors() {
-        final List<Acceptor<?>> acceptors = new ArrayList<>();
+        if (acceptors == null) {
+            acceptors = new ArrayList<>();
 
-        for (Listener listener : api.getDefinition().getListeners()) {
-            if (listener.getType() == ListenerType.HTTP) {
-                acceptors.addAll(prepareHttpAcceptors(listener));
+            for (Listener listener : api.getDefinition().getListeners()) {
+                if (listener.getType() == ListenerType.HTTP) {
+                    acceptors.addAll(prepareHttpAcceptors(listener));
+                }
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -874,9 +874,12 @@ class DefaultApiReactorTest {
         HttpListener httpListener = new HttpListener();
         Path path = new Path("host", "path");
         httpListener.setPaths(List.of(path));
+        httpListener.setEntrypoints(new ArrayList<>());
         SubscriptionListener subscriptionListener = new SubscriptionListener();
+        subscriptionListener.setEntrypoints(new ArrayList<>());
         when(apiDefinition.getListeners()).thenReturn(List.of(httpListener, subscriptionListener));
 
+        cut = buildApiReactor();
         List<Acceptor<?>> acceptors = cut.acceptors();
         assertThat(acceptors).hasSize(1);
         Acceptor<?> acceptor1 = acceptors.get(0);
@@ -891,7 +894,9 @@ class DefaultApiReactorTest {
         HttpListener httpListener = new HttpListener();
         Path path = new Path(null, "path");
         httpListener.setPaths(List.of(path));
+        httpListener.setEntrypoints(new ArrayList<>());
         SubscriptionListener subscriptionListener = new SubscriptionListener();
+        subscriptionListener.setEntrypoints(new ArrayList<>());
         when(apiDefinition.getListeners()).thenReturn(List.of(httpListener, subscriptionListener));
         when(accessPointManager.getByEnvironmentId(ENVIRONMENT_ID))
             .thenReturn(
@@ -901,6 +906,7 @@ class DefaultApiReactorTest {
                 )
             );
 
+        cut = buildApiReactor();
         List<Acceptor<?>> acceptors = cut.acceptors();
         assertThat(acceptors).hasSize(1);
         Acceptor<?> acceptor1 = acceptors.get(0);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6349

## Description

This PR fixes a memory leak occurring after several redeployments of a V4 API. 
The leak was because acceptor instances were created several times. With the introduction of AccessPoints, some acceptors now listen to internal events. The additional acceptors that are wrongly recreated caused the previous one not properly cleaned up.


