### PR TITLE
feat(helm): improve the probes definition for the gateway

### DIFF
--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -187,7 +187,7 @@ spec:
             successThreshold: 1
             failureThreshold: 2
             httpGet:
-              path: /_node/health?probes=sync-process
+              path: /_node/health?probes=http-server
               scheme: HTTP
               port: 18082
               {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}
@@ -206,7 +206,7 @@ spec:
             successThreshold: 1
             failureThreshold: 29
             httpGet:
-              path: /_node/health?probes=http-server
+              path: /_node/health?probes=http-server,sync-process
               scheme: HTTP
               port: 18082
               {{- if eq .Values.gateway.services.core.http.authentication.type "basic" }}

--- a/helm/tests/gateway/deployment_probes_test.yaml
+++ b/helm/tests/gateway/deployment_probes_test.yaml
@@ -8,7 +8,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /_node/health?probes=sync-process
+          value: /_node/health?probes=http-server
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders[0].value
           value: Basic YWRtaW46YWRtaW5hZG1pbg==
@@ -27,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /_node/health?probes=sync-process
+          value: /_node/health?probes=http-server
       - notExists:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders
 
@@ -64,7 +64,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
-          value: /_node/health?probes=http-server
+          value: /_node/health?probes=http-server,sync-process
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders[0].value
           value: Basic YWRtaW46YWRtaW5hZG1pbg==
@@ -83,7 +83,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
-          value: /_node/health?probes=http-server
+          value: /_node/health?probes=http-server,sync-process
       - notExists:
           path: spec.template.spec.containers[0].startupProbe.httpGet.httpHeaders
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6669

## Description

As a reminder, you can see what are [https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/](Liveness, Readiness, and Startup
Probes).

By default, `startupProbe`, `livenessProbe` and `readinessProbe` are
enable and configured like:

```yaml
livenessProbe:
periodSeconds: 15
timeoutSeconds: 2
successThreshold: 1
failureThreshold: 3
httpGet:
path: /_node/health?probes=http-server
scheme: HTTP
port: 18082
readinessProbe:
periodSeconds: 10
timeoutSeconds: 2
successThreshold: 1
failureThreshold: 2
httpGet:
path: /_node/health?probes=sync-process
scheme: HTTP
port: 18082
startupProbe:
initialDelaySeconds: 10
periodSeconds: 10
timeoutSeconds: 1
successThreshold: 1
failureThreshold: 29
httpGet:
path: /_node/health?probes=http-server
scheme: HTTP
port: 18082
```

This mean that on startup, we can wait maximum 29*10 = around 5 minutes
for the HTTP server to start to answer. This is a really high value, but
not an issue.

Then, during the pod life, the `liveness` keep the pod running until the
HTTP server answer. And the ingress forward request to this pod until
the `readiness` is OK.

However, the gateway is built to continue to serve the traffic when the
repositories aren't available. As long as there is no restart, the
traffic is handled. It allows giving enough time for the administrator
in charge of the platform to solve the issue. Most of the time, the
end-user applications do not suffer from any issues. The only trouble is
that there is no possibility to redeploy new version of the apis during
this time.

So we should first ensure that the gateway is sync before handleing
traffic and then keep it running even if some sync issue occur. Like
ephemeral network issue to the bridge, or the database.

This improvement can be resume as:

```yaml
startupProbe:
httpGet:
path: /_node/health?probes=http-server,sync-process
livenessProbe:
httpGet:
path: /_node/health?probes=http-server
readinessProbe:
httpGet:
path: /_node/health?probes=http-server
```
