### PR TITLE
fix: return empty array ofaccepted issuers in trust manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-gateway-api.version>3.8.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-scoring-api.version>0.2.0</gravitee-scoring-api.version>
-        <gravitee-node.version>6.4.0</gravitee-node.version>
+        <gravitee-node.version>6.4.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>4.1.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

APIM-6628

## Description

Update version of node. This fix will be back ported in other PRs to via node updates 
* 4.1 & 4.2 (using updated gravitee-node 4.8.x)
* 4.3 (using updated gravitee-node 5.12.x)
* 4.4 (using updated gravitee-node 6.0.x)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-txowuhirxt.chromatic.com)
<!-- Storybook placeholder end -->
