### PR TITLE
fix: define display format on top bar link list

### DIFF
--- a/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.scss
+++ b/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.scss
@@ -50,7 +50,14 @@ $typography: map.get(gio.$mat-theme, typography);
 
 .mat-column-order {
   width: 1%;
-  vertical-align: bottom;
+}
+
+.mat-column-name {
+  width: 25%;
+}
+
+.mat-column-target {
+  word-break: break-all;
 }
 
 .mat-column-actions {
@@ -60,6 +67,7 @@ $typography: map.get(gio.$mat-theme, typography);
 
 .drag-cursor {
   cursor: move;
+  display: table-cell;
 }
 
 .cdk-drag-preview {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6632

## Description

Fix the size and the way big target are displayed in Top Bar link list.

## Additional context
Before 
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/bddfd602-2123-4776-8a44-2aa681d7c853">

After
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/8b8f4d75-d728-46b1-b4f8-7265ff5bf210">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mzzdfgvhrx.chromatic.com)
<!-- Storybook placeholder end -->
