### PR TITLE
fix(helm): add missing common.labels in gateway-technical-ingress.yaml

### DIFF
--- a/helm/templates/gateway/gateway-technical-ingress.yaml
+++ b/helm/templates/gateway/gateway-technical-ingress.yaml
@@ -16,6 +16,11 @@ metadata:
     app.kubernetes.io/component: "{{ .Values.gateway.name }}"
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- if and .Values.common .Values.common.labels }}
+    {{- range $key, $value := .Values.common.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
   annotations:
     {{- if .Values.gateway.services.core.ingress.annotations }}
     {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.core.ingress.annotations "ingressClassName" .Values.gateway.services.core.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}

--- a/helm/tests/gateway/ingress_labels_test.yaml
+++ b/helm/tests/gateway/ingress_labels_test.yaml
@@ -1,8 +1,9 @@
 suite: Test API Gateway Ingress - labels
-templates:
-  - "gateway/gateway-ingress.yaml"
+
 tests:
   - it: Sets common ingress labels
+    templates:
+      - "gateway/gateway-ingress.yaml"
     chart:
       version: 3.1.0
       appVersion: 3.21.0
@@ -20,6 +21,35 @@ tests:
             app.kubernetes.io/managed-by: Helm 
             app.kubernetes.io/name: apim 
             app.kubernetes.io/version: 3.21.0 
+            helm.sh/chart: apim-3.1.0
+            acme.com/team: api
+            acme.com/feature: products
+
+  - it: Sets common ingress labels on technical ingress too
+    templates:
+      - "gateway/gateway-technical-ingress.yaml"
+    chart:
+      version: 3.1.0
+      appVersion: 3.21.0
+    set:
+      common:
+        labels:
+          acme.com/team: api
+          acme.com/feature: products
+      gateway:
+        services:
+          core:
+            ingress:
+              enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/component: gateway
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: apim
+            app.kubernetes.io/version: 3.21.0
             helm.sh/chart: apim-3.1.0
             acme.com/team: api
             acme.com/feature: products


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6698

## Description

The helm values have a `common.labels` section which is already use in
the gateway ingress to fill common labels.

Here we replicate them into technical gateway ingress

