### PR TITLE
fix(rest-api-service): use right path operator when add OAS validation policy

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCase.java
@@ -237,7 +237,7 @@ public class OAIToImportApiUseCase {
                 .configuration(new ObjectMapper().writeValueAsString(new LinkedHashMap<>(Map.of("resourceName", "OpenAPI Specification"))))
                 .build();
 
-            var httpSelector = HttpSelector.builder().path("/").pathOperator(Operator.EQUALS).build();
+            var httpSelector = HttpSelector.builder().path("/").pathOperator(Operator.STARTS_WITH).build();
 
             var flow = Flow
                 .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -52,7 +52,9 @@ import io.gravitee.apim.infra.domain_service.api.ApiImportDomainServiceLegacyWra
 import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.plugin.EndpointConnectorPluginLegacyWrapper;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
@@ -282,6 +284,8 @@ class OAIToImportApiUseCaseTest {
                 .satisfies(flow -> {
                     assertThat(flow.getName()).isEqualTo("OpenAPI Specification Validation");
                     assertThat(flow.getRequest()).isNotNull();
+                    assertThat(((HttpSelector) flow.getSelectors().get(0)).getPath()).isEqualTo("/");
+                    assertThat(((HttpSelector) flow.getSelectors().get(0)).getPathOperator()).isEqualTo(Operator.STARTS_WITH);
                     var oasValidationStep = flow.getRequest().get(0);
                     assertThat(oasValidationStep.getPolicy()).isEqualTo("oas-validation");
                     assertThat(oasValidationStep.getConfiguration()).isEqualTo("{\"resourceName\":\"OpenAPI Specification\"}");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-4329

## Description

Oups sry. We wants a STARTS_WITH operation because it's for all calls ... not just the exact match one 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

