### PR TITLE
Apim 6245 handle permissions portal next settings

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -419,6 +419,9 @@
                   [routerLink]="[environmentRootRouterLink, '_portal']"
                   target="_blank"
                   class="new-developer-portal-actions__content"
+                  *gioPermission="{
+                    anyOf: ['environment-settings-u', 'environment-settings-r', 'environment-theme-u', 'environment-theme-r']
+                  }"
                 >
                   <div>Open Settings</div>
                   <mat-icon [inline]="true" svgIcon="gio:external-link"></mat-icon>

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.spec.ts
@@ -25,6 +25,7 @@ import { PortalBannerHarness } from './portal-banner.harness';
 
 import { fakePortalSettings } from '../../../entities/portal/portalSettings.fixture';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 
 describe('DeveloperPortalBannerComponent', () => {
   let fixture: ComponentFixture<PortalBannerComponent>;
@@ -37,6 +38,12 @@ describe('DeveloperPortalBannerComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GioTestingModule, NoopAnimationsModule, PortalBannerComponent],
+      providers: [
+        {
+          provide: GioTestingPermissionProvider,
+          useValue: ['environment-settings-u'],
+        },
+      ],
     }).compileComponents();
 
     httpTestingController = TestBed.inject(HttpTestingController);

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.ts
@@ -34,6 +34,7 @@ import { PortalSettings } from '../../../entities/portal/portalSettings';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { BannerRadioButtonComponent } from '../../components/banner-radio-button/banner-radio-button.component';
 import { PortalHeaderComponent } from '../../components/header/portal-header.component';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 interface BannerForm {
   enabled: FormControl<boolean>;
@@ -75,6 +76,7 @@ export class PortalBannerComponent implements OnInit {
   constructor(
     private readonly portalSettingsService: PortalSettingsService,
     private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
@@ -98,6 +100,11 @@ export class PortalBannerComponent implements OnInit {
       subTitleText: new FormControl<string>(this.settings.portalNext.banner?.subtitle, [Validators.required]),
     });
     this.formInitialValues = this.form.getRawValue();
+
+    const isReadOnly = !this.permissionService.hasAnyMatching(['environment-settings-u']);
+    if (isReadOnly) {
+      this.form.disable();
+    }
   }
 
   reset() {

--- a/gravitee-apim-console-webui/src/portal/customization/portal-customization.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/portal-customization.component.spec.ts
@@ -18,6 +18,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PortalCustomizationComponent } from './portal-customization.component';
 
 import { GioTestingModule } from '../../shared/testing';
+import { GioTestingPermissionProvider } from '../../shared/components/gio-permission/gio-permission.service';
 
 describe('PortalCustomizationComponent', () => {
   let component: PortalCustomizationComponent;
@@ -26,6 +27,12 @@ describe('PortalCustomizationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PortalCustomizationComponent, GioTestingModule],
+      providers: [
+        {
+          provide: GioTestingPermissionProvider,
+          useValue: ['environment-theme-u'],
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PortalCustomizationComponent);

--- a/gravitee-apim-console-webui/src/portal/customization/theme/portal-theme.component.html
+++ b/gravitee-apim-console-webui/src/portal/customization/theme/portal-theme.component.html
@@ -25,7 +25,13 @@
     <mat-card class="portal-theme__left__form">
       <div class="portal-theme__left__form__header">
         <span class="gio-badge-accent"><mat-icon svgIcon="gio:chat-lines"></mat-icon>&nbsp;Applies to new portal only</span>
-        <button mat-stroked-button type="button" (click)="restoreDefaultValues()" matTooltip="Restore default values">
+        <button
+          mat-stroked-button
+          type="button"
+          (click)="restoreDefaultValues()"
+          [disabled]="isReadOnly"
+          matTooltip="Restore default values"
+        >
           <mat-icon svgIcon="gio:refresh-ccw"></mat-icon>
         </button>
       </div>

--- a/gravitee-apim-console-webui/src/portal/customization/theme/portal-theme.component.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/theme/portal-theme.component.ts
@@ -34,6 +34,7 @@ import { PortalHeaderComponent } from '../../components/header/portal-header.com
 import { UiPortalThemeService } from '../../../services-ngx/ui-theme.service';
 import { ThemePortalNext, UpdateThemePortalNext } from '../../../entities/management-api-v2';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 export interface ThemeVM {
   logo?: string[];
@@ -79,6 +80,7 @@ export class PortalThemeComponent implements OnInit, OnDestroy {
   constructor(
     private readonly uiPortalThemeService: UiPortalThemeService,
     private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   private initialTheme: ThemePortalNext;
@@ -101,6 +103,7 @@ export class PortalThemeComponent implements OnInit, OnDestroy {
   ];
 
   public portalThemeForm;
+  public isReadOnly: boolean = true;
 
   private unsubscribe$: Subject<void> = new Subject<void>();
 
@@ -147,6 +150,11 @@ export class PortalThemeComponent implements OnInit, OnDestroy {
               takeUntil(this.unsubscribe$),
             )
             .subscribe();
+
+          this.isReadOnly = !this.permissionService.hasAnyMatching(['environment-theme-u']);
+          if (this.isReadOnly) {
+            this.portalThemeForm.disable();
+          }
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.spec.ts
@@ -17,11 +17,13 @@ import { TestBed } from '@angular/core/testing';
 
 import { PortalNavigationService } from './portal-navigation.service';
 
+import { GioTestingModule } from '../../shared/testing';
+
 describe('PortalNavigationService', () => {
   let service: PortalNavigationService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({ imports: [GioTestingModule] });
     service = TestBed.inject(PortalNavigationService);
   });
 

--- a/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation/portal-navigation.service.ts
@@ -15,6 +15,8 @@
  */
 import { Injectable } from '@angular/core';
 
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+
 export interface MenuItem {
   icon?: string;
   routerLink?: string;
@@ -32,28 +34,37 @@ export interface GroupItem {
   providedIn: 'root',
 })
 export class PortalNavigationService {
-  constructor() {}
+  constructor(private readonly permissionService: GioPermissionService) {}
 
   public getCustomizationRoutes(): GroupItem {
-    const items: MenuItem[] = [
-      {
-        displayName: 'Customization',
-        routerLink: 'customization',
-        icon: 'gio:palette',
-        children: [
-          {
-            displayName: 'Theme',
-            routerLink: 'theme',
-            icon: 'gio:color-picker',
-          },
-          {
-            displayName: 'Banner',
-            routerLink: 'banner',
-            icon: 'gio:chat-lines',
-          },
-        ],
-      },
-    ];
+    const items: MenuItem[] = [];
+
+    const customization: MenuItem = {
+      displayName: 'Customization',
+      routerLink: 'customization',
+      icon: 'gio:palette',
+      children: [],
+    };
+
+    if (this.permissionService.hasAnyMatching(['environment-theme-r', 'environment-theme-u'])) {
+      customization.children.push({
+        displayName: 'Theme',
+        routerLink: 'theme',
+        icon: 'gio:color-picker',
+      });
+    }
+    if (this.permissionService.hasAnyMatching(['environment-settings-r', 'environment-settings-u'])) {
+      customization.children.push({
+        displayName: 'Banner',
+        routerLink: 'banner',
+        icon: 'gio:chat-lines',
+      });
+    }
+
+    if (customization.children.length) {
+      items.push(customization);
+    }
+
     return {
       title: 'Customization',
       subtitle: 'Customize the look, feel, and behavior of the new Developer Portal.',

--- a/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
+++ b/gravitee-apim-console-webui/src/portal/portal-settings-routing.module.ts
@@ -30,24 +30,30 @@ const portalRoutes: Routes = [
   {
     path: '',
     component: PortalNavigationComponent,
-    canActivate: [PermissionGuard.checkRouteDataPermissions, HasLicenseGuard, EnvironmentGuard.initEnvConfigAndLoadPermissions],
+    canActivate: [EnvironmentGuard.initEnvConfigAndLoadPermissions],
+    canActivateChild: [HasLicenseGuard, PermissionGuard.checkRouteDataPermissions],
     children: [
       {
         path: 'customization',
         component: PortalCustomizationComponent,
-        data: {
-          permissions: {
-            anyOf: ['organization-settings-r'],
-          },
-        },
         children: [
           {
             path: 'banner',
             component: PortalBannerComponent,
+            data: {
+              permissions: {
+                anyOf: ['environment-settings-r', 'environment-settings-u'],
+              },
+            },
           },
           {
             path: 'theme',
             component: PortalThemeComponent,
+            data: {
+              permissions: {
+                anyOf: ['environment-theme-r', 'environment-theme-u'],
+              },
+            },
           },
           {
             path: '',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6245

## Description

Implement permissions for portal-next customization:
- within theme/banner components
- within router
- Open Settings button in Settings > Portal > Settings > New Developer Portal

Theme in read-only:

https://github.com/user-attachments/assets/1d88d9eb-c5d1-4e8f-9d28-20afe774b118


Banner in read-only:

<img width="1203" alt="Screenshot 2024-08-20 at 11 41 01" src="https://github.com/user-attachments/assets/6e8baede-11c7-48e5-8984-25513651390f">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bqzeaeuiap.chromatic.com)
<!-- Storybook placeholder end -->
