### PR TITLE
APIM 5428: info page refresh after duplicating

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.spec.ts
@@ -33,6 +33,7 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApiGeneralInfoModule } from './api-general-info.module';
 import { ApiGeneralInfoComponent } from './api-general-info.component';
@@ -59,9 +60,7 @@ describe('ApiGeneralInfoComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            snapshot: {
-              params: { apiId: API_ID },
-            },
+            params: of({ apiId: API_ID }),
           },
         },
         {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -102,10 +102,12 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
 
     this.isQualityEnabled = this.constants.env?.settings?.apiQualityMetrics?.enabled;
 
-    this.apiId = this.activatedRoute.snapshot.params.apiId;
-
-    combineLatest([this.apiService.get(this.apiId), this.categoryService.list()])
+    this.activatedRoute.params
       .pipe(
+        switchMap((params) => {
+          this.apiId = params.apiId;
+          return combineLatest([this.apiService.get(this.apiId), this.categoryService.list()]);
+        }),
         switchMap(([api, categories]) =>
           combineLatest([isImgUrl(api._links['pictureUrl']), isImgUrl(api._links['backgroundUrl'])]).pipe(
             map(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5428

## Description

Fixed info page refresh after duplicating api, via activatedRoute change in api Id.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wzjadcjbhi.chromatic.com)
<!-- Storybook placeholder end -->
