### PR TITLE
fix: define a PrimaryKey for scoring_reports table

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/06_add_scoring_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/06_add_scoring_table.yml
@@ -6,6 +6,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}scoring_reports
             columns:
+              - column: { name: id, type: bigint, autoIncrement: true, constraints: { primaryKey: true, nullable: false } }
               - column: { name: report_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: api_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: page_id, type: nvarchar(64), constraints: { nullable: false } }


### PR DESCRIPTION
## Description

MySQL requires all tables to have PrimaryKey...

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tcvisgysjc.chromatic.com)
<!-- Storybook placeholder end -->
