### PR TITLE
fix: improve event_organizations and events_latest_organizations tables creation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_2/00_add_event_organizations.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_2/00_add_event_organizations.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.4.2_add_event_organizations
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}event_organizations
@@ -42,6 +43,6 @@ databaseChangeLog:
                   type: nvarchar(64)
             tableName: ${gravitee_prefix}events_latest_environments
         - sql:
-            sql: insert into ${gravitee_prefix}event_organizations(event_id, organization_id) select e.id, env.organization_id from ${gravitee_prefix}events e join ${gravitee_prefix}event_environments ee on ee.event_id = e.id join ${gravitee_prefix}environments env on env.id = ee.environment_id;
+            sql: insert into ${gravitee_prefix}event_organizations(event_id, organization_id) select distinct e.id, env.organization_id from ${gravitee_prefix}events e join ${gravitee_prefix}event_environments ee on ee.event_id = e.id join ${gravitee_prefix}environments env on env.id = ee.environment_id;
         - sql:
-            sql: insert into ${gravitee_prefix}events_latest_organizations(event_id, organization_id) select e.id, env.organization_id from ${gravitee_prefix}events_latest e join ${gravitee_prefix}event_environments ee on ee.event_id = e.id join ${gravitee_prefix}environments env on env.id = ee.environment_id;
+            sql: insert into ${gravitee_prefix}events_latest_organizations(event_id, organization_id) select distinct e.id, env.organization_id from ${gravitee_prefix}events_latest e join ${gravitee_prefix}event_environments ee on ee.event_id = e.id join ${gravitee_prefix}environments env on env.id = ee.environment_id;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Today the migration from APIM 4.3.x to 4.4.x can fail if we run APIM + a JDBC database if the organization is linked to multiple environments. The goal of this PR is to fix the migration.

Basically we run this select in the insert
```sql
select e.id, env.organization_id
from events e
         join event_environments ee on ee.event_id = e.id
         join environments env on env.id = ee.environment_id
 ```
 
 But when we publish an organization the `event_environments`table can contains multiple rows which link the event to all the environments. So we get multiple results and the insert 💥  

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

