### PR TITLE
fix: make sure debug does not block the eventloop

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorEventListener.java
@@ -28,12 +28,12 @@ import io.gravitee.gateway.reactor.ReactorEvent;
  */
 public class ReactorEventListener extends AbstractService<ReactorEventListener> implements EventListener<ReactorEvent, Reactable> {
 
-    private final ReactorHandlerRegistry reactorHandlerRegistry;
+    protected final EventManager eventManager;
+    protected final ReactorHandlerRegistry reactorHandlerRegistry;
 
     public ReactorEventListener(EventManager eventManager, ReactorHandlerRegistry reactorHandlerRegistry) {
+        this.eventManager = eventManager;
         this.reactorHandlerRegistry = reactorHandlerRegistry;
-
-        eventManager.subscribeForEvents(this, ReactorEvent.class);
     }
 
     @Override
@@ -54,12 +54,14 @@ public class ReactorEventListener extends AbstractService<ReactorEventListener> 
     @Override
     protected void doStart() throws Exception {
         super.doStart();
+        eventManager.subscribeForEvents(this, ReactorEvent.class);
     }
 
     @Override
     protected void doStop() throws Exception {
         super.doStop();
 
+        eventManager.unsubscribeForEvents(this, ReactorEvent.class);
         reactorHandlerRegistry.clear();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorEventListenerTest.java
@@ -41,6 +41,7 @@ public class ReactorEventListenerTest {
         MockitoAnnotations.initMocks(this);
 
         reactorEventListener = new ReactorEventListener(eventManager, reactorHandlerRegistry);
+        reactorEventListener.start();
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -36,6 +36,7 @@ import io.gravitee.gateway.reactor.impl.ReactableEvent;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.ApiDebugStatus;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
@@ -43,6 +44,7 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.net.OpenSSLEngineOptions;
 import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
 import java.security.GeneralSecurityException;
 import java.util.Date;
 import java.util.List;
@@ -58,11 +60,9 @@ public class DebugReactorEventListener extends ReactorEventListener {
 
     private final Logger logger = LoggerFactory.getLogger(DebugReactorEventListener.class);
     private final Vertx vertx;
-    private final EventManager eventManager;
     private final EventRepository eventRepository;
     private final ObjectMapper objectMapper;
     private final VertxDebugHttpClientConfiguration debugHttpClientConfiguration;
-    private final ReactorHandlerRegistry reactorHandlerRegistry;
     private final AccessPointManager accessPointManager;
     private final DataEncryptor dataEncryptor;
 
@@ -78,11 +78,9 @@ public class DebugReactorEventListener extends ReactorEventListener {
     ) {
         super(eventManager, reactorHandlerRegistry);
         this.vertx = vertx;
-        this.eventManager = eventManager;
         this.eventRepository = eventRepository;
         this.objectMapper = objectMapper;
         this.debugHttpClientConfiguration = debugHttpClientConfiguration;
-        this.reactorHandlerRegistry = reactorHandlerRegistry;
         this.accessPointManager = accessPointManager;
         this.dataEncryptor = dataEncryptor;
     }
@@ -108,8 +106,9 @@ public class DebugReactorEventListener extends ReactorEventListener {
                     updateEvent(debugEvent, ApiDebugStatus.DEBUGGING);
 
                     logger.info("Sending request to debug");
-                    vertx
-                        .createHttpClient(buildClientOptions())
+                    HttpClient httpClient = vertx.createHttpClient(buildClientOptions());
+
+                    httpClient
                         .rxRequest(
                             new RequestOptions()
                                 .setMethod(HttpMethod.valueOf(debugApiRequest.getMethod()))
@@ -129,6 +128,8 @@ public class DebugReactorEventListener extends ReactorEventListener {
                         )
                         .doOnSuccess(httpClientResponse -> logger.debug("Response status: {}", httpClientResponse.statusCode()))
                         .flatMap(io.vertx.rxjava3.core.http.HttpClientResponse::rxBody)
+                        .doFinally(httpClient::close)
+                        .subscribeOn(Schedulers.io())
                         .subscribe(
                             body -> {
                                 logger.info("Debugging successful, removing the handler.");
@@ -180,18 +181,6 @@ public class DebugReactorEventListener extends ReactorEventListener {
             failEvent(event);
             return null;
         }
-    }
-
-    @Override
-    protected void doStart() throws Exception {
-        super.doStart();
-        eventManager.subscribeForEvents(this, ReactorEvent.class);
-    }
-
-    @Override
-    protected void doStop() throws Exception {
-        super.doStop();
-        reactorHandlerRegistry.clear();
     }
 
     private HttpClientOptions buildClientOptions() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -24,8 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -177,7 +179,7 @@ class DebugReactorEventListenerTest {
         verify(dataEncryptor, times(1)).decrypt("encrypted");
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
         verify(eventRepository, times(1)).update(eventCaptor.capture());
 
         final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
@@ -218,7 +220,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
         verify(eventRepository, times(1)).update(eventCaptor.capture());
 
         final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
@@ -258,7 +260,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
 
         verify(eventRepository, times(2)).update(eventCaptor.capture());
 
@@ -293,7 +295,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
 
         verify(eventRepository, times(2)).update(eventCaptor.capture());
 
@@ -327,7 +329,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
 
         verify(eventRepository, times(2)).update(eventCaptor.capture());
 
@@ -356,7 +358,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(1)).create(any(DebugApi.class));
         verify(reactorHandlerRegistry, times(1)).contains(any(DebugApi.class));
-        verify(reactorHandlerRegistry, times(1)).remove(any(DebugApi.class));
+        verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApi.class));
 
         verify(eventRepository, times(2)).update(eventCaptor.capture());
 
@@ -384,7 +386,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(0)).create(any());
         verify(reactorHandlerRegistry, times(1)).contains(any());
-        verify(reactorHandlerRegistry, times(0)).remove(any());
+        verify(reactorHandlerRegistry, after(500).times(0)).remove(any());
     }
 
     @Test
@@ -393,7 +395,7 @@ class DebugReactorEventListenerTest {
 
         verify(reactorHandlerRegistry, times(0)).create(any());
         verify(reactorHandlerRegistry, times(0)).contains(any());
-        verify(reactorHandlerRegistry, times(0)).remove(any());
+        verify(reactorHandlerRegistry, after(500).times(0)).remove(any());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
@@ -41,17 +41,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class EndpointDiscoveryVerticle extends AbstractVerticle implements EventListener<ReactorEvent, Reactable> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointDiscoveryVerticle.class);
     private final Map<Api, List<ServiceDiscovery>> apiServiceDiscoveries = new HashMap<>();
 
     @Autowired
@@ -89,19 +88,19 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
                     break;
             }
         } else {
-            LOGGER.warn("Endpoint discovery service is not compatible with api V4");
+            log.debug("Endpoint discovery service does not apply to V4 API which now uses a dedicated API service.");
         }
     }
 
     private void stopServiceDiscovery(Api api) {
         List<ServiceDiscovery> discoveries = apiServiceDiscoveries.remove(api);
         if (discoveries != null) {
-            LOGGER.info("Stop service discovery for API id[{}] name[{}]", api.getId(), api.getName());
+            log.info("Stop service discovery for API id[{}] name[{}]", api.getId(), api.getName());
             discoveries.forEach(serviceDiscovery -> {
                 try {
                     serviceDiscovery.stop();
                 } catch (Exception ex) {
-                    LOGGER.error("Unexpected error while stopping service discovery", ex);
+                    log.error("Unexpected error while stopping service discovery", ex);
                 }
             });
         }
@@ -123,7 +122,7 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
         final EndpointGroup group,
         final EndpointDiscoveryService discoveryService
     ) {
-        LOGGER.info(
+        log.info(
             "A discovery service is defined for API id[{}] name[{}] group[{}] type[{}]",
             api.getId(),
             api.getName(),
@@ -144,7 +143,7 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
                     group.setEndpoints(endpoints);
                 }
                 serviceDiscovery.listen(event -> {
-                    LOGGER.info("Receiving a service discovery event id[{}] type[{}]", event.service().id(), event.type());
+                    log.info("Receiving a service discovery event id[{}] type[{}]", event.service().id(), event.type());
                     Endpoint endpoint = createEndpoint(event.service(), group);
                     switch (event.type()) {
                         case REGISTER:
@@ -156,10 +155,10 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
                     }
                 });
             } catch (Exception ex) {
-                LOGGER.error("An errors occurs while starting to listen from service discovery provider", ex);
+                log.error("An errors occurs while starting to listen from service discovery provider", ex);
             }
         } else {
-            LOGGER.error(
+            log.error(
                 "No Service Discovery plugin found for type[{}] api[{}] group[{}]",
                 discoveryService.getProvider(),
                 api.getId(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
@@ -38,8 +38,7 @@ import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Promise;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 
@@ -48,9 +47,9 @@ import org.springframework.core.env.Environment;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Slf4j
 public class EndpointHealthcheckVerticle extends AbstractVerticle implements EventListener<ReactorEvent, Reactable> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointHealthcheckVerticle.class);
     private final Map<Api, List<EndpointRuleCronHandler>> apiHandlers = new ConcurrentHashMap<>();
 
     @Autowired
@@ -97,7 +96,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
                     break;
             }
         } else {
-            LOGGER.warn("Health check service is not compatible with api V4");
+            log.debug("Health check service does not apply to V4 API which now uses a dedicated API service.");
         }
     }
 
@@ -119,7 +118,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
         // Configure handlers on resolved API endpoints
         final List<EndpointRule> healthCheckEndpoints = endpointResolver.resolve(api);
         if (!healthCheckEndpoints.isEmpty()) {
-            LOGGER.debug("Health-check for API id[{}] name[{}] is enabled", api.getId(), api.getName());
+            log.debug("Health-check for API id[{}] name[{}] is enabled", api.getId(), api.getName());
             apiHandlers.put(api, new ArrayList<>());
             healthCheckEndpoints.forEach(rule -> addHandler(api, rule));
         }
@@ -142,21 +141,21 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
 
             apiHandlers.get(api).add(cronHandler);
 
-            LOGGER.debug(
+            log.debug(
                 "Add health-check for endpoint name[{}] target[{}] with cron[{}]",
                 rule.endpoint().getName(),
                 rule.endpoint().getTarget(),
                 rule.schedule()
             );
         } catch (Exception ex) {
-            LOGGER.error("An error occurs while creating an health-check runner", ex);
+            log.error("An error occurs while creating an health-check runner", ex);
         }
     }
 
     private void removeHandlers(Api api) {
         List<EndpointRuleCronHandler> handlers = apiHandlers.remove(api);
         if (handlers != null) {
-            LOGGER.debug("Stop health-check for API id[{}] name[{}]", api.getId(), api.getName());
+            log.debug("Stop health-check for API id[{}] name[{}]", api.getId(), api.getName());
             handlers.forEach(handler -> handler.cancel());
         }
     }
@@ -170,7 +169,7 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
                 .findFirst();
 
             endpointCronHandler.ifPresent(handler -> {
-                LOGGER.debug(
+                log.debug(
                     "Remove health-check handler id[{}] for endpoint name[{}] type[{}] target[{}]",
                     handler.getTimerId(),
                     endpoint.getName(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6596

## Description

This fix PR ensures that:

- The debug API process does not occur on the sync process thread so it does not block it (which leads to API not being synchronized anymore).
- The debug mode completion stage does not occur on the vertx event loop which can cause deadlocks and block the traffic

It also fixes some minor other issues discovered during the troubleshooting:
- The HTTP client created to run the debug request is now properly closed once the debug is over
- DebugEventListener was registered twice to the EventManager leading to the debug event being handled twice
- The remaining warn logs displayed when a V4 API is deployed are no longer valid and have been rewritten and moved to the debug level.

