### PR TITLE
Block groups member's integration role dropdown from choosing Primary Owner

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/addMember.dialog.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/addMember.dialog.html
@@ -37,7 +37,21 @@
         <md-option ng-repeat="role in $ctrl.applicationRoles" ng-value="role.name" ng-disabled="role.system"> {{role.name}} </md-option>
       </md-select>
     </div>
-    <div ng-if="!$ctrl.defaultApiRole && !$ctrl.defaultApplicationRole" style="margin: 0 0 8px 0; text-align: right">
+    <div layout="row" layout-align="space-between center">
+      <span>Choose an Integration role</span>
+      <md-select
+        ng-model="$ctrl.defaultIntegrationRole"
+        aria-label="Integration Role"
+        class="md-no-underline"
+        ng-disabled="!$ctrl.canChangeDefaultIntegrationRole"
+      >
+        <md-option ng-repeat="role in $ctrl.integrationRoles" ng-value="role.name" ng-disabled="role.system"> {{role.name}} </md-option>
+      </md-select>
+    </div>
+    <div
+      ng-if="!$ctrl.defaultApiRole && !$ctrl.defaultApplicationRole && !$ctrl.defaultIntegrationRole"
+      style="margin: 0 0 8px 0; text-align: right"
+    >
       <em style="color: red">Select at least one role</em>
     </div>
     <form name="formMember" ng-submit="$event.preventDefault()">

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/addMember.dialog.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/addMember.dialog.html
@@ -37,23 +37,7 @@
         <md-option ng-repeat="role in $ctrl.applicationRoles" ng-value="role.name" ng-disabled="role.system"> {{role.name}} </md-option>
       </md-select>
     </div>
-    <div layout="row" layout-align="space-between center">
-      <span>Choose an Integration role</span>
-      <md-select
-        ng-model="$ctrl.defaultIntegrationRole"
-        aria-label="Integration role"
-        class="md-no-underline"
-        ng-disabled="!$ctrl.canChangeDefaultIntegrationRole"
-      >
-        <md-option ng-repeat="role in $ctrl.integrationRoles" ng-value="role.name" ng-disabled="$ctrl.isIntegrationRoleDisabled(role)">
-          {{role.name}}
-        </md-option>
-      </md-select>
-    </div>
-    <div
-      ng-if="!$ctrl.defaultApiRole && !$ctrl.defaultApplicationRole && !$ctrl.defaultIntegrationRole"
-      style="margin: 0 0 8px 0; text-align: right"
-    >
+    <div ng-if="!$ctrl.defaultApiRole && !$ctrl.defaultApplicationRole" style="margin: 0 0 8px 0; text-align: right">
       <em style="color: red">Select at least one role</em>
     </div>
     <form name="formMember" ng-submit="$event.preventDefault()">

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/addMemberDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/addMemberDialog.controller.ts
@@ -28,24 +28,31 @@ function DialogAddGroupMemberController(
   group: any,
   defaultApiRole: string,
   defaultApplicationRole: string,
+  defaultIntegrationRole: string,
   apiRoles: Role[],
   applicationRoles: Role[],
+  integrationRoles: Role[],
   canChangeDefaultApiRole,
   canChangeDefaultApplicationRole,
+  canChangeDefaultIntegrationRole,
   isApiRoleDisabled,
 ) {
   this.group = group;
   this.apiRoles = apiRoles;
   this.applicationRoles = applicationRoles;
+  this.integrationRoles = integrationRoles;
 
   this.defaultApiRole = defaultApiRole;
   this.defaultApplicationRole = defaultApplicationRole;
+  this.defaultIntegrationRole = defaultIntegrationRole;
   this.usersSelected = [];
   this.defaultApiRole = defaultApiRole ? defaultApiRole : find(apiRoles, { default: true })?.name;
   this.defaultApplicationRole = defaultApplicationRole ? defaultApplicationRole : find(applicationRoles, { default: true }).name;
+  this.defaultIntegrationRole = defaultIntegrationRole ? defaultIntegrationRole : find(integrationRoles, { default: true }).name;
 
   this.canChangeDefaultApiRole = canChangeDefaultApiRole;
   this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
+  this.canChangeDefaultIntegrationRole = canChangeDefaultIntegrationRole;
   this.isApiRoleDisabled = isApiRoleDisabled;
 
   this.hide = () => {
@@ -63,6 +70,7 @@ function DialogAddGroupMemberController(
         roles: {
           API: this.defaultApiRole,
           APPLICATION: this.defaultApplicationRole,
+          INTEGRATION: this.defaultIntegrationRole,
         },
       };
 
@@ -72,7 +80,7 @@ function DialogAddGroupMemberController(
   };
 
   this.invalid = (): boolean => {
-    return (!this.defaultApiRole && !this.defaultApplicationRole) || this.usersSelected.length === 0;
+    return (!this.defaultApiRole && !this.defaultApplicationRole && !this.defaultIntegrationRole) || this.usersSelected.length === 0;
   };
 
   this.hasPrimaryOwner = (): boolean => {
@@ -84,10 +92,13 @@ DialogAddGroupMemberController.$inject = [
   'group',
   'defaultApiRole',
   'defaultApplicationRole',
+  'defaultIntegrationRole',
   'apiRoles',
   'applicationRoles',
+  'integrationRoles',
   'canChangeDefaultApiRole',
   'canChangeDefaultApplicationRole',
+  'canChangeDefaultIntegrationRole',
   'isApiRoleDisabled',
 ];
 

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/addMemberDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/addMemberDialog.controller.ts
@@ -28,34 +28,25 @@ function DialogAddGroupMemberController(
   group: any,
   defaultApiRole: string,
   defaultApplicationRole: string,
-  defaultIntegrationRole: string,
   apiRoles: Role[],
   applicationRoles: Role[],
-  integrationRoles: Role[],
   canChangeDefaultApiRole,
   canChangeDefaultApplicationRole,
-  canChangeDefaultIntegrationRole,
   isApiRoleDisabled,
-  isIntegrationRoleDisabled,
 ) {
   this.group = group;
   this.apiRoles = apiRoles;
   this.applicationRoles = applicationRoles;
-  this.integrationRoles = integrationRoles;
 
   this.defaultApiRole = defaultApiRole;
   this.defaultApplicationRole = defaultApplicationRole;
-  this.defaultIntegrationRole = defaultIntegrationRole;
   this.usersSelected = [];
   this.defaultApiRole = defaultApiRole ? defaultApiRole : find(apiRoles, { default: true })?.name;
   this.defaultApplicationRole = defaultApplicationRole ? defaultApplicationRole : find(applicationRoles, { default: true }).name;
-  this.defaultIntegrationRole = defaultIntegrationRole ? defaultIntegrationRole : find(integrationRoles, { default: true }).name;
 
   this.canChangeDefaultApiRole = canChangeDefaultApiRole;
   this.canChangeDefaultApplicationRole = canChangeDefaultApplicationRole;
-  this.canChangeDefaultIntegrationRole = canChangeDefaultIntegrationRole;
   this.isApiRoleDisabled = isApiRoleDisabled;
-  this.isIntegrationRoleDisabled = isIntegrationRoleDisabled;
 
   this.hide = () => {
     $mdDialog.cancel();
@@ -72,7 +63,6 @@ function DialogAddGroupMemberController(
         roles: {
           API: this.defaultApiRole,
           APPLICATION: this.defaultApplicationRole,
-          INTEGRATION: this.defaultIntegrationRole,
         },
       };
 
@@ -82,14 +72,11 @@ function DialogAddGroupMemberController(
   };
 
   this.invalid = (): boolean => {
-    return (!this.defaultApiRole && !this.defaultApplicationRole && !this.defaultIntegrationRole) || this.usersSelected.length === 0;
+    return (!this.defaultApiRole && !this.defaultApplicationRole) || this.usersSelected.length === 0;
   };
 
   this.hasPrimaryOwner = (): boolean => {
-    return (
-      (this.defaultApiRole === RoleName.PRIMARY_OWNER || this.defaultIntegrationRole === RoleName.PRIMARY_OWNER) &&
-      this.usersSelected.length > 0
-    );
+    return this.defaultApiRole === RoleName.PRIMARY_OWNER && this.usersSelected.length > 0;
   };
 }
 DialogAddGroupMemberController.$inject = [
@@ -97,15 +84,11 @@ DialogAddGroupMemberController.$inject = [
   'group',
   'defaultApiRole',
   'defaultApplicationRole',
-  'defaultIntegrationRole',
   'apiRoles',
   'applicationRoles',
-  'integrationRoles',
   'canChangeDefaultApiRole',
   'canChangeDefaultApplicationRole',
-  'canChangeDefaultIntegrationRole',
   'isApiRoleDisabled',
-  'isIntegrationRoleDisabled',
 ];
 
 export default DialogAddGroupMemberController;

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ajs.ts
@@ -33,6 +33,7 @@ interface IGroupDetailComponentScope extends ng.IScope {
   groupApplications: any[];
   selectedApiRole: string;
   selectedApplicationRole: string;
+  selectedIntegrationRole: string;
   currentTab: string;
   formGroup: any;
 }
@@ -85,17 +86,20 @@ const GroupComponentAjs: ng.IComponentOptions = {
             GroupService.get(this.activatedRoute?.snapshot?.params?.groupId),
             RoleService.list('API'),
             RoleService.list('APPLICATION'),
+            RoleService.list('INTEGRATION'),
             GroupService.getInvitations(this.activatedRoute?.snapshot?.params?.groupId),
           ])
-            .then(([groupsResponse, apiRolesResponse, applicationRolesResponse, invitationsResponse]) => {
+            .then(([groupsResponse, apiRolesResponse, applicationRolesResponse, integrationRolesResponse, invitationsResponse]) => {
               this.group = groupsResponse.data;
               this.apiRoles = [{ scope: 'API', name: '', system: false }].concat(apiRolesResponse);
               this.applicationRoles = [{ scope: 'APPLICATION', name: '', system: false }].concat(applicationRolesResponse);
+              this.integrationRoles = [{ scope: 'INTEGRATION', name: '', system: false }].concat(integrationRolesResponse);
               this.invitations = invitationsResponse.data;
 
               if (this.group.roles) {
                 this.selectedApiRole = this.group.roles.API;
                 this.selectedApplicationRole = this.group.roles.APPLICATION;
+                this.selectedIntegrationRole = this.group.roles.INTEGRATION;
               }
               this.apiByDefault = this.group.event_rules && this.group.event_rules.findIndex((rule) => rule.event === 'API_CREATE') !== -1;
               this.applicationByDefault =
@@ -122,6 +126,7 @@ const GroupComponentAjs: ng.IComponentOptions = {
         this.isSuperAdmin = UserService.isUserHasPermissions(['environment-group-u']);
         this.canChangeDefaultApiRole = this.isSuperAdmin || !this.group.lock_api_role;
         this.canChangeDefaultApplicationRole = this.isSuperAdmin || !this.group.lock_application_role;
+        this.canChangeDefaultIntegrationRole = this.isSuperAdmin;
 
         /*
         It is written in the members list: "Enable email invitation and/or user search to allow the group administrator to add users."
@@ -247,11 +252,14 @@ const GroupComponentAjs: ng.IComponentOptions = {
             locals: {
               defaultApiRole: this.selectedApiRole,
               defaultApplicationRole: this.selectedApplicationRole,
+              defaultIntegrationRole: this.selectedIntegrationRole,
               group: this.group,
               apiRoles: this.apiRoles,
               applicationRoles: this.applicationRoles,
+              integrationRoles: this.integrationRoles,
               canChangeDefaultApiRole: this.canChangeDefaultApiRole,
               canChangeDefaultApplicationRole: this.canChangeDefaultApplicationRole,
+              canChangeDefaultIntegrationRole: this.canChangeDefaultIntegrationRole,
               isApiRoleDisabled: this.isApiRoleDisabled,
             },
           })

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
@@ -203,80 +203,64 @@
             <md-table-container ng-if="$ctrl.membersLoaded" ng-cloak>
               <table md-table ng-init="orderGrp = 'displayName'">
                 <thead md-head md-order="orderGrp">
-                  <tr md-row>
-                    <th md-column width="18%" md-order-by="displayName">Name</th>
-                    <th md-column width="18%">Group Admin</th>
-                    <th md-column width="18%">API Role</th>
-                    <th md-column width="18%">Application Role</th>
-                    <th md-column width="18%">Integration Role</th>
-                    <th md-column width="10%"></th>
-                  </tr>
+                <tr md-row>
+                  <th md-column width="22%" md-order-by="displayName">Name</th>
+                  <th md-column width="22%">Group Admin</th>
+                  <th md-column width="22%">API Role</th>
+                  <th md-column width="22%">Application Role</th>
+                  <th md-column width="12%"></th>
+                </tr>
                 </thead>
                 <tbody md-body>
-                  <tr style="height: 30px" ng-if="$ctrl.members.length === 0">
-                    <td md-cell style="text-align: center" colspan="5">None.</td>
-                  </tr>
-                  <tr md-row ng-repeat="member in $ctrl.members | orderBy: orderGrp">
-                    <td md-cell>{{member.displayName}}</td>
-                    <td md-cell>
-                      <md-checkbox
-                        ng-model="member.roles['GROUP']"
-                        ng-true-value="'ADMIN'"
-                        ng-false-value="''"
-                        ng-change="$ctrl.updateRole(member)"
-                        aria-label="Administrator of this group"
-                        ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
+                <tr style="height: 30px" ng-if="$ctrl.members.length === 0">
+                  <td md-cell style="text-align: center" colspan="5">None.</td>
+                </tr>
+                <tr md-row ng-repeat="member in $ctrl.members | orderBy: orderGrp">
+                  <td md-cell>{{member.displayName}}</td>
+                  <td md-cell>
+                    <md-checkbox
+                      ng-model="member.roles['GROUP']"
+                      ng-true-value="'ADMIN'"
+                      ng-false-value="''"
+                      ng-change="$ctrl.updateRole(member)"
+                      aria-label="Administrator of this group"
+                      ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
+                    >
+                    </md-checkbox>
+                  </td>
+                  <td md-cell>
+                    <md-select
+                      ng-model="member.roles['API']"
+                      aria-label="API Role"
+                      ng-change="$ctrl.updateRole(member)"
+                      ng-disabled="!$ctrl.canChangeDefaultApiRole"
+                    >
+                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                      >{{role.name}}</md-option
                       >
-                      </md-checkbox>
-                    </td>
-                    <td md-cell>
-                      <md-select
-                        ng-model="member.roles['API']"
-                        aria-label="API Role"
-                        ng-change="$ctrl.updateRole(member, 'API')"
-                        ng-disabled="!$ctrl.canChangeDefaultApiRole"
+                    </md-select>
+                  </td>
+                  <td md-cell>
+                    <md-select
+                      ng-model="member.roles['APPLICATION']"
+                      aria-label="Application Role"
+                      ng-change="$ctrl.updateRole(member)"
+                      ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
+                    >
+                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                      >{{role.name}}</md-option
                       >
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
-                          >{{role.name}}</md-option
-                        >
-                      </md-select>
-                    </td>
-                    <td md-cell>
-                      <md-select
-                        ng-model="member.roles['APPLICATION']"
-                        aria-label="Application Role"
-                        ng-change="$ctrl.updateRole(member, 'APPLICATION')"
-                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
-                      >
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
-                          >{{role.name}}</md-option
-                        >
-                      </md-select>
-                    </td>
-                    <td md-cell>
-                      <md-select
-                        ng-model="member.roles['INTEGRATION']"
-                        aria-label="Integration Role"
-                        ng-change="$ctrl.updateRole(member, 'INTEGRATION')"
-                        ng-disabled="!$ctrl.canChangeDefaultIntegrationRole"
-                      >
-                        <md-option
-                          ng-value="role.name"
-                          ng-repeat="role in $ctrl.integrationRoles"
-                          ng-disabled="$ctrl.isIntegrationRoleDisabled(role)"
-                          >{{role.name}}</md-option
-                        >
-                      </md-select>
-                    </td>
-                    <td md-cell ng-click="$event.stopPropagation()">
-                      <div layout="row" layout-align="end center">
+                    </md-select>
+                  </td>
+                  <td md-cell ng-click="$event.stopPropagation()">
+                    <div layout="row" layout-align="end center">
                         <span ng-if="$ctrl.isSuperAdmin || ($ctrl.group.manageable && $ctrl.currentUserId !== member.id)">
                           <md-tooltip md-direction="top">delete</md-tooltip>
                           <ng-md-icon icon="delete" ng-click="$ctrl.removeUser($event, member)" aria-label="delete-user"></ng-md-icon>
                         </span>
-                      </div>
-                    </td>
-                  </tr>
+                    </div>
+                  </td>
+                </tr>
                 </tbody>
               </table>
               <div ng-if="$ctrl.invitations.length > 0">
@@ -284,44 +268,44 @@
                 <h3 style="color: red">Pending invitations</h3>
                 <table md-table ng-init="orderInvitation = 'email'">
                   <thead md-head md-order="orderInvitation">
-                    <tr md-row>
-                      <th md-column md-order-by="email">Email</th>
-                      <th md-column>API Role</th>
-                      <th md-column>Application Role</th>
-                      <th md-column md-order-by="created_at">Invitation date</th>
-                      <th md-column></th>
-                    </tr>
+                  <tr md-row>
+                    <th md-column md-order-by="email">Email</th>
+                    <th md-column>API Role</th>
+                    <th md-column>Application Role</th>
+                    <th md-column md-order-by="created_at">Invitation date</th>
+                    <th md-column></th>
+                  </tr>
                   </thead>
                   <tbody md-body>
-                    <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
-                      <td md-cell>{{invitation.email}}</td>
-                      <td md-cell>
-                        <md-select
-                          ng-model="invitation.api_role"
-                          aria-label="API Role"
-                          ng-change="$ctrl.updateInvitation(invitation)"
-                          ng-disabled="!$ctrl.canChangeDefaultApiRole"
+                  <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
+                    <td md-cell>{{invitation.email}}</td>
+                    <td md-cell>
+                      <md-select
+                        ng-model="invitation.api_role"
+                        aria-label="API Role"
+                        ng-change="$ctrl.updateInvitation(invitation)"
+                        ng-disabled="!$ctrl.canChangeDefaultApiRole"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                        >{{role.name}}</md-option
                         >
-                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
-                            >{{role.name}}</md-option
-                          >
-                        </md-select>
-                      </td>
-                      <td md-cell>
-                        <md-select
-                          ng-model="invitation.application_role"
-                          aria-label="Application Role"
-                          ng-change="$ctrl.updateInvitation(invitation)"
-                          ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
+                      </md-select>
+                    </td>
+                    <td md-cell>
+                      <md-select
+                        ng-model="invitation.application_role"
+                        aria-label="Application Role"
+                        ng-change="$ctrl.updateInvitation(invitation)"
+                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                        >{{role.name}}</md-option
                         >
-                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
-                            >{{role.name}}</md-option
-                          >
-                        </md-select>
-                      </td>
-                      <td md-cell>{{invitation.created_at | date}}</td>
-                      <td md-cell ng-click="$event.stopPropagation()">
-                        <div layout="row" layout-align="end center">
+                      </md-select>
+                    </td>
+                    <td md-cell>{{invitation.created_at | date}}</td>
+                    <td md-cell ng-click="$event.stopPropagation()">
+                      <div layout="row" layout-align="end center">
                           <span ng-if="$ctrl.group.manageable">
                             <md-tooltip md-direction="top">delete</md-tooltip>
                             <ng-md-icon
@@ -330,9 +314,9 @@
                               aria-label="delete-user"
                             ></ng-md-icon>
                           </span>
-                        </div>
-                      </td>
-                    </tr>
+                      </div>
+                    </td>
+                  </tr>
                   </tbody>
                 </table>
               </div>
@@ -355,25 +339,25 @@
             <md-table-container>
               <table md-table>
                 <thead md-head>
-                  <tr md-row>
-                    <th md-column>Name</th>
-                    <th md-column>Version</th>
-                    <th md-column>Visibility</th>
-                  </tr>
+                <tr md-row>
+                  <th md-column>Name</th>
+                  <th md-column>Version</th>
+                  <th md-column>Visibility</th>
+                </tr>
                 </thead>
                 <tbody md-body>
-                  <tr style="height: 30px" ng-if="groupApis.length === 0">
-                    <td md-cell style="text-align: center" colspan="3">None.</td>
-                  </tr>
-                  <tr ng-repeat="api in groupApis" md-row>
-                    <td md-cell>{{api.name}}</td>
-                    <td md-cell>{{api.version}}</td>
-                    <td md-cell>
-                      <ng-md-icon icon="{{api.visibility==='PUBLIC' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd">
-                        <md-tooltip>{{api.visibility}}</md-tooltip>
-                      </ng-md-icon>
-                    </td>
-                  </tr>
+                <tr style="height: 30px" ng-if="groupApis.length === 0">
+                  <td md-cell style="text-align: center" colspan="3">None.</td>
+                </tr>
+                <tr ng-repeat="api in groupApis" md-row>
+                  <td md-cell>{{api.name}}</td>
+                  <td md-cell>{{api.version}}</td>
+                  <td md-cell>
+                    <ng-md-icon icon="{{api.visibility==='PUBLIC' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd">
+                      <md-tooltip>{{api.visibility}}</md-tooltip>
+                    </ng-md-icon>
+                  </td>
+                </tr>
                 </tbody>
               </table>
             </md-table-container>
@@ -386,19 +370,19 @@
             <md-table-container>
               <table md-table>
                 <thead md-head>
-                  <tr md-row>
-                    <th md-column>Name</th>
-                    <th md-column>Type</th>
-                  </tr>
+                <tr md-row>
+                  <th md-column>Name</th>
+                  <th md-column>Type</th>
+                </tr>
                 </thead>
                 <tbody md-body>
-                  <tr style="height: 30px" ng-if="groupApplications.length === 0">
-                    <td md-cell style="text-align: center" colspan="2">None.</td>
-                  </tr>
-                  <tr ng-repeat="application in groupApplications" md-row>
-                    <td md-cell>{{application.name}}</td>
-                    <td md-cell>{{application.type}}</td>
-                  </tr>
+                <tr style="height: 30px" ng-if="groupApplications.length === 0">
+                  <td md-cell style="text-align: center" colspan="2">None.</td>
+                </tr>
+                <tr ng-repeat="application in groupApplications" md-row>
+                  <td md-cell>{{application.name}}</td>
+                  <td md-cell>{{application.type}}</td>
+                </tr>
                 </tbody>
               </table>
             </md-table-container>
@@ -423,7 +407,7 @@
     <!-- The button is always displayed, but is disabled if the current user is a group admin and the maximum number of members has been reached -->
     <md-button aria-label="menu" class="md-fab md-success" ng-disabled="!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached()">
       <md-tooltip md-direction="top" md-visible="false"
-        >Add member{{!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached() ? " is not available because maximum number of members has been
+      >Add member{{!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached() ? " is not available because maximum number of members has been
         reached" : ""}}</md-tooltip
       >
       <ng-md-icon icon="add"></ng-md-icon>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.html
@@ -203,64 +203,77 @@
             <md-table-container ng-if="$ctrl.membersLoaded" ng-cloak>
               <table md-table ng-init="orderGrp = 'displayName'">
                 <thead md-head md-order="orderGrp">
-                <tr md-row>
-                  <th md-column width="22%" md-order-by="displayName">Name</th>
-                  <th md-column width="22%">Group Admin</th>
-                  <th md-column width="22%">API Role</th>
-                  <th md-column width="22%">Application Role</th>
-                  <th md-column width="12%"></th>
-                </tr>
+                  <tr md-row>
+                    <th md-column width="18%" md-order-by="displayName">Name</th>
+                    <th md-column width="18%">Group Admin</th>
+                    <th md-column width="18%">API Role</th>
+                    <th md-column width="18%">Application Role</th>
+                    <th md-column width="18%">Integration Role</th>
+                    <th md-column width="10%"></th>
+                  </tr>
                 </thead>
                 <tbody md-body>
-                <tr style="height: 30px" ng-if="$ctrl.members.length === 0">
-                  <td md-cell style="text-align: center" colspan="5">None.</td>
-                </tr>
-                <tr md-row ng-repeat="member in $ctrl.members | orderBy: orderGrp">
-                  <td md-cell>{{member.displayName}}</td>
-                  <td md-cell>
-                    <md-checkbox
-                      ng-model="member.roles['GROUP']"
-                      ng-true-value="'ADMIN'"
-                      ng-false-value="''"
-                      ng-change="$ctrl.updateRole(member)"
-                      aria-label="Administrator of this group"
-                      ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
-                    >
-                    </md-checkbox>
-                  </td>
-                  <td md-cell>
-                    <md-select
-                      ng-model="member.roles['API']"
-                      aria-label="API Role"
-                      ng-change="$ctrl.updateRole(member)"
-                      ng-disabled="!$ctrl.canChangeDefaultApiRole"
-                    >
-                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
-                      >{{role.name}}</md-option
+                  <tr style="height: 30px" ng-if="$ctrl.members.length === 0">
+                    <td md-cell style="text-align: center" colspan="5">None.</td>
+                  </tr>
+                  <tr md-row ng-repeat="member in $ctrl.members | orderBy: orderGrp">
+                    <td md-cell>{{member.displayName}}</td>
+                    <td md-cell>
+                      <md-checkbox
+                        ng-model="member.roles['GROUP']"
+                        ng-true-value="'ADMIN'"
+                        ng-false-value="''"
+                        ng-change="$ctrl.updateRole(member)"
+                        aria-label="Administrator of this group"
+                        ng-disabled="!ctrl.isSuperAdmin && !($ctrl.group.manageable && $ctrl.group.system_invitation)"
                       >
-                    </md-select>
-                  </td>
-                  <td md-cell>
-                    <md-select
-                      ng-model="member.roles['APPLICATION']"
-                      aria-label="Application Role"
-                      ng-change="$ctrl.updateRole(member)"
-                      ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
-                    >
-                      <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
-                      >{{role.name}}</md-option
+                      </md-checkbox>
+                    </td>
+                    <td md-cell>
+                      <md-select
+                        ng-model="member.roles['API']"
+                        aria-label="API Role"
+                        ng-change="$ctrl.updateRole(member)"
+                        ng-disabled="!$ctrl.canChangeDefaultApiRole"
                       >
-                    </md-select>
-                  </td>
-                  <td md-cell ng-click="$event.stopPropagation()">
-                    <div layout="row" layout-align="end center">
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                          >{{role.name}}</md-option
+                        >
+                      </md-select>
+                    </td>
+                    <td md-cell>
+                      <md-select
+                        ng-model="member.roles['APPLICATION']"
+                        aria-label="Application Role"
+                        ng-change="$ctrl.updateRole(member)"
+                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                          >{{role.name}}</md-option
+                        >
+                      </md-select>
+                    </td>
+                    <td md-cell>
+                      <md-select
+                        ng-model="member.roles['INTEGRATION']"
+                        aria-label="Integration Role"
+                        ng-change="$ctrl.updateRole(member)"
+                        ng-disabled="!$ctrl.canChangeDefaultIntegrationRole"
+                      >
+                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.integrationRoles" ng-disabled="role.system"
+                          >{{role.name}}</md-option
+                        >
+                      </md-select>
+                    </td>
+                    <td md-cell ng-click="$event.stopPropagation()">
+                      <div layout="row" layout-align="end center">
                         <span ng-if="$ctrl.isSuperAdmin || ($ctrl.group.manageable && $ctrl.currentUserId !== member.id)">
                           <md-tooltip md-direction="top">delete</md-tooltip>
                           <ng-md-icon icon="delete" ng-click="$ctrl.removeUser($event, member)" aria-label="delete-user"></ng-md-icon>
                         </span>
-                    </div>
-                  </td>
-                </tr>
+                      </div>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
               <div ng-if="$ctrl.invitations.length > 0">
@@ -268,44 +281,44 @@
                 <h3 style="color: red">Pending invitations</h3>
                 <table md-table ng-init="orderInvitation = 'email'">
                   <thead md-head md-order="orderInvitation">
-                  <tr md-row>
-                    <th md-column md-order-by="email">Email</th>
-                    <th md-column>API Role</th>
-                    <th md-column>Application Role</th>
-                    <th md-column md-order-by="created_at">Invitation date</th>
-                    <th md-column></th>
-                  </tr>
+                    <tr md-row>
+                      <th md-column md-order-by="email">Email</th>
+                      <th md-column>API Role</th>
+                      <th md-column>Application Role</th>
+                      <th md-column md-order-by="created_at">Invitation date</th>
+                      <th md-column></th>
+                    </tr>
                   </thead>
                   <tbody md-body>
-                  <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
-                    <td md-cell>{{invitation.email}}</td>
-                    <td md-cell>
-                      <md-select
-                        ng-model="invitation.api_role"
-                        aria-label="API Role"
-                        ng-change="$ctrl.updateInvitation(invitation)"
-                        ng-disabled="!$ctrl.canChangeDefaultApiRole"
-                      >
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
-                        >{{role.name}}</md-option
+                    <tr md-row ng-repeat="invitation in $ctrl.invitations | orderBy: orderInvitation">
+                      <td md-cell>{{invitation.email}}</td>
+                      <td md-cell>
+                        <md-select
+                          ng-model="invitation.api_role"
+                          aria-label="API Role"
+                          ng-change="$ctrl.updateInvitation(invitation)"
+                          ng-disabled="!$ctrl.canChangeDefaultApiRole"
                         >
-                      </md-select>
-                    </td>
-                    <td md-cell>
-                      <md-select
-                        ng-model="invitation.application_role"
-                        aria-label="Application Role"
-                        ng-change="$ctrl.updateInvitation(invitation)"
-                        ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
-                      >
-                        <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
-                        >{{role.name}}</md-option
+                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.apiRoles" ng-disabled="$ctrl.isApiRoleDisabled(role)"
+                            >{{role.name}}</md-option
+                          >
+                        </md-select>
+                      </td>
+                      <td md-cell>
+                        <md-select
+                          ng-model="invitation.application_role"
+                          aria-label="Application Role"
+                          ng-change="$ctrl.updateInvitation(invitation)"
+                          ng-disabled="!$ctrl.canChangeDefaultApplicationRole"
                         >
-                      </md-select>
-                    </td>
-                    <td md-cell>{{invitation.created_at | date}}</td>
-                    <td md-cell ng-click="$event.stopPropagation()">
-                      <div layout="row" layout-align="end center">
+                          <md-option ng-value="role.name" ng-repeat="role in $ctrl.applicationRoles" ng-disabled="role.system"
+                            >{{role.name}}</md-option
+                          >
+                        </md-select>
+                      </td>
+                      <td md-cell>{{invitation.created_at | date}}</td>
+                      <td md-cell ng-click="$event.stopPropagation()">
+                        <div layout="row" layout-align="end center">
                           <span ng-if="$ctrl.group.manageable">
                             <md-tooltip md-direction="top">delete</md-tooltip>
                             <ng-md-icon
@@ -314,9 +327,9 @@
                               aria-label="delete-user"
                             ></ng-md-icon>
                           </span>
-                      </div>
-                    </td>
-                  </tr>
+                        </div>
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -339,25 +352,25 @@
             <md-table-container>
               <table md-table>
                 <thead md-head>
-                <tr md-row>
-                  <th md-column>Name</th>
-                  <th md-column>Version</th>
-                  <th md-column>Visibility</th>
-                </tr>
+                  <tr md-row>
+                    <th md-column>Name</th>
+                    <th md-column>Version</th>
+                    <th md-column>Visibility</th>
+                  </tr>
                 </thead>
                 <tbody md-body>
-                <tr style="height: 30px" ng-if="groupApis.length === 0">
-                  <td md-cell style="text-align: center" colspan="3">None.</td>
-                </tr>
-                <tr ng-repeat="api in groupApis" md-row>
-                  <td md-cell>{{api.name}}</td>
-                  <td md-cell>{{api.version}}</td>
-                  <td md-cell>
-                    <ng-md-icon icon="{{api.visibility==='PUBLIC' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd">
-                      <md-tooltip>{{api.visibility}}</md-tooltip>
-                    </ng-md-icon>
-                  </td>
-                </tr>
+                  <tr style="height: 30px" ng-if="groupApis.length === 0">
+                    <td md-cell style="text-align: center" colspan="3">None.</td>
+                  </tr>
+                  <tr ng-repeat="api in groupApis" md-row>
+                    <td md-cell>{{api.name}}</td>
+                    <td md-cell>{{api.version}}</td>
+                    <td md-cell>
+                      <ng-md-icon icon="{{api.visibility==='PUBLIC' ? 'public' : 'lock'}}" size="20" style="fill: #cdcdcd">
+                        <md-tooltip>{{api.visibility}}</md-tooltip>
+                      </ng-md-icon>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </md-table-container>
@@ -370,19 +383,19 @@
             <md-table-container>
               <table md-table>
                 <thead md-head>
-                <tr md-row>
-                  <th md-column>Name</th>
-                  <th md-column>Type</th>
-                </tr>
+                  <tr md-row>
+                    <th md-column>Name</th>
+                    <th md-column>Type</th>
+                  </tr>
                 </thead>
                 <tbody md-body>
-                <tr style="height: 30px" ng-if="groupApplications.length === 0">
-                  <td md-cell style="text-align: center" colspan="2">None.</td>
-                </tr>
-                <tr ng-repeat="application in groupApplications" md-row>
-                  <td md-cell>{{application.name}}</td>
-                  <td md-cell>{{application.type}}</td>
-                </tr>
+                  <tr style="height: 30px" ng-if="groupApplications.length === 0">
+                    <td md-cell style="text-align: center" colspan="2">None.</td>
+                  </tr>
+                  <tr ng-repeat="application in groupApplications" md-row>
+                    <td md-cell>{{application.name}}</td>
+                    <td md-cell>{{application.type}}</td>
+                  </tr>
                 </tbody>
               </table>
             </md-table-container>
@@ -407,7 +420,7 @@
     <!-- The button is always displayed, but is disabled if the current user is a group admin and the maximum number of members has been reached -->
     <md-button aria-label="menu" class="md-fab md-success" ng-disabled="!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached()">
       <md-tooltip md-direction="top" md-visible="false"
-      >Add member{{!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached() ? " is not available because maximum number of members has been
+        >Add member{{!$ctrl.isSuperAdmin && $ctrl.isMaxInvitationReached() ? " is not available because maximum number of members has been
         reached" : ""}}</md-tooltip
       >
       <ng-md-icon icon="add"></ng-md-icon>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/membershipState.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/membershipState.ts
@@ -37,7 +37,10 @@ export interface Member {
 }
 
 export class MemberState {
-  constructor(private member, private previousMemberState) {}
+  constructor(
+    private member,
+    private previousMemberState,
+  ) {}
 
   wasPrimaryOwner(): boolean {
     return !this.isNewMember() && this.previousMemberState.roles[RoleScope.API] === RoleName.PRIMARY_OWNER;

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/transferOwnershipDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/transferOwnershipDialog.controller.ts
@@ -36,10 +36,8 @@ class DialogTransferOwnershipController {
     private members: Member[],
     private group: any,
     private transferType: ApiOwnershipTransferType,
-    private primaryOwnerWithScopes,
   ) {
     this.usersSelected = [];
-    this.primaryOwnerWithScopes = primaryOwnerWithScopes;
     this.userFilterFn = this.userFilterFn.bind(this);
   }
 
@@ -68,6 +66,6 @@ class DialogTransferOwnershipController {
     return this.transferType === ApiOwnershipTransferType.PROMOTE_NEW_PRIMARY_OWNER;
   }
 }
-DialogTransferOwnershipController.$inject = ['$mdDialog', 'primaryOwner', 'members', 'group', 'transferType', 'primaryOwnerWithScopes'];
+DialogTransferOwnershipController.$inject = ['$mdDialog', 'primaryOwner', 'members', 'group', 'transferType'];
 
 export default DialogTransferOwnershipController;

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/transferOwnershipDialog.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/transferOwnershipDialog.html
@@ -17,18 +17,12 @@
 -->
 <md-dialog aria-label="Add member" layout-padding flex="30">
   <md-dialog-content class="searchMembers">
-    <p ng-if="!$ctrl.isPromotion()">You need to transfer roles before going further.</p>
-    <div ng-repeat="primaryOwnerWithScope in $ctrl.primaryOwnerWithScopes">
-      <h4>Transfer {{primaryOwnerWithScope.roleScope}} Primary Ownership for {{$ctrl.group.name}}</h4>
-      <p>
-        User <code>{{primaryOwnerWithScope.member.displayName}}</code> has role
-        <code>{{primaryOwnerWithScope.roleScope}} Primary Owner</code>.
-      </p>
-      <p ng-if="$ctrl.isPromotion()">
-        If you go further, <code>{{primaryOwnerWithScope.member.displayName}}</code> will be demoted to the role
-        <code>{{primaryOwnerWithScope.roleScope}} Owner</code>.
-      </p>
-    </div>
+    <h4>Transfer API Primary Ownership for {{$ctrl.group.name}}</h4>
+    <p>User <code>{{$ctrl.primaryOwner.displayName}}</code> has role <code>API Primary Owner</code>.</p>
+    <p ng-if="!$ctrl.isPromotion()">You need to transfer this role before going further.</p>
+    <p ng-if="$ctrl.isPromotion()">
+      If you go further, <code>{{$ctrl.primaryOwner.displayName}}</code> will be demoted to the role <code>API Owner</code>.
+    </p>
     <form name="formMember" ng-submit="$event.preventDefault()" ng-if="!$ctrl.isPromotion()">
       <gv-user-autocomplete
         users-selected="$ctrl.usersSelected"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6533

## Description

The task is about blocking the group member’s integration role dropdown and greying out the Primary Owner role (similar to the Application Role) 

It also required reverting some unnecessary changes made for task APIM-6139

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/b12984fc-80f3-4166-ba08-768331ec2f91">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cffmyuclox.chromatic.com)
<!-- Storybook placeholder end -->
