### PR TITLE
fix(portal-next): only show status filter if subscriptions exist for api

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.html
@@ -16,7 +16,7 @@
 
 -->
 @if (subscriptionsList$ | async; as subscriptions) {
-  @if (!!subscriptions.length || !!subscriptionsStatus.value) {
+  @if (subscriptionsExist) {
     <mat-form-field appearance="outline">
       <mat-label i18n="@@subscriptionStatusSelectLabel">Status</mat-label>
       <mat-select [formControl]="subscriptionsStatus" multiple id="api-tab-subscription__select">
@@ -29,7 +29,11 @@
   @if (subscriptions.length === 0) {
     <div class="api-tab-subscription__empty" id="no-subscriptions">
       <header i18n="@@noSubscriptionAvailable" class="api-tab-subscription__empty-header">No subscription found</header>
-      <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
+      @if (subscriptionsStatus.value?.length) {
+        <p i18n="@@noSubscriptionsFoundWithFilter">Try unchecking some of the chosen filters.</p>
+      } @else {
+        <p i18n="@@subscribeToApi">Subscribe to our API and your subscription will show up here.</p>
+      }
     </div>
   } @else {
     <table mat-table [dataSource]="subscriptions" class="api-tab-subscriptions__table">

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.spec.ts
@@ -50,6 +50,7 @@ describe('SubscriptionsTableComponent', () => {
     it('should show empty Subscription list', async () => {
       expectSubscriptionList(fakeSubscriptionResponse({ data: [] }), 'testId', '');
       expect(fixture.nativeElement.querySelector('#no-subscriptions')).toBeDefined();
+      expect(await getStatusSelectionOptional()).toEqual(null);
     });
   });
 
@@ -67,6 +68,7 @@ describe('SubscriptionsTableComponent', () => {
         plan: '-',
         status: 'Rejected',
       });
+      expect(await getStatusSelectionOptional()).toBeTruthy();
     });
 
     it('should show filtered subscription list', async () => {
@@ -83,5 +85,9 @@ describe('SubscriptionsTableComponent', () => {
     httpTestingController
       .expectOne(`${TESTING_BASE_URL}/subscriptions?apiId=${apiId}${status ? '&statuses=' + `${status}` : ''}&size=-1`)
       .flush(subscriptionResponse);
+  }
+
+  async function getStatusSelectionOptional(): Promise<MatSelectHarness | null> {
+    return await harnessLoader.getHarnessOrNull(MatSelectHarness);
   }
 });

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.ts
@@ -58,6 +58,7 @@ export class SubscriptionsTableComponent implements OnInit {
   public subscriptionStatusesList = Object.values(SubscriptionStatusEnum);
   public subscriptionsStatus: FormControl<SubscriptionStatusEnum[] | null> = new FormControl<SubscriptionStatusEnum[]>([]);
   public subscriptionsList$!: Observable<Subscription[]>;
+  public subscriptionsExist: boolean = false;
 
   constructor(
     private capitalizeFirstPipe: CapitalizeFirstPipe,
@@ -77,6 +78,9 @@ export class SubscriptionsTableComponent implements OnInit {
       startWith(this.subscriptionsStatus.value),
       switchMap(status => this.subscriptionService.list({ apiId: this.apiId, statuses: status, size: -1 })),
       map(response => {
+        if (this.subscriptionsStatus.value?.length === 0 && response.data.length) {
+          this.subscriptionsExist = true;
+        }
         return response.data
           ? response.data.map(sub => ({
               ...sub,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5378

## Description

Only show the subscription status filter if an API has filters

Has subscriptions, but none are applicable to the filter selected: 

<img width="1124" alt="Screenshot 2024-08-20 at 11 04 33" src="https://github.com/user-attachments/assets/79319fdc-0b8a-4b2b-8d63-ae4b8f57c504">


Does not have any subscriptions:

<img width="1144" alt="Screenshot 2024-08-20 at 11 04 22" src="https://github.com/user-attachments/assets/769a48cb-4260-47d9-8ea6-28389062f54d">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ncditmddhm.chromatic.com)
<!-- Storybook placeholder end -->
