### PR TITLE
chore: upgrade reporter-cloud to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <gravitee-reporter-elasticsearch.version>5.3.2</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.2</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.2</gravitee-reporter-tcp.version>
-        <gravitee-reporter-cloud.version>1.0.1</gravitee-reporter-cloud.version>
+        <gravitee-reporter-cloud.version>1.1.0</gravitee-reporter-cloud.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-tracer-jaeger.version>3.0.1</gravitee-tracer-jaeger.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-348

## Description

This PR updates to the latest version of cloud-reporter to 1.1.0 which brings better memory management and retry mechanism when pushing reports to the cloud.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xqbqgnkkun.chromatic.com)
<!-- Storybook placeholder end -->
