### PR TITLE
fix: check websocket is upgraded when evaluating HTTP response is streaming data

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/utils/RequestUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/utils/RequestUtils.java
@@ -15,15 +15,17 @@
  */
 package io.gravitee.gateway.http.utils;
 
-import static io.vertx.core.http.HttpHeaders.*;
+import static io.vertx.core.http.HttpHeaders.CONNECTION;
+import static io.vertx.core.http.HttpHeaders.CONTENT_LENGTH;
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+import static io.vertx.core.http.HttpHeaders.UPGRADE;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
@@ -70,7 +72,7 @@ public final class RequestUtils {
     /**
      * Check if the given request is streaming
      *
-     * @param request
+     * @param request the request to test
      * @return <code>true</code> if the given request is streaming, <code>false</code> otherwise.
      */
     public static boolean isStreaming(final Request request) {
@@ -78,20 +80,21 @@ public final class RequestUtils {
     }
 
     /**
-     * Check if the given request/response is streaming
+     * Check if the given response is streaming
      *
-     * @param request
-     * @return <code>true</code> if the given request/response is streaming, <code>false</code> otherwise.
+     * @param request  the vertx http request
+     * @param response the http response
+     * @return <code>true</code> if the given response is streaming (websocket/gRPC/SEE...), <code>false</code> otherwise.
      */
-    public static boolean isStreaming(final Request request, final Response response) {
-        return hasStreamingContentType(response.headers()) || request.isWebSocket();
+    public static boolean isStreaming(VertxHttpServerRequest request, final Response response) {
+        return hasStreamingContentType(response.headers()) || request.isWebSocketUpgraded();
     }
 
     /**
-     * Check if the given requ
+     * Check if the given headers contains streaming information
      *
-     * @param httpHeaders
-     * @return <code>true</code> if the given request is websocket one, <code>false</code> otherwise.
+     * @param httpHeaders header to test
+     * @return true for gRPC, SSE, octet-stream
      */
     private static boolean hasStreamingContentType(final HttpHeaders httpHeaders) {
         String contentLengthHeaderValue = httpHeaders.get(CONTENT_LENGTH);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
@@ -25,7 +25,6 @@ import io.gravitee.gateway.reactive.core.context.AbstractResponse;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.vertx.core.http.HttpHeaders;
-import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
 import java.util.concurrent.atomic.AtomicReference;
 import org.reactivestreams.Subscription;
@@ -152,7 +151,7 @@ public class VertxHttpServerResponse extends AbstractResponse {
     @Override
     public boolean isStreaming() {
         if (isStreaming == null) {
-            isStreaming = RequestUtils.isStreaming(vertxHttpServerRequest, this);
+            isStreaming = RequestUtils.isStreaming(this.vertxHttpServerRequest, this);
         }
         return isStreaming;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/utils/RequestUtilsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/utils/RequestUtilsTest.java
@@ -29,10 +29,9 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.Response;
-import io.reactivex.rxjava3.core.Flowable;
+import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
@@ -189,7 +188,7 @@ class RequestUtilsTest {
     class StreamingResponseTest {
 
         @Mock
-        Request request;
+        VertxHttpServerRequest request;
 
         @Mock
         Response response;
@@ -204,6 +203,7 @@ class RequestUtilsTest {
 
         @Test
         void should_not_be_streaming_when_no_headers_nor_no_websocket() {
+            lenient().when(request.isWebSocketUpgraded()).thenReturn(false);
             assertFalse(RequestUtils.isStreaming(request, response));
         }
 
@@ -228,7 +228,7 @@ class RequestUtilsTest {
 
         @Test
         void should_be_streaming_request_when_websocket() {
-            lenient().when(request.isWebSocket()).thenReturn(true);
+            lenient().when(request.isWebSocketUpgraded()).thenReturn(true);
             assertTrue(RequestUtils.isStreaming(request, response));
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponseTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.when;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.http.utils.RequestUtils;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.message.Message;
 import io.gravitee.gateway.reactive.core.MessageFlow;
@@ -411,16 +409,17 @@ class VertxHttpServerResponseTest {
         @Test
         void should_check_streaming_only_once() {
             requestUtilsMockedStatic
-                .when(() -> RequestUtils.isStreaming(any(Request.class), any(Response.class)))
+                .when(() -> RequestUtils.isStreaming(any(VertxHttpServerRequest.class), any(Response.class)))
                 .thenAnswer(invocation -> true);
 
-            cut = spy(new VertxHttpServerResponse(request));
-
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 2; i++) {
                 assertTrue(cut.isStreaming());
             }
 
-            requestUtilsMockedStatic.verify(() -> RequestUtils.isStreaming(any(Request.class), any(Response.class)), times(1));
+            requestUtilsMockedStatic.verify(
+                () -> RequestUtils.isStreaming(any(VertxHttpServerRequest.class), any(Response.class)),
+                times(1)
+            );
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-353

Related to cloud gate for federation agent. Realised that 404 where not having content where they should have.

## Description

* We don't send chucks when request is a streaming request
* But during websocket upgrade, we need to send chucks if the response is not an upgrade response (errors mainly)

*As a result, a response is a streaming response only if the websocket was indeed upgraded*

Test have been re-organized a bit to test the method rather than the underlying utility class. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

