### PR TITLE
[portal-next] Don't depend on adapter implementation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_menu_link/PortalMenuLinkCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_menu_link/PortalMenuLinkCrudServiceImpl.java
@@ -29,14 +29,10 @@ import org.springframework.stereotype.Component;
 public class PortalMenuLinkCrudServiceImpl implements PortalMenuLinkCrudService {
 
     private final PortalMenuLinkRepository portalMenuLinkRepository;
-    private final PortalMenuLinkAdapter portalMenuLinkAdapter;
+    private final PortalMenuLinkAdapter portalMenuLinkAdapter = PortalMenuLinkAdapter.INSTANCE;
 
-    public PortalMenuLinkCrudServiceImpl(
-        @Lazy PortalMenuLinkRepository portalMenuLinkRepository,
-        PortalMenuLinkAdapter portalMenuLinkAdapter
-    ) {
+    public PortalMenuLinkCrudServiceImpl(@Lazy PortalMenuLinkRepository portalMenuLinkRepository) {
         this.portalMenuLinkRepository = portalMenuLinkRepository;
-        this.portalMenuLinkAdapter = portalMenuLinkAdapter;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_menu_link/PortalMenuLinkQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_menu_link/PortalMenuLinkQueryServiceImpl.java
@@ -31,15 +31,11 @@ import org.springframework.stereotype.Service;
 public class PortalMenuLinkQueryServiceImpl implements PortalMenuLinkQueryService {
 
     private final PortalMenuLinkRepository portalMenuLinkRepository;
-    private final PortalMenuLinkAdapter portalMenuLinkAdapter;
+    private final PortalMenuLinkAdapter portalMenuLinkAdapter = PortalMenuLinkAdapter.INSTANCE;
     private static final Logger logger = LoggerFactory.getLogger(PortalMenuLinkQueryServiceImpl.class);
 
-    public PortalMenuLinkQueryServiceImpl(
-        @Lazy final PortalMenuLinkRepository portalMenuLinkRepository,
-        PortalMenuLinkAdapter portalMenuLinkAdapter
-    ) {
+    public PortalMenuLinkQueryServiceImpl(@Lazy final PortalMenuLinkRepository portalMenuLinkRepository) {
         this.portalMenuLinkRepository = portalMenuLinkRepository;
-        this.portalMenuLinkAdapter = portalMenuLinkAdapter;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_menu_link/PortalMenuLinkCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_menu_link/PortalMenuLinkCrudServiceImplTest.java
@@ -30,7 +30,6 @@ import io.gravitee.apim.core.portal_menu_link.exception.PortalMenuLinkNotFoundEx
 import io.gravitee.apim.core.portal_menu_link.model.PortalMenuLink;
 import io.gravitee.apim.core.portal_menu_link.model.PortalMenuLinkType;
 import io.gravitee.apim.infra.adapter.PortalMenuLinkAdapter;
-import io.gravitee.apim.infra.adapter.PortalMenuLinkAdapterImpl;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import java.util.Optional;
@@ -44,16 +43,13 @@ import org.mockito.ArgumentCaptor;
 public class PortalMenuLinkCrudServiceImplTest {
 
     PortalMenuLinkRepository repository;
-    PortalMenuLinkAdapter mapper;
     PortalMenuLinkCrudServiceImpl service;
 
     @BeforeEach
     void setUp() {
         repository = mock(PortalMenuLinkRepository.class);
 
-        mapper = new PortalMenuLinkAdapterImpl();
-
-        service = new PortalMenuLinkCrudServiceImpl(repository, mapper);
+        service = new PortalMenuLinkCrudServiceImpl(repository);
     }
 
     @Nested
@@ -185,7 +181,7 @@ public class PortalMenuLinkCrudServiceImplTest {
             var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.PortalMenuLink.class);
             verify(repository).update(captor.capture());
 
-            assertThat(captor.getValue()).isEqualTo(mapper.toRepository(portalMenuLink));
+            assertThat(captor.getValue()).isEqualTo(PortalMenuLinkAdapter.INSTANCE.toRepository(portalMenuLink));
             assertThat(captor.getValue().getName()).isEqualTo("newName");
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_menu_link/PortalMenuLinkQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_menu_link/PortalMenuLinkQueryServiceImplTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
-import io.gravitee.apim.infra.adapter.PortalMenuLinkAdapter;
-import io.gravitee.apim.infra.adapter.PortalMenuLinkAdapterImpl;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import io.gravitee.repository.management.model.PortalMenuLink;
@@ -35,14 +33,12 @@ import org.junit.jupiter.api.Test;
 class PortalMenuLinkQueryServiceImplTest {
 
     PortalMenuLinkRepository repository;
-    PortalMenuLinkAdapter mapper;
     PortalMenuLinkQueryServiceImpl service;
 
     @BeforeEach
     void setUp() {
         repository = mock(PortalMenuLinkRepository.class);
-        mapper = new PortalMenuLinkAdapterImpl();
-        service = new PortalMenuLinkQueryServiceImpl(repository, mapper);
+        service = new PortalMenuLinkQueryServiceImpl(repository);
     }
 
     @Nested


### PR DESCRIPTION
## Issue

N/A

## Description

Use inner instance of the adapter instead of using the generated implementation