### PR TITLE
fix(console): order APIs by name only when no query

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -36,7 +36,7 @@
   (filtersChange)="onFiltersChanged($event)"
   [paginationPageSizeOptions]="[5, 10, 25, 50]"
 >
-  <table mat-table matSort [dataSource]="apisTableDS" matSortActive="name" matSortDirection="asc" id="apisTable" aria-label="Apis table">
+  <table mat-table matSort [dataSource]="apisTableDS" id="apisTable" aria-label="Apis table">
     <!-- Picture Column -->
     <ng-container matColumnDef="picture">
       <th mat-header-cell *matHeaderCellDef id="picture"></th>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -185,14 +185,14 @@ describe('ApisListComponent', () => {
 
       await loader.getHarness(GioTableWrapperHarness).then((tableWrapper) => tableWrapper.setSearchValue('bad-search'));
       await tick(400);
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10&sortBy=name`);
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=10`);
       expect(req.request.body).toEqual({ query: 'bad-search' });
 
       req.flush('Internal error', { status: 500, statusText: 'Internal error' });
 
       await loader.getHarness(GioTableWrapperHarness).then((tableWrapper) => tableWrapper.setSearchValue('good-search'));
 
-      expectApisListRequest([], 'name', 'good-search');
+      expectApisListRequest([], null, 'good-search');
     }));
 
     it('should display one row with kubernetes icon', fakeAsync(async () => {
@@ -214,13 +214,12 @@ describe('ApisListComponent', () => {
       const nameSort = await loader.getHarness(MatSortHeaderHarness.with({ selector: '#name' })).then((sortHarness) => sortHarness.host());
       await nameSort.click();
       apis.map((api) => expectSyncedApi(api.id, true));
-      // APIs are sorted by name by default, so clicking a first time will reverse the order
-      expectApisListRequest(apis, '-name');
+      expectApisListRequest(apis, 'name');
 
       fixture.detectChanges();
       await nameSort.click();
       apis.map((api) => expectSyncedApi(api.id, true));
-      expectApisListRequest(apis, 'name');
+      expectApisListRequest(apis, '-name');
     }));
 
     it('should order rows by contextPath', fakeAsync(async () => {


### PR DESCRIPTION
## Issue

N/A

## Description

Always sort by name by default is not a good thing, because when trying to search for APIs by using a query, the results will be sorted by name instead of by relevance.

So this PR modifies the code to force a sort by name **only if** no search term is present and no specific order has been asked by the user
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xygynfzoxz.chromatic.com)
<!-- Storybook placeholder end -->
