### PR TITLE
feat: update hide gateways view for cloud flag

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -147,7 +147,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       },
     ];
 
-    if (this.constants?.org?.settings?.management?.installationType !== 'multi-tenant') {
+    if (!this.constants?.org?.settings?.cloud?.enabled) {
       mainMenuItems.push({
         icon: 'gio:cloud-server',
         displayName: 'Gateways',

--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -33,6 +33,7 @@ export interface ConsoleSettings {
   trialInstance?: ConsoleSettingsTrialInstance;
   federation?: ConsoleSettingsFederation;
   scoring?: ConsoleSettingsScoring;
+  cloud?: ConsoleSettingsCloud;
 }
 
 export interface ConsoleSettingsEmail {
@@ -185,5 +186,9 @@ export interface ConsoleSettingsFederation {
 }
 
 export interface ConsoleSettingsScoring {
+  enabled?: boolean;
+}
+
+export interface ConsoleSettingsCloud {
   enabled?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/cloud-guard.ts
+++ b/gravitee-apim-console-webui/src/management/cloud-guard.ts
@@ -21,13 +21,13 @@ import { Constants } from '../entities/Constants';
 @Injectable({
   providedIn: 'root',
 })
-export class NotMultiTenantGuard implements CanActivate {
+export class CloudGuard implements CanActivate {
   constructor(
     private router: Router,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
   canActivate(_route: ActivatedRouteSnapshot): boolean {
-    return this.constants?.org?.settings?.management?.installationType !== 'multi-tenant';
+    return !this.constants?.org?.settings?.cloud?.enabled;
   }
 }

--- a/gravitee-apim-console-webui/src/management/management-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/management-routing.module.ts
@@ -24,7 +24,7 @@ import { InstanceDetailsEnvironmentComponent } from './instances/instance-detail
 import { InstanceDetailsMonitoringComponent } from './instances/instance-details/instance-details-monitoring/instance-details-monitoring.component';
 import { EnvAuditComponent } from './audit/env-audit.component';
 import { MessagesComponent } from './messages/messages.component';
-import { NotMultiTenantGuard } from './not-multi-tenant-guard';
+import { CloudGuard } from './cloud-guard';
 
 import { TasksComponent } from '../user/tasks/tasks.component';
 import { UserComponent } from '../user/my-accout/user.component';
@@ -84,7 +84,7 @@ const managementRoutes: Routes = [
       },
       {
         path: 'gateways',
-        canActivate: [NotMultiTenantGuard],
+        canActivate: [CloudGuard],
         component: InstanceListComponent,
         data: {
           permissions: {
@@ -109,8 +109,7 @@ const managementRoutes: Routes = [
       {
         path: 'gateways/:instanceId',
         component: InstanceDetailsComponent,
-        canActivate: [NotMultiTenantGuard],
-        canActivateChild: [NotMultiTenantGuard],
+        canActivate: [CloudGuard],
         data: {
           permissions: {
             anyOf: ['environment-instance-r'],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -409,6 +409,7 @@ public enum Key {
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
     TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
+    CLOUD_ENABLED("cloud.enabled", "false", Set.of(SYSTEM)),
 
     EXTERNAL_AUTH_ENABLED("auth.external.enabled", "false", Set.of(SYSTEM)),
     EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED("auth.external.allowAccountDeletion", "true", Set.of(SYSTEM));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Cloud.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Cloud.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.model.annotations.ParameterKey;
+import io.gravitee.rest.api.model.parameters.Key;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Cloud {
+
+    @ParameterKey(Key.CLOUD_ENABLED)
+    private Boolean enabled;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
@@ -38,6 +38,7 @@ public class ConsoleConfigEntity {
     private TrialInstance trialInstance;
     private Federation federation;
     private Scoring scoring;
+    private Cloud cloud;
 
     public ConsoleConfigEntity() {
         super();
@@ -56,5 +57,6 @@ public class ConsoleConfigEntity {
         trialInstance = new TrialInstance();
         federation = new Federation();
         scoring = new Scoring();
+        cloud = new Cloud();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
@@ -48,6 +48,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
     private TrialInstance trialInstance;
     private Federation federation;
     private Scoring scoring;
+    private Cloud cloud;
 
     public ConsoleSettingsEntity() {
         super();
@@ -67,6 +68,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
         trialInstance = new TrialInstance();
         federation = new Federation();
         scoring = new Scoring();
+        cloud = new Cloud();
     }
 
     //Classes

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -489,6 +489,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getTrialInstance(),
             consoleConfigEntity.getFederation(),
             consoleConfigEntity.getScoring(),
+            consoleConfigEntity.getCloud(),
         };
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1835

## Description

Rather than hiding this based on the installation type being multi-tenant which was introduced here https://github.com/gravitee-io/gravitee-api-management/pull/8876 we have decided it is better to have a separate cloud flag which controls this being hidden as there may be use cases where APIM is run in multi-tenant mode but would want the gateway view still available

Also made change to routing, removing uneccessary and problematic canActivateChild (fixes cypress tests)

Cloud disabled:
<img width="1054" alt="Screenshot 2024-09-11 at 15 32 50" src="https://github.com/user-attachments/assets/1b32d9db-7b22-4d3e-bb7f-a803dd412187">


Cloud enabled:
<img width="2118" alt="Screenshot 2024-09-11 at 15 34 36" src="https://github.com/user-attachments/assets/76bc8c4c-1773-4159-8e00-47de1a09594c">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ryyxjimniu.chromatic.com)
<!-- Storybook placeholder end -->
