### PR TITLE
fix(portal-next): calculate first page of results by page number

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/applications.component.ts
@@ -45,7 +45,6 @@ export class ApplicationsComponent {
 
   private applicationService = inject(ApplicationService);
   private page$ = new BehaviorSubject(1);
-  private initialLoad = true;
 
   constructor() {
     this.applicationPaginator$ = this.loadApplications$();
@@ -63,8 +62,7 @@ export class ApplicationsComponent {
     return this.page$.pipe(
       tap(_ => this.loadingPage$.next(true)),
       switchMap(currentPage => {
-        if (this.initialLoad) {
-          this.initialLoad = false;
+        if (currentPage === 1) {
           return of({ page: currentPage, size: 18 });
         } else if (currentPage === 2) {
           this.page$.next(3);

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -80,7 +80,6 @@ export class CatalogComponent {
   private apiService = inject(ApiService);
   private categoriesService = inject(CategoriesService);
   private page$ = new BehaviorSubject(1);
-  private initialLoad: boolean = true;
 
   constructor(
     private route: ActivatedRoute,
@@ -131,8 +130,7 @@ export class CatalogComponent {
     return this.page$.pipe(
       tap(_ => this.loadingPage$.next(true)),
       switchMap(currentPage => {
-        if (this.initialLoad) {
-          this.initialLoad = false;
+        if (currentPage === 1) {
           return of({ page: currentPage, size: 18 });
         } else if (currentPage === 2) {
           this.page$.next(3);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6428

## Description

For the API screen, we were loading 18 results based upon the value of `initialLoad`, which wasn't reset when the category or search term changed. 

The fix depends upon if the page is currently `1` in order to return 18 results.


https://github.com/user-attachments/assets/c2d76b9a-1b4e-4ec5-942e-2ab61e9f6cca


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

