### PR TITLE
fix(rest-api): SPG steps collection may be empty but shouldn't be null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.apim.core.shared_policy_group.model;
 
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+
 import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.v4.ApiType;
@@ -27,7 +30,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.jetbrains.annotations.NotNull;
 
 @Data
 @NoArgsConstructor
@@ -151,7 +153,7 @@ public class SharedPolicyGroup {
             .prerequisiteMessage(createSharedPolicyGroup.getPrerequisiteMessage())
             .apiType(createSharedPolicyGroup.getApiType())
             .phase(createSharedPolicyGroup.getPhase())
-            .steps(createSharedPolicyGroup.getSteps())
+            .steps(ofNullable(createSharedPolicyGroup.getSteps()).orElse(emptyList()))
             .build();
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6508

## Description

It is possible to restore a version without steps.

https://github.com/user-attachments/assets/14dad30b-8926-4df2-a138-3546ebf478ba



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

