### PR TITLE
feat: hide gateway view and details for multi tenant

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -145,21 +145,25 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
         permissions: ['environment-application-r'],
         category: 'Applications',
       },
-      {
+    ];
+
+    if (this.constants?.org?.settings?.management?.installationType !== 'multi-tenant') {
+      mainMenuItems.push({
         icon: 'gio:cloud-server',
         displayName: 'Gateways',
         routerLink: './gateways',
         permissions: ['environment-instance-r'],
         category: 'Gateways',
-      },
-      {
-        icon: 'gio:shield-check',
-        routerLink: './api-score',
-        displayName: 'API Score',
-        permissions: ['environment-integration-r'],
-        category: 'API Score',
-      },
-    ];
+      });
+    }
+
+    mainMenuItems.push({
+      icon: 'gio:shield-check',
+      routerLink: './api-score',
+      displayName: 'API Score',
+      permissions: ['environment-integration-r'],
+      category: 'API Score',
+    });
 
     mainMenuItems.push(
       {

--- a/gravitee-apim-console-webui/src/management/management-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/management-routing.module.ts
@@ -24,6 +24,7 @@ import { InstanceDetailsEnvironmentComponent } from './instances/instance-detail
 import { InstanceDetailsMonitoringComponent } from './instances/instance-details/instance-details-monitoring/instance-details-monitoring.component';
 import { EnvAuditComponent } from './audit/env-audit.component';
 import { MessagesComponent } from './messages/messages.component';
+import { NotMultiTenantGuard } from './not-multi-tenant-guard';
 
 import { TasksComponent } from '../user/tasks/tasks.component';
 import { UserComponent } from '../user/my-accout/user.component';
@@ -83,6 +84,7 @@ const managementRoutes: Routes = [
       },
       {
         path: 'gateways',
+        canActivate: [NotMultiTenantGuard],
         component: InstanceListComponent,
         data: {
           permissions: {
@@ -107,6 +109,8 @@ const managementRoutes: Routes = [
       {
         path: 'gateways/:instanceId',
         component: InstanceDetailsComponent,
+        canActivate: [NotMultiTenantGuard],
+        canActivateChild: [NotMultiTenantGuard],
         data: {
           permissions: {
             anyOf: ['environment-instance-r'],

--- a/gravitee-apim-console-webui/src/management/not-multi-tenant-guard.ts
+++ b/gravitee-apim-console-webui/src/management/not-multi-tenant-guard.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { Inject, Injectable } from '@angular/core';
+
+import { Constants } from '../entities/Constants';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotMultiTenantGuard implements CanActivate {
+  constructor(
+    private router: Router,
+    @Inject(Constants) private readonly constants: Constants,
+  ) {}
+
+  canActivate(_route: ActivatedRouteSnapshot): boolean {
+    return this.constants?.org?.settings?.management?.installationType !== 'multi-tenant';
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1835

## Description

If a cloud user/ multi tenant we don't want apim gateway view to be available and users should instead view gateways from cloud interface. 

Screenshot with gateways sidebar link not present as in multi tenant mode: 
<img width="1710" alt="Screenshot 2024-09-05 at 11 18 03" src="https://github.com/user-attachments/assets/e081c02e-b94b-4019-8250-0b16ffd823f4">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ncqzfsupoe.chromatic.com)
<!-- Storybook placeholder end -->
