### PR TITLE
Apim 5458 portal next guides links

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-markdown/page-markdown.component.ts
@@ -16,6 +16,7 @@
 import { Component, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
+import { InnerLinkDirective } from '../../../directives/inner-link.directive';
 import { Page } from '../../../entities/page/page';
 import { ConfigService } from '../../../services/config.service';
 import { MarkdownService } from '../../../services/markdown.service';
@@ -23,8 +24,8 @@ import { MarkdownService } from '../../../services/markdown.service';
 @Component({
   selector: 'app-page-markdown',
   standalone: true,
-  imports: [],
-  template: `<div id="#markdown" [innerHTML]="markdownHtml"></div>`,
+  imports: [InnerLinkDirective],
+  template: `<div id="#markdown" [innerHTML]="markdownHtml" appInnerLink></div>`,
   encapsulation: ViewEncapsulation.ShadowDom,
   styleUrl: './page-markdown.component.scss',
 })

--- a/gravitee-apim-portal-webui-next/src/directives/inner-link.directive.ts
+++ b/gravitee-apim-portal-webui-next/src/directives/inner-link.directive.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, HostListener } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Directive({
+  selector: '[appInnerLink]',
+  standalone: true,
+})
+export class InnerLinkDirective {
+  constructor(private router: Router) {}
+
+  @HostListener('click', ['$event'])
+  public onClick(e: PointerEvent) {
+    if (e.target) {
+      const target: HTMLLinkElement = e.target as HTMLLinkElement;
+
+      const href = target.getAttribute('href');
+      if (target.tagName === 'A' && href) {
+        if (href && !href.startsWith('https:') && !href.startsWith('http:')) {
+          e.preventDefault();
+          this.router.navigateByUrl(href);
+        }
+      }
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/markdown.service.spec.ts
@@ -87,68 +87,73 @@ describe('MarkdownService', () => {
     },
   ];
 
-  beforeEach(() => {
+  const init = (pageBaseUrl = PAGE_BASE_URL) => {
     TestBed.configureTestingModule({
       imports: [RouterModule.forRoot([]), AppTestingModule],
     });
     service = TestBed.inject(MarkdownService);
-    renderer = service.renderer(BASE_URL, PAGE_BASE_URL, PAGES);
-  });
+    renderer = service.renderer(BASE_URL, pageBaseUrl, PAGES);
+  };
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
-  });
+  describe('Legacy support', () => {
+    beforeEach(() => {
+      init();
+    });
 
-  it('should use correct portal media url', () => {
-    // @ts-expect-error possibly undefined
-    const renderedImage = renderer.image(
-      'https://host:port/contextpath/management/organizations/DEFAULT/environments/DEFAULT/portal/media/123456789',
-      'title',
-      'text',
-    );
+    it('should use correct portal media url', () => {
+      // @ts-expect-error possibly undefined
+      const renderedImage = renderer.image(
+        'https://host:port/contextpath/management/organizations/DEFAULT/environments/DEFAULT/portal/media/123456789',
+        'title',
+        'text',
+      );
 
-    expect(renderedImage).toBeDefined();
-    expect(renderedImage).toEqual(`<img alt="text" title="title" src="${BASE_URL}/media/123456789" />`);
-  });
+      expect(renderedImage).toBeDefined();
+      expect(renderedImage).toEqual(`<img alt="text" title="title" src="${BASE_URL}/media/123456789" />`);
+    });
 
-  it('should use correct api media url', () => {
-    // @ts-expect-error possibly undefined
-    const renderedImage = renderer.image(
-      'https://host:port/contextpath/management/organizations/DEFAULT/environments/DEFAULT/apis/1A2Z3E4R5T6Y/media/123456789',
-      'title',
-      'text',
-    );
+    it('should use correct api media url', () => {
+      // @ts-expect-error possibly undefined
+      const renderedImage = renderer.image(
+        'https://host:port/contextpath/management/organizations/DEFAULT/environments/DEFAULT/apis/1A2Z3E4R5T6Y/media/123456789',
+        'title',
+        'text',
+      );
 
-    expect(renderedImage).not.toBeNull();
-    expect(renderedImage).toEqual(`<img alt="text" title="title" src="${BASE_URL}/apis/1A2Z3E4R5T6Y/media/123456789" />`);
-  });
+      expect(renderedImage).not.toBeNull();
+      expect(renderedImage).toEqual(`<img alt="text" title="title" src="${BASE_URL}/apis/1A2Z3E4R5T6Y/media/123456789" />`);
+    });
 
-  it('should use a.internal-link for render an portal page link', () => {
-    // @ts-expect-error possibly undefined
-    const renderedLink = renderer.link('/#!/settings/pages/123456789', 'title', 'text');
+    it('should use a.internal-link for render an portal page link', () => {
+      // @ts-expect-error possibly undefined
+      const renderedLink = renderer.link('/#!/settings/pages/123456789', 'title', 'text');
 
-    expect(renderedLink).not.toBeNull();
-    expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
-  });
+      expect(renderedLink).not.toBeNull();
+      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
+    });
 
-  it('should use a.internal-link for render an api page link', () => {
-    // @ts-expect-error possibly undefined
-    const renderedLink = renderer.link('/#!/apis/1A2Z3E4R5T6Y/documentation/123456789', 'title', 'text');
+    it('should use a.internal-link for render an api page link', () => {
+      // @ts-expect-error possibly undefined
+      const renderedLink = renderer.link('/#!/apis/1A2Z3E4R5T6Y/documentation/123456789', 'title', 'text');
 
-    expect(renderedLink).not.toBeNull();
-    expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
-  });
+      expect(renderedLink).not.toBeNull();
+      expect(renderedLink).toEqual('<a class="internal-link" href="/catalog/api/1234/documentation?page=123456789">text</a>');
+    });
 
-  it('should use a.anchor for render an anchor', () => {
-    // @ts-expect-error possibly undefined
-    const renderedLink = renderer.link('#anchor', 'Anchor', '');
+    it('should use a.anchor for render an anchor', () => {
+      // @ts-expect-error possibly undefined
+      const renderedLink = renderer.link('#anchor', 'Anchor', '');
 
-    expect(renderedLink).not.toBeNull();
-    expect(renderedLink).toEqual('<a class="anchor" href="#anchor"></a>');
+      expect(renderedLink).not.toBeNull();
+      expect(renderedLink).toEqual('<a class="anchor" href="#anchor"></a>');
+    });
   });
 
   describe('Relative link -- /#!/documentation', () => {
     describe('within Api scope -- /api', () => {
+      beforeEach(() => {
+        init();
+      });
       it('should find page by its name', () => {
         // @ts-expect-error possibly undefined
         const renderedLink = renderer.link('/#!/documentation/api/myPage#MARKDOWN', 'title', 'text');
@@ -225,6 +230,95 @@ describe('MarkdownService', () => {
         'Bad format path: %s -- should return original link',
         async (path: string) => {
           const link = `/documentation/api/${path}`;
+          // @ts-expect-error possibly undefined
+          const renderedLink = renderer.link(link, 'title', 'text');
+
+          expect(renderedLink).not.toBeNull();
+          expect(renderedLink).toEqual(`<a href="${link}" title="title">text</a>`);
+        },
+      );
+    });
+
+    describe('within Guides scope -- /guides', () => {
+      beforeEach(() => {
+        init('/guides');
+      });
+      it('should find page by its name', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/myPage#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=123456789">text</a>');
+      });
+
+      it('should find page by its name and file type', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/myPage#SWAGGER', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=22">text</a>');
+      });
+
+      it('should find SWAGGER page by OPENAPI file reference', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/myPage#OPENAPI', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=22">text</a>');
+      });
+
+      it('should find page by its name with spaces', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/my%20Page#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=33">text</a>');
+      });
+
+      it('should find page by its name and path', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/parent/myPage#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=44">text</a>');
+      });
+
+      it('should find page with multi layer path with spaces', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/grand%20parent/my%20parent/my%20page#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=55">text</a>');
+      });
+
+      it('should find page with symbols its name', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/my#$%^&*(){}?>.\\|éàêcrazy@%20page#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=66">text</a>');
+      });
+
+      it('should return link with file name even if not found', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/doesNotExist#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=doesNotExist">text</a>');
+      });
+
+      it('should return link with file name even if parent id invalid', () => {
+        // @ts-expect-error possibly undefined
+        const renderedLink = renderer.link('/#!/documentation/environment/doesNotExist/myPage#MARKDOWN', 'title', 'text');
+
+        expect(renderedLink).not.toBeNull();
+        expect(renderedLink).toEqual('<a class="internal-link" href="/guides?page=myPage">text</a>');
+      });
+
+      it.each(['myPage#typeDoesNotExist', 'myPage', 'myPage#', '#MARKDOWN', '#', 'parent#FOLDER'])(
+        'Bad format path: %s -- should return original link',
+        async (path: string) => {
+          const link = `/documentation/guides/${path}`;
           // @ts-expect-error possibly undefined
           const renderedLink = renderer.link(link, 'title', 'text');
 

--- a/gravitee-apim-portal-webui-next/src/services/markdown.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/markdown.service.ts
@@ -63,6 +63,9 @@ export class MarkdownService {
         const parsedSettingsUrl = /\/#!\/settings\/pages\/([\w-]+)/g.exec(href);
         const parsedApisUrl = /\/#!\/apis\/(?:[\w-]+)\/documentation\/([\w-]+)/g.exec(href);
         const parsedRelativeDocApiUrl = /\/#!\/documentation\/api\/(.*)#([MARKDOWN|SWAGGER|OPENAPI|ASYNCAPI|ASCIIDOC]+)/g.exec(href);
+        const parsedRelativeDocEnvUrl = /\/#!\/documentation\/environment\/(.*)#([MARKDOWN|SWAGGER|OPENAPI|ASYNCAPI|ASCIIDOC]+)/g.exec(
+          href,
+        );
 
         let pageId: string | undefined;
 
@@ -71,7 +74,9 @@ export class MarkdownService {
         } else if (parsedApisUrl) {
           pageId = parsedApisUrl[1];
         } else if (parsedRelativeDocApiUrl) {
-          pageId = pageIdFromParsedRelativeDocApiUrl(parsedRelativeDocApiUrl, pages);
+          pageId = pageIdFromParsedRelativeDocUrl(parsedRelativeDocApiUrl, pages);
+        } else if (parsedRelativeDocEnvUrl) {
+          pageId = pageIdFromParsedRelativeDocUrl(parsedRelativeDocEnvUrl, pages);
         }
 
         if (pageBaseUrl && pageId) {
@@ -113,16 +118,16 @@ const INTERNAL_LINK_CLASSNAME = 'internal-link';
  * Find the page ID from the parsed url.
  * If the page is not found, the page name is returned.
  *
- * @param parsedDocApiUrl - ex. ['/#!/documentation/api/my/doc%20page#MARKDOWN', 'my/doc%20page', 'MARKDOWN']
+ * @param parsedDocUrl - ex. ['/#!/documentation/api/my/doc%20page#MARKDOWN', 'my/doc%20page', 'MARKDOWN']
  * @param pages - pages to search for locating the relative documentation
  */
-const pageIdFromParsedRelativeDocApiUrl = (parsedDocApiUrl: RegExpExecArray, pages: Page[]) => {
-  const pagePath = parsedDocApiUrl[1];
+const pageIdFromParsedRelativeDocUrl = (parsedDocUrl: RegExpExecArray, pages: Page[]) => {
+  const pagePath = parsedDocUrl[1];
   const pathWithSpaces = pagePath.replace(/%20/g, ' ');
   const splitPath = pathWithSpaces.split('/');
   const pageName = splitPath[splitPath.length - 1];
 
-  const pageType = parsedDocApiUrl[2] === 'OPENAPI' ? 'SWAGGER' : parsedDocApiUrl[2];
+  const pageType = parsedDocUrl[2] === 'OPENAPI' ? 'SWAGGER' : parsedDocUrl[2];
 
   const pageId = findPageId(pageType, undefined, 0, splitPath, pages);
   return pageId ?? pageName;

--- a/gravitee-apim-portal-webui/src/app/pages/documentation/documentation.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/documentation/documentation.component.html
@@ -15,4 +15,4 @@
     limitations under the License.
 
 -->
-<app-gv-documentation [pages]="pages" [rootDir]="rootDir" [fragment]="fragment"></app-gv-documentation>
+<app-gv-documentation [pages]="pages" [rootDir]="rootDir" [fragment]="fragment" [pageBaseUrl]="pageBaseUrl"></app-gv-documentation>

--- a/gravitee-apim-portal-webui/src/app/pages/documentation/documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/documentation/documentation.component.ts
@@ -26,6 +26,7 @@ export class DocumentationComponent implements OnInit {
   pages: Page[];
   rootDir: string;
   fragment: string;
+  pageBaseUrl: string = '/documentation/root';
 
   constructor(private portalService: PortalService, private activeRoute: ActivatedRoute) {}
 

--- a/gravitee-apim-portal-webui/src/app/services/markdown.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/markdown.service.ts
@@ -63,6 +63,9 @@ export class MarkdownService {
         const parsedSettingsUrl = /\/#!\/settings\/pages\/([\w-]+)/g.exec(href);
         const parsedApisUrl = /\/#!\/apis\/(?:[\w-]+)\/documentation\/([\w-]+)/g.exec(href);
         const parsedRelativeDocApiUrl = /\/#!\/documentation\/api\/(.*)#([MARKDOWN|SWAGGER|OPENAPI|ASYNCAPI|ASCIIDOC]+)/g.exec(href);
+        const parsedRelativeDocEnvUrl = /\/#!\/documentation\/environment\/(.*)#([MARKDOWN|SWAGGER|OPENAPI|ASYNCAPI|ASCIIDOC]+)/g.exec(
+          href,
+        );
 
         let pageId: string;
 
@@ -71,7 +74,9 @@ export class MarkdownService {
         } else if (parsedApisUrl) {
           pageId = parsedApisUrl[1];
         } else if (parsedRelativeDocApiUrl) {
-          pageId = pageIdFromParsedRelativeDocApiUrl(parsedRelativeDocApiUrl, pages);
+          pageId = pageIdFromParsedRelativeDocUrl(parsedRelativeDocApiUrl, pages);
+        } else if (parsedRelativeDocEnvUrl) {
+          pageId = pageIdFromParsedRelativeDocUrl(parsedRelativeDocEnvUrl, pages);
         }
 
         if (pageBaseUrl && pageId) {
@@ -108,16 +113,16 @@ const INTERNAL_LINK_CLASSNAME = 'internal-link';
  * Find the page ID from the parsed url.
  * If the page is not found, the page name is returned.
  *
- * @param parsedDocApiUrl - ex. ['/#!/documentation/api/my/doc%20page#MARKDOWN', 'my/doc%20page', 'MARKDOWN']
+ * @param parsedDocUrl - ex. ['/#!/documentation/api/my/doc%20page#MARKDOWN', 'my/doc%20page', 'MARKDOWN']
  * @param pages - pages to search for locating the relative documentation
  */
-const pageIdFromParsedRelativeDocApiUrl = (parsedDocApiUrl: RegExpExecArray, pages: Page[]) => {
-  const pagePath = parsedDocApiUrl[1];
+const pageIdFromParsedRelativeDocUrl = (parsedDocUrl: RegExpExecArray, pages: Page[]) => {
+  const pagePath = parsedDocUrl[1];
   const pathWithSpaces = pagePath.replace(/%20/g, ' ');
   const splitPath = pathWithSpaces.split('/');
   const pageName = splitPath[splitPath.length - 1];
 
-  const pageType = parsedDocApiUrl[2] === 'OPENAPI' ? 'SWAGGER' : parsedDocApiUrl[2];
+  const pageType = parsedDocUrl[2] === 'OPENAPI' ? 'SWAGGER' : parsedDocUrl[2];
 
   const pageId = findPageId(pageType, undefined, 0, splitPath, pages);
   return pageId ?? pageName;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5458

## Description

Add relative internal links for environment-level documentation to portal-next and portal

A user can add a relative link within environment-level documentation while using the page name: 

```txt
/#!/documentation/environment/path/to%20my/page#MARKDOWN
```

https://github.com/user-attachments/assets/9f56bd24-c6b3-46aa-92a4-1187ce088907

❗ Note: ❗ -- Including the work of https://github.com/gravitee-io/gravitee-api-management/pull/8777 because it's easier to test 🙃 . Best to wait to merge until other PR is ready.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qjuzectrgj.chromatic.com)
<!-- Storybook placeholder end -->
