### PR TITLE
[portal-next] use parenthesis for content only in logs filtering

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.spec.ts
@@ -400,7 +400,7 @@ describe('ApplicationLogTableComponent', () => {
               },
             }),
             1,
-            `(api:\\"${API_ID}\\")`,
+            `api:(\\"${API_ID}\\")`,
           );
           expectGetSubscriptions(
             fakeSubscriptionResponse({
@@ -452,7 +452,7 @@ describe('ApplicationLogTableComponent', () => {
               },
             }),
             1,
-            `(api:\\"${API_ID_1}\\" OR \\"${API_ID_2}\\")`,
+            `api:(\\"${API_ID_1}\\" OR \\"${API_ID_2}\\")`,
           );
           expectGetSubscriptions(
             fakeSubscriptionResponse({
@@ -489,7 +489,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ methods: [GET_METHOD] });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(method:\\"${GET_METHOD}\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `method:(\\"${GET_METHOD}\\")`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -522,7 +522,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(method:\\"${GET_METHOD}\\" OR \\"7\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `method:(\\"${GET_METHOD}\\" OR \\"7\\")`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -540,7 +540,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ responseTimes: RESPONSE_TIME });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(response-time:[${RESPONSE_TIME}])`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `response-time:([${RESPONSE_TIME}])`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -573,7 +573,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(response-time:[${RESPONSE_TIME}] OR [100 TO 200])`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `response-time:([${RESPONSE_TIME}] OR [100 TO 200])`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -906,7 +906,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ requestId: REQUEST_ID });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(_id:\\"${REQUEST_ID}\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `_id:\\"${REQUEST_ID}\\"`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -934,7 +934,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(_id:\\"new-request-id\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `_id:\\"new-request-id\\"`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -952,7 +952,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ transactionId: TRANSACTION_ID });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(transaction:\\"${TRANSACTION_ID}\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `transaction:\\"${TRANSACTION_ID}\\"`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -980,7 +980,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(transaction:\\"new-transaction-id\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `transaction:\\"new-transaction-id\\"`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -998,7 +998,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ httpStatuses: OK });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(status:\\"${OK}\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `status:(\\"${OK}\\")`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -1033,7 +1033,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(status:\\"${OK}\\" OR \\"404\\")`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `status:(\\"${OK}\\" OR \\"404\\")`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -1051,7 +1051,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ messageText: MESSAGE_TEXT });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(body:*${MESSAGE_TEXT}*)`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*${MESSAGE_TEXT}*`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -1079,7 +1079,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(body:*actually find this*)`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `body:*actually find this*`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();
@@ -1097,7 +1097,7 @@ describe('ApplicationLogTableComponent', () => {
         beforeEach(async () => {
           await init({ path: PATH });
 
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(uri:*${PATH}*)`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `uri:*${PATH}*`);
           expectGetSubscriptions(fakeSubscriptionResponse());
           fixture.detectChanges();
         });
@@ -1125,7 +1125,7 @@ describe('ApplicationLogTableComponent', () => {
           expect(await searchButton.isDisabled()).toEqual(false);
 
           await searchButton.click();
-          expectGetApplicationLogs(fakeLogsResponse(), 1, `(uri:*\\\\/different-path*)`);
+          expectGetApplicationLogs(fakeLogsResponse(), 1, `uri:*\\\\/different-path*`);
         });
         it('should reset filter', async () => {
           const resetButton = await getResetFilterButton();

--- a/gravitee-apim-portal-webui-next/src/services/application-log.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-log.service.spec.ts
@@ -85,7 +85,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(api:\\"${API_ID_1}\\" OR \\"${API_ID_2}\\")`,
+          `&query=api:(\\"${API_ID_1}\\" OR \\"${API_ID_2}\\")`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -105,7 +105,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(method:\\"${GET_METHOD.value}\\" OR \\"${POST_METHOD.value}\\")`,
+          `&query=method:(\\"${GET_METHOD.value}\\" OR \\"${POST_METHOD.value}\\")`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -125,7 +125,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(response-time:[${responseTimeOne}] OR [${responseTimeTwo}])`,
+          `&query=response-time:([${responseTimeOne}] OR [${responseTimeTwo}])`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -144,7 +144,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(_id:\\"${requestId}\\")`,
+          `&query=_id:\\"${requestId}\\"`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -163,7 +163,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(transaction:\\"${transactionId}\\")`,
+          `&query=transaction:\\"${transactionId}\\"`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -183,7 +183,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(status:\\"${OK}\\" OR \\"${NOT_FOUND}\\")`,
+          `&query=status:(\\"${OK}\\" OR \\"${NOT_FOUND}\\")`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -202,7 +202,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(body:*${messageText}*)`,
+          `&query=body:*${messageText}*`,
       );
       expect(req.request.method).toEqual('GET');
 
@@ -221,7 +221,7 @@ describe('ApplicationLogService', () => {
 
       const req = httpTestingController.expectOne(
         `${TESTING_BASE_URL}/applications/${APP_ID}/logs?page=1&size=10&from=${yesterdayInMilliseconds}&to=${currentDateInMilliseconds}&order=DESC&field=@timestamp` +
-          `&query=(uri:*${path}*)`,
+          `&query=uri:*${path}*`,
       );
       expect(req.request.method).toEqual('GET');
 

--- a/gravitee-apim-portal-webui-next/src/services/application-log.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-log.service.ts
@@ -142,7 +142,7 @@ export class ApplicationLogService {
 
   private createQuotationsQuerySegment(root: string, value?: string) {
     if (value && value.length) {
-      return this.createQuotationsListQuerySegment(root, [value]);
+      return `${root}\:\\"${value}\\"`;
     }
     return undefined;
   }
@@ -150,7 +150,7 @@ export class ApplicationLogService {
   private createQuotationsListQuerySegment(root: string, values?: string[]) {
     if (values?.length) {
       const queryContent = values.map(v => `\\"${v}\\"`).join(' OR ');
-      return `(${root}\:${queryContent})`;
+      return `${root}\:(${queryContent})`;
     }
     return undefined;
   }
@@ -158,7 +158,7 @@ export class ApplicationLogService {
   private createListQuerySegment(root: string, values?: string[]) {
     if (values?.length) {
       const queryContent = values.map(v => `[${v}]`).join(' OR ');
-      return `(${root}\:${queryContent})`;
+      return `${root}\:(${queryContent})`;
     }
     return undefined;
   }
@@ -166,7 +166,7 @@ export class ApplicationLogService {
   private createAsteriskQuerySegment(root: string, value?: string) {
     if (value && value.length) {
       const cleanValue = value.replace('/', '\\\\/');
-      return `(${root}\:*${cleanValue}*)`;
+      return `${root}\:*${cleanValue}*`;
     }
     return undefined;
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6439

## Description

Do not include query key in the parenthesis when building query string.