### PR TITLE
Apim 6107 navigate api list filters

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -30,16 +30,13 @@
 
 @if (filterList$ | async; as filterList) {
   <div class="catalog__filters">
-    <app-api-filter
-      (selectedFilter)="onFilterSelection($event, filterList)"
-      [filterList]="filterList"
-      [filterParam]="filter"></app-api-filter>
+    <app-api-filter (selectedFilter)="onFilterSelection($event)" [filterList]="filterList" [filterParam]="filter()" />
     <div class="catalog__filters__bottom-row">
       <div class="catalog__filters__bottom-row__filter-labels">
-        @if (selectedCategory) {
-          <div class="m3-headline-medium">{{ selectedCategory.name }}</div>
-          @if (selectedCategory.description) {
-            <div class="m3-label-large">{{ selectedCategory.description }}</div>
+        @if (filterAsCategory(); as category) {
+          <div class="m3-headline-medium">{{ category.name }}</div>
+          @if (category.description) {
+            <div class="m3-label-large">{{ category.description }}</div>
           }
         } @else {
           <div class="m3-headline-medium" i18n="@@allApisLabel">All</div>
@@ -56,7 +53,7 @@
     <mat-card id="no-apis" appearance="outlined">
       <mat-card-content>
         <div>
-          @if (query || filter) {
+          @if (query || filter()) {
             <p i18n="@@noFilteredApisAvailable">
               Your search didn't return any APIs. Please try again with different keywords or categories.
             </p>

--- a/gravitee-apim-portal-webui-next/src/components/api-filter/api-filter.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-filter/api-filter.component.html
@@ -16,7 +16,7 @@
 
 -->
 <mat-button-toggle-group class="api-filter" [formControl]="toggleControl" [value]="currentValue" (change)="onSelectedFilter($event.value)">
-  <mat-button-toggle [value]="'all'" class="api-filter__button" i18n="@@apiFilterDefaultOption">All</mat-button-toggle>
+  <mat-button-toggle [value]="''" class="api-filter__button" i18n="@@apiFilterDefaultOption">All</mat-button-toggle>
   @for (filter of filterList | slice: 0 : 4; track filter.id) {
     <mat-button-toggle [value]="filter.id" class="api-filter__button m3-label-large">
       {{ filter.name }}

--- a/gravitee-apim-portal-webui-next/src/components/api-filter/api-filter.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-filter/api-filter.component.ts
@@ -56,21 +56,19 @@ export class ApiFilterComponent {
   selectedFilter = output<string>();
 
   public selectedOption!: string | undefined;
-  public currentValue: string = 'all';
+  public currentValue: string = '';
   public isFilterOpen: boolean = false;
   public toggleControl = new FormControl(this.currentValue);
 
   constructor(private eRef: ElementRef) {
     effect(() => {
-      if (this.filterParam()) {
-        const currentParamValue = this.filterList.slice(4).filter(filter => filter.id === this.filterParam());
-        if (currentParamValue.length) {
-          this.selectedOption = currentParamValue[0].name;
-        } else {
-          this.currentValue = this.filterParam();
-          this.toggleControl.setValue(this.filterParam());
-          this.selectedOption = '';
-        }
+      const currentParamValue = this.filterList.slice(4).filter(filter => filter.id === this.filterParam());
+      if (currentParamValue.length) {
+        this.selectedOption = currentParamValue[0].name;
+      } else {
+        this.currentValue = this.filterParam();
+        this.toggleControl.setValue(this.filterParam());
+        this.selectedOption = '';
       }
     });
   }
@@ -86,11 +84,7 @@ export class ApiFilterComponent {
   }
 
   onSelectedFilter(filterId: string | undefined): void {
-    if (filterId) {
-      this.selectedFilter.emit(filterId);
-    } else {
-      this.toggleControl.setValue(this.currentValue);
-    }
+    this.selectedFilter.emit(filterId ?? '');
   }
 
   selectOption(option: Category): void {

--- a/gravitee-apim-portal-webui-next/src/components/search-bar/search-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/search-bar/search-bar.component.ts
@@ -35,9 +35,7 @@ export class SearchBarComponent implements OnInit {
 
   constructor() {
     effect(() => {
-      if (this.searchParam()) {
-        this.searchControl.setValue(this.searchParam());
-      }
+      this.searchControl.setValue(this.searchParam());
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6107

## Description

Have the catalog component rely upon the activated route for all values

Note: There is a cancelled call, and it's to be expected. We want to call the backend if either the page or the query params change. However, when changing a query param, they both are changed 🙃 so it's called twice, with the first call cancelled.

https://github.com/user-attachments/assets/cb09e8e8-dd29-4b68-9102-c714c885e96b


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eckngwtzch.chromatic.com)
<!-- Storybook placeholder end -->
