### PR TITLE
fix: rework assembly dependencies for the prod bundles

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -118,6 +118,7 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
+                <include>com.graviteesource.*:*:jar</include>
             </includes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -136,6 +136,7 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
+                <include>com.graviteesource.*:*:jar</include>
             </includes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>644</fileMode>


### PR DESCRIPTION
## Issue

N/A

## Description

Rework assembly dependencies to include cloud-initializer lib in the full distribution ZIP.