### PR TITLE
--wip allows changing http2 multiplexing

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/GrpcHttpClientFactory.java
@@ -15,11 +15,10 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.client;
 
-import io.gravitee.apim.common.mapper.HttpClientOptionsMapper;
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.ProtocolVersion;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptions;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptionsMapper;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
@@ -15,12 +15,11 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.client;
 
-import io.gravitee.apim.common.mapper.HttpClientOptionsMapper;
 import io.gravitee.apim.common.mapper.HttpProxyOptionsMapper;
 import io.gravitee.apim.common.mapper.SslOptionsMapper;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.node.api.configuration.Configuration;
-import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptionsMapper;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 import io.vertx.rxjava3.core.Vertx;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientFactory.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.vertx.client.http.VertxHttpProtocolVersion;
+import io.gravitee.node.vertx.client.http.VertxHttpProxyOptions;
+import io.gravitee.node.vertx.client.ssl.KeyStore;
+import io.gravitee.node.vertx.client.ssl.SslOptions;
+import io.gravitee.node.vertx.client.ssl.TrustStore;
+import io.gravitee.node.vertx.proxy.VertxProxyOptionsUtils;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Slf4j
+@Builder
+public class VertxHttpClientFactory {
+
+    public static final int UNSECURE_PORT = 80;
+    public static final int SECURE_PORT = 443;
+
+    // Dummy {@link URLStreamHandler} implementation to avoid unknown protocol issue with default implementation (which knows how to handle only http and https protocol).
+    public static final URLStreamHandler URL_HANDLER = new URLStreamHandler() {
+        @Override
+        protected URLConnection openConnection(URL u) {
+            return null;
+        }
+    };
+    protected static final String HTTP_SSL_OPENSSL_CONFIGURATION = "http.ssl.openssl";
+
+    @NonNull
+    private final Vertx vertx;
+
+    @NonNull
+    private final Configuration nodeConfiguration;
+
+    private String name;
+    private boolean shared;
+    private String defaultTarget;
+    private VertxHttpProxyOptions proxyOptions;
+    private VertxHttpClientOptions httpOptions;
+    private SslOptions sslOptions;
+
+    public HttpClient createHttpClient() {
+        if (httpOptions == null) {
+            httpOptions = new VertxHttpClientOptions();
+        }
+        return vertx.createHttpClient(createHttpClientOptions());
+    }
+
+    public static boolean isSecureProtocol(String protocol) {
+        return protocol.charAt(protocol.length() - 1) == 's' && protocol.length() > 2;
+    }
+
+    public static URL buildUrl(String uri) {
+        try {
+            return new URL(null, uri, URL_HANDLER);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Target [" + uri + "] is not valid");
+        }
+    }
+
+    public static int getPort(URL target, boolean isSecured) {
+        final int defaultPort = isSecured ? SECURE_PORT : UNSECURE_PORT;
+        return target.getPort() != -1 ? target.getPort() : defaultPort;
+    }
+
+    public static String toAbsoluteUri(RequestOptions requestOptions, String defaultHost, int defaultPort) {
+        return (
+            (Boolean.TRUE.equals(requestOptions.isSsl()) ? "https://" : "http://") +
+            (
+                (requestOptions.getHost() != null ? requestOptions.getHost() : defaultHost) +
+                (requestOptions.getPort() != null ? ":" + requestOptions.getPort() : (defaultPort != -1 ? ":" + defaultPort : "")) +
+                requestOptions.getURI()
+            )
+        );
+    }
+
+    private io.vertx.core.http.HttpClientOptions createHttpClientOptions() {
+        io.vertx.core.http.HttpClientOptions options = new io.vertx.core.http.HttpClientOptions();
+
+        options
+            .setPipelining(httpOptions.isPipelining())
+            .setKeepAlive(httpOptions.isKeepAlive())
+            .setIdleTimeout((int) (httpOptions.getIdleTimeout() / 1000))
+            .setKeepAliveTimeout((int) (httpOptions.getKeepAliveTimeout() / 1000))
+            .setConnectTimeout((int) httpOptions.getConnectTimeout())
+            .setMaxPoolSize(httpOptions.getMaxConcurrentConnections())
+            .setDecompressionSupported(httpOptions.isUseCompression())
+            .setTryUsePerFrameWebSocketCompression(httpOptions.isUseCompression())
+            .setTryUsePerMessageWebSocketCompression(httpOptions.isUseCompression())
+            .setWebSocketCompressionAllowClientNoContext(httpOptions.isUseCompression())
+            .setWebSocketCompressionRequestServerNoContext(httpOptions.isUseCompression());
+
+        if (httpOptions.getVersion() == VertxHttpProtocolVersion.HTTP_2) {
+            options
+                .setProtocolVersion(HttpVersion.HTTP_2)
+                .setHttp2ClearTextUpgrade(httpOptions.isClearTextUpgrade())
+                .setHttp2MaxPoolSize(httpOptions.getMaxConcurrentConnections())
+                .setHttp2MultiplexingLimit(httpOptions.getHttp2MultiplexingLimit());
+        }
+
+        final URL target = buildUrl(defaultTarget);
+
+        configureHttpProxy(options);
+        configureSsl(options, target);
+
+        if (name != null) {
+            options.setName(name);
+        }
+
+        return options
+            .setShared(shared)
+            .setDefaultPort(getPort(target, isSecureProtocol(target.getProtocol())))
+            .setDefaultHost(target.getHost());
+    }
+
+    private void configureHttpProxy(final io.vertx.core.http.HttpClientOptions options) {
+        if (proxyOptions != null && proxyOptions.isEnabled()) {
+            if (proxyOptions.isUseSystemProxy()) {
+                setSystemProxy(options);
+            } else {
+                ProxyOptions vertxProxyOptions;
+                vertxProxyOptions = new ProxyOptions();
+                vertxProxyOptions.setHost(this.proxyOptions.getHost());
+                vertxProxyOptions.setPort(this.proxyOptions.getPort());
+                vertxProxyOptions.setUsername(this.proxyOptions.getUsername());
+                vertxProxyOptions.setPassword(this.proxyOptions.getPassword());
+                vertxProxyOptions.setType(ProxyType.valueOf(this.proxyOptions.getType().name()));
+                options.setProxyOptions(vertxProxyOptions);
+            }
+        }
+    }
+
+    private void configureSsl(final io.vertx.core.http.HttpClientOptions options, final URL target) {
+        if (isSecureProtocol(target.getProtocol())) {
+            // Configure SSL.
+            options.setSsl(true);
+
+            if (Boolean.TRUE.equals(nodeConfiguration.getProperty(HTTP_SSL_OPENSSL_CONFIGURATION, Boolean.class, false))) {
+                options.setSslEngineOptions(new OpenSSLEngineOptions());
+            }
+
+            if (sslOptions != null) {
+                options.setVerifyHost(sslOptions.isHostnameVerifier()).setTrustAll(sslOptions.isTrustAll());
+
+                try {
+                    // Client truststore configuration (trust server certificate).
+                    sslOptions.trustStore().flatMap(TrustStore::trustOptions).ifPresent(options::setTrustOptions);
+
+                    // Client keystore configuration (client certificate for mtls).
+                    sslOptions.keyStore().flatMap(KeyStore::keyCertOptions).ifPresent(options::setKeyCertOptions);
+                } catch (KeyStore.KeyStoreCertOptionsException | TrustStore.TrustOptionsException e) {
+                    throw new IllegalArgumentException(e.getMessage() + " for " + target);
+                }
+            }
+        }
+
+        options.setUseAlpn(true);
+    }
+
+    private void setSystemProxy(final io.vertx.core.http.HttpClientOptions options) {
+        try {
+            options.setProxyOptions(VertxProxyOptionsUtils.buildProxyOptions(nodeConfiguration));
+        } catch (Exception e) {
+            log.warn(
+                "HttpClient (name[{}] target[{}]) requires a system proxy to be defined but some configurations are missing or not well defined: {}",
+                name,
+                defaultTarget,
+                e.getMessage()
+            );
+            log.warn("Ignoring system proxy");
+        }
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientOptions.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import io.gravitee.node.vertx.client.http.VertxHttpProtocolVersion;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.*;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VertxHttpClientOptions {
+
+    @Serial
+    private static final long serialVersionUID = -6047350282117115405L;
+
+    public static final int DEFAULT_HTTP2_MULTIPLEXING_LIMIT = -1;
+    public static final long DEFAULT_IDLE_TIMEOUT = 60000;
+    public static final long DEFAULT_KEEP_ALIVE_TIMEOUT = 30000;
+    public static final long DEFAULT_CONNECT_TIMEOUT = 5000;
+    public static final long DEFAULT_READ_TIMEOUT = 10000;
+    public static final int DEFAULT_MAX_CONCURRENT_CONNECTIONS = 100;
+    public static final boolean DEFAULT_KEEP_ALIVE = true;
+    public static final boolean DEFAULT_PIPELINING = false;
+    public static final boolean DEFAULT_USE_COMPRESSION = true;
+    public static final boolean DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING = false;
+    public static final boolean DEFAULT_FOLLOW_REDIRECTS = false;
+    public static final boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
+    public static final VertxHttpProtocolVersion DEFAULT_PROTOCOL_VERSION = VertxHttpProtocolVersion.HTTP_1_1;
+
+    private int http2MultiplexingLimit = DEFAULT_HTTP2_MULTIPLEXING_LIMIT;
+    private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+    private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
+    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+    private boolean keepAlive = DEFAULT_KEEP_ALIVE;
+    private long readTimeout = DEFAULT_READ_TIMEOUT;
+    private boolean pipelining = DEFAULT_PIPELINING;
+    private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+    private boolean useCompression = DEFAULT_USE_COMPRESSION;
+    private boolean clearTextUpgrade = DEFAULT_CLEAR_TEXT_UPGRADE;
+    private VertxHttpProtocolVersion version = DEFAULT_PROTOCOL_VERSION;
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptions.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.configuration;
+
+import static io.gravitee.node.vertx.client.http.VertxHttpClientOptions.*;
+
+import io.gravitee.definition.model.v4.http.ProtocolVersion;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.*;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HttpClientOptions implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -7061411805967594667L;
+
+    @Builder.Default
+    private int http2MultiplexingLimit = -1;
+
+    @Builder.Default
+    private long idleTimeout = DEFAULT_IDLE_TIMEOUT;
+
+    @Builder.Default
+    private long keepAliveTimeout = DEFAULT_KEEP_ALIVE_TIMEOUT;
+
+    @Builder.Default
+    private long connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+    @Builder.Default
+    private boolean keepAlive = DEFAULT_KEEP_ALIVE;
+
+    @Builder.Default
+    private long readTimeout = DEFAULT_READ_TIMEOUT;
+
+    @Builder.Default
+    private boolean pipelining = DEFAULT_PIPELINING;
+
+    @Builder.Default
+    private int maxConcurrentConnections = DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+
+    @Builder.Default
+    private boolean useCompression = DEFAULT_USE_COMPRESSION;
+
+    @Builder.Default
+    private boolean propagateClientAcceptEncoding = DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING;
+
+    @Builder.Default
+    private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+
+    @Builder.Default
+    private boolean clearTextUpgrade = DEFAULT_CLEAR_TEXT_UPGRADE;
+
+    @Builder.Default
+    private ProtocolVersion version = ProtocolVersion.valueOf(DEFAULT_PROTOCOL_VERSION.name());
+
+    public boolean isPropagateClientAcceptEncoding() {
+        // Propagate Accept-Encoding can only be made if useCompression is disabled.
+        return !useCompression && propagateClientAcceptEncoding;
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptionsMapper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpClientOptionsMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.configuration;
+
+import io.gravitee.plugin.endpoint.http.proxy.client.VertxHttpClientOptions;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * This is a terrible hack that must not be committed!
+ */
+@Mapper
+public interface HttpClientOptionsMapper {
+    HttpClientOptionsMapper INSTANCE = Mappers.getMapper(HttpClientOptionsMapper.class);
+
+    VertxHttpClientOptions map(HttpClientOptions httpClientOptions);
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
@@ -17,7 +17,6 @@ package io.gravitee.plugin.endpoint.http.proxy.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.http.HttpHeader;
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.HttpProxyOptions;
 import io.gravitee.definition.model.v4.ssl.SslOptions;
 import io.gravitee.gateway.reactive.api.connector.endpoint.EndpointConnectorSharedConfiguration;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/sharedConfiguration/schema-form.json
@@ -103,6 +103,17 @@
             "description":"Maximum pool size for connections.",
             "default":20
         },
+        "http2MultiplexingLimit":{
+            "type":"integer",
+            "title":"Max concurrent stream for an HTTP/2 connection",
+            "default":-1,
+            "gioConfig": {
+                "banner": {
+                    "title": "Max concurrent stream for an HTTP/2 connection",
+                    "text": "Limit of the number concurrent streams for each HTTP/2 connection. The effective number of streams for a connection is the min of this value and the server's initial settings. Setting the value to -1 means to use the value sent by the server's initial settings. -1 is the default value."
+                }
+            }
+        },
         "http":{
             "type":"object",
             "title":"Security configuration",
@@ -190,6 +201,9 @@
                         },
                         "maxConcurrentConnections":{
                             "$ref":"#/definitions/maxConcurrentConnections"
+                        },
+                        "http2MultiplexingLimit":{
+                            "$ref":"#/definitions/http2MultiplexingLimit"
                         }
                     },
                     "required":[

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
@@ -20,12 +20,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpClientOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

This allows for circumventing latency issues with GRPC when dealing with large response bodies when connected to a remote GRPC backend (not on the same network).

We have discovered a flow control issue when proxying GRPC calls that is related to HTTP/2 and dramatically increases the latency when passing through the gateway.
Technically, the http/2 connection window size between the client and the gateway is updated too many times compared to when the client connects to the backend directly. Sometimes it is even negative (that is a big issue). This slows down the throughput in a way that creates important latencies.
This congestion seems to occur when the gateway uses a single connection with the backend and uses http2 multiplexing to handle all the incoming requests. By forcing the multiplexing to 1, it forces the gateway to establish a connection to handle a request (and reuse this connection for the next requests, a bit like we have for HTTP/1.1). That way, we can mitigate the congestion because each request is handled by a dedicated connection instead of 1 connection handling all the requests at the same time (by relying on multiplexing).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bihdzneqhl.chromatic.com)
<!-- Storybook placeholder end -->
