### PR TITLE
feat(console): User can add a home page for a v4 API: Choose Existing…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -87,6 +87,7 @@ import { ApiScoreComponent } from './api-score/api-score.component';
 import { ApiDocumentationV4DefaultPageComponent } from './documentation-v4/documentation-default-page/api-documentation-v4-default-page.component';
 import { DocumentationEditCustomPageComponent } from './documentation-v4/documentation-edit-custom-page/documentation-edit-custom-page.component';
 import { DocumentationEditHomepageComponent } from './documentation-v4/documentation-edit-homepage/documentation-edit-homepage.component';
+import { ApiDocumentationChooseExistingPageComponent } from './documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component';
 
 import { DocumentationManagementComponent } from '../../components/documentation/documentation-management.component';
 import { DocumentationNewPageComponent } from '../../components/documentation/new-page.component';
@@ -898,6 +899,16 @@ const apisRoutes: Routes = [
               },
             },
             component: DocumentationEditHomepageComponent,
+          },
+          {
+            path: 'main-pages/homepage/choose',
+            data: {
+              docs: null,
+              permissions: {
+                anyOf: ['api-documentation-c', 'api-documentation-u', 'api-documentation-r'],
+              },
+            },
+            component: ApiDocumentationChooseExistingPageComponent,
           },
           {
             path: 'main-pages/homepage/:pageId',

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card>
+  <mat-card-content class="custom-content">
+    <div class="header">
+      <div class="header__content">
+        <div>
+          <span class="mat-h2">Select an Existing Page as Your Homepage</span>
+        </div>
+        <div class="header__subtitle">
+          Set an existing page as the homepage. This will be shown by default when users view the API in the Developer Portal.
+        </div>
+      </div>
+
+      <div>
+        <button mat-raised-button [disabled]="isReadOnly" (click)="goBackToDefaultPage()">Exit without saving</button>
+      </div>
+    </div>
+
+    <div>
+      <api-documentation-choose-page-list [pages]="pages" (selectPage)="selectPage($event)"></api-documentation-choose-page-list>
+    </div>
+    <gio-banner-warning>
+      This choice is final. Once a page is set as the homepage, it will no longer be listed under Documentation Pages.
+    </gio-banner-warning>
+
+    <div>
+      <button mat-raised-button color="primary" [disabled]="isReadOnly" (click)="saveWithConfirmation()">Set as Homepage</button>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.scss
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'src/scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .header__subtitle {
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    @include mat.m2-typography-level($typography, 'body-2');
+  }
+}
+
+.custom-content {
+  display: flex;
+  flex-flow: column;
+  gap: 20px;
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { ActivatedRoute } from '@angular/router';
+
+import { ApiDocumentationChooseExistingPageComponent } from './api-documentation-choose-existing-page.component';
+
+import { Breadcrumb, fakeMarkdown, Page } from '../../../../../entities/management-api-v2';
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
+
+describe('ApiDocumentationChooseExistingPageComponent', () => {
+  let fixture: ComponentFixture<ApiDocumentationChooseExistingPageComponent>;
+  const API_ID = 'api-id';
+  let httpTestingController: HttpTestingController;
+
+  const init = async (pages: Page[], breadcrumb: Breadcrumb[]) => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatIconTestingModule, GioTestingModule, ApiDocumentationChooseExistingPageComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { apiId: API_ID } } },
+        },
+        {
+          provide: InteractivityChecker,
+          useValue: {
+            isFocusable: () => true,
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiDocumentationChooseExistingPageComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne({
+        method: 'GET',
+        url: `https://url.test:3000/management/v2/environments/DEFAULT/apis/${API_ID}`,
+      })
+      .flush({ id: API_ID, lifecycleState: 'PUBLISHED' });
+
+    httpTestingController
+      .expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages`,
+      })
+      .flush({ pages, breadcrumb });
+  };
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('Header', () => {
+    it('should display header content', async () => {
+      const pages = [fakeMarkdown({ id: 'page-id', homepage: false })];
+      const breadcrumb = [];
+      await init(pages, breadcrumb);
+      const headerContent = fixture.nativeElement.querySelector('.header__content');
+      expect(headerContent).toBeTruthy();
+      const headerTitle = headerContent.querySelector('.mat-h2');
+      expect(headerTitle.textContent).toContain('Select an Existing Page as Your Homepage');
+    });
+
+    it('should display Exit without saving button', async () => {
+      const pages = [fakeMarkdown({ id: 'page-id', homepage: false })];
+      const breadcrumb = [];
+      await init(pages, breadcrumb);
+      const exitButton = fixture.nativeElement.querySelector('.header button');
+      expect(exitButton).toBeTruthy();
+      expect(exitButton.disabled).toBe(false);
+    });
+
+    it('should display Set as Homepage button', async () => {
+      const pages = [fakeMarkdown({ id: 'page-id', homepage: false })];
+      const breadcrumb = [];
+      await init(pages, breadcrumb);
+      const saveButton = fixture.nativeElement.querySelector('button[color="primary"]');
+      expect(saveButton).toBeTruthy();
+      expect(saveButton.disabled).toBe(false);
+    });
+
+    it('should display the gio-banner-warning content', async () => {
+      const pages = [fakeMarkdown({ id: 'page-id', homepage: false })];
+      const breadcrumb = [];
+      await init(pages, breadcrumb);
+      const bannerWarning = fixture.nativeElement.querySelector('gio-banner-warning');
+      expect(bannerWarning).toBeTruthy();
+      expect(bannerWarning.textContent).toContain(
+        'This choice is final. Once a page is set as the homepage, it will no longer be listed under Documentation Pages.',
+      );
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-existing-page/api-documentation-choose-existing-page.component.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatDialog, MatDialogActions, MatDialogClose, MatDialogContent } from '@angular/material/dialog';
+import { MatIcon } from '@angular/material/icon';
+import { Subject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { filter, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { MatCard, MatCardContent } from '@angular/material/card';
+import { GioBannerModule, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+
+import { ApiDocumentationChoosePageListComponent } from '../api-documentation-choose-page-list/api-documentation-choose-page-list.component';
+import { Api, Page } from '../../../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
+import { ApiDocumentationV2Service } from '../../../../../services-ngx/api-documentation-v2.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+
+@Component({
+  selector: 'api-documentation-choose-existing-page',
+  standalone: true,
+  imports: [
+    ApiDocumentationChoosePageListComponent,
+    MatButton,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogContent,
+    MatIcon,
+    MatIconButton,
+    MatCard,
+    GioBannerModule,
+    MatCardContent,
+  ],
+  templateUrl: './api-documentation-choose-existing-page.component.html',
+  styleUrl: './api-documentation-choose-existing-page.component.scss',
+})
+export class ApiDocumentationChooseExistingPageComponent implements OnInit {
+  api: Api;
+  pages: Page[];
+  isLoading = false;
+  selectedPageId: string;
+  isReadOnly: boolean;
+  private unsubscribe$: Subject<void> = new Subject<void>();
+
+  @Output() pageSelected = new EventEmitter<string>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  constructor(
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly router: Router,
+    private readonly apiV2Service: ApiV2Service,
+    private readonly apiDocumentationV2Service: ApiDocumentationV2Service,
+    private readonly snackBarService: SnackBarService,
+    private readonly matDialog: MatDialog,
+  ) {}
+
+  ngOnInit() {
+    this.isLoading = true;
+
+    this.apiV2Service
+      .get(this.activatedRoute.snapshot.params.apiId)
+      .pipe(
+        tap((api) => {
+          this.api = api;
+          this.isReadOnly = this.api.originContext?.origin === 'KUBERNETES';
+        }),
+        switchMap(() => this.apiDocumentationV2Service.getApiPages(this.api.id)),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe((res) => {
+        this.pages = res.pages.filter((p) => p.generalConditions !== true && p.homepage !== true);
+        this.isLoading = false;
+      });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+  }
+
+  saveWithConfirmation() {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Confirm Homepage Selection',
+          content: 'This choice is final. Once a page becomes the homepage, it will no longer be accessible in your Documentation Pages.',
+          confirmButton: 'Confirm',
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter((confirmed) => !!confirmed),
+        switchMap(() => this.apiDocumentationV2Service.getApiPage(this.api.id, this.selectedPageId)),
+        switchMap((chosenPage: Page) =>
+          this.apiDocumentationV2Service.updateDocumentationPage(this.api.id, chosenPage.id, {
+            ...chosenPage,
+            homepage: true,
+          }),
+        ),
+      )
+      .subscribe({
+        next: () => {
+          this.snackBarService.success('Homepage chosen successfully');
+          this.goBackToDefaultPage();
+        },
+        error: (error) => {
+          this.snackBarService.error(error?.error?.message ?? 'An error occurred when choosing a homepage');
+        },
+      });
+  }
+
+  cancel() {
+    this.cancelled.emit();
+  }
+
+  selectPage(pageId: string) {
+    this.selectedPageId = pageId;
+  }
+
+  goBackToDefaultPage() {
+    this.router.navigate(['../../'], {
+      relativeTo: this.activatedRoute,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.html
@@ -1,0 +1,70 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="header">Name</div>
+<div class="scrollable-container">
+  <mat-tree [dataSource]="dataSource" [treeControl]="treeControl" class="documentation-pages-list__tree">
+    <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding (click)="onSelectPage(node)" class="documentation-pages-list__tree__node">
+      <div class="node-radio-container">
+        <mat-radio-group [(ngModel)]="selectedPageId">
+          <mat-radio-button [value]="node.id" (change)="onSelectPage(node)">
+            {{ node.name }}
+            <img
+              [ngSrc]="node.logoForPageType"
+              height="24"
+              width="24"
+              [alt]="node.titleForPageType"
+              [matTooltip]="node.tooltipForPageType"
+            />
+            @if (node.published) {
+              <span class="gio-badge-success"> Published </span>
+            } @else {
+              <span class="gio-badge-neutral"> Unpublished </span>
+            }
+            @if (node.visibility === 'PUBLIC') {
+              <span class="gio-badge-neutral"> Public </span>
+            }
+          </mat-radio-button>
+        </mat-radio-group>
+      </div>
+    </mat-tree-node>
+
+    <mat-tree-node
+      *matTreeNodeDef="let node; when: hasChild"
+      matTreeNodePadding
+      matTreeNodeToggle
+      (click)="onSelectPage(node)"
+      [cdkTreeNodeTypeaheadLabel]="node.name"
+      class="documentation-pages-list__tree__node"
+    >
+      <div class="node-tree-container">
+        <div class="left-content">
+          <mat-icon svgIcon="gio:folder"></mat-icon>
+          {{ node.name }}
+        </div>
+        @if (node.isLoading()) {
+          <mat-progress-bar mode="indeterminate" class="tree-progress-bar"></mat-progress-bar>
+        }
+        <button mat-icon-button [attr.aria-label]="'Toggle ' + node.name" matTreeNodeToggle>
+          <mat-icon class="mat-icon-rtl-mirror">
+            {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
+          </mat-icon>
+        </button>
+      </div>
+    </mat-tree-node>
+  </mat-tree>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.scss
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use 'sass:map';
+@use '@angular/material/index' as mat;
+@use '@gravitee/ui-particles-angular/index' as gio;
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, darker10);
+  border-radius: 8px;
+  display: flex;
+  flex-flow: column;
+  overflow: hidden;
+}
+
+.header {
+  padding: 20px;
+  border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter80');
+  background-color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'default');
+}
+
+.documentation-pages-list {
+  &__tree {
+    &__node {
+      display: flex;
+      width: 100%;
+      cursor: pointer;
+      gap: 8px;
+      align-items: center;
+      border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter80');
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+}
+
+.tree-progress-bar {
+  margin-left: 30px;
+}
+
+.scrollable-container {
+  max-height: 530px;
+  overflow-y: scroll;
+}
+
+.node-radio-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 20px;
+  width: 100%;
+
+  .left-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.node-tree-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: 30px;
+  width: 100%;
+
+  .left-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MatTreeModule } from '@angular/material/tree';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { FormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ApiDocumentationChoosePageListComponent, PageData } from './api-documentation-choose-page-list.component';
+
+import { Page } from '../../../../../entities/management-api-v2';
+
+describe('ApiDocumentationChoosePageListComponent', () => {
+  let component: ApiDocumentationChoosePageListComponent;
+  let fixture: ComponentFixture<ApiDocumentationChoosePageListComponent>;
+
+  const pages: Page[] = [
+    { id: 'page-id', name: 'Page 1', type: 'MARKDOWN', published: true, visibility: 'PUBLIC', generalConditions: false, parentId: null },
+    {
+      id: 'folder-id',
+      name: 'Folder 1',
+      type: 'FOLDER',
+      published: false,
+      visibility: 'PRIVATE',
+      generalConditions: false,
+      parentId: null,
+    },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        MatTreeModule,
+        MatRadioModule,
+        MatIconModule,
+        MatTooltipModule,
+        FormsModule,
+        ApiDocumentationChoosePageListComponent,
+      ],
+      providers: [PageData],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiDocumentationChoosePageListComponent);
+    component = fixture.componentInstance;
+    component.pages = pages;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should render the page list', () => {
+    const matTreeElement = fixture.debugElement.query(By.css('mat-tree'));
+    expect(matTreeElement).toBeTruthy();
+  });
+
+  it('should render both page types', () => {
+    component.pages = pages;
+
+    component.ngOnChanges({
+      pages: {
+        currentValue: pages,
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+    });
+
+    fixture.detectChanges();
+
+    const matTreeNodes = fixture.debugElement.queryAll(By.css('mat-tree-node'));
+    expect(matTreeNodes.length).toBe(2);
+
+    const markdownNode = matTreeNodes.find((node) => node.nativeElement.textContent.includes('Page 1'));
+    const folderNode = matTreeNodes.find((node) => node.nativeElement.textContent.includes('Folder 1'));
+
+    expect(markdownNode).toBeTruthy();
+    expect(folderNode).toBeTruthy();
+  });
+
+  it('should not render both page types if pages are empty', () => {
+    component.pages = [];
+    fixture.detectChanges();
+
+    component.ngOnChanges({
+      pages: {
+        currentValue: pages,
+        previousValue: null,
+        firstChange: true,
+        isFirstChange: () => true,
+      },
+    });
+
+    fixture.detectChanges();
+
+    const matTreeNodes = fixture.debugElement.queryAll(By.css('mat-tree-node'));
+    expect(matTreeNodes.length).toBe(0);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-choose-page-list/api-documentation-choose-page-list.component.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Injectable,
+  Input,
+  Output,
+  signal,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
+import { MatTreeModule, MatTree, MatTreeNode, MatTreeNodePadding, MatTreeNodeToggle } from '@angular/material/tree';
+import { MatIcon } from '@angular/material/icon';
+import { MatIconButton } from '@angular/material/button';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { map } from 'rxjs/operators';
+import { BehaviorSubject, merge, Observable } from 'rxjs';
+import { CollectionViewer, DataSource, SelectionChange } from '@angular/cdk/collections';
+import { MatRadioModule } from '@angular/material/radio';
+import { FormsModule } from '@angular/forms';
+import { NgIf, NgOptimizedImage, TitleCasePipe } from '@angular/common';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { getLogoForPageType, getTitleForPageType, getTooltipForPageType, Page } from '../../../../../entities/management-api-v2';
+
+export class PageFlatNode {
+  constructor(
+    public id: string,
+    public name: string,
+    public type: string,
+    public published: boolean,
+    public visibility: string,
+    public generalConditions: boolean,
+    public level = 1,
+    public expandable = false,
+    public logoForPageType: string,
+    public titleForPageType: string,
+    public tooltipForPageType: string,
+    public isLoading = signal(false),
+  ) {}
+}
+
+@Injectable({ providedIn: 'root' })
+export class PageData {
+  private pages: Page[] = [];
+
+  setPages(pages: Page[]): void {
+    this.pages = pages;
+  }
+
+  initialData(): PageFlatNode[] {
+    if (!this.pages) {
+      return [];
+    }
+    return this.pages.filter((page) => !page.parentId).map((page) => this.getPageFlatNode(page));
+  }
+
+  getPageFlatNode(page: Page, level: number = 0) {
+    const logoForPageType = getLogoForPageType(page.type);
+    const titleForPageType = getTitleForPageType(page.type);
+    const tooltipForPageType = getTooltipForPageType(page.type);
+    return new PageFlatNode(
+      page.id,
+      page.name,
+      page.type,
+      page.published,
+      page.visibility,
+      page.generalConditions,
+      level,
+      page.type === 'FOLDER',
+      logoForPageType ? logoForPageType.toString() : '',
+      titleForPageType ? titleForPageType.toLowerCase() + ' logo' : '',
+      tooltipForPageType,
+    );
+  }
+
+  getChildren(parentId: string): Page[] {
+    return this.pages.filter((page) => page.parentId === parentId);
+  }
+
+  isExpandable(page: Page): boolean {
+    return page.type === 'FOLDER';
+  }
+}
+
+export class PageDataSource implements DataSource<PageFlatNode> {
+  dataChange = new BehaviorSubject<PageFlatNode[]>([]);
+  private _collectionViewer: CollectionViewer;
+
+  get data(): PageFlatNode[] {
+    return this.dataChange.value;
+  }
+
+  set data(value: PageFlatNode[]) {
+    this._treeControl.dataNodes = value;
+    this.dataChange.next(value);
+  }
+
+  constructor(
+    private _treeControl: FlatTreeControl<PageFlatNode>,
+    private _pageData: PageData,
+  ) {}
+
+  connect(collectionViewer: CollectionViewer): Observable<PageFlatNode[]> {
+    this._treeControl.expansionModel.changed.subscribe((change) => {
+      if ((change as SelectionChange<PageFlatNode>).added || (change as SelectionChange<PageFlatNode>).removed) {
+        this.handleTreeControl(change as SelectionChange<PageFlatNode>);
+      }
+    });
+
+    return merge(collectionViewer.viewChange, this.dataChange).pipe(map(() => this.data));
+  }
+
+  disconnect(collectionViewer: CollectionViewer): void {
+    this._collectionViewer = collectionViewer;
+  }
+
+  handleTreeControl(change: SelectionChange<PageFlatNode>) {
+    if (change.added) {
+      change.added.forEach((node) => this.toggleNode(node, true));
+    }
+    if (change.removed) {
+      change.removed
+        .slice()
+        .reverse()
+        .forEach((node) => this.toggleNode(node, false));
+    }
+  }
+
+  toggleNode(node: PageFlatNode, expand: boolean) {
+    const children = this._pageData.getChildren(node.id);
+    const index = this.data.indexOf(node);
+    if (!children || index < 0) {
+      return;
+    }
+
+    node.isLoading.set(true);
+
+    setTimeout(() => {
+      if (expand) {
+        const nodes = children.map((page) => this._pageData.getPageFlatNode(page, node.level + 1));
+        this.data.splice(index + 1, 0, ...nodes);
+      } else {
+        const count = 0;
+        this.data.splice(index + 1, count);
+      }
+
+      this.dataChange.next(this.data);
+      node.isLoading.set(false);
+    }, 1000);
+  }
+}
+
+@Component({
+  selector: 'api-documentation-choose-page-list',
+  templateUrl: './api-documentation-choose-page-list.component.html',
+  styleUrl: './api-documentation-choose-page-list.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatIcon,
+    MatTreeNode,
+    MatTree,
+    MatProgressBar,
+    MatTreeNodePadding,
+    MatTreeNodeToggle,
+    MatIconButton,
+    MatTreeModule,
+    FormsModule,
+    MatRadioModule,
+    NgOptimizedImage,
+    MatTooltip,
+    NgIf,
+    TitleCasePipe,
+  ],
+  standalone: true,
+})
+export class ApiDocumentationChoosePageListComponent implements OnChanges {
+  @Input() pages: Page[];
+  @Output() selectPage = new EventEmitter<string>();
+
+  selectedPageId: string;
+  treeControl: FlatTreeControl<PageFlatNode>;
+  dataSource: PageDataSource;
+
+  constructor(private pageData: PageData) {
+    this.treeControl = new FlatTreeControl<PageFlatNode>(this.getLevel, this.isExpandable);
+    this.dataSource = new PageDataSource(this.treeControl, pageData);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.pages) {
+      this.pageData.setPages(this.pages);
+      this.dataSource.data = this.pageData.initialData();
+    }
+  }
+
+  getLevel = (node: PageFlatNode) => node.level;
+
+  isExpandable = (node: PageFlatNode) => node.expandable;
+
+  hasChild = (_: number, _nodeData: PageFlatNode) => _nodeData.expandable;
+
+  onSelectPage(node: PageFlatNode) {
+    this.selectPage.emit(node.id);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-home-page-header/api-documentation-v4-home-page-header.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-home-page-header/api-documentation-v4-home-page-header.component.html
@@ -16,11 +16,21 @@
 
 -->
 <h3 class="header__title">Homepage</h3>
-<div class="header__action" *gioPermission="{ anyOf: ['api-documentation-c'] }">
-  <button [disabled]="true" class="header__action__button" mat-stroked-button>Choose Existing Page</button>
-  <api-documentation-v4-add-page-button
-    [disabled]="hasPages"
-    (addPage)="addPage.emit($event)"
-    text="Create New Page"
-  ></api-documentation-v4-add-page-button>
-</div>
+@if (!hasHomepage) {
+  <div class="header__action" *gioPermission="{ anyOf: ['api-documentation-c'] }">
+    <button
+      [disabled]="noCustomPages || isReadOnly"
+      class="header__action__button"
+      mat-stroked-button
+      (click)="selectPage.emit()"
+      *gioPermission="{ anyOf: ['api-documentation-u'] }"
+    >
+      Choose Existing Page
+    </button>
+    <api-documentation-v4-add-page-button
+      [disabled]="isReadOnly"
+      (addPage)="addPage.emit($event)"
+      text="Create New Page"
+    ></api-documentation-v4-add-page-button>
+  </div>
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-home-page-header/api-documentation-v4-home-page-header.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-home-page-header/api-documentation-v4-home-page-header.component.ts
@@ -27,9 +27,11 @@ export class ApiDocumentationV4HomePageHeaderComponent {
   @Input()
   isReadOnly: boolean;
   @Input()
-  hasPages: boolean;
+  hasHomepage: boolean;
+  @Input()
+  noCustomPages: boolean;
   @Output()
   addPage = new EventEmitter<PageType>();
   @Output()
-  selectPage = new EventEmitter<string>();
+  selectPage = new EventEmitter<void>();
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.html
@@ -18,14 +18,16 @@
 <mat-card>
   <api-documentation-home-page-header
     [isReadOnly]="isReadOnly"
-    [hasPages]="page != null"
+    [hasHomepage]="!!homepage"
+    [noCustomPages]="!pages?.length"
+    (selectPage)="chooseHomepage()"
     (addPage)="addPage($event)"
   ></api-documentation-home-page-header>
   <mat-card-content>
-    @if (page != null) {
+    @if (homepage) {
       <api-documentation-v4-pages-list
         mode="HOME_PAGE"
-        [pages]="[page]"
+        [pages]="[homepage]"
         [isReadOnly]="isReadOnly"
         (onEditPage)="editPage($event)"
         (onPublishPage)="publishPage($event)"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.spec.ts
@@ -103,7 +103,7 @@ describe('ApiDocumentationV4DefaultPageComponent', () => {
       })
       .flush(fakeApiV4({ id: API_ID, lifecycleState: apiLifecycleStatus }));
 
-    expectGetPages(pages, breadcrumb, parentId);
+    expectGetPages(pages, breadcrumb);
   };
 
   afterEach(() => {
@@ -128,7 +128,7 @@ describe('ApiDocumentationV4DefaultPageComponent', () => {
 
       expect(routerNavigateSpy).toHaveBeenCalledWith(['.', 'homepage', 'new'], {
         relativeTo: expect.anything(),
-        queryParams: { parentId: 'ROOT', pageType: 'MARKDOWN', homepage: true },
+        queryParams: { parentId: undefined, pageType: 'MARKDOWN', homepage: true },
       });
     });
   });
@@ -152,10 +152,10 @@ describe('ApiDocumentationV4DefaultPageComponent', () => {
     });
   });
 
-  const expectGetPages = (pages: Page[], breadcrumb: Breadcrumb[], parentId = 'ROOT') => {
+  const expectGetPages = (pages: Page[], breadcrumb: Breadcrumb[]) => {
     const req = httpTestingController.expectOne({
       method: 'GET',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages?parentId=${parentId}`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/pages`,
     });
 
     req.flush({ pages, breadcrumb });

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-default-page/api-documentation-v4-default-page.component.ts
@@ -24,7 +24,6 @@ import { ApiDocumentationV2Service } from '../../../../services-ngx/api-document
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { Api, Page, PageType } from '../../../../entities/management-api-v2';
-
 @Component({
   selector: 'api-documentation-default-page',
   templateUrl: './api-documentation-v4-default-page.component.html',
@@ -34,7 +33,8 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
   private unsubscribe$: Subject<void> = new Subject<void>();
   api: Api;
   parentId: string;
-  page: Page;
+  pages: Page[];
+  homepage: Page;
   isLoading = false;
   isReadOnly = false;
 
@@ -58,14 +58,14 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
           this.isReadOnly = api.originContext?.origin === 'KUBERNETES';
         }),
         switchMap(() => this.activatedRoute.queryParams),
-        switchMap((queryParams) => {
-          this.parentId = queryParams.parentId || 'ROOT';
-          return this.apiDocumentationV2Service.getApiPages(this.api.id, this.parentId);
+        switchMap(() => {
+          return this.apiDocumentationV2Service.getApiPages(this.api.id);
         }),
         takeUntil(this.unsubscribe$),
       )
       .subscribe((res) => {
-        this.page = res.pages.find((p) => p.homepage === true);
+        this.pages = res.pages;
+        this.homepage = this.pages.find((p) => p.homepage === true);
         this.isLoading = false;
       });
   }
@@ -144,8 +144,8 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
     this.matDialog
       .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
         data: {
-          title: 'Delete your page',
-          content: 'Are you sure you want to delete this page? This action is irreversible.',
+          title: 'Delete Homepage',
+          content: 'Are you sure you want to delete this page? This action is irreversible. Do you want to continue?',
           confirmButton: 'Delete',
         },
       })
@@ -157,12 +157,18 @@ export class ApiDocumentationV4DefaultPageComponent implements OnInit, OnDestroy
       )
       .subscribe({
         next: (_) => {
-          this.snackBarService.success('Page deleted successfully');
+          this.snackBarService.success('Homepage deleted successfully');
           this.ngOnInit();
         },
         error: (error) => {
-          this.snackBarService.error(error?.error?.message ?? 'Error while deleting page');
+          this.snackBarService.error(error?.error?.message ?? 'Error when deleting homepage');
         },
       });
+  }
+
+  chooseHomepage() {
+    this.router.navigate(['.', 'homepage', 'choose'], {
+      relativeTo: this.activatedRoute,
+    });
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-documentation-v2.service.ts
@@ -38,8 +38,12 @@ export class ApiDocumentationV2Service {
   createDocumentationPage(apiId: string, createDocumentation: CreateDocumentation): Observable<Page> {
     return this.http.post<Page>(`${this.constants.env.v2BaseURL}/apis/${apiId}/pages`, createDocumentation);
   }
-  getApiPages(apiId: string, parentId: string): Observable<ApiDocumentationPageResult> {
-    return this.http.get<ApiDocumentationPageResult>(`${this.constants.env.v2BaseURL}/apis/${apiId}/pages?parentId=${parentId}`).pipe(
+  getApiPages(apiId: string, parentId?: string): Observable<ApiDocumentationPageResult> {
+    const url = parentId
+      ? `${this.constants.env.v2BaseURL}/apis/${apiId}/pages?parentId=${parentId}`
+      : `${this.constants.env.v2BaseURL}/apis/${apiId}/pages`;
+
+    return this.http.get<ApiDocumentationPageResult>(url).pipe(
       map((result: ApiDocumentationPageResult) => {
         // TODO: update this filter with new supported types
         const filteredResult: ApiDocumentationPageResult = {


### PR DESCRIPTION
… Page for Homepage

## Issue

https://gravitee.atlassian.net/browse/APIM-5923

## Description

As an API publisher

I want to choose a home page from existing pages for my v4 API

so that users in the portal can see the home page under the Details section when they find my API in the catalog.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

https://github.com/user-attachments/assets/c4cb9474-2f5c-48da-8717-8396b5aa7f9a

<img width="1724" alt="Screenshot 2024-08-29 at 18 04 18" src="https://github.com/user-attachments/assets/e3378b00-30d9-4bfc-b4ad-aaeb52cfc7e1">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-usbjiekggg.chromatic.com)
<!-- Storybook placeholder end -->
