### PR TITLE
ci: use latest 4.0.x version for bridge tests

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/bridge-compatibility-tests/bridge-compatibility-tests.yml
@@ -321,7 +321,7 @@ workflows:
                 - 4.3.x-latest
                 - 4.2.x-latest
                 - 4.1.x-latest
-                - 4.0.x-latest
+                - graviteeio@4.0
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-bridge-compatibility-tests.ts
@@ -61,7 +61,7 @@ export class BridgeCompatibilityTestsWorkflow {
         matrix: {
           execution_mode: ['v3', 'v4-emulation-engine'],
           database: ['bridge'],
-          apim_client_tag: ['4.3.x-latest', '4.2.x-latest', '4.1.x-latest', '4.0.x-latest'],
+          apim_client_tag: ['4.3.x-latest', '4.2.x-latest', '4.1.x-latest', 'graviteeio@4.0'],
         },
       }),
     ];


### PR DESCRIPTION
## Issue

N/A

## Description

Use the latest 4.0 version of APIM from docker hub for bridge tests