### PR TITLE
--wip allows changing http2 multiplexing

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
@@ -15,10 +15,9 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.client;
 
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.ProtocolVersion;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.http.vertx.client.VertxHttpClient;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptions;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
@@ -16,7 +16,6 @@
 package io.gravitee.plugin.endpoint.http.proxy.client;
 
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.http.vertx.client.VertxHttpClient;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
@@ -42,7 +41,9 @@ public class HttpClientFactory {
             synchronized (this) {
                 // Double-checked locking.
                 if (httpClientCreated.compareAndSet(false, true)) {
-                    httpClient = buildHttpClient(ctx, configuration, sharedConfiguration).build().createHttpClient();
+                    VertxHttpClient vertxHttpClient = buildHttpClient(ctx, configuration, sharedConfiguration).build();
+
+                    httpClient = vertxHttpClient.createHttpClient();
                 }
             }
         }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClient.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClient.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import io.gravitee.common.util.VertxProxyOptionsUtils;
+import io.gravitee.definition.model.v4.http.HttpProxyOptions;
+import io.gravitee.definition.model.v4.http.ProtocolVersion;
+import io.gravitee.definition.model.v4.ssl.SslOptions;
+import io.gravitee.gateway.reactive.tcp.AbstractBaseClient;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptions;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Slf4j
+@Builder
+public class VertxHttpClient extends AbstractBaseClient {
+
+    public static final int UNSECURE_PORT = 80;
+    public static final int SECURE_PORT = 443;
+
+    // Dummy {@link URLStreamHandler} implementation to avoid unknown protocol issue with default implementation (which knows how to handle only http and https protocol).
+    public static final URLStreamHandler URL_HANDLER = new URLStreamHandler() {
+        @Override
+        protected URLConnection openConnection(URL u) {
+            return null;
+        }
+    };
+    protected static final String HTTP_SSL_OPENSSL_CONFIGURATION = "http.ssl.openssl";
+
+    @NonNull
+    private final Vertx vertx;
+
+    @NonNull
+    private final Configuration nodeConfiguration;
+
+    private String name;
+    private boolean shared;
+    private String defaultTarget;
+    private HttpProxyOptions proxyOptions;
+    private HttpClientOptions httpOptions;
+    private SslOptions sslOptions;
+
+    public HttpClient createHttpClient() {
+        if (httpOptions == null) {
+            httpOptions = new HttpClientOptions();
+        }
+        return vertx.createHttpClient(createHttpClientOptions());
+    }
+
+    public static boolean isSecureProtocol(String protocol) {
+        return protocol.charAt(protocol.length() - 1) == 's' && protocol.length() > 2;
+    }
+
+    public static URL buildUrl(String uri) {
+        try {
+            return new URL(null, uri, URL_HANDLER);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Target [" + uri + "] is not valid");
+        }
+    }
+
+    public static int getPort(URL target, boolean isSecured) {
+        final int defaultPort = isSecured ? SECURE_PORT : UNSECURE_PORT;
+        return target.getPort() != -1 ? target.getPort() : defaultPort;
+    }
+
+    public static String toAbsoluteUri(RequestOptions requestOptions, String defaultHost, int defaultPort) {
+        return (
+            (Boolean.TRUE.equals(requestOptions.isSsl()) ? "https://" : "http://") +
+            (
+                (requestOptions.getHost() != null ? requestOptions.getHost() : defaultHost) +
+                (requestOptions.getPort() != null ? ":" + requestOptions.getPort() : (defaultPort != -1 ? ":" + defaultPort : "")) +
+                requestOptions.getURI()
+            )
+        );
+    }
+
+    private io.vertx.core.http.HttpClientOptions createHttpClientOptions() {
+        io.vertx.core.http.HttpClientOptions options = new io.vertx.core.http.HttpClientOptions();
+
+        options
+            .setPipelining(httpOptions.isPipelining())
+            .setKeepAlive(httpOptions.isKeepAlive())
+            .setIdleTimeout((int) (httpOptions.getIdleTimeout() / 1000))
+            .setKeepAliveTimeout((int) (httpOptions.getKeepAliveTimeout() / 1000))
+            .setConnectTimeout((int) httpOptions.getConnectTimeout())
+            .setMaxPoolSize(httpOptions.getMaxConcurrentConnections())
+            .setTryUseCompression(httpOptions.isUseCompression())
+            .setTryUsePerFrameWebSocketCompression(httpOptions.isUseCompression())
+            .setTryUsePerMessageWebSocketCompression(httpOptions.isUseCompression())
+            .setWebSocketCompressionAllowClientNoContext(httpOptions.isUseCompression())
+            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression());
+
+        if (httpOptions.getVersion() == ProtocolVersion.HTTP_2) {
+            options
+                .setProtocolVersion(HttpVersion.HTTP_2)
+                .setHttp2ClearTextUpgrade(httpOptions.isClearTextUpgrade())
+                .setHttp2MaxPoolSize(httpOptions.getMaxConcurrentConnections())
+                .setHttp2MultiplexingLimit(httpOptions.getHttp2MultiplexingLimit());
+        }
+
+        final URL target = buildUrl(defaultTarget);
+
+        configureHttpProxy(options);
+        configureSsl(options, target);
+
+        if (name != null) {
+            options.setName(name);
+        }
+
+        return options
+            .setShared(shared)
+            .setDefaultPort(getPort(target, isSecureProtocol(target.getProtocol())))
+            .setDefaultHost(target.getHost());
+    }
+
+    private void configureHttpProxy(final io.vertx.core.http.HttpClientOptions options) {
+        if (proxyOptions != null && proxyOptions.isEnabled()) {
+            if (proxyOptions.isUseSystemProxy()) {
+                setSystemProxy(options);
+            } else {
+                ProxyOptions proxyOptions;
+                proxyOptions = new ProxyOptions();
+                proxyOptions.setHost(this.proxyOptions.getHost());
+                proxyOptions.setPort(this.proxyOptions.getPort());
+                proxyOptions.setUsername(this.proxyOptions.getUsername());
+                proxyOptions.setPassword(this.proxyOptions.getPassword());
+                proxyOptions.setType(ProxyType.valueOf(this.proxyOptions.getType().name()));
+                options.setProxyOptions(proxyOptions);
+            }
+        }
+    }
+
+    private void configureSsl(final io.vertx.core.http.HttpClientOptions options, final URL target) {
+        if (isSecureProtocol(target.getProtocol())) {
+            // Configure SSL.
+            options.setSsl(true);
+
+            if (nodeConfiguration.getProperty(HTTP_SSL_OPENSSL_CONFIGURATION, Boolean.class, false)) {
+                options.setSslEngineOptions(new OpenSSLEngineOptions());
+            }
+
+            if (sslOptions != null) {
+                options.setVerifyHost(sslOptions.isHostnameVerifier()).setTrustAll(sslOptions.isTrustAll());
+
+                // Client truststore configuration (trust server certificate).
+                super.configureTrustStore(options, sslOptions, defaultTarget);
+
+                // Client keystore configuration (client certificate for mtls).
+                super.configureKeyStore(options, sslOptions, defaultTarget);
+            }
+        }
+
+        options.setUseAlpn(true);
+    }
+
+    private void setSystemProxy(final io.vertx.core.http.HttpClientOptions options) {
+        try {
+            VertxProxyOptionsUtils.setSystemProxy(options, nodeConfiguration);
+        } catch (Exception e) {
+            log.warn(
+                "HttpClient (name[{}] target[{}]) requires a system proxy to be defined but some configurations are missing or not well defined: {}",
+                name,
+                defaultTarget,
+                e.getMessage()
+            );
+            log.warn("Ignoring system proxy");
+        }
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptions.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.configuration;
+
+import static io.gravitee.node.vertx.client.http.VertxHttpClientOptions.*;
+
+import io.gravitee.definition.model.v4.http.ProtocolVersion;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.*;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HttpClientOptions implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -7061411805967594667L;
+
+    @Builder.Default
+    private int http2MultiplexingLimit = -1;
+
+    @Builder.Default
+    private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+
+    @Builder.Default
+    private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
+
+    @Builder.Default
+    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+    @Builder.Default
+    private boolean keepAlive = DEFAULT_KEEP_ALIVE;
+
+    @Builder.Default
+    private long readTimeout = DEFAULT_READ_TIMEOUT;
+
+    @Builder.Default
+    private boolean pipelining = DEFAULT_PIPELINING;
+
+    @Builder.Default
+    private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+
+    @Builder.Default
+    private boolean useCompression = DEFAULT_USE_COMPRESSION;
+
+    @Builder.Default
+    private boolean propagateClientAcceptEncoding = DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING;
+
+    @Builder.Default
+    private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+
+    @Builder.Default
+    private boolean clearTextUpgrade = DEFAULT_CLEAR_TEXT_UPGRADE;
+
+    @Builder.Default
+    private ProtocolVersion version = ProtocolVersion.valueOf(DEFAULT_PROTOCOL_VERSION.name());
+
+    public boolean isPropagateClientAcceptEncoding() {
+        // Propagate Accept-Encoding can only be made if useCompression is disabled.
+        return !useCompression && propagateClientAcceptEncoding;
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
@@ -17,7 +17,6 @@ package io.gravitee.plugin.endpoint.http.proxy.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpHeader;
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.HttpProxyOptions;
 import io.gravitee.definition.model.v4.ssl.SslOptions;
 import io.gravitee.gateway.reactive.api.connector.endpoint.EndpointConnectorSharedConfiguration;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -103,6 +103,17 @@
             "description":"Maximum pool size for connections.",
             "default":20
         },
+        "http2MultiplexingLimit":{
+            "type":"integer",
+            "title":"Max concurrent stream for an HTTP/2 connection",
+            "default":-1,
+            "gioConfig": {
+                "banner": {
+                    "title": "Max concurrent stream for an HTTP/2 connection",
+                    "text": "Limit of the number concurrent streams for each HTTP/2 connection. The effective number of streams for a connection is the min of this value and the server's initial settings. Setting the value to -1 means to use the value sent by the server's initial settings. -1 is the default value."
+                }
+            }
+        },
         "http":{
             "type":"object",
             "title":"Security configuration",
@@ -190,6 +201,9 @@
                         },
                         "maxConcurrentConnections":{
                             "$ref":"#/definitions/maxConcurrentConnections"
+                        },
+                        "http2MultiplexingLimit":{
+                            "$ref":"#/definitions/http2MultiplexingLimit"
                         }
                     },
                     "required":[

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
@@ -20,12 +20,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

This allows for circumventing latency issues with GRPC when dealing with large response bodies when connected to a remote GRPC backend (not on the same network).

We have discovered a flow control issue when proxying GRPC calls that is related to HTTP/2 and dramatically increases the latency when passing through the gateway.
Technically, the http/2 connection window size between the client and the gateway is updated too many times compared to when the client connects to the backend directly. Sometimes it is even negative (that is a big issue). This slows down the throughput in a way that creates important latencies.
This congestion seems to occur when the gateway uses a single connection with the backend and uses http2 multiplexing to handle all the incoming requests. By forcing the multiplexing to 1, it forces the gateway to establish a connection to handle a request (and reuse this connection for the next requests, a bit like we have for HTTP/1.1). That way, we can mitigate the congestion because each request is handled by a dedicated connection instead of 1 connection handling all the requests at the same time (by relying on multiplexing).

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mzjcwtvort.chromatic.com)
<!-- Storybook placeholder end -->
