### PR TITLE
fix: Handle MongoDB exception in GatewayNodeMetadataResolver during installation id retrieval

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
@@ -86,7 +86,7 @@ public class GatewayNodeMetadataResolver implements NodeMetadataResolver {
     private String getInstallationId() {
         try {
             return installationRepository.find().map(Installation::getId).orElse(null);
-        } catch (TechnicalException e) {
+        } catch (Exception e) {
             logger.warn("Unable to load installation id", e);
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6626

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

