### PR TITLE
fix: allow user to access deprecated plan in policy studio

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
@@ -84,7 +84,9 @@ describe('GioPolicyStudioLayoutComponent', () => {
     httpTestingController.expectOne(LICENSE_CONFIGURATION_TESTING.resourceURL);
 
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`).flush(api);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/plans?page=1&perPage=9999`);
+    httpTestingController.expectOne(
+      `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED`,
+    );
 
     fixture.detectChanges();
   });
@@ -104,9 +106,11 @@ describe('GioPolicyStudioLayoutComponent', () => {
       component.onSubmit();
 
       httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`).flush(api);
-      httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/plans?page=1&perPage=9999`).flush({
-        data: plans,
-      });
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED`)
+        .flush({
+          data: plans,
+        });
 
       const apiReq = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}` });
       expect(apiReq.request.body.flowMode).toEqual(apiDefinitionToSave.flow_mode);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6558

## Description

 allow user to access deprecated plan in policy studio

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mcaycunkkv.chromatic.com)
<!-- Storybook placeholder end -->
