### PR TITLE
SharedPolicyGroup: improvement for undeploy & for repository 

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SharedPolicyGroupHistoryRepository.java
@@ -21,10 +21,13 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.SharedPolicyGroupHistoryCriteria;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.SharedPolicyGroup;
+import java.util.Optional;
 
 public interface SharedPolicyGroupHistoryRepository extends CrudRepository<SharedPolicyGroup, String> {
     Page<SharedPolicyGroup> search(SharedPolicyGroupHistoryCriteria criteria, Pageable pageable, Sortable sortable)
         throws TechnicalException;
 
     Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException;
+
+    Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SharedPolicyGroupHistoryRepository.java
@@ -26,5 +26,5 @@ public interface SharedPolicyGroupHistoryRepository extends CrudRepository<Share
     Page<SharedPolicyGroup> search(SharedPolicyGroupHistoryCriteria criteria, Pageable pageable, Sortable sortable)
         throws TechnicalException;
 
-    Page<SharedPolicyGroup> searchLatestBySharedPolicyPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException;
+    Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
@@ -216,4 +216,33 @@ public class JdbcSharedPolicyGroupHistoryRepository
             throw new TechnicalException("Failed to search for SharedPolicyGroups", ex);
         }
     }
+
+    @Override
+    public Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId)
+        throws TechnicalException {
+        Objects.requireNonNull(environmentId, "EnvironmentId must not be null");
+        Objects.requireNonNull(sharedPolicyGroupId, "SharedPolicyGroupId must not be null");
+        LOGGER.debug("JdbcSharedPolicyGroupHistoryRepository.getLatestBySharedPolicyGroupId({}, {})", environmentId, sharedPolicyGroupId);
+
+        try {
+            StringJoiner andWhere = new StringJoiner(" AND ");
+            List<Object> andWhereParams = new ArrayList<>();
+
+            andWhere.add("environment_id = ?");
+            andWhereParams.add(environmentId);
+            andWhere.add("id = ?");
+            andWhereParams.add(sharedPolicyGroupId);
+
+            var result = jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " WHERE " + andWhere + " ORDER BY updated_at DESC " + createPagingClause(1, 0),
+                getOrm().getRowMapper(),
+                andWhereParams.toArray()
+            );
+
+            return Optional.ofNullable(result.isEmpty() ? null : result.get(0));
+        } catch (Exception ex) {
+            LOGGER.error("Failed to search for SharedPolicyGroupHistory:", ex);
+            throw new TechnicalException("Failed to search for SharedPolicyGroupHistory", ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
@@ -166,13 +166,12 @@ public class JdbcSharedPolicyGroupHistoryRepository
     }
 
     @Override
-    public Page<SharedPolicyGroup> searchLatestBySharedPolicyPolicyGroupId(String environmentId, Pageable pageable)
-        throws TechnicalException {
+    public Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException {
         try {
             Objects.requireNonNull(pageable, "Pageable must not be null");
             Objects.requireNonNull(environmentId, "EnvironmentId must not be null");
             LOGGER.debug(
-                "JdbcSharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId({}, {})",
+                "JdbcSharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId({}, {})",
                 environmentId,
                 pageable.toString()
             );

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSharedPolicyGroupHistoryRepository.java
@@ -78,17 +78,24 @@ public class JdbcSharedPolicyGroupHistoryRepository
 
     @Override
     protected String getId(SharedPolicyGroup item) {
-        return item.getId();
+        throw new IllegalStateException("Not implemented");
     }
 
     @Override
     public SharedPolicyGroup create(SharedPolicyGroup item) throws TechnicalException {
-        return super.create(item);
+        LOGGER.debug("JdbcSharedPolicyGroupHistoryRepository<{}>.create({})", getOrm().getTableName(), item);
+        try {
+            jdbcTemplate.update(buildInsertPreparedStatementCreator(item));
+            return getLatestBySharedPolicyGroupId(item.getEnvironmentId(), item.getId()).orElse(null);
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to create SharedPolicyGroup item:", ex);
+            throw new TechnicalException("Failed to create SharedPolicyGroup item", ex);
+        }
     }
 
     @Override
     public SharedPolicyGroup update(final SharedPolicyGroup item) throws TechnicalException {
-        return super.update(item);
+        throw new IllegalStateException("Not implemented");
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
@@ -143,8 +143,13 @@ public class MongoSharedPolicyGroupHistoryRepository implements SharedPolicyGrou
     }
 
     @Override
-    public void delete(String s) throws TechnicalException {
-        throw new IllegalStateException("Not implemented");
+    public void delete(String id) throws TechnicalException {
+        try {
+            internalSharedPolicyGroupHistoryMongoRepo.deleteBySharedPolicyGroupId(id);
+        } catch (Exception e) {
+            LOGGER.error("An error occurred when deleting shared policy group history [{}]", id, e);
+            throw new TechnicalException("An error occurred when deleting shared policy group history");
+        }
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.SharedPolicyGroup;
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupHistoryMongo;
+import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupMongo;
 import io.gravitee.repository.mongodb.management.internal.sharedpolicygrouphistory.SharedPolicyGroupHistoryMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
@@ -93,6 +94,28 @@ public class MongoSharedPolicyGroupHistoryRepository implements SharedPolicyGrou
             LOGGER.error("An error occurred when searching for shared policy group history", e);
             throw new TechnicalException("An error occurred when searching for shared policy group history", e);
         }
+    }
+
+    @Override
+    public Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId)
+        throws TechnicalException {
+        LOGGER.debug(
+            "Get latest shared policy group by environment ID [{}] and shared policy group ID [{}]",
+            environmentId,
+            sharedPolicyGroupId
+        );
+
+        final SharedPolicyGroupHistoryMongo sharedPolicyGroupMongo = internalSharedPolicyGroupHistoryMongoRepo
+            .getLatestBySharedPolicyGroupId(environmentId, sharedPolicyGroupId)
+            .orElse(null);
+
+        LOGGER.debug(
+            "Get shared policy group by environment ID [{}] and shared policy group ID [{}] - Done",
+            environmentId,
+            sharedPolicyGroupId
+        );
+
+        return Optional.ofNullable(mapSharedPolicyGroupHistory(sharedPolicyGroupMongo));
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSharedPolicyGroupHistoryRepository.java
@@ -73,18 +73,17 @@ public class MongoSharedPolicyGroupHistoryRepository implements SharedPolicyGrou
     }
 
     @Override
-    public Page<SharedPolicyGroup> searchLatestBySharedPolicyPolicyGroupId(String environmentId, Pageable pageable)
-        throws TechnicalException {
+    public Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException {
         Objects.requireNonNull(pageable, "Pageable must not be null");
         Objects.requireNonNull(environmentId, "EnvironmentId must not be null");
         LOGGER.debug(
-            "MongoSharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId({}, {})",
+            "MongoSharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId({}, {})",
             environmentId,
             pageable.toString()
         );
 
         try {
-            return this.internalSharedPolicyGroupHistoryMongoRepo.searchLatestBySharedPolicyPolicyGroupId(
+            return this.internalSharedPolicyGroupHistoryMongoRepo.searchLatestBySharedPolicyGroupId(
                     environmentId,
                     pageable.pageNumber(),
                     pageable.pageSize()

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepository.java
@@ -16,9 +16,15 @@
 package io.gravitee.repository.mongodb.management.internal.sharedpolicygrouphistory;
 
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupHistoryMongo;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SharedPolicyGroupHistoryMongoRepository
-    extends MongoRepository<SharedPolicyGroupHistoryMongo, String>, SharedPolicyGroupHistoryMongoRepositoryCustom {}
+    extends MongoRepository<SharedPolicyGroupHistoryMongo, String>, SharedPolicyGroupHistoryMongoRepositoryCustom {
+    // Get SPG binding by environmentId and sharedPolicyGroupId sorted by deployedAt limit 1
+    @Aggregation(pipeline = { "{$match: { environmentId : ?0, 'id' : ?1 }}", "{$sort: {updatedAt: -1}}", "{$limit: 1}" })
+    Optional<SharedPolicyGroupHistoryMongo> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryCustom.java
@@ -23,4 +23,5 @@ import org.springframework.data.domain.PageRequest;
 public interface SharedPolicyGroupHistoryMongoRepositoryCustom {
     Page<SharedPolicyGroupHistoryMongo> search(SharedPolicyGroupHistoryCriteria sharedPolicyGroupHistoryCriteria, PageRequest pageRequest);
     Page<SharedPolicyGroupHistoryMongo> searchLatestBySharedPolicyGroupId(String environmentId, int page, int size);
+    void deleteBySharedPolicyGroupId(String sharedPolicyGroupId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryCustom.java
@@ -22,5 +22,5 @@ import org.springframework.data.domain.PageRequest;
 
 public interface SharedPolicyGroupHistoryMongoRepositoryCustom {
     Page<SharedPolicyGroupHistoryMongo> search(SharedPolicyGroupHistoryCriteria sharedPolicyGroupHistoryCriteria, PageRequest pageRequest);
-    Page<SharedPolicyGroupHistoryMongo> searchLatestBySharedPolicyPolicyGroupId(String environmentId, int page, int size);
+    Page<SharedPolicyGroupHistoryMongo> searchLatestBySharedPolicyGroupId(String environmentId, int page, int size);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
@@ -67,7 +67,7 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
     }
 
     @Override
-    public Page<SharedPolicyGroupHistoryMongo> searchLatestBySharedPolicyPolicyGroupId(String environmentId, int page, int size) {
+    public Page<SharedPolicyGroupHistoryMongo> searchLatestBySharedPolicyGroupId(String environmentId, int page, int size) {
         Objects.requireNonNull(environmentId, "environmentId must not be null");
         var collectionName = mongoTemplate.getCollectionName(SharedPolicyGroupHistoryMongo.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
@@ -121,4 +121,11 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
 
         return new Page<>(sharedPolicyGroups, pageRequest.getPageNumber(), pageRequest.getPageSize(), total);
     }
+
+    @Override
+    public void deleteBySharedPolicyGroupId(String sharedPolicyGroupId) {
+        Objects.requireNonNull(sharedPolicyGroupId, "sharedPolicyGroupId must not be null");
+        var query = new Query(where("id").is(sharedPolicyGroupId));
+        mongoTemplate.remove(query, SharedPolicyGroupHistoryMongo.class);
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/sharedpolicygrouphistories/IdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/sharedpolicygrouphistories/IdIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.sharedpolicygrouphistories;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("IdIndexUpgrader")
+public class IdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("sharedpolicygrouphistories")
+            .name("i1")
+            .key("id", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSharedPolicyGroupHistoryRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.SharedPolicyGroupHistoryCrit
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.SharedPolicyGroup;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @author GraviteeSource Team
@@ -40,5 +41,11 @@ public class NoOpSharedPolicyGroupHistoryRepository
     @Override
     public Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException {
         return new Page<>(List.of(), 0, 0, 0L);
+    }
+
+    @Override
+    public Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId)
+        throws TechnicalException {
+        return Optional.empty();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSharedPolicyGroupHistoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSharedPolicyGroupHistoryRepository.java
@@ -38,8 +38,7 @@ public class NoOpSharedPolicyGroupHistoryRepository
     }
 
     @Override
-    public Page<SharedPolicyGroup> searchLatestBySharedPolicyPolicyGroupId(String environmentId, Pageable pageable)
-        throws TechnicalException {
+    public Page<SharedPolicyGroup> searchLatestBySharedPolicyGroupId(String environmentId, Pageable pageable) throws TechnicalException {
         return new Page<>(List.of(), 0, 0, 0L);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
@@ -259,6 +259,22 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
         assertThat(page.getTotalElements()).isEqualTo(0);
     }
 
+    @Test
+    public void should_getLatestBySharedPolicyGroupId() throws TechnicalException {
+        final var sharedPolicyGroup = sharedPolicyGroupHistoryRepository.getLatestBySharedPolicyGroupId(
+            "environmentId",
+            "sharedPolicyGroupId_1"
+        );
+        assertThat(sharedPolicyGroup).isPresent();
+        assertThat(sharedPolicyGroup.get().getName()).isEqualTo("Name changed 9 times");
+    }
+
+    @Test
+    public void should_getLatestBySharedPolicyGroupId_with_no_result() throws TechnicalException {
+        final var sharedPolicyGroup = sharedPolicyGroupHistoryRepository.getLatestBySharedPolicyGroupId("environmentId", "unknown");
+        assertThat(sharedPolicyGroup).isEmpty();
+    }
+
     private static SharedPolicyGroup.SharedPolicyGroupBuilder getDefaultSharedPolicyGroupBuilder(String id) {
         return SharedPolicyGroup
             .builder()

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
@@ -216,8 +216,8 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
     }
 
     @Test
-    public void should_searchLatestBySharedPolicyPolicyGroupId() throws TechnicalException {
-        final var page1 = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId(
+    public void should_searchLatestBySharedPolicyGroupId() throws TechnicalException {
+        final var page1 = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId(
             "environmentId",
             new PageableBuilder().pageNumber(0).pageSize(2).build()
         );
@@ -228,7 +228,7 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
         assertThat(page1.getContent().get(0).getName()).isEqualTo("Name changed 9 times");
         assertThat(page1.getContent().get(1).getName()).isEqualTo("Yet another SPG 2");
 
-        final var page2 = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId(
+        final var page2 = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId(
             "environmentId",
             new PageableBuilder().pageNumber(1).pageSize(2).build()
         );
@@ -238,8 +238,8 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
     }
 
     @Test
-    public void should_searchLatestBySharedPolicyPolicyGroupId_with_no_result() throws TechnicalException {
-        final var page = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId(
+    public void should_searchLatestBySharedPolicyGroupId_with_no_result() throws TechnicalException {
+        final var page = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId(
             "unknown",
             new PageableBuilder().pageNumber(0).pageSize(2).build()
         );
@@ -249,8 +249,8 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
     }
 
     @Test
-    public void should_searchLatestBySharedPolicyPolicyGroupId_with_no_result_with_unknown_environment() throws TechnicalException {
-        final var page = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId(
+    public void should_searchLatestBySharedPolicyGroupId_with_no_result_with_unknown_environment() throws TechnicalException {
+        final var page = sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId(
             "unknown",
             new PageableBuilder().pageNumber(0).pageSize(2).build()
         );

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
@@ -64,40 +64,24 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
 
     @Test
     public void should_create() throws Exception {
-        var date = new Date();
-        final SharedPolicyGroup sharedPolicyGroup = SharedPolicyGroup
-            .builder()
-            .id("id_create_test")
-            .name("name")
-            .version(1)
-            .description("description")
-            .prerequisiteMessage("prerequisiteMessage")
-            .crossId("crossId")
-            .apiType(ApiType.PROXY)
-            .phase(SharedPolicyGroup.ExecutionPhase.REQUEST)
-            .definition("definition")
-            .lifecycleState(SharedPolicyGroupLifecycleState.UNDEPLOYED)
-            .environmentId("environmentId")
-            .organizationId("organizationId")
-            .deployedAt(date)
-            .createdAt(date)
-            .updatedAt(date)
-            .build();
+        final SharedPolicyGroup sharedPolicyGroupV1 = getDefaultSharedPolicyGroupBuilder("id_create_test").name("Name v1").build();
+        sharedPolicyGroupHistoryRepository.create(sharedPolicyGroupV1);
 
-        final SharedPolicyGroup create = sharedPolicyGroupHistoryRepository.create(sharedPolicyGroup);
+        final SharedPolicyGroup sharedPolicyGroupV2 = getDefaultSharedPolicyGroupBuilder("id_create_test").name("Name v2").build();
+        final SharedPolicyGroup create = sharedPolicyGroupHistoryRepository.create(sharedPolicyGroupV2);
 
-        assertThat(create.getName()).isEqualTo(sharedPolicyGroup.getName());
-        assertThat(create.getVersion()).isEqualTo(sharedPolicyGroup.getVersion());
-        assertThat(create.getDescription()).isEqualTo(sharedPolicyGroup.getDescription());
-        assertThat(create.getPrerequisiteMessage()).isEqualTo(sharedPolicyGroup.getPrerequisiteMessage());
-        assertThat(create.getCrossId()).isEqualTo(sharedPolicyGroup.getCrossId());
-        assertThat(create.getApiType()).isEqualTo(sharedPolicyGroup.getApiType());
-        assertThat(create.getPhase()).isEqualTo(sharedPolicyGroup.getPhase());
-        assertThat(create.getDefinition()).isEqualTo(sharedPolicyGroup.getDefinition());
-        assertThat(create.getLifecycleState()).isEqualTo(sharedPolicyGroup.getLifecycleState());
-        assertThat(create.getEnvironmentId()).isEqualTo(sharedPolicyGroup.getEnvironmentId());
-        assertThat(create.getOrganizationId()).isEqualTo(sharedPolicyGroup.getOrganizationId());
-        assertThat(create.getDeployedAt()).isEqualTo(sharedPolicyGroup.getDeployedAt());
+        assertThat(create.getName()).isEqualTo(sharedPolicyGroupV2.getName());
+        assertThat(create.getVersion()).isEqualTo(sharedPolicyGroupV2.getVersion());
+        assertThat(create.getDescription()).isEqualTo(sharedPolicyGroupV2.getDescription());
+        assertThat(create.getPrerequisiteMessage()).isEqualTo(sharedPolicyGroupV2.getPrerequisiteMessage());
+        assertThat(create.getCrossId()).isEqualTo(sharedPolicyGroupV2.getCrossId());
+        assertThat(create.getApiType()).isEqualTo(sharedPolicyGroupV2.getApiType());
+        assertThat(create.getPhase()).isEqualTo(sharedPolicyGroupV2.getPhase());
+        assertThat(create.getDefinition()).isEqualTo(sharedPolicyGroupV2.getDefinition());
+        assertThat(create.getLifecycleState()).isEqualTo(sharedPolicyGroupV2.getLifecycleState());
+        assertThat(create.getEnvironmentId()).isEqualTo(sharedPolicyGroupV2.getEnvironmentId());
+        assertThat(create.getOrganizationId()).isEqualTo(sharedPolicyGroupV2.getOrganizationId());
+        assertThat(create.getDeployedAt()).isEqualTo(sharedPolicyGroupV2.getDeployedAt());
         assertThat(create.getCreatedAt()).isEqualTo(create.getCreatedAt());
         assertThat(create.getUpdatedAt()).isEqualTo(create.getUpdatedAt());
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupHistoryRepositoryTest.java
@@ -259,6 +259,23 @@ public class SharedPolicyGroupHistoryRepositoryTest extends AbstractManagementRe
         assertThat(sharedPolicyGroup).isEmpty();
     }
 
+    @Test
+    public void should_delete() throws TechnicalException {
+        final var sharedPolicyGroup = sharedPolicyGroupHistoryRepository.getLatestBySharedPolicyGroupId(
+            "environmentId",
+            "sharedPolicyGroupId_1"
+        );
+        assertThat(sharedPolicyGroup).isPresent();
+
+        sharedPolicyGroupHistoryRepository.delete(sharedPolicyGroup.get().getId());
+
+        final var sharedPolicyGroupAfterDelete = sharedPolicyGroupHistoryRepository.getLatestBySharedPolicyGroupId(
+            "environmentId",
+            "sharedPolicyGroupId_1"
+        );
+        assertThat(sharedPolicyGroupAfterDelete).isEmpty();
+    }
+
     private static SharedPolicyGroup.SharedPolicyGroupBuilder getDefaultSharedPolicyGroupBuilder(String id) {
         return SharedPolicyGroup
             .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -92,31 +92,22 @@ public class SharedPolicyGroup {
      */
     private SharedPolicyGroupLifecycleState lifecycleState;
 
-    public io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup deploy() {
+    public void deploy() {
         lifecycleState = SharedPolicyGroupLifecycleState.DEPLOYED;
         version = version != null ? version + 1 : 1;
         final ZonedDateTime now = TimeProvider.now();
         deployedAt = now;
         updatedAt = now;
-
-        return io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup
-            .builder()
-            .id(crossId)
-            .environmentId(environmentId)
-            .policies(steps)
-            .phase(io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.valueOf(phase.name()))
-            .name(name)
-            .deployedAt(Date.from(deployedAt.toInstant()))
-            .build();
     }
 
-    public io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup undeploy() {
+    public void undeploy() {
         lifecycleState = SharedPolicyGroupLifecycleState.UNDEPLOYED;
-        version = version != null ? version + 1 : 1;
         final ZonedDateTime now = TimeProvider.now();
         deployedAt = now;
         updatedAt = now;
+    }
 
+    public io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup toDefinition() {
         return io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup
             .builder()
             .id(crossId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/query_service/SharedPolicyGroupHistoryQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/query_service/SharedPolicyGroupHistoryQueryService.java
@@ -22,7 +22,7 @@ import io.gravitee.rest.api.model.common.Sortable;
 import java.util.stream.Stream;
 
 public interface SharedPolicyGroupHistoryQueryService {
-    Stream<SharedPolicyGroup> streamLatestBySharedPolicyPolicyGroupId(String environmentId);
+    Stream<SharedPolicyGroup> streamLatestBySharedPolicyGroupId(String environmentId);
 
     Page<SharedPolicyGroup> search(String environmentId, String sharedPolicyGroupId, Pageable pageable, Sortable sortable);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/query_service/SharedPolicyGroupHistoryQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/query_service/SharedPolicyGroupHistoryQueryService.java
@@ -19,10 +19,13 @@ import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroup;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public interface SharedPolicyGroupHistoryQueryService {
     Stream<SharedPolicyGroup> streamLatestBySharedPolicyGroupId(String environmentId);
 
     Page<SharedPolicyGroup> search(String environmentId, String sharedPolicyGroupId, Pageable pageable, Sortable sortable);
+
+    Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/use_case/DeploySharedPolicyGroupUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/use_case/DeploySharedPolicyGroupUseCase.java
@@ -51,9 +51,9 @@ public class DeploySharedPolicyGroupUseCase {
             input.sharedPolicyGroupId()
         );
 
-        final io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup definition = existingSharedPolicyGroup.deploy();
+        existingSharedPolicyGroup.deploy();
 
-        publishEvent(input, definition, existingSharedPolicyGroup);
+        publishEvent(input, existingSharedPolicyGroup.toDefinition(), existingSharedPolicyGroup);
 
         final SharedPolicyGroup updatedSharedPolicyGroup = sharedPolicyGroupCrudService.update(existingSharedPolicyGroup);
         sharedPolicyGroupHistoryCrudService.create(updatedSharedPolicyGroup);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/use_case/GetSharedPolicyGroupPolicyPluginsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/use_case/GetSharedPolicyGroupPolicyPluginsUseCase.java
@@ -34,7 +34,7 @@ public class GetSharedPolicyGroupPolicyPluginsUseCase {
      */
     public Output execute(Input input) {
         var result = sharedPolicyGroupHistoryQueryService
-            .streamLatestBySharedPolicyPolicyGroupId(input.environmentId())
+            .streamLatestBySharedPolicyGroupId(input.environmentId())
             .filter(SharedPolicyGroup::isDeployed)
             .map(SharedPolicyGroupPolicyPlugin::fromSharedPolicyGroup)
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
@@ -63,7 +63,8 @@ public class SharedPolicyGroupHistoryQueryServiceImpl implements SharedPolicyGro
         } catch (TechnicalException e) {
             logger.error("An error occurred while streaming all last shared policy groups by environment ID {}", environmentId, e);
             throw new TechnicalDomainException(
-                "An error occurred while trying to stream all last shared policy groups by environment ID: " + environmentId + e
+                "An error occurred while trying to stream all last shared policy groups by environment ID: " + environmentId,
+                e
             );
         }
     }
@@ -94,10 +95,11 @@ public class SharedPolicyGroupHistoryQueryServiceImpl implements SharedPolicyGro
                 e
             );
             throw new TechnicalDomainException(
-                "An error occurred while trying to search shared policy group histories by environment ID: " +
-                environmentId +
-                " and sharedPolicyGroupId: " +
-                sharedPolicyGroupId +
+                String.format(
+                    "An error occurred while trying to search shared policy group histories by environment ID: %s and sharedPolicyGroupId: %s",
+                    environmentId,
+                    sharedPolicyGroupId
+                ),
                 e
             );
         }
@@ -119,10 +121,11 @@ public class SharedPolicyGroupHistoryQueryServiceImpl implements SharedPolicyGro
                 e
             );
             throw new TechnicalDomainException(
-                "An error occurred while trying to get the latest shared policy group by environment ID: " +
-                environmentId +
-                " and sharedPolicyGroupId: " +
-                sharedPolicyGroupId +
+                String.format(
+                    "An error occurred while trying to get the latest shared policy group by environment ID: %s and sharedPolicyGroupId: %s",
+                    environmentId,
+                    sharedPolicyGroupId
+                ),
                 e
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +95,31 @@ public class SharedPolicyGroupHistoryQueryServiceImpl implements SharedPolicyGro
             );
             throw new TechnicalDomainException(
                 "An error occurred while trying to search shared policy group histories by environment ID: " +
+                environmentId +
+                " and sharedPolicyGroupId: " +
+                sharedPolicyGroupId +
+                e
+            );
+        }
+    }
+
+    @Override
+    public Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId) {
+        Assert.notNull(environmentId, "EnvironmentId must not be null");
+        Assert.notNull(sharedPolicyGroupId, "SharedPolicyGroupId must not be null");
+        try {
+            return sharedPolicyGroupHistoryRepository
+                .getLatestBySharedPolicyGroupId(environmentId, sharedPolicyGroupId)
+                .map(sharedPolicyGroupAdapter::toEntity);
+        } catch (TechnicalException e) {
+            logger.error(
+                "An error occurred while getting the latest shared policy group by environment ID {} and sharedPolicyGroupId {}",
+                environmentId,
+                sharedPolicyGroupId,
+                e
+            );
+            throw new TechnicalDomainException(
+                "An error occurred while trying to get the latest shared policy group by environment ID: " +
                 environmentId +
                 " and sharedPolicyGroupId: " +
                 sharedPolicyGroupId +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImpl.java
@@ -52,11 +52,11 @@ public class SharedPolicyGroupHistoryQueryServiceImpl implements SharedPolicyGro
     }
 
     @Override
-    public Stream<SharedPolicyGroup> streamLatestBySharedPolicyPolicyGroupId(String environmentId) {
+    public Stream<SharedPolicyGroup> streamLatestBySharedPolicyGroupId(String environmentId) {
         try {
             return PageUtils
                 .toStream(repositoryPageable ->
-                    sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyPolicyGroupId(environmentId, repositoryPageable)
+                    sharedPolicyGroupHistoryRepository.searchLatestBySharedPolicyGroupId(environmentId, repositoryPageable)
                 )
                 .map(sharedPolicyGroupAdapter::toEntity);
         } catch (TechnicalException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SharedPolicyGroupHistoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SharedPolicyGroupHistoryQueryServiceInMemory.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -68,6 +69,15 @@ public class SharedPolicyGroupHistoryQueryServiceInMemory
             : matches.subList((pageNumber - 1) * pageSize, Math.min(pageNumber * pageSize, matches.size()));
 
         return new Page<>(page, pageNumber, pageSize, matches.size());
+    }
+
+    @Override
+    public Optional<SharedPolicyGroup> getLatestBySharedPolicyGroupId(String environmentId, String sharedPolicyGroupId) {
+        return storage
+            .stream()
+            .filter(spg -> spg.getEnvironmentId().equals(environmentId))
+            .filter(spg -> spg.getId().equals(sharedPolicyGroupId))
+            .max(Comparator.comparing(SharedPolicyGroup::getUpdatedAt));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SharedPolicyGroupHistoryQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SharedPolicyGroupHistoryQueryServiceInMemory.java
@@ -33,7 +33,7 @@ public class SharedPolicyGroupHistoryQueryServiceInMemory
     final ArrayList<SharedPolicyGroup> storage = new ArrayList<>();
 
     @Override
-    public Stream<SharedPolicyGroup> streamLatestBySharedPolicyPolicyGroupId(String environmentId) {
+    public Stream<SharedPolicyGroup> streamLatestBySharedPolicyGroupId(String environmentId) {
         return storage.stream().filter(spg -> spg.getEnvironmentId().equals(environmentId));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/UndeploySharedPolicyGroupUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/UndeploySharedPolicyGroupUseCaseTest.java
@@ -24,6 +24,7 @@ import inmemory.EventCrudInMemory;
 import inmemory.EventLatestCrudInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
+import inmemory.SharedPolicyGroupHistoryQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditActor;
@@ -78,6 +79,8 @@ class UndeploySharedPolicyGroupUseCaseTest {
     private final SharedPolicyGroupCrudServiceInMemory sharedPolicyGroupCrudService = new SharedPolicyGroupCrudServiceInMemory();
     private final SharedPolicyGroupHistoryCrudServiceInMemory sharedPolicyGroupHistoryCrudService =
         new SharedPolicyGroupHistoryCrudServiceInMemory();
+    private final SharedPolicyGroupHistoryQueryServiceInMemory sharedPolicyGroupHistoryQueryService =
+        new SharedPolicyGroupHistoryQueryServiceInMemory();
     private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
     private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
 
@@ -104,6 +107,7 @@ class UndeploySharedPolicyGroupUseCaseTest {
                 eventLatestCrudInMemory,
                 sharedPolicyGroupCrudService,
                 sharedPolicyGroupHistoryCrudService,
+                sharedPolicyGroupHistoryQueryService,
                 auditService
             );
     }
@@ -123,10 +127,11 @@ class UndeploySharedPolicyGroupUseCaseTest {
             .phase(PolicyPlugin.ExecutionPhase.REQUEST)
             .id(SHARED_POLICY_GROUP_ID)
             .crossId(SHARED_POLICY_GROUP_CROSS_ID)
-            .lifecycleState(SharedPolicyGroup.SharedPolicyGroupLifecycleState.UNDEPLOYED)
+            .lifecycleState(SharedPolicyGroup.SharedPolicyGroupLifecycleState.DEPLOYED)
             .version(1)
             .build();
         sharedPolicyGroupCrudService.initWith(List.of(existingSharedPolicyGroup));
+        sharedPolicyGroupHistoryQueryService.initWith(List.of(existingSharedPolicyGroup));
 
         // When
         cut.execute(new Input(SHARED_POLICY_GROUP_ID, ENV_ID, AUDIT_INFO));
@@ -189,7 +194,7 @@ class UndeploySharedPolicyGroupUseCaseTest {
             .satisfies(sharedPolicyGroup -> {
                 assertThat(sharedPolicyGroup.getId()).isEqualTo(SHARED_POLICY_GROUP_ID);
                 assertThat(sharedPolicyGroup.getLifecycleState()).isEqualTo(SharedPolicyGroup.SharedPolicyGroupLifecycleState.UNDEPLOYED);
-                assertThat(sharedPolicyGroup.getVersion()).isEqualTo(2);
+                assertThat(sharedPolicyGroup.getVersion()).isEqualTo(1);
             });
         assertThat(sharedPolicyGroupHistoryCrudService.storage())
             .hasSize(1)
@@ -197,7 +202,7 @@ class UndeploySharedPolicyGroupUseCaseTest {
             .satisfies(sharedPolicyGroup -> {
                 assertThat(sharedPolicyGroup.getId()).isEqualTo(SHARED_POLICY_GROUP_ID);
                 assertThat(sharedPolicyGroup.getLifecycleState()).isEqualTo(SharedPolicyGroup.SharedPolicyGroupLifecycleState.UNDEPLOYED);
-                assertThat(sharedPolicyGroup.getVersion()).isEqualTo(2);
+                assertThat(sharedPolicyGroup.getVersion()).isEqualTo(1);
             });
 
         // - Check audit

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/shared_policy_group/SharedPolicyGroupHistoryQueryServiceImplTest.java
@@ -62,10 +62,10 @@ class SharedPolicyGroupHistoryQueryServiceImplTest {
         void streamByEnvironmentIdAndState_should_return_empty_stream() {
             // Given
             String environmentId = "environmentId";
-            when(repository.searchLatestBySharedPolicyPolicyGroupId(eq(environmentId), any())).thenReturn(new Page<>(List.of(), 0, 0, 0));
+            when(repository.searchLatestBySharedPolicyGroupId(eq(environmentId), any())).thenReturn(new Page<>(List.of(), 0, 0, 0));
 
             // When
-            List<SharedPolicyGroup> result = service.streamLatestBySharedPolicyPolicyGroupId(environmentId).toList();
+            List<SharedPolicyGroup> result = service.streamLatestBySharedPolicyGroupId(environmentId).toList();
             // Then
             assertThat(result).isEmpty();
         }
@@ -76,7 +76,7 @@ class SharedPolicyGroupHistoryQueryServiceImplTest {
             // Given
             String environmentId = "environmentId";
             when(
-                repository.searchLatestBySharedPolicyPolicyGroupId(
+                repository.searchLatestBySharedPolicyGroupId(
                     eq(environmentId),
                     any(io.gravitee.repository.management.api.search.Pageable.class)
                 )
@@ -111,7 +111,7 @@ class SharedPolicyGroupHistoryQueryServiceImplTest {
                 });
 
             // When
-            var result = service.streamLatestBySharedPolicyPolicyGroupId(environmentId).toList();
+            var result = service.streamLatestBySharedPolicyGroupId(environmentId).toList();
 
             // Then
             assertThat(result).isNotEmpty();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5391

## Description

- impl getLatestBySharedPolicyId to find last SPG from histories
- fix minor create bug
- impl delete all for history by SPGId
- use the last SPG of the history to undeploy it instead of the SPG -> this allow later to add PENDING state for SPG

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

