### PR TITLE
fix: order APIs by name when listing APIs in mAPI v2

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -36,7 +36,7 @@
   (filtersChange)="onFiltersChanged($event)"
   [paginationPageSizeOptions]="[5, 10, 25, 50]"
 >
-  <table mat-table matSort [dataSource]="apisTableDS" id="apisTable" aria-label="Apis table">
+  <table mat-table matSort [dataSource]="apisTableDS" matSortActive="name" matSortDirection="asc" id="apisTable" aria-label="Apis table">
     <!-- Picture Column -->
     <ng-container matColumnDef="picture">
       <th mat-header-cell *matHeaderCellDef id="picture"></th>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -185,14 +185,14 @@ describe('ApisListComponent', () => {
 
       await loader.getHarness(GioTableWrapperHarness).then((tableWrapper) => tableWrapper.setSearchValue('bad-search'));
       await tick(400);
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10&sortBy=name`);
       expect(req.request.body).toEqual({ query: 'bad-search' });
 
       req.flush('Internal error', { status: 500, statusText: 'Internal error' });
 
       await loader.getHarness(GioTableWrapperHarness).then((tableWrapper) => tableWrapper.setSearchValue('good-search'));
 
-      expectApisListRequest([], null, 'good-search');
+      expectApisListRequest([], 'name', 'good-search');
     }));
 
     it('should display one row with kubernetes icon', fakeAsync(async () => {
@@ -214,12 +214,13 @@ describe('ApisListComponent', () => {
       const nameSort = await loader.getHarness(MatSortHeaderHarness.with({ selector: '#name' })).then((sortHarness) => sortHarness.host());
       await nameSort.click();
       apis.map((api) => expectSyncedApi(api.id, true));
-      expectApisListRequest(apis, 'name');
+      // APIs are sorted by name by default, so clicking a first time will reverse the order
+      expectApisListRequest(apis, '-name');
 
       fixture.detectChanges();
       await nameSort.click();
       apis.map((api) => expectSyncedApi(api.id, true));
-      expectApisListRequest(apis, '-name');
+      expectApisListRequest(apis, 'name');
     }));
 
     it('should order rows by contextPath', fakeAsync(async () => {
@@ -246,13 +247,8 @@ describe('ApisListComponent', () => {
       const apis = [api];
       await initComponent(apis);
       expect(await loader.getAllHarnesses(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toHaveLength(0);
-
-      const nameSort = await loader.getHarness(MatSortHeaderHarness.with({ selector: '#name' })).then((sortHarness) => sortHarness.host());
-      await nameSort.click();
-
       expectSyncedApi(api.id, false);
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-is-not-synced' }))).toBeTruthy();
-      expectApisListRequest(apis, 'name');
     }));
 
     describe('onAddApiClick', () => {
@@ -296,7 +292,8 @@ describe('ApisListComponent', () => {
     });
 
     async function initComponent(apis: Api[]) {
-      expectApisListRequest(apis);
+      // APIs are sorted by name by default
+      expectApisListRequest(apis, 'name');
       loader = TestbedHarnessEnvironment.loader(fixture);
       fixture.detectChanges();
     }
@@ -364,7 +361,8 @@ describe('ApisListComponent', () => {
     }));
 
     async function initComponent(api: Api, score = 1) {
-      expectApisListRequest([api]);
+      // APIs are sorted by name by default
+      expectApisListRequest([api], 'name');
       loader = TestbedHarnessEnvironment.loader(fixture);
       expectSyncedApi(api.id, true);
       expectQualityRequest(api.id, score);

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -71,6 +71,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
   filters: GioTableWrapperFilters = {
     pagination: { index: 1, size: 10 },
     searchTerm: '',
+    sort: { active: 'name', direction: 'asc' },
   };
   isQualityDisplayed: boolean;
   searchLabel = 'Search APIs | name:"My api *" ownerName:admin';

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -19,6 +19,7 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
 
 import com.google.common.base.Strings;
+import io.gravitee.common.data.domain.Order;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.exception.InvalidImageException;
@@ -34,6 +35,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.param.ApiSortByParam;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
 import io.gravitee.rest.api.management.v2.rest.security.Permissions;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -111,6 +113,7 @@ public class ApisResource extends AbstractResource {
             getAuthenticatedUser(),
             isAdmin(),
             expands,
+            new SortableImpl("name", true),
             paginationParam.toPageable()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
@@ -134,6 +135,7 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
                 eq("UnitTests"),
                 eq(true),
                 isNull(),
+                eq(new SortableImpl("name", true)),
                 eq(new PageableImpl(1, 10))
             )
         )
@@ -212,6 +214,7 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
                 eq("UnitTests"),
                 eq(true),
                 isNull(),
+                eq(new SortableImpl("name", true)),
                 eq(new PageableImpl(1, 10))
             )
         )
@@ -290,6 +293,7 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
                 eq("UnitTests"),
                 eq(true),
                 isNull(),
+                eq(new SortableImpl("name", true)),
                 eq(new PageableImpl(1, 10))
             )
         )
@@ -357,7 +361,14 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         apiList.add(returnedApi2);
 
         when(
-            apiServiceV4.findAll(eq(GraviteeContext.getExecutionContext()), eq("UnitTests"), eq(true), isNull(), eq(new PageableImpl(1, 2)))
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                isNull(),
+                eq(new SortableImpl("name", true)),
+                eq(new PageableImpl(1, 2))
+            )
         )
             .thenReturn(new Page<>(apiList, 1, 2, 42));
 
@@ -421,6 +432,7 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
                 eq("UnitTests"),
                 eq(true),
                 eq(Set.of("deploymentState", "primaryOwner")),
+                eq(new SortableImpl("name", true)),
                 eq(new PageableImpl(1, 2))
             )
         )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.v4;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
@@ -51,6 +52,7 @@ public interface ApiService {
         final String userId,
         final boolean isAdmin,
         final Set<String> expands,
+        final Sortable sortable,
         final Pageable pageable
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -54,6 +54,7 @@ import io.gravitee.rest.api.model.WorkflowReferenceType;
 import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.alert.AlertTriggerEntity;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.notification.GenericNotificationConfigEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -681,6 +682,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final String userId,
         final boolean isAdmin,
         final Set<String> expands,
+        final Sortable sortable,
         final Pageable pageable
     ) {
         ApiCriteria.Builder criteria = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
@@ -698,7 +700,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
         Page<Api> apis = apiRepository.search(
             criteria.build(),
-            null,
+            convert(sortable),
             convert(pageable),
             new ApiFieldFilter.Builder().excludePicture().build()
         );
@@ -730,7 +732,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final boolean isAdmin,
         final Pageable pageable
     ) {
-        return this.findAll(executionContext, userId, isAdmin, Collections.emptySet(), pageable);
+        return this.findAll(executionContext, userId, isAdmin, Collections.emptySet(), null, pageable);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -34,10 +34,13 @@ import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.AlertService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -406,6 +409,7 @@ public class ApiServiceImpl_findAllTest {
 
     @Test
     public void should_expand_primary_owner() {
+        var sortable = new SortableBuilder().field("name").order(Order.ASC).build();
         var pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
         var api1 = new Api();
         api1.setId("API_1");
@@ -413,7 +417,7 @@ public class ApiServiceImpl_findAllTest {
         when(
             apiRepository.search(
                 eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
-                isNull(),
+                eq(sortable),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())
             )
@@ -428,6 +432,7 @@ public class ApiServiceImpl_findAllTest {
             "UnitTests",
             true,
             Set.of("primaryOwner"),
+            new SortableImpl("name", true),
             new PageableImpl(1, 10)
         );
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6641

## Description

Sort APIs by name by default
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jnatbthfik.chromatic.com)
<!-- Storybook placeholder end -->
