### PR TITLE
fix(console): add Applies to both portal badges to category settings …

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -196,9 +196,9 @@ export interface EnvSettings {
       enabled: boolean;
     };
     banner: {
-      enabled: true;
-      title: 'testTitle';
-      subtitle: 'testSubtitle';
+      enabled: boolean;
+      title: string;
+      subtitle: string;
     };
   };
   reCaptcha: {

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.html
@@ -17,6 +17,9 @@
 -->
 <div class="title">
   <h1>Categories</h1>
+  @if (hasPortalNextEnabled) {
+    <span class="gio-badge-warning"> <mat-icon svgIcon="gio:chat-lines"> </mat-icon>&nbsp;Applies to both portals </span>
+  }
 </div>
 
 <mat-card>

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.scss
@@ -9,8 +9,8 @@
 .title {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin-bottom: 16px;
+  gap: 16px;
 
   h1 {
     margin-bottom: 0;

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.spec.ts
@@ -24,6 +24,7 @@ import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing'
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
+import { By } from '@angular/platform-browser';
 
 import { CategoriesModule } from './categories.module';
 import { CategoriesComponent } from './categories.component';
@@ -74,6 +75,16 @@ describe('CategoriesComponent', () => {
         automaticValidation: { enabled: true },
       },
       uploadMedia: { enabled: true, maxSizeInOctet: 10 },
+    },
+    portalNext: {
+      access: {
+        enabled: true,
+      },
+      banner: {
+        enabled: true,
+        title: 'testTitle',
+        subtitle: 'testSubtitle',
+      },
     },
   };
 
@@ -248,6 +259,32 @@ describe('CategoriesComponent', () => {
 
       expectDeleteCategory(CATEGORIES()[0].id);
       expectGetCategoriesList();
+    });
+  });
+
+  describe('Applies to both portals badge', () => {
+    it('should show badge when portal next is enabled', async () => {
+      await init({ ...DEFAULT_PORTAL_SETTINGS, portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, access: { enabled: true } } });
+      expectGetCategoriesList([
+        { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
+      ]);
+      fixture.detectChanges();
+
+      const title = fixture.debugElement.query(By.css('.title'));
+      const element: HTMLDivElement = title.nativeElement;
+      expect(element.innerHTML).toContain('Applies to both portals');
+    });
+    it('should not show badge when portal next is disabled', async () => {
+      await init({ ...DEFAULT_PORTAL_SETTINGS, portalNext: { ...DEFAULT_PORTAL_SETTINGS.portalNext, access: { enabled: false } } });
+      expectGetCategoriesList([
+        { id: 'cat-1', name: 'cat-1', key: 'cat-1', order: 1, hidden: false, description: 'nice cat', totalApis: 1 },
+      ]);
+      fixture.detectChanges();
+
+      const title = fixture.debugElement.query(By.css('.title'));
+      const element: HTMLDivElement = title.nativeElement;
+      const innerHTML = element.innerHTML;
+      expect(innerHTML.includes('Applies to both portals')).toEqual(false);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/categories.component.ts
@@ -38,6 +38,7 @@ export class CategoriesComponent implements OnInit {
   displayedColumns: string[] = ['picture', 'name', 'description', 'count', 'actions'];
   portalSettingsForm: FormGroup<{ enabled: FormControl<boolean> }>;
   portalSettingsInitialValue: unknown;
+  hasPortalNextEnabled: boolean = false;
 
   private categoryList = new BehaviorSubject(1);
   private destroyRef = inject(DestroyRef);
@@ -58,6 +59,8 @@ export class CategoriesComponent implements OnInit {
     }
 
     this.initializeSettings(this.environmentSettingsService.getSnapshot().portal.apis.categoryMode.enabled);
+
+    this.hasPortalNextEnabled = this.environmentSettingsService.getSnapshot().portalNext?.access?.enabled === true;
 
     this.categoriesDS$ = this.categoryList.pipe(
       switchMap((_) => this.categoryService.list(true)),

--- a/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.html
@@ -23,7 +23,12 @@
   <form [formGroup]="categoryDetails" class="content">
     <mat-card>
       <mat-card-content>
-        <h2>General</h2>
+        <div class="title-information">
+          <h2>General</h2>
+          @if (hasPortalNextEnabled) {
+            <span class="gio-badge-warning"> <mat-icon svgIcon="gio:chat-lines"> </mat-icon>&nbsp;Applies to both portals </span>
+          }
+        </div>
         <div class="general">
           <div class="general__left">
             <mat-form-field>
@@ -87,7 +92,12 @@
       <mat-card *gioPermission="{ anyOf: ['environment-api-r'] }">
         <mat-card-content>
           <div class="apis__title">
-            <h2>APIs</h2>
+            <div class="title-information">
+              <h2>APIs</h2>
+              @if (hasPortalNextEnabled) {
+                <span class="gio-badge-warning"> <mat-icon svgIcon="gio:chat-lines"> </mat-icon>&nbsp;Applies to both portals </span>
+              }
+            </div>
             <button
               class="add-button"
               (click)="addApiToCategory(category)"

--- a/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.scss
@@ -108,3 +108,14 @@ $typography: map.get(gio.$mat-theme, typography);
   padding: 0 8px;
   text-align: end;
 }
+
+.title-information {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding-bottom: 18px;
+
+  & > h2 {
+    margin: 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/categories/category/category.component.ts
@@ -39,6 +39,7 @@ import {
   GioApiSelectDialogData,
   GioApiSelectDialogResult,
 } from '../../../../shared/components/gio-api-select-dialog/gio-api-select-dialog.component';
+import { EnvironmentSettingsService } from '../../../../services-ngx/environment-settings.service';
 
 interface ApiVM {
   id: string;
@@ -69,6 +70,7 @@ export class CategoryComponent implements OnInit {
   }>;
   highlightApiControl: FormControl<string>;
   categoryDetailsInitialValue: unknown;
+  hasPortalNextEnabled: boolean = false;
 
   category$: Observable<Category>;
   pages$: Observable<Page[]>;
@@ -91,6 +93,7 @@ export class CategoryComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     private matDialog: MatDialog,
+    private environmentSettingsService: EnvironmentSettingsService,
   ) {}
 
   ngOnInit() {
@@ -138,6 +141,8 @@ export class CategoryComponent implements OnInit {
     );
 
     this.pages$ = this.refreshData.pipe(switchMap((_) => this.documentationService.listPortalPages(PageType.MARKDOWN, true)));
+
+    this.hasPortalNextEnabled = this.environmentSettingsService.getSnapshot().portalNext?.access?.enabled === true;
   }
 
   onSubmit() {


### PR DESCRIPTION
…pages

## Issue

https://gravitee.atlassian.net/browse/APIM-6794

## Description

Add "Applies to both portals" to category pages when portal next is enabled:

<img width="1432" alt="Screenshot 2024-09-12 at 16 05 44" src="https://github.com/user-attachments/assets/8c0e6e96-a57f-4beb-933b-36602a6bbdb6">

<img width="1427" alt="Screenshot 2024-09-12 at 16 05 29" src="https://github.com/user-attachments/assets/fe870fff-6b27-4e1b-a586-43302aabe883">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sqahghigst.chromatic.com)
<!-- Storybook placeholder end -->
