### PR TITLE
test(portal-next): fix flaky "test suite failed to run"

### DIFF
--- a/gravitee-apim-portal-webui-next/package.json
+++ b/gravitee-apim-portal-webui-next/package.json
@@ -14,7 +14,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:ci": "jest --runInBand",
-    "test:coverage": "JEST_JUNIT_ADD_FILE_ATTRIBUTE=true JEST_JUNIT_OUTPUT_DIR=\"coverage\" NODE_OPTIONS=--max-old-space-size=6144 jest --ci --reporters=default --reporters=jest-junit --max-workers=3 --collect-coverage",
+    "test:coverage": "JEST_JUNIT_ADD_FILE_ATTRIBUTE=true JEST_JUNIT_OUTPUT_DIR=\"coverage\" NODE_OPTIONS=--max-old-space-size=6144 jest --ci --reporters=default --reporters=jest-junit --collect-coverage  --runInBand",
     "lint:eslint": "ng lint --max-warnings=0",
     "lint:eslint:fix": "ng lint --max-warnings=0 --fix",
     "lint:prettier": "prettier --check \"**/*.{js,ts,json,html,scss}\"",


### PR DESCRIPTION
## Description

When running the job `yarn lint:coverage` in the `Lint & test APIM Portal Next` step in the CI, there is a flaky error that happens on tests:

```txt
● Test suite failed to run

    A jest worker process (pid=997) was terminated by another process: signal=SIGKILL, exitCode=null. Operating system logs may contain more information on why this occurred.

      at ChildProcessWorker._onExit (node_modules/jest-worker/build/workers/ChildProcessWorker.js:370:23)
```

The tests are unable to run in parallel, and increasing the max workers does not solve the issue, either. It has been reported [by others as an issue](https://stackoverflow.com/a/76750621/24895850). 

By changing `yarn test:coverage` to use `--runInBand`, tests are run synchronously and are thus no longer killing parallel tests.

This is a temporary solution: when upgrading `jest` in the future, try switching back to max workers to see if the issue has been resolved.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

