### PR TITLE
Apim 5971 v4 documentation swagger config

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/documentation/editDocumentation.ts
@@ -39,6 +39,7 @@ export interface EditDocumentationSwagger extends BaseEditDocumentation {
   content?: string;
   homepage?: boolean;
   source?: PageSource;
+  configuration?: unknown;
 }
 
 export interface EditDocumentationAsyncApi extends BaseEditDocumentation {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.html
@@ -44,7 +44,12 @@
       <gio-form-label>Exclude the selected groups</gio-form-label>
       When selected, reverses the operation for the group permissions. Users belonging to any of the specified groups will NOT be able to
       view the page.
-      <mat-slide-toggle gioFormSlideToggle formControlName="excludeGroups" aria-label="Exclude selected groups"></mat-slide-toggle>
+      <mat-slide-toggle
+        gioFormSlideToggle
+        formControlName="excludeGroups"
+        aria-label="Exclude selected groups"
+        [disabled]="form.value.accessControlGroups.length === 0"
+      ></mat-slide-toggle>
     </gio-form-slide-toggle>
   }
 </form>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.spec.ts
@@ -18,12 +18,13 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { signal } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { ApiDocumentationV4PageConfigurationHarness } from './api-documentation-v4-page-configuration.harness';
-import { ApiDocumentationV4PageConfigurationComponent } from './api-documentation-v4-page-configuration.component';
+import { ApiDocumentationV4PageConfigurationComponent, PageConfigurationForm } from './api-documentation-v4-page-configuration.component';
 
 import { GioTestingModule } from '../../../../../shared/testing';
-import { fakeGroup, fakePage, Group, Page, PageType } from '../../../../../entities/management-api-v2';
+import { fakeGroup, fakePage, Group, Page, PageType, Visibility } from '../../../../../entities/management-api-v2';
 
 describe('ApiDocumentationV4PageConfigurationComponent', () => {
   let fixture: ComponentFixture<ApiDocumentationV4PageConfigurationComponent>;
@@ -46,6 +47,12 @@ describe('ApiDocumentationV4PageConfigurationComponent', () => {
     fixture.componentInstance.pageType = pageType;
     fixture.componentInstance.homepage = homepage;
     fixture.componentInstance.groups = groups;
+    fixture.componentInstance.form = new FormGroup<PageConfigurationForm>({
+      name: new FormControl<string>(initialName, [Validators.required]),
+      visibility: new FormControl<Visibility>('PUBLIC', [Validators.required]),
+      accessControlGroups: new FormControl<string[]>([]),
+      excludeGroups: new FormControl<boolean>(false),
+    });
     fixture.detectChanges();
   };
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component.ts
@@ -25,16 +25,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import {
-  AbstractControl,
-  FormControl,
-  FormGroup,
-  FormsModule,
-  ReactiveFormsModule,
-  ValidationErrors,
-  ValidatorFn,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { MatError, MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
 import { MatInput } from '@angular/material/input';
@@ -53,22 +44,6 @@ export interface PageConfigurationForm {
   accessControlGroups: FormControl<string[]>;
   excludeGroups: FormControl<boolean>;
 }
-
-export interface PageConfigurationData {
-  id: string;
-  name: string;
-  visibility?: Visibility;
-  excludedAccessControls: boolean;
-  accessControlGroups: string[];
-}
-
-export const INIT_PAGE_CONFIGURATION_FORM = () =>
-  new FormGroup<PageConfigurationForm>({
-    name: new FormControl<string>('', [Validators.required]),
-    visibility: new FormControl<Visibility>('PUBLIC', [Validators.required]),
-    accessControlGroups: new FormControl<string[]>([]),
-    excludeGroups: new FormControl<boolean>({ value: false, disabled: true }),
-  });
 
 @Component({
   selector: 'api-documentation-v4-page-configuration',
@@ -100,7 +75,7 @@ export class ApiDocumentationV4PageConfigurationComponent implements OnInit, OnC
   pageType: PageType;
 
   @Input()
-  form: FormGroup<PageConfigurationForm> = INIT_PAGE_CONFIGURATION_FORM();
+  form!: FormGroup<PageConfigurationForm>;
 
   @Input()
   groups: Group[] = [];
@@ -109,7 +84,7 @@ export class ApiDocumentationV4PageConfigurationComponent implements OnInit, OnC
   apiPages: Page[] = [];
 
   @Input()
-  data?: PageConfigurationData;
+  pageId?: string;
 
   @Input()
   homepage?: boolean;
@@ -120,7 +95,6 @@ export class ApiDocumentationV4PageConfigurationComponent implements OnInit, OnC
   ngOnInit() {
     this.setExistingNames();
 
-    this.form.controls.name.setValue(this.name());
     this.form.controls.name.addValidators([this.pageNameUniqueValidator()]);
 
     this.form.controls.name.valueChanges
@@ -146,18 +120,6 @@ export class ApiDocumentationV4PageConfigurationComponent implements OnInit, OnC
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.data && this.data) {
-      this.form.controls.name.setValue(this.data.name);
-      this.form.controls.visibility.setValue(this.data.visibility);
-      this.form.controls.accessControlGroups.setValue(this.data.accessControlGroups);
-
-      this.form.controls.excludeGroups.setValue(this.data.excludedAccessControls === true);
-      if (this.form.value.accessControlGroups.length === 0) {
-        this.form.controls.excludeGroups.disable();
-      } else {
-        this.form.controls.excludeGroups.enable();
-      }
-    }
     if (changes.apiPages) {
       this.setExistingNames();
     }
@@ -170,7 +132,7 @@ export class ApiDocumentationV4PageConfigurationComponent implements OnInit, OnC
 
   private setExistingNames(): void {
     this.existingNames = this.apiPages
-      .filter((page) => page.type === this.pageType && (!this.data || page.id !== this.data.id))
+      .filter((page) => page.type === this.pageType && (!this.pageId || page.id !== this.pageId))
       .map((page) => page.name.toLowerCase().trim());
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
@@ -38,7 +38,7 @@
   <mat-card-content>
     <div class="tab">
       <form [formGroup]="form">
-        <mat-tab-group [selectedIndex]="1">
+        <mat-tab-group [selectedIndex]="page.type === 'SWAGGER' ? 2 : 1">
           <mat-tab label="Configure Page">
             <div class="tab__content">
               <api-documentation-v4-page-configuration
@@ -52,6 +52,131 @@
               />
             </div>
           </mat-tab>
+          @if (page.type === 'SWAGGER') {
+            <mat-tab label="Configure OpenAPI Viewer">
+              <div class="open-api-configuration" formGroupName="openApiConfiguration">
+                <gio-form-slide-toggle>
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    formControlName="entrypointsAsServers"
+                    data-test-id="entrypoints-as-servers-toggle"
+                  />
+                  <gio-form-label>
+                    <div>Use API entrypoints as server URLs</div>
+                    <div class="mat-body-2">The base URL in the specification is replaced by the API entrypoints.</div>
+                  </gio-form-label>
+                </gio-form-slide-toggle>
+                <mat-form-field>
+                  <mat-label>Base URL</mat-label>
+                  <input matInput type="text" formControlName="tryItURL" data-test-id="base-url" />
+                  <mat-hint
+                    >Custom base URL to use as server URL. If empty and not using API entrypoints as a base URL, the server URL from the
+                    specification will be used.</mat-hint
+                  >
+                </mat-form-field>
+                <gio-form-slide-toggle>
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    data-test-id="context-path-as-server-toggle"
+                    formControlName="entrypointAsBasePath"
+                  />
+                  <gio-form-label>
+                    <div>Use context-path of API as server URL</div>
+                    <div class="mat-body-2">The context-path of the API will replace the path of the server URL.</div>
+                  </gio-form-label>
+                </gio-form-slide-toggle>
+                <mat-form-field appearance="outline">
+                  <mat-label>OpenAPI Documentation Viewer</mat-label>
+                  <mat-select formControlName="viewer" data-test-id="open-api-viewer">
+                    <mat-option value="Swagger">SwaggerUI</mat-option>
+                    <mat-option value="Redoc">Redoc</mat-option>
+                  </mat-select>
+                </mat-form-field>
+                @if (form.controls.openApiConfiguration.value.viewer === 'Swagger') {
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="try-it" formControlName="tryIt" />
+                    <gio-form-label>
+                      <div>Enable "Try It!" mode</div>
+                      <div class="mat-body-2">
+                        Allows trying the API from the Developer Portal for authenticated users. You may have to configure CORS in the
+                        entrypoint section.
+                      </div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="try-it-anonymous" formControlName="tryItAnonymous" />
+                    <gio-form-label>
+                      <div>Enable "Try It!" mode for anonymous users</div>
+                      <div class="mat-body-2">
+                        Allows users not logged into the Developer Portal to try the API from the OpenAPI spec when the page and API are
+                        public.
+                      </div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="show-url" formControlName="showURL" />
+                    <gio-form-label>
+                      <div>Show URL to download content</div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="display-operation-id" formControlName="displayOperationId" />
+                    <gio-form-label>
+                      <div>Display the <code>operationId</code> in the operation list</div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="use-pkce" formControlName="usePkce" />
+                    <gio-form-label>
+                      <div>Use PKCE with OAuth</div>
+                      <div class="mat-body-2">Uses PKCE when authentication with OAuth authorization code flow.</div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <mat-form-field appearance="outline">
+                    <mat-label>Expand content on the page</mat-label>
+                    <mat-select formControlName="docExpansion" data-test-id="doc-expansion">
+                      <mat-option value="list">Only tags</mat-option>
+                      <mat-option value="full">Tags and operations</mat-option>
+                      <mat-option value="none">Default</mat-option>
+                    </mat-select>
+                    <mat-hint>Determines whether to expand operations, tags, or nothing by default when the page is opened.</mat-hint>
+                  </mat-form-field>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="enable-filtering" formControlName="enableFiltering" />
+                    <gio-form-label>
+                      <div>Add top bar to filter content</div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="show-extensions" formControlName="showExtensions" />
+                    <gio-form-label>
+                      <div>Display vendor extensions</div>
+                      <div class="mat-body-2">
+                        Determines whether vendor extension (X-) fields and values for operations, parameters, and schemas should be
+                        displayed.
+                      </div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <gio-form-slide-toggle>
+                    <mat-slide-toggle gioFormSlideToggle data-test-id="show-common-extensions" formControlName="showCommonExtensions" />
+                    <gio-form-label>
+                      <div>Display extension fields for Parameters</div>
+                      <div class="mat-body-2">
+                        Determines whether pattern, maxLength, minLength, maximum, and minimum extensions should be shown.
+                      </div>
+                    </gio-form-label>
+                  </gio-form-slide-toggle>
+                  <mat-form-field>
+                    <mat-label>Max number of tagged operations displayed</mat-label>
+                    <input matInput type="number" min="-1" formControlName="maxDisplayedTags" data-test-id="max-displayed-tags" />
+                    <mat-hint
+                      >Limits the number of tagged operations displayed to the specific value. -1 means to show all operations.</mat-hint
+                    >
+                  </mat-form-field>
+                }
+              </div>
+            </mat-tab>
+          }
           <mat-tab label="Content">
             <div class="tab__content">
               <api-documentation-content formControlName="content" [published]="page?.published || isReadOnly" [pageType]="page.type" />

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
@@ -179,6 +179,11 @@
           }
           <mat-tab label="Content">
             <div class="tab__content">
+              @if (page.source?.type) {
+                <gio-banner-info
+                  >This content is a preview and cannot be edited because the page is linked to an external source.</gio-banner-info
+                >
+              }
               <api-documentation-content formControlName="content" [published]="page?.published || isReadOnly" [pageType]="page.type" />
 
               @if (form.controls.content.errors?.required) {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
@@ -45,7 +45,7 @@
                 [name]="name"
                 [pageType]="page.type"
                 [apiPages]="pages"
-                [data]="pageConfigurationData"
+                [pageId]="page.id"
                 [form]="form.controls.pageConfiguration"
                 [groups]="groups"
                 [homepage]="isHomepage"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.scss
@@ -30,3 +30,8 @@ $typography: map.get(gio.$mat-theme, typography);
     gap: 8px;
   }
 }
+
+.open-api-configuration {
+  display: flex;
+  flex-flow: column;
+}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
@@ -341,6 +341,27 @@ describe('DocumentationEditPageComponent', () => {
           });
         });
       });
+      describe('with fetched page', () => {
+        const PAGE = fakeMarkdown({
+          id: 'page-id',
+          name: 'page-name',
+          content: 'my content',
+          source: { type: 'http-fetcher', configuration: { some: 'config' } },
+        });
+
+        beforeEach(async () => {
+          await init(PAGE, undefined);
+          initPageServiceRequests({ pages: [PAGE], breadcrumb: [], parentId: undefined });
+        });
+
+        it('should not allow editing content', async () => {
+          const editor = await harnessLoader
+            .getHarness(ApiDocumentationV4ContentEditorHarness)
+            .then((harness) => harness.getContentEditor());
+          expect(editor).toBeDefined();
+          expect(await editor.isDisabled()).toEqual(true);
+        });
+      });
       describe('with OpenAPI page', () => {
         describe('with no configuration', () => {
           const PAGE = fakeSwagger({

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -149,13 +149,6 @@ export class DocumentationEditPageComponent implements OnInit {
       ? this.page.accessControls.filter((ac) => ac.referenceType === 'GROUP').map((ac) => ac.referenceId)
       : [];
 
-    this.pageConfigurationData = {
-      id: this.page.id,
-      name: this.page.name,
-      visibility: this.page.visibility,
-      excludedAccessControls: this.page.excludedAccessControls === true,
-      accessControlGroups: this.initialAccessControlGroups,
-    };
 
     this.form.controls.content.setValue(this.page.content);
 

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -16,6 +16,7 @@
 import { Input, Component, OnInit, signal, inject, DestroyRef } from '@angular/core';
 import { AsyncPipe, NgOptimizedImage } from '@angular/common';
 import {
+  GioBannerModule,
   GioConfirmDialogComponent,
   GioConfirmDialogData,
   GioFormJsonSchemaModule,
@@ -109,6 +110,7 @@ interface EditPageForm {
     MatTab,
     MatCardContent,
     ApiDocumentationV4PageHeaderComponent,
+    GioBannerModule,
   ],
   templateUrl: './documentation-edit-page.component.html',
   styleUrl: './documentation-edit-page.component.scss',
@@ -191,6 +193,9 @@ export class DocumentationEditPageComponent implements OnInit {
       this.form.disable();
     }
 
+    if (this.page.source?.type) {
+      this.form.controls.content.disable();
+    }
 
     this.form.controls.openApiConfiguration.controls.entrypointsAsServers.valueChanges
       .pipe(distinctUntilChanged(isEqual), takeUntilDestroyed(this.destroyRef))

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.harness.ts
@@ -16,6 +16,9 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatTabHarness } from '@angular/material/tabs/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class DocumentationEditPageHarness extends ComponentHarness {
   public static hostSelector = 'documentation-edit-page';
@@ -24,6 +27,29 @@ export class DocumentationEditPageHarness extends ComponentHarness {
   private locatePublishChangesButton = this.locatorFor(MatButtonHarness.with({ text: 'Publish changes' }));
   private locateConfigurePageTab = this.locatorFor(MatTabHarness.with({ label: 'Configure Page' }));
   private locateContentTab = this.locatorFor(MatTabHarness.with({ label: 'Content' }));
+  private locateOpenApiConfigurationTab = this.locatorFor(MatTabHarness.with({ label: 'Configure OpenAPI Viewer' }));
+  private locateEntrypointsAsServersToggle = this.locatorFor(
+    MatSlideToggleHarness.with({ selector: '[data-test-id="entrypoints-as-servers-toggle"]' }),
+  );
+  private locateContextPathAsServerToggle = this.locatorFor(
+    MatSlideToggleHarness.with({ selector: '[data-test-id="context-path-as-server-toggle"]' }),
+  );
+  private locateBaseUrlInput = this.locatorFor(MatInputHarness.with({ selector: '[data-test-id="base-url"]' }));
+  private locateViewerSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-test-id="open-api-viewer"]' }));
+  private locateTryItToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="try-it"]' }));
+  private locateTryItAnonymousToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="try-it-anonymous"]' }));
+  private locateShowUrlToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="show-url"]' }));
+  private locateDisplayOperationIdToggle = this.locatorFor(
+    MatSlideToggleHarness.with({ selector: '[data-test-id="display-operation-id"]' }),
+  );
+  private locateUsePkceToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="use-pkce"]' }));
+  private locateEnableFilteringToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="enable-filtering"]' }));
+  private locateShowExtensionsToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-test-id="show-extensions"]' }));
+  private locateShowCommonExtensionsToggle = this.locatorFor(
+    MatSlideToggleHarness.with({ selector: '[data-test-id="show-common-extensions"]' }),
+  );
+  private locateDocExpansionSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-test-id="doc-expansion"]' }));
+  private locateMaxOperationsDisplayedInput = this.locatorFor(MatInputHarness.with({ selector: '[data-test-id="max-displayed-tags"]' }));
 
   async getDeleteButton(): Promise<MatButtonHarness | undefined> {
     return await this.locateDeleteButton();
@@ -39,5 +65,68 @@ export class DocumentationEditPageHarness extends ComponentHarness {
 
   async openContentTab(): Promise<void> {
     return await this.locateContentTab().then((tab) => tab.select());
+  }
+
+  async openOpenApiConfigurationTab(): Promise<void> {
+    return await this.locateOpenApiConfigurationTab().then((tab) => tab.select());
+  }
+
+  /**
+   * OpenAPI viewer configuration
+   */
+  async getEntrypointsAsServersToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateEntrypointsAsServersToggle();
+  }
+
+  async getBaseUrlInput(): Promise<MatInputHarness> {
+    return await this.locateBaseUrlInput();
+  }
+
+  async getContextPathAsServerToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateContextPathAsServerToggle();
+  }
+
+  async getOpenApiViewerSelect(): Promise<MatSelectHarness> {
+    return await this.locateViewerSelect();
+  }
+
+  async getTryItToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateTryItToggle();
+  }
+
+  async getTryItAnonymousToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateTryItAnonymousToggle();
+  }
+
+  async getShowUrlToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateShowUrlToggle();
+  }
+
+  async getDisplayOperationIdToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateDisplayOperationIdToggle();
+  }
+
+  async getUsePkceToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateUsePkceToggle();
+  }
+
+  async getEnableFilteringToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateEnableFilteringToggle();
+  }
+
+  async getShowExtensionsToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateShowExtensionsToggle();
+  }
+
+  async getShowCommonExtensionsToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateShowCommonExtensionsToggle();
+  }
+
+  async getDocExpansionSelect(): Promise<MatSelectHarness> {
+    return await this.locateDocExpansionSelect();
+  }
+
+  async getMaxOperationsDisplayedInput(): Promise<MatInputHarness> {
+    return await this.locateMaxOperationsDisplayedInput();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.html
@@ -33,7 +33,6 @@
               [name]="name"
               [pageType]="pageType"
               [apiPages]="pages"
-              [data]="stepOneData"
               [form]="form.controls.stepOne"
               [groups]="groups"
               [homepage]="createHomepage"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
@@ -63,13 +63,7 @@ describe('DocumentationNewPageComponent', () => {
   ) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ApiDocumentationV4Module, FormsModule, GioTestingModule, CommonModule, DocumentationNewPageComponent],
-      providers: [
-        // {
-        //   provide: ActivatedRoute,
-        //   useValue: { snapshot: { params: { apiId: API_ID, pageId }, queryParams: { parentId, pageType: 'MARKDOWN' } } },
-        // },
-        { provide: GioTestingPermissionProvider, useValue: apiPermissions },
-      ],
+      providers: [{ provide: GioTestingPermissionProvider, useValue: apiPermissions }],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -228,7 +228,7 @@ export class DocumentationNewPageComponent implements OnInit {
           this.selectedFetcherSchema = undefined;
           this.sourceConfiguration = undefined;
         }),
-        debounceTime(500),
+        debounceTime(10),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe((value) => {
@@ -286,7 +286,7 @@ export class DocumentationNewPageComponent implements OnInit {
     // Only Markdown, Swagger, and AsyncAPI pages can be created
     if (this.pageType !== 'MARKDOWN' && this.pageType !== 'SWAGGER' && this.pageType !== 'ASYNCAPI') {
       this.snackBarService.error(`Cannot create page with type [${this.pageType}]`);
-      return;
+      return EMPTY;
     }
     const createPage: CreateDocumentation = {
       type: this.pageType as CreateDocumentationType,

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -52,14 +52,13 @@ import {
   Page,
   PageSource,
   PageType,
+  Visibility,
 } from '../../../../../entities/management-api-v2';
 import { GioPermissionModule } from '../../../../../shared/components/gio-permission/gio-permission.module';
 import { ApiDocumentationV4ContentEditorComponent } from '../api-documentation-v4-content-editor/api-documentation-v4-content-editor.component';
 import { ApiDocumentationV4FileUploadComponent } from '../api-documentation-v4-file-upload/api-documentation-v4-file-upload.component';
 import {
   ApiDocumentationV4PageConfigurationComponent,
-  INIT_PAGE_CONFIGURATION_FORM,
-  PageConfigurationData,
   PageConfigurationForm,
 } from '../api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component';
 import { ApiDocumentationV4PageHeaderComponent } from '../api-documentation-v4-page-header/api-documentation-v4-page-header.component';
@@ -134,7 +133,6 @@ export class DocumentationNewPageComponent implements OnInit {
   page: Page;
   isReadOnly: boolean = false;
   groups: Group[];
-  stepOneData: PageConfigurationData = undefined;
 
   name = signal<string | undefined>(undefined);
 
@@ -157,17 +155,23 @@ export class DocumentationNewPageComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    if (this.createHomepage) {
+      this.name.set('Homepage');
+    }
+
     this.form = new FormGroup<CreatePageForm>({
-      stepOne: INIT_PAGE_CONFIGURATION_FORM(),
+      stepOne: new FormGroup<PageConfigurationForm>({
+        name: new FormControl<string>(this.name(), [Validators.required]),
+        visibility: new FormControl<Visibility>('PUBLIC', [Validators.required]),
+        accessControlGroups: new FormControl<string[]>([]),
+        excludeGroups: new FormControl<boolean>(false),
+      }),
       content: new FormControl<string>('', [Validators.required]),
       sourceType: new FormControl<string>(this.defaultSourceType, [Validators.required]),
       source: new FormControl<string>(''),
     });
 
     this.sourceConfiguration = new FormControl<undefined | unknown>({});
-    if (this.createHomepage) {
-      this.name.set('Homepage');
-    }
 
     this.isReadOnly = this.api.originContext?.origin === 'KUBERNETES';
 

--- a/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, Component, ElementRef, Input } from '@angular/core';
+
+import { Page } from '../../../entities/page/page';
+import { RedocService } from '../../../services/redoc.service';
+
+@Component({
+  selector: 'app-page-redoc',
+  standalone: true,
+  imports: [],
+  template: `<div id="redoc"></div>`,
+})
+export class PageRedocComponent implements AfterViewInit {
+  @Input()
+  page!: Page;
+
+  constructor(
+    private element: ElementRef,
+    private redocService: RedocService,
+  ) {}
+
+  ngAfterViewInit() {
+    const redocElement = this.element.nativeElement.querySelector('#redoc');
+
+    // Force the right-side panel to join into the middle panel
+    const options = { theme: { breakpoints: { medium: '120rem' } } };
+
+    this.redocService.init(this.page.content, options, redocElement);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.harness.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class PageRedocHarness extends ComponentHarness {
+  public static hostSelector = 'app-page-redoc';
+  protected locateRedoc = this.locatorFor('#redoc');
+
+  public async getRedoc(): Promise<TestElement> {
+    return await this.locateRedoc();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.html
@@ -17,7 +17,11 @@
 -->
 @switch (page.type) {
   @case ('SWAGGER') {
-    <app-page-swagger [page]="page" />
+    @if (page.configuration?.viewer?.toLowerCase() === 'redoc') {
+      <app-page-redoc [page]="page" />
+    } @else {
+      <app-page-swagger [page]="page" />
+    }
   }
   @case ('MARKDOWN') {
     <app-page-markdown [pages]="pages" [content]="page.content" [apiId]="apiId" />

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.spec.ts
@@ -20,9 +20,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PageAsciidocHarness } from './page-asciidoc/page-asciidoc.harness';
 import { PageAsyncApiHarness } from './page-async-api/page-async-api.harness';
 import { PageMarkdownHarness } from './page-markdown/page-markdown.harness';
+import { PageRedocHarness } from './page-redoc/page-redoc.harness';
 import { PageSwaggerHarness } from './page-swagger/page-swagger.harness';
 import { PageComponent } from './page.component';
 import { fakePage } from '../../entities/page/page.fixtures';
+import { RedocService } from '../../services/redoc.service';
 import { AppTestingModule } from '../../testing/app-testing.module';
 
 describe('PageComponent', () => {
@@ -33,6 +35,12 @@ describe('PageComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PageComponent, AppTestingModule],
+      providers: [
+        {
+          provide: RedocService,
+          useValue: { init: (_content: string | undefined, _options: unknown, _el: unknown) => {} },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PageComponent);
@@ -52,6 +60,19 @@ describe('PageComponent', () => {
       const swagger = await harnessLoader.getHarnessOrNull(PageSwaggerHarness);
       expect(swagger).toBeTruthy();
       expect(await swagger?.getSwagger()).toBeTruthy();
+    });
+  });
+
+  describe('redoc', () => {
+    beforeEach(() => {
+      component.page = fakePage({ type: 'SWAGGER', configuration: { viewer: 'Redoc' } });
+      fixture.detectChanges();
+    });
+
+    it('should show redoc content', async () => {
+      const redoc = await harnessLoader.getHarnessOrNull(PageRedocHarness);
+      expect(redoc).toBeTruthy();
+      expect(await redoc?.getRedoc()).toBeTruthy();
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.ts
@@ -18,13 +18,14 @@ import { Component, Input } from '@angular/core';
 import { PageAsciidocComponent } from './page-asciidoc/page-asciidoc.component';
 import { PageAsyncApiComponent } from './page-async-api/page-async-api.component';
 import { PageMarkdownComponent } from './page-markdown/page-markdown.component';
+import { PageRedocComponent } from './page-redoc/page-redoc.component';
 import { PageSwaggerComponent } from './page-swagger/page-swagger.component';
 import { Page } from '../../entities/page/page';
 
 @Component({
   selector: 'app-page',
   standalone: true,
-  imports: [PageSwaggerComponent, PageMarkdownComponent, PageAsciidocComponent, PageAsyncApiComponent],
+  imports: [PageSwaggerComponent, PageMarkdownComponent, PageAsciidocComponent, PageAsyncApiComponent, PageRedocComponent],
   templateUrl: './page.component.html',
   styleUrl: './page.component.scss',
 })

--- a/gravitee-apim-portal-webui-next/src/index.html
+++ b/gravitee-apim-portal-webui-next/src/index.html
@@ -36,6 +36,10 @@
     <script type="application/javascript">
       window.global ||= window;
     </script>
+    <script
+      src="https://cdn.redoc.ly/redoc/v2.1.5/bundles/redoc.standalone.js"
+      integrity="sha384-0GrsyTQc9Oqd8h+b2dbc4XdR2T/DYpy0tLNNstyx+LBMUyiBbcWPbEs9aRmUcaxD"
+      crossorigin="anonymous"></script>
   </head>
   <body>
     <app-root></app-root>

--- a/gravitee-apim-portal-webui-next/src/services/redoc.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/redoc.service.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+
+import { readYaml } from '../app/helpers/yaml-parser';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare let Redoc: any;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RedocService {
+  constructor() {}
+
+  init(content: string | undefined, options: unknown, elementId: unknown): void {
+    if (content) {
+      const swaggerSpec = this.parseContent(content);
+      Redoc.init(swaggerSpec, options, elementId);
+    }
+  }
+
+  private parseContent(content: string): unknown {
+    try {
+      return JSON.parse(content);
+    } catch (e) {
+      return readYaml(content);
+    }
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5971

## Description

- Add banner to edit for when page source is defined + set content to read-only
- Show open api configuration on edit for swagger pages
- Add Redoc to portal-next

https://github.com/user-attachments/assets/27c76114-7de1-43ed-b201-b3b9d33da579

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nkicceqtoq.chromatic.com)
<!-- Storybook placeholder end -->
