### PR TITLE
feat(portal-next): allow user to subscribe to mtls plans

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api-choose-plan/subscribe-to-api-choose-plan.component.html
@@ -22,7 +22,13 @@
       [id]="plan.id"
       [plan]="plan"
       [selected]="selectedPlanId() === plan.id"
-      [disabled]="plan.security !== 'KEY_LESS' && plan.security !== 'API_KEY' && plan.security !== 'OAUTH2' && plan.security !== 'JWT'"
+      [disabled]="
+        plan.security !== 'KEY_LESS' &&
+        plan.security !== 'API_KEY' &&
+        plan.security !== 'OAUTH2' &&
+        plan.security !== 'JWT' &&
+        plan.security !== 'MTLS'
+      "
       (selectPlan)="selectPlan.emit(plan)"></app-plan-card>
   }
 </div>

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -61,6 +61,7 @@ export interface ApplicationOwnerLinks {
 export interface ApplicationSettings {
   oauth?: ApplicationSettingsOAuth;
   app?: ApplicationSettingsApp;
+  tls?: ApplicationSettingsTls;
 }
 
 export interface ApplicationSettingsApp {
@@ -75,6 +76,10 @@ export interface ApplicationSettingsOAuth {
   renew_client_secret_supported: boolean;
   response_types: string[];
   grant_types: string[];
+}
+
+export interface ApplicationSettingsTls {
+  client_certificate: string;
 }
 
 export interface ApplicationLinks {

--- a/gravitee-apim-portal-webui-next/src/entities/plan/plan.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/plan/plan.ts
@@ -27,7 +27,7 @@ export interface Plan {
   mode: PlanMode;
   usage_configuration?: PlanUsageConfiguration;
 }
-export type PlanSecurityEnum = 'API_KEY' | 'KEY_LESS' | 'JWT' | 'OAUTH2';
+export type PlanSecurityEnum = 'API_KEY' | 'KEY_LESS' | 'JWT' | 'OAUTH2' | 'MTLS';
 export const PlanSecurityEnum = {
   APIKEY: 'API_KEY' as PlanSecurityEnum,
   KEYLESS: 'KEY_LESS' as PlanSecurityEnum,
@@ -50,6 +50,8 @@ export const getPlanSecurityTypeLabel = (securityType: PlanSecurityEnum | undefi
       return 'API Key';
     case 'KEY_LESS':
       return 'Keyless';
+    case 'MTLS':
+      return 'mTLS';
     default:
       return '';
   }

--- a/gravitee-apim-portal-webui-next/src/services/application.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application.service.ts
@@ -37,14 +37,14 @@ export class ApplicationService {
     return this.http.get<ApplicationType>(`${this.configService.baseURL}/applications/${applicationId}/configuration`);
   }
 
-  list(page?: number, size?: number, forSubscriptions?: boolean): Observable<ApplicationsResponse> {
+  list(page?: number, size?: number, forSubscription?: boolean): Observable<ApplicationsResponse> {
     const pageParam = page ? 'page=' + page : 'page=1';
     const perPageParam = size ? 'size=' + size : 'size=10';
 
     const paramList = [pageParam, perPageParam];
 
-    if (forSubscriptions !== undefined) {
-      paramList.push('forSubscriptions=' + forSubscriptions);
+    if (forSubscription !== undefined) {
+      paramList.push('forSubscription=' + forSubscription);
     }
 
     return this.http.get<ApplicationsResponse>(`${this.configService.baseURL}/applications?${paramList.join('&')}`);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6572

## Description

Allow users to subscribe to mTLS plans


https://github.com/user-attachments/assets/b68db149-643f-4e0a-975a-d12d2e0eb552


If an application is missing a client certificate: 
<img width="1057" alt="Screenshot 2024-09-05 at 15 04 32" src="https://github.com/user-attachments/assets/a8d81d1c-d757-4ec2-a709-7b12a6692d6a">


If an application already has a mTLS subscription to the current api for a different plan:
<img width="1017" alt="Screenshot 2024-09-05 at 15 07 36" src="https://github.com/user-attachments/assets/14860ae9-b8d3-419d-9f86-9631bc1e0834">



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

