### PR TITLE
fix: redirect to log using full url to include all path segments

### DIFF
--- a/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/analytics/logs/platform-logs.controller.ts
@@ -122,8 +122,12 @@ class PlatformLogsController {
   }
 
   showLogDetails(log) {
+    const fullUrl = window.location.href;
+    const index = fullUrl.indexOf('/#!');
+    const baseUrl = fullUrl.substring(0, index + 3);
+
     return (
-      '/#!' +
+      baseUrl +
       this.ngRouter.createUrlTree(['.', log.id], {
         relativeTo: this.activatedRoute,
         queryParams: {

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/analytics-logs.controller.ajs.ts
@@ -150,8 +150,12 @@ class ApiAnalyticsLogsControllerAjs {
   }
 
   goToLog(log: any) {
+    const fullUrl = window.location.href;
+    const index = fullUrl.indexOf('/#!');
+    const baseUrl = fullUrl.substring(0, index + 3);
+
     return (
-      '/#!' +
+      baseUrl +
       this.ngRouter.createUrlTree(['.', log.id], {
         relativeTo: this.activatedRoute,
         queryParams: {

--- a/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/logs/application-logs.controller.ts
@@ -115,8 +115,12 @@ class ApplicationLogsController {
   }
 
   goToLog(log: any) {
+    const fullUrl = window.location.href;
+    const index = fullUrl.indexOf('/#!');
+    const baseUrl = fullUrl.substring(0, index + 3);
+
     return (
-      '/#!' +
+      baseUrl +
       this.ngRouter.createUrlTree(['.', log.id], {
         relativeTo: this.activatedRoute,
         queryParams: {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6573

## Description

Redirect to log using full url to include all path segments.

💡 Using this image image: graviteeio.azurecr.io/apim-management-ui:apim-6573-logs-redirect-latest on our registry and docker compose https://github.com/gravitee-io/gravitee-api-management/tree/master/docker/quick-setup/nginx allow us to test the fix 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rdmiobzgmm.chromatic.com)
<!-- Storybook placeholder end -->
