### PR TITLE
APIM 6072: Add primary and secondary button to portal-next banner

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -199,6 +199,12 @@ export function fakePortalSettings(attributes?: Partial<PortalSettings>): Portal
         enabled: true,
         title: 'testTitle',
         subtitle: 'testSubtitle',
+        primaryButton: {
+          enabled: false,
+        },
+        secondaryButton: {
+          enabled: false,
+        },
       },
     },
   };

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -229,5 +229,15 @@ export interface PortalSettingsPortalNext {
     title?: string;
     subtitle?: string;
     enabled?: boolean;
+    primaryButton?: BannerButton;
+    secondaryButton?: BannerButton;
   };
+}
+
+export interface BannerButton {
+  enabled?: boolean;
+  label?: string;
+  target?: string;
+  type?: 'EXTERNAL';
+  visibility?: 'PUBLIC' | 'PRIVATE';
 }

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -197,6 +197,7 @@ describe('PortalSettingsComponent', () => {
             enabled: false,
           },
           banner: {
+            ...portalSettingsMock.portalNext.banner,
             enabled: true,
             title: 'testTitle',
             subtitle: 'testSubtitle',

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.html
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.html
@@ -19,84 +19,164 @@
 
 @if (form) {
   <form [formGroup]="form" class="developer-portal-banner__container">
-    <mat-card class="developer-portal-banner">
-      <mat-card-content>
-        <h3>Choose feature banner</h3>
-        <div class="developer-portal-banner__row-one">
-          <mat-radio-group class="developer-portal-banner__row-one__radio-group" aria-label="Select a status" formControlName="enabled">
-            <banner-radio-button
-              title="None"
-              subtitle="No banner will be shown on the catalog page"
-              [value]="false"
-              [selected]="form.controls.enabled.value === false"
-              [disabled]="false"
-            >
-            </banner-radio-button>
+    <mat-card>
+      <mat-card-content class="developer-portal-banner">
+        <div>
+          <h3>Choose feature banner</h3>
+          <div class="developer-portal-banner__row-one">
+            <mat-radio-group class="developer-portal-banner__row-one__radio-group" aria-label="Select a status" formControlName="enabled">
+              <banner-radio-button
+                title="None"
+                subtitle="No banner will be shown on the catalog page"
+                [value]="false"
+                [selected]="form.controls.enabled.value === false"
+                [disabled]="false"
+              >
+              </banner-radio-button>
 
-            <banner-radio-button
-              title="Featured banner"
-              subtitle="Feature your own message and actions in the catalog page"
-              [value]="true"
-              [selected]="form.controls.enabled.value === true"
-              [disabled]="false"
-            >
-            </banner-radio-button>
-          </mat-radio-group>
-          @if (form.controls.enabled.value) {
-            <img
-              class="developer-portal-banner__row-one__image"
-              ngSrc="/assets/banner-featured.svg"
-              alt="Gravitee.io"
-              height="305"
-              width="400"
-            />
-          } @else {
-            <img
-              class="developer-portal-banner__row-one__image"
-              ngSrc="/assets/banner-none.svg"
-              alt="Gravitee.io"
-              height="305"
-              width="400"
-            />
-          }
+              <banner-radio-button
+                title="Featured banner"
+                subtitle="Feature your own message and actions in the catalog page"
+                [value]="true"
+                [selected]="form.controls.enabled.value === true"
+                [disabled]="false"
+              >
+              </banner-radio-button>
+            </mat-radio-group>
+            @if (form.controls.enabled.value) {
+              <img
+                class="developer-portal-banner__row-one__image"
+                ngSrc="/assets/banner-featured.svg"
+                alt="Gravitee.io"
+                height="305"
+                width="400"
+              />
+            } @else {
+              <img
+                class="developer-portal-banner__row-one__image"
+                ngSrc="/assets/banner-none.svg"
+                alt="Gravitee.io"
+                height="305"
+                width="400"
+              />
+            }
+          </div>
         </div>
         @if (form.controls.enabled.value) {
-          <div class="developer-portal-banner__row-two">
-            <div>
-              <div class="header-row">
-                <h3 class="header__title">Information</h3>
-              </div>
-              <div>
-                <mat-form-field class="input_text">
-                  <mat-label>Title Text</mat-label>
-                  <input type="text" maxlength="150" matInput aria-label="Logging configuration condition" formControlName="titleText" />
-                  @if (form.controls.titleText?.errors?.required) {
-                    <mat-error>Title is required</mat-error>
-                  }
-                </mat-form-field>
-              </div>
-              <div>
-                <mat-form-field class="input_text">
-                  <mat-label>Subtitle Text</mat-label>
-                  <input
-                    type="text"
-                    #input
-                    maxlength="250"
-                    matInput
-                    aria-label="Logging configuration condition"
-                    formControlName="subTitleText"
-                  />
-                  <mat-hint>{{ input.value.length }}/250</mat-hint>
-                  @if (form.controls.subTitleText?.errors?.required) {
-                    <mat-error>Subtitle is required</mat-error>
-                  }
-                </mat-form-field>
-              </div>
+          <div class="developer-portal-banner__information">
+            <div class="header-row">
+              <h3 class="header__title">Information</h3>
+            </div>
+            <div class="developer-portal-banner__information__fields">
+              <mat-form-field class="input_text">
+                <mat-label>Title Text</mat-label>
+                <input type="text" maxlength="150" matInput aria-label="Logging configuration condition" formControlName="titleText" />
+                @if (form.controls.titleText?.errors?.required) {
+                  <mat-error>Title is required</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field class="input_text">
+                <mat-label>Subtitle Text</mat-label>
+                <input
+                  type="text"
+                  #input
+                  maxlength="250"
+                  matInput
+                  aria-label="Logging configuration condition"
+                  formControlName="subTitleText"
+                />
+                <mat-hint>{{ input.value.length }}/250</mat-hint>
+                @if (form.controls.subTitleText?.errors?.required) {
+                  <mat-error>Subtitle is required</mat-error>
+                }
+              </mat-form-field>
             </div>
           </div>
+          <form [formGroup]="form.controls.primaryButton">
+            <div class="developer-portal-banner__button__header">
+              <h3 class="header__title">Primary Button</h3>
+              <div class="developer-portal-banner__button__header__toggle">
+                <gio-form-slide-toggle>
+                  Display in the banner
+                  <mat-slide-toggle aria-label="Enable banner primary button" gioFormSlideToggle formControlName="enabled" />
+                </gio-form-slide-toggle>
+              </div>
+            </div>
+            <div class="developer-portal-banner__button__inputs">
+              <mat-form-field>
+                <mat-label>Button Text</mat-label>
+                <input aria-label="Set primary button text" type="text" maxlength="150" matInput formControlName="label" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Target URL</mat-label>
+                <input aria-label="Set primary button url" type="text" maxlength="150" matInput formControlName="target" />
+              </mat-form-field>
+              <gio-form-selection-inline
+                data-testid="primary-button-visibility"
+                [formControl]="form.controls.primaryButton.controls.visibility"
+              >
+                <gio-form-selection-inline-card value="PUBLIC">
+                  <gio-form-selection-inline-card-content icon="gio:language">
+                    <gio-card-content-title>Public</gio-card-content-title>
+                    <gio-card-content-subtitle>Every user can see the primary button in the Developer Portal.</gio-card-content-subtitle>
+                  </gio-form-selection-inline-card-content>
+                </gio-form-selection-inline-card>
+
+                <gio-form-selection-inline-card value="PRIVATE">
+                  <gio-form-selection-inline-card-content icon="gio:lock">
+                    <gio-card-content-title>Private</gio-card-content-title>
+                    <gio-card-content-subtitle
+                      >Users must be authenticated in the Developer Portal to see the primary button.</gio-card-content-subtitle
+                    >
+                  </gio-form-selection-inline-card-content>
+                </gio-form-selection-inline-card>
+              </gio-form-selection-inline>
+            </div>
+          </form>
+          <form [formGroup]="form.controls.secondaryButton">
+            <div class="developer-portal-banner__button__header">
+              <h3 class="header__title">Secondary Button</h3>
+              <div class="developer-portal-banner__button__header__toggle">
+                <gio-form-slide-toggle>
+                  Display in the banner
+                  <mat-slide-toggle aria-label="Enable banner secondary button" gioFormSlideToggle formControlName="enabled" />
+                </gio-form-slide-toggle>
+              </div>
+            </div>
+            <div class="developer-portal-banner__button__inputs">
+              <mat-form-field>
+                <mat-label>Button Text</mat-label>
+                <input aria-label="Set secondary button text" type="text" maxlength="150" matInput formControlName="label" />
+              </mat-form-field>
+              <mat-form-field>
+                <mat-label>Target URL</mat-label>
+                <input aria-label="Set secondary button url" type="text" maxlength="150" matInput formControlName="target" />
+              </mat-form-field>
+              <gio-form-selection-inline
+                data-testid="secondary-button-visibility"
+                [formControl]="form.controls.secondaryButton.controls.visibility"
+              >
+                <gio-form-selection-inline-card value="PUBLIC">
+                  <gio-form-selection-inline-card-content icon="gio:language">
+                    <gio-card-content-title>Public</gio-card-content-title>
+                    <gio-card-content-subtitle>Every user can see the secondary button in the Developer Portal.</gio-card-content-subtitle>
+                  </gio-form-selection-inline-card-content>
+                </gio-form-selection-inline-card>
+
+                <gio-form-selection-inline-card value="PRIVATE">
+                  <gio-form-selection-inline-card-content icon="gio:lock">
+                    <gio-card-content-title>Private</gio-card-content-title>
+                    <gio-card-content-subtitle
+                      >Users must be authenticated in the Developer Portal to see the secondary button.</gio-card-content-subtitle
+                    >
+                  </gio-form-selection-inline-card-content>
+                </gio-form-selection-inline-card>
+              </gio-form-selection-inline>
+            </div>
+          </form>
         }
       </mat-card-content>
     </mat-card>
-    <gio-save-bar [form]="form" [formInitialValues]="form" (resetClicked)="reset()" (submitted)="submit()"></gio-save-bar>
+    <gio-save-bar [form]="form" [formInitialValues]="formInitialValues" (resetClicked)="reset()" (submitted)="submit()"></gio-save-bar>
   </form>
 }

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.scss
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.scss
@@ -22,16 +22,45 @@
 }
 
 .developer-portal-banner {
-  .input_text {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
+  display: flex;
+  flex-flow: column;
+  gap: 32px;
 
-    mat-form-field {
-      flex: 1;
+  &__row-one {
+    &__radio-group {
+      .selected {
+        border: 2px solid mat.m2-get-color-from-palette(gio.$mat-accent-palette, 'default') !important;
+        color: mat.m2-get-color-from-palette(gio.$mat-accent-palette, 'default');
+      }
     }
+  }
+  &__information {
+    display: flex;
+    flex-flow: column;
 
-    input[matInput] {
+    &__fields {
+      display: flex;
+      flex-flow: column;
+      gap: 16px;
+    }
+  }
+
+  &__button {
+    &__header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      &__toggle {
+        gio-form-slide-toggle {
+          width: max-content;
+        }
+      }
+    }
+    &__inputs {
+      display: flex;
+      flex-flow: column;
+      gap: 16px;
       width: 100%;
     }
   }
@@ -94,9 +123,4 @@
       gap: 24px;
     }
   }
-}
-
-.selected {
-  border: 2px solid mat.m2-get-color-from-palette(gio.$mat-accent-palette, 'default') !important;
-  color: mat.m2-get-color-from-palette(gio.$mat-accent-palette, 'default');
 }

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.spec.ts
@@ -90,6 +90,20 @@ describe('DeveloperPortalBannerComponent', () => {
         banner: {
           ...PORTAL_SETTINGS.portalNext.banner,
           enabled: false,
+          primaryButton: {
+            enabled: false,
+            label: '',
+            target: '',
+            type: 'EXTERNAL',
+            visibility: 'PUBLIC',
+          },
+          secondaryButton: {
+            enabled: false,
+            label: '',
+            target: '',
+            type: 'EXTERNAL',
+            visibility: 'PUBLIC',
+          },
         },
       },
     });
@@ -119,6 +133,38 @@ describe('DeveloperPortalBannerComponent', () => {
     expect(title).toBe(testTitle);
     expect(subtitle).toBe(testSubtitle);
 
+    const primaryButtonText = await componentHarness.getPrimaryButtonTextInput();
+    expect(await primaryButtonText.getValue()).toEqual('');
+    await primaryButtonText.setValue('Primary button');
+
+    const primaryButtonEnableToggle = await componentHarness.getPrimaryButtonEnableToggle();
+    expect(await primaryButtonEnableToggle.isChecked()).toEqual(false);
+    await primaryButtonEnableToggle.toggle();
+
+    const currentPrimaryButtonVisibility = await componentHarness.getPrimaryButtonVisibilityValue();
+    expect(currentPrimaryButtonVisibility).toEqual('PUBLIC');
+    await componentHarness.setPrimaryButtonVisibility('PRIVATE');
+
+    const primaryButtonTarget = await componentHarness.getPrimaryButtonTargetInput();
+    expect(await primaryButtonTarget.getValue()).toEqual('');
+    await primaryButtonTarget.setValue('cats-rule');
+
+    const secondaryButtonText = await componentHarness.getSecondaryButtonTextInput();
+    expect(await secondaryButtonText.getValue()).toEqual('');
+    await secondaryButtonText.setValue('Secondary button');
+
+    const secondaryButtonEnableToggle = await componentHarness.getSecondaryButtonEnableToggle();
+    expect(await secondaryButtonEnableToggle.isChecked()).toEqual(false);
+    await secondaryButtonEnableToggle.toggle();
+
+    const currentSecondaryButtonVisibility = await componentHarness.getSecondaryButtonVisibilityValue();
+    expect(currentSecondaryButtonVisibility).toEqual('PUBLIC');
+    await componentHarness.setSecondaryButtonVisibility('PRIVATE');
+
+    const secondaryButtonTarget = await componentHarness.getSecondaryButtonTargetInput();
+    expect(await secondaryButtonTarget.getValue()).toEqual('');
+    await secondaryButtonTarget.setValue('dogs-drool');
+
     const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
     expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
     await saveBar.clickSubmit();
@@ -128,7 +174,6 @@ describe('DeveloperPortalBannerComponent', () => {
       url: `${CONSTANTS_TESTING.env.baseURL}/settings`,
     });
 
-    request.flush({});
     expect(request.request.body).toEqual({
       ...PORTAL_SETTINGS,
       portalNext: {
@@ -137,9 +182,87 @@ describe('DeveloperPortalBannerComponent', () => {
           enabled: true,
           title: testTitle,
           subtitle: testSubtitle,
+          primaryButton: {
+            enabled: true,
+            label: 'Primary button',
+            target: 'cats-rule',
+            type: 'EXTERNAL',
+            visibility: 'PRIVATE',
+          },
+          secondaryButton: {
+            enabled: true,
+            label: 'Secondary button',
+            target: 'dogs-drool',
+            type: 'EXTERNAL',
+            visibility: 'PRIVATE',
+          },
         },
       },
     });
+    request.flush({});
+
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal` }).flush({});
+    httpTestingController
+      .expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/settings`,
+      })
+      .flush(PORTAL_SETTINGS);
+  });
+
+  it('should require text + target when primary button is enabled', async () => {
+    getSettings();
+
+    const primaryButtonEnableToggle = await componentHarness.getPrimaryButtonEnableToggle();
+    expect(await primaryButtonEnableToggle.isChecked()).toEqual(false);
+    await primaryButtonEnableToggle.toggle();
+
+    const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(true);
+
+    const primaryButtonText = await componentHarness.getPrimaryButtonTextInput();
+    await primaryButtonText.setValue('Primary button');
+
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(true);
+
+    const primaryButtonTarget = await componentHarness.getPrimaryButtonTargetInput();
+    await primaryButtonTarget.setValue('cats-rule');
+
+    await componentHarness.setPrimaryButtonVisibility('PRIVATE');
+
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+    await saveBar.clickSubmit();
+
+    const request = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${CONSTANTS_TESTING.env.baseURL}/settings`,
+    });
+    expect(request.request.body).toEqual({
+      ...PORTAL_SETTINGS,
+      portalNext: {
+        ...PORTAL_SETTINGS.portalNext,
+        banner: {
+          ...PORTAL_SETTINGS.portalNext.banner,
+          enabled: true,
+          primaryButton: {
+            enabled: true,
+            label: 'Primary button',
+            target: 'cats-rule',
+            type: 'EXTERNAL',
+            visibility: 'PRIVATE',
+          },
+          secondaryButton: {
+            enabled: false,
+            label: '',
+            target: '',
+            type: 'EXTERNAL',
+            visibility: 'PUBLIC',
+          },
+        },
+      },
+    });
+    request.flush({});
+
     httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal` }).flush({});
     httpTestingController
       .expectOne({

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.component.ts
@@ -19,27 +19,35 @@ import { MatCardModule } from '@angular/material/card';
 import { ReactiveFormsModule, Validators, FormControl, FormGroup, FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioFormSelectionInlineModule, GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { EMPTY } from 'rxjs';
 import { MatOption } from '@angular/material/autocomplete';
-import { MatSelect } from '@angular/material/select';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, startWith, tap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { GioRoleModule } from '../../../shared/components/gio-role/gio-role.module';
 import { PortalSettingsService } from '../../../services-ngx/portal-settings.service';
-import { PortalSettings } from '../../../entities/portal/portalSettings';
+import { BannerButton, PortalSettings } from '../../../entities/portal/portalSettings';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { BannerRadioButtonComponent } from '../../components/banner-radio-button/banner-radio-button.component';
 import { PortalHeaderComponent } from '../../components/header/portal-header.component';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
+interface ButtonForm {
+  enabled: FormControl<boolean>;
+  label: FormControl<string>;
+  visibility: FormControl<string>;
+  target: FormControl<string>;
+}
+
 interface BannerForm {
   enabled: FormControl<boolean>;
   titleText: FormControl<string>;
   subTitleText: FormControl<string>;
+  primaryButton: FormGroup<ButtonForm>;
+  secondaryButton: FormGroup<ButtonForm>;
 }
 
 @Component({
@@ -58,12 +66,12 @@ interface BannerForm {
     GioRoleModule,
     FormsModule,
     MatOption,
-    MatSelect,
     GioFormSlideToggleModule,
     MatSlideToggle,
     NgOptimizedImage,
     BannerRadioButtonComponent,
     PortalHeaderComponent,
+    GioFormSelectionInlineModule,
   ],
   standalone: true,
 })
@@ -98,8 +106,14 @@ export class PortalBannerComponent implements OnInit {
       enabled: new FormControl<boolean>(this.settings.portalNext.banner?.enabled ?? false, [Validators.required]),
       titleText: new FormControl<string>(this.settings.portalNext.banner?.title, [Validators.required]),
       subTitleText: new FormControl<string>(this.settings.portalNext.banner?.subtitle, [Validators.required]),
+      primaryButton: this.initializeButtonForm(this.settings.portalNext.banner?.primaryButton),
+      secondaryButton: this.initializeButtonForm(this.settings.portalNext.banner?.secondaryButton),
     });
+
     this.formInitialValues = this.form.getRawValue();
+
+    this.handleButtonFormEnabledChanges(this.form.controls.primaryButton, this.form.getRawValue().primaryButton.enabled);
+    this.handleButtonFormEnabledChanges(this.form.controls.secondaryButton, this.form.getRawValue().secondaryButton.enabled);
 
     const isReadOnly = !this.permissionService.hasAnyMatching(['environment-settings-u']);
     if (isReadOnly) {
@@ -121,6 +135,8 @@ export class PortalBannerComponent implements OnInit {
           enabled: this.form.controls.enabled.value,
           title: this.form.controls.titleText.value,
           subtitle: this.form.controls.subTitleText.value,
+          primaryButton: this.prepareButtonForUpdate(this.form.controls.primaryButton),
+          secondaryButton: this.prepareButtonForUpdate(this.form.controls.secondaryButton),
         },
       },
     };
@@ -135,6 +151,52 @@ export class PortalBannerComponent implements OnInit {
         }),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.ngOnInit());
+      .subscribe(() => {
+        this.form.reset();
+        this.ngOnInit();
+      });
+  }
+
+  private initializeButtonForm(button: BannerButton | undefined): FormGroup<ButtonForm> {
+    return new FormGroup<ButtonForm>({
+      enabled: new FormControl<boolean>(button?.enabled ?? false, [Validators.required]),
+      label: new FormControl<string>(button?.label ?? ''),
+      visibility: new FormControl<string>(button?.visibility ?? 'PUBLIC'),
+      target: new FormControl<string>(button?.target ?? ''),
+    });
+  }
+
+  private handleButtonFormEnabledChanges(buttonForm: FormGroup<ButtonForm>, startWithEnabledValue: boolean): void {
+    buttonForm.controls.enabled.valueChanges
+      .pipe(
+        startWith(startWithEnabledValue),
+        tap((_) => {
+          if (buttonForm.controls.enabled.value) {
+            buttonForm.controls.target.addValidators(Validators.required);
+            buttonForm.controls.label.addValidators(Validators.required);
+            buttonForm.controls.visibility.addValidators(Validators.required);
+          } else {
+            buttonForm.controls.target.clearValidators();
+            buttonForm.controls.label.clearValidators();
+            buttonForm.controls.visibility.clearValidators();
+          }
+          buttonForm.controls.target.updateValueAndValidity();
+          buttonForm.controls.label.updateValueAndValidity();
+          buttonForm.controls.visibility.updateValueAndValidity();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private prepareButtonForUpdate(buttonForm: FormGroup<ButtonForm>): BannerButton {
+    const rawValue = buttonForm.getRawValue();
+    return {
+      enabled: rawValue.enabled,
+      target: rawValue.target,
+      visibility: rawValue.visibility === 'PRIVATE' ? 'PRIVATE' : 'PUBLIC',
+      label: rawValue.label,
+      type: 'EXTERNAL',
+    };
   }
 }

--- a/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/banner/portal-banner.harness.ts
@@ -15,7 +15,8 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
-import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { GioFormSelectionInlineCardHarness, GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 import { BannerRadioButtonHarness } from '../../components/banner-radio-button/banner-radio-button.harness';
 
@@ -24,6 +25,17 @@ export class PortalBannerHarness extends ComponentHarness {
 
   private getTitleInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName=titleText]' }));
   private getSubtitleInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName=subTitleText]' }));
+  private locatePrimaryButtonTextInput = this.locatorFor(MatInputHarness.with({ selector: '[aria-label="Set primary button text"]' }));
+  private locateSecondaryButtonTextInput = this.locatorFor(MatInputHarness.with({ selector: '[aria-label="Set secondary button text"]' }));
+  private locatePrimaryButtonTargetInput = this.locatorFor(MatInputHarness.with({ selector: '[aria-label="Set primary button url"]' }));
+  private locateSecondaryButtonTargetInput = this.locatorFor(MatInputHarness.with({ selector: '[aria-label="Set secondary button url"]' }));
+  private locateAllToggles = this.locatorForAll(MatSlideToggleHarness);
+  private locatePrimaryButtonVisibilityOptions = this.locatorForAll(
+    GioFormSelectionInlineCardHarness.with({ ancestor: '[data-testid="primary-button-visibility"]' }),
+  );
+  private locateSecondaryButtonVisibilityOptions = this.locatorForAll(
+    GioFormSelectionInlineCardHarness.with({ ancestor: '[data-testid="secondary-button-visibility"]' }),
+  );
   private getSaveBar = this.locatorFor(GioSaveBarHarness);
   private locateBannerRadio = (title: string) => this.locatorFor(BannerRadioButtonHarness.with({ title }))();
 
@@ -61,5 +73,77 @@ export class PortalBannerHarness extends ComponentHarness {
 
   public reset() {
     return this.getSaveBar().then((saveBar) => saveBar.clickReset());
+  }
+
+  /**
+   * Primary button
+   */
+
+  public async getPrimaryButtonTextInput(): Promise<MatInputHarness> {
+    return await this.locatePrimaryButtonTextInput();
+  }
+
+  public async getPrimaryButtonTargetInput(): Promise<MatInputHarness> {
+    return await this.locatePrimaryButtonTargetInput();
+  }
+
+  public async getPrimaryButtonEnableToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateAllToggles().then((toggles) => toggles[0]);
+  }
+
+  public async getPrimaryButtonVisibilityValue(): Promise<string> {
+    return await this.getVisibilityValue(await this.locatePrimaryButtonVisibilityOptions());
+  }
+
+  public async setPrimaryButtonVisibility(visibility: 'PUBLIC' | 'PRIVATE'): Promise<void> {
+    return await this.selectVisibilityOption(visibility, await this.locatePrimaryButtonVisibilityOptions());
+  }
+
+  /**
+   * Secondary button
+   */
+
+  public async getSecondaryButtonTextInput(): Promise<MatInputHarness> {
+    return await this.locateSecondaryButtonTextInput();
+  }
+
+  public async getSecondaryButtonTargetInput(): Promise<MatInputHarness> {
+    return await this.locateSecondaryButtonTargetInput();
+  }
+
+  public async getSecondaryButtonEnableToggle(): Promise<MatSlideToggleHarness> {
+    return await this.locateAllToggles().then((toggles) => toggles[1]);
+  }
+
+  public async getSecondaryButtonVisibilityValue(): Promise<string> {
+    return await this.getVisibilityValue(await this.locateSecondaryButtonVisibilityOptions());
+  }
+
+  public async setSecondaryButtonVisibility(visibility: 'PUBLIC' | 'PRIVATE'): Promise<void> {
+    return await this.selectVisibilityOption(visibility, await this.locateSecondaryButtonVisibilityOptions());
+  }
+
+  private async getVisibilityValue(inlineHarnesses: GioFormSelectionInlineCardHarness[]): Promise<string> {
+    const publicOption = inlineHarnesses[0];
+    const privateOption = inlineHarnesses[1];
+    if (await publicOption.isSelected()) {
+      return await publicOption.getValue();
+    }
+    if (await privateOption.isSelected()) {
+      return await privateOption.getValue();
+    }
+    return new Promise(null);
+  }
+
+  private async selectVisibilityOption(
+    visibilityOptionValue: 'PUBLIC' | 'PRIVATE',
+    inlineHarnesses: GioFormSelectionInlineCardHarness[],
+  ): Promise<void> {
+    const publicOption = inlineHarnesses[0];
+    const privateOption = inlineHarnesses[1];
+    if (visibilityOptionValue === 'PUBLIC') {
+      return await publicOption.host().then((opt) => opt.click());
+    }
+    return await privateOption.host().then((opt) => opt.click());
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.html
@@ -17,12 +17,28 @@
 -->
 @if (showBanner) {
   <app-banner>
-    <div class="welcome-banner-content">
-      @if (bannerTitle) {
-        <div class="m3-headline-large">{{ bannerTitle }}</div>
-      }
-      @if (bannerSubtitle) {
-        <div class="m3-title-small">{{ bannerSubtitle }}</div>
+    <div class="welcome-banner">
+      <div class="welcome-banner__content">
+        @if (bannerTitle) {
+          <div class="m3-headline-large">{{ bannerTitle }}</div>
+        }
+        @if (bannerSubtitle) {
+          <div class="m3-title-small">{{ bannerSubtitle }}</div>
+        }
+      </div>
+      @if (primaryButton.displayed || secondaryButton.displayed) {
+        <div class="welcome-banner__actions">
+          @if (primaryButton.displayed) {
+            <a [href]="primaryButton.href" target="_blank" mat-flat-button class="welcome-banner__actions__primary-button">{{
+              primaryButton.label
+            }}</a>
+          }
+          @if (secondaryButton.displayed) {
+            <a [href]="secondaryButton.href" target="_blank" class="m3-label-large welcome-banner__actions__secondary-button">{{
+              secondaryButton.label
+            }}</a>
+          }
+        </div>
       }
     </div>
   </app-banner>

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
@@ -13,17 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../scss/theme';
+
 :host {
   display: flex;
   flex-flow: column;
   gap: 32px;
 }
 
-.welcome-banner-content {
+.welcome-banner {
   display: flex;
   flex-flow: column;
   padding: 16px;
-  gap: 24px;
+  gap: 36px;
+
+  &__content {
+    display: flex;
+    flex-flow: column;
+    gap: 24px;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+
+    &__secondary-button {
+      color: theme.$banner-text-color;
+      text-decoration: none;
+    }
+  }
 }
 
 .api-list__container {

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -22,5 +22,15 @@ export class ConfigurationPortalNext {
     enabled?: boolean;
     title?: string;
     subtitle?: string;
+    primaryButton?: BannerButton;
+    secondaryButton?: BannerButton;
   };
+}
+
+export interface BannerButton {
+  enabled?: boolean;
+  label?: string;
+  target?: string;
+  type?: string;
+  visibility?: string;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -90,6 +90,19 @@ public enum Key {
         new HashSet<>(singletonList(ENVIRONMENT))
     ),
     PORTAL_NEXT_BANNER_CONFIG_ENABLED("portal.next.banner.enabled", "true", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_PRIMARY_BUTTON_ENABLED("portal.next.banner.primaryButton.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_PRIMARY_BUTTON_TARGET("portal.next.banner.primaryButton.target", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_PRIMARY_BUTTON_TYPE("portal.next.banner.primaryButton.type", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_PRIMARY_BUTTON_LABEL("portal.next.banner.primaryButton.label", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_PRIMARY_BUTTON_VISIBILITY("portal.next.banner.primaryButton.visibility", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_SECONDARY_BUTTON_ENABLED("portal.next.banner.secondaryButton.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_SECONDARY_BUTTON_TARGET("portal.next.banner.secondaryButton.target", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_SECONDARY_BUTTON_TYPE("portal.next.banner.secondaryButton.type", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_SECONDARY_BUTTON_LABEL("portal.next.banner.secondaryButton.label", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_BANNER_SECONDARY_BUTTON_VISIBILITY(
+        "portal.next.banner.secondaryButton.visibility",
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
     PORTAL_NEXT_ACCESS_ENABLED("portal.next.access.enabled", "false", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_COLOR_PRIMARY("portal.next.theme.color.primary", "#613CB0", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_COLOR_SECONDARY("portal.next.theme.color.secondary", "#958BA9", new HashSet<>(singletonList(ENVIRONMENT))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -44,8 +44,6 @@ public class PortalNext {
     }
 
     @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Banner {
 
@@ -57,5 +55,59 @@ public class PortalNext {
 
         @ParameterKey(Key.PORTAL_NEXT_BANNER_CONFIG_ENABLED)
         private Boolean enabled;
+
+        private PrimaryButton primaryButton;
+
+        private SecondaryButton secondaryButton;
+
+        public Banner() {
+            super();
+            primaryButton = new PrimaryButton();
+            secondaryButton = new SecondaryButton();
+        }
+
+        @Data
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class PrimaryButton {
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_PRIMARY_BUTTON_LABEL)
+            private String label;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_PRIMARY_BUTTON_TARGET)
+            private String target;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_PRIMARY_BUTTON_ENABLED)
+            private Boolean enabled;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_PRIMARY_BUTTON_TYPE)
+            private String type;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_PRIMARY_BUTTON_VISIBILITY)
+            private String visibility;
+        }
+
+        @Data
+        @AllArgsConstructor
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class SecondaryButton {
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_SECONDARY_BUTTON_LABEL)
+            private String label;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_SECONDARY_BUTTON_TARGET)
+            private String target;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_SECONDARY_BUTTON_ENABLED)
+            private Boolean enabled;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_SECONDARY_BUTTON_TYPE)
+            private String type;
+
+            @ParameterKey(Key.PORTAL_NEXT_BANNER_SECONDARY_BUTTON_VISIBILITY)
+            private String visibility;
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -61,8 +61,50 @@ public class ConfigurationMapper {
             configuration.setEnabled(banner.getEnabled());
             configuration.setTitle(banner.getTitle());
             configuration.setSubtitle(banner.getSubtitle());
+            configuration.setPrimaryButton(convert(banner.getPrimaryButton()));
+            configuration.setSecondaryButton(convert(banner.getSecondaryButton()));
         }
         return configuration;
+    }
+
+    private BannerButton convert(PortalNext.Banner.PrimaryButton primaryButton) {
+        BannerButton button = new BannerButton();
+        if (Objects.nonNull(primaryButton)) {
+            button.enabled(primaryButton.getEnabled());
+            button.label(primaryButton.getLabel());
+            button.target(primaryButton.getTarget());
+            button.type(convertBannerButtonType(primaryButton.getType()));
+            button.visibility(convertBannerButtonVisibility(primaryButton.getVisibility()));
+        }
+        return button;
+    }
+
+    private BannerButton convert(PortalNext.Banner.SecondaryButton secondaryButton) {
+        BannerButton button = new BannerButton();
+        if (Objects.nonNull(secondaryButton)) {
+            button.enabled(secondaryButton.getEnabled());
+            button.label(secondaryButton.getLabel());
+            button.target(secondaryButton.getTarget());
+            button.type(convertBannerButtonType(secondaryButton.getType()));
+            button.visibility(convertBannerButtonVisibility(secondaryButton.getVisibility()));
+        }
+        return button;
+    }
+
+    private BannerButton.TypeEnum convertBannerButtonType(String bannerButtonType) {
+        try {
+            return BannerButton.TypeEnum.fromValue(bannerButtonType);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private BannerButton.VisibilityEnum convertBannerButtonVisibility(String bannerButtonVisibility) {
+        try {
+            return BannerButton.VisibilityEnum.fromValue(bannerButtonVisibility);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private ConfigurationAnalytics convert(Analytics analytics) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4791,6 +4791,32 @@ components:
                 subtitle:
                     description: Subtitle to display on the homepage banner.
                     type: string
+                primaryButton:
+                  $ref: "#/components/schemas/BannerButton"
+                secondaryButton:
+                  $ref: "#/components/schemas/BannerButton"
+        BannerButton:
+          type: object
+          description: Button displayed in the Portal Next banner
+          properties:
+            enabled:
+              description: Button is displayed
+              type: boolean
+            label:
+              description: Button label
+              type: string
+            type:
+              description: Type of link
+              enum:
+                - EXTERNAL
+            target:
+              description: Target of the link
+              type: string
+            visibility:
+              description: Visibility of the button
+              enum:
+                - PUBLIC
+                - PRIVATE
         ConfigurationPortalApis:
             properties:
                 tilesMode:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -57,7 +57,17 @@ public class ConfigurationMapperTest {
         String bannerTitle,
         String bannerSubtitle,
         Boolean inputEnabled,
-        Boolean expectedEnabled
+        Boolean expectedEnabled,
+        String primaryButtonLabel,
+        String primaryButtonTarget,
+        String primaryButtonType,
+        String primaryButtonVisibility,
+        Boolean primaryButtonEnabled,
+        String secondaryButtonLabel,
+        String secondaryButtonTarget,
+        String secondaryButtonType,
+        String secondaryButtonVisibility,
+        Boolean secondaryButtonEnabled
     ) {
         PortalNext portalNext = new PortalNext();
         portalNext.setSiteTitle(siteTitle);
@@ -65,6 +75,25 @@ public class ConfigurationMapperTest {
         banner.setEnabled(bannerEnabled);
         banner.setTitle(bannerTitle);
         banner.setSubtitle(bannerSubtitle);
+
+        var primaryButton = new PortalNext.Banner.PrimaryButton();
+        primaryButton.setEnabled(primaryButtonEnabled);
+        primaryButton.setLabel(primaryButtonLabel);
+        primaryButton.setTarget(primaryButtonTarget);
+        primaryButton.setType(primaryButtonType);
+        primaryButton.setVisibility(primaryButtonVisibility);
+
+        banner.setPrimaryButton(primaryButton);
+
+        var secondaryButton = new PortalNext.Banner.SecondaryButton();
+        secondaryButton.setEnabled(secondaryButtonEnabled);
+        secondaryButton.setLabel(secondaryButtonLabel);
+        secondaryButton.setTarget(secondaryButtonTarget);
+        secondaryButton.setType(secondaryButtonType);
+        secondaryButton.setVisibility(secondaryButtonVisibility);
+
+        banner.setSecondaryButton(secondaryButton);
+
         portalNext.setBanner(banner);
         portalNext.setAccess(new Enabled(inputEnabled));
 
@@ -77,12 +106,67 @@ public class ConfigurationMapperTest {
         Assertions.assertEquals(bannerEnabled, configurationPortalNext.getBanner().getEnabled());
         Assertions.assertNotNull(configurationPortalNext.getAccess());
         Assertions.assertEquals(expectedEnabled, configurationPortalNext.getAccess().getEnabled());
+
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getPrimaryButton());
+        Assertions.assertEquals(primaryButtonEnabled, configurationPortalNext.getBanner().getPrimaryButton().getEnabled());
+        Assertions.assertEquals(primaryButtonLabel, configurationPortalNext.getBanner().getPrimaryButton().getLabel());
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getPrimaryButton().getType());
+        Assertions.assertEquals(primaryButtonType, configurationPortalNext.getBanner().getPrimaryButton().getType().getValue());
+        Assertions.assertEquals(primaryButtonTarget, configurationPortalNext.getBanner().getPrimaryButton().getTarget());
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getPrimaryButton().getVisibility());
+        Assertions.assertEquals(primaryButtonVisibility, configurationPortalNext.getBanner().getPrimaryButton().getVisibility().getValue());
+
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getSecondaryButton());
+        Assertions.assertEquals(secondaryButtonEnabled, configurationPortalNext.getBanner().getSecondaryButton().getEnabled());
+        Assertions.assertEquals(secondaryButtonLabel, configurationPortalNext.getBanner().getSecondaryButton().getLabel());
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getSecondaryButton().getType());
+        Assertions.assertEquals(secondaryButtonType, configurationPortalNext.getBanner().getSecondaryButton().getType().getValue());
+        Assertions.assertEquals(secondaryButtonTarget, configurationPortalNext.getBanner().getSecondaryButton().getTarget());
+        Assertions.assertNotNull(configurationPortalNext.getBanner().getSecondaryButton().getVisibility());
+        Assertions.assertEquals(
+            secondaryButtonVisibility,
+            configurationPortalNext.getBanner().getSecondaryButton().getVisibility().getValue()
+        );
     }
 
     private static Stream<Arguments> provideParameters() {
         return Stream.of(
-            Arguments.of("Test Site Title", true, "Test Banner Title", "Test Banner Subtitle", true, true),
-            Arguments.of("Test Site Title", false, "Test Banner Title", "Test Banner Subtitle", false, false)
+            Arguments.of(
+                "Test Site Title",
+                true,
+                "Test Banner Title",
+                "Test Banner Subtitle",
+                true,
+                true,
+                "Primary button",
+                "primary-target",
+                "EXTERNAL",
+                "PUBLIC",
+                true,
+                "Secondary button",
+                "secondary-target",
+                "EXTERNAL",
+                "PRIVATE",
+                false
+            ),
+            Arguments.of(
+                "Test Site Title",
+                false,
+                "Test Banner Title",
+                "Test Banner Subtitle",
+                false,
+                false,
+                "Primary button",
+                "primary-target",
+                "EXTERNAL",
+                "PUBLIC",
+                true,
+                "Secondary button",
+                "secondary-target",
+                "EXTERNAL",
+                "PRIVATE",
+                false
+            )
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -49,7 +49,17 @@
     "banner": {
       "enabled": true,
       "title": "banner title",
-      "subtitle": "banner subtitle"
+      "subtitle": "banner subtitle",
+      "primaryButton": {
+        "enabled": true,
+        "label": "Primary button",
+        "target": "primary-button",
+        "type": "EXTERNAL",
+        "visibility": "PRIVATE"
+      },
+      "secondaryButton": {
+        "enabled": false
+      }
     }
   },
   "authentication" : {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
@@ -153,7 +153,17 @@
     "banner": {
       "enabled": true,
       "title": "banner title",
-      "subtitle": "banner subtitle"
+      "subtitle": "banner subtitle",
+      "primaryButton": {
+        "enabled": true,
+        "label": "Primary button",
+        "target": "primary-button",
+        "type": "EXTERNAL",
+        "visibility": "PRIVATE"
+      },
+      "secondaryButton": {
+        "enabled": false
+      }
     }
   },
   "reCaptcha": {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -447,6 +447,8 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             portalConfigEntity.getPortal().getUserCreation(),
             portalConfigEntity.getPortalNext(),
             portalConfigEntity.getPortalNext().getBanner(),
+            portalConfigEntity.getPortalNext().getBanner().getPrimaryButton(),
+            portalConfigEntity.getPortalNext().getBanner().getSecondaryButton(),
             portalConfigEntity.getReCaptcha(),
             portalConfigEntity.getScheduler(),
             portalConfigEntity.getDashboards(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6072

## Description

User can configure banner buttons for portal next

https://github.com/user-attachments/assets/cee017a3-d900-4499-bd30-5fc2c7ece055


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-exnvfrqqel.chromatic.com)
<!-- Storybook placeholder end -->
