### PR TITLE
feat: also disable gateway resources if cloud.enabled flag is true in…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -282,6 +282,12 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     protected CategoryDomainService categoryDomainService;
 
+    @Autowired
+    protected InstanceService instanceService;
+
+    @Autowired
+    protected MonitoringService monitoringService;
+
     @Before
     public void setUp() throws Exception {
         when(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstanceResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstanceResourceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.InstanceEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstanceResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "instances/123";
+    }
+
+    @Before
+    public void init() {
+        reset(instanceService, parameterService);
+    }
+
+    @Test
+    public void shouldThrowCloudEnabledException_whenCloudIsEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(true);
+
+        final Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.SERVICE_UNAVAILABLE_503, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnInstance_whenCloudNotEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(false);
+
+        InstanceEntity mockInstance = new InstanceEntity();
+        mockInstance.setEnvironments(Set.of(GraviteeContext.getCurrentEnvironment()));
+        when(instanceService.findByEvent(any(), any())).thenReturn(mockInstance);
+
+        final Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(mockInstance, response.readEntity(InstanceEntity.class));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstancesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstancesResourceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.InstanceListItem;
+import io.gravitee.rest.api.model.InstanceQuery;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstancesResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "instances";
+    }
+
+    @Before
+    public void init() {
+        reset(instanceService, parameterService);
+    }
+
+    @Test
+    public void shouldThrowCloudEnabledException_whenCloudIsEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(true);
+
+        final Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.SERVICE_UNAVAILABLE_503, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnInstances_whenCloudIsNotEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(false);
+
+        when(instanceService.search(any(), any(InstanceQuery.class))).thenReturn(mock(Page.class));
+
+        final Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/MonitoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/MonitoringResourceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.InstanceEntity;
+import io.gravitee.rest.api.model.monitoring.MonitoringData;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MonitoringResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "instances/123/monitoring/456";
+    }
+
+    @Before
+    public void init() {
+        reset(instanceService, monitoringService, parameterService);
+    }
+
+    @Test
+    public void shouldThrowCloudEnabledException_whenCloudIsEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(true);
+
+        final Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.SERVICE_UNAVAILABLE_503, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnMonitoringData_whenCloudNotEnabled() {
+        ExecutionContext executionContext = new ExecutionContext(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        when(
+            parameterService.findAsBoolean(
+                executionContext,
+                Key.CLOUD_ENABLED,
+                GraviteeContext.getCurrentOrganization(),
+                ParameterReferenceType.ORGANIZATION
+            )
+        )
+            .thenReturn(false);
+
+        InstanceEntity mockInstance = new InstanceEntity();
+        mockInstance.setEnvironments(Set.of("DEFAULT"));
+        MonitoringData mockMonitoringData = new MonitoringData();
+        when(instanceService.findByEvent(any(), any())).thenReturn(mockInstance);
+        when(monitoringService.findMonitoring(any(), any())).thenReturn(mockMonitoringData);
+        when(environmentService.findOrganizationIdsByEnvironments(any())).thenReturn(new HashSet<>(Collections.singleton("DEFAULT")));
+
+        Response response = envTarget().request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        assertEquals(mockMonitoringData, response.readEntity(MonitoringData.class));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -102,11 +102,13 @@ import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.FetcherService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.rest.api.service.InstanceService;
 import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.LogsService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.MessageService;
+import io.gravitee.rest.api.service.MonitoringService;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.PageService;
@@ -148,6 +150,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @Import(
@@ -747,5 +750,15 @@ public class ResourceContextConfiguration {
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
         return new ValidatePageSourceDomainServiceImpl();
+    }
+
+    @Bean
+    public InstanceService instanceService() {
+        return mock(InstanceService.class);
+    }
+
+    @Bean
+    public MonitoringService monitoringService() {
+        return mock(MonitoringService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static io.gravitee.common.http.HttpStatusCode.SERVICE_UNAVAILABLE_503;
+
+import java.util.Map;
+
+public class CloudEnabledException extends AbstractManagementException {
+
+    @Override
+    public int getHttpStatusCode() {
+        return SERVICE_UNAVAILABLE_503;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Gateway information is unavailable";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "cloud.enabled";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return null;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-1835

## Description

Sorry missed the code freeze, found that in addition to hiding gateway view when cloud is enabled https://github.com/gravitee-io/gravitee-api-management/pull/8954 we also want to remove access to gateway details through the API. 

Would it be possible for us to get this in 4.5.x release? 
