### PR TITLE
fix: push plan subscription failure command not created for JDBC

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.html
@@ -43,6 +43,14 @@
             {{ subscription.status }}
           </div>
         </div>
+
+        <div class="subscription__row">
+          <div class="mat-body-2">Consumer status</div>
+          <div id="subscription-consumer-status">
+            {{ subscription.consumerStatus }}
+          </div>
+        </div>
+
         <div class="subscription__row">
           <div class="mat-body-2">Subscribed by</div>
           <div id="subscription-subscribed-by">

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.spec.ts
@@ -150,6 +150,18 @@ describe('ApiGeneralSubscriptionEditComponent', () => {
       expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.detail.portal.subscriptions');
     });
 
+    it('should load accepted subscription with consumer status', async () => {
+      await initComponent({
+        ...BASIC_SUBSCRIPTION(),
+        consumerStatus: 'FAILURE',
+      });
+      expectApiKeyListGet();
+
+      const harness = await loader.getHarness(ApiGeneralSubscriptionEditHarness);
+
+      expect(await harness.getConsumerStatus()).toEqual('FAILURE');
+    });
+
     it('should load pending subscription', async () => {
       const pendingSubscription = BASIC_SUBSCRIPTION();
       pendingSubscription.status = 'PENDING';

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.component.ts
@@ -25,6 +25,7 @@ import {
   PlanMode,
   PlanSecurityType,
   SubscriptionConsumerConfiguration,
+  SubscriptionConsumerStatus,
   SubscriptionStatus,
 } from '../../../../../entities/management-api-v2';
 import { ApiSubscriptionV2Service } from '../../../../../services-ngx/api-subscription-v2.service';
@@ -67,6 +68,7 @@ interface SubscriptionDetailVM {
   id: string;
   plan: { id: string; label: string; securityType: PlanSecurityType; mode: PlanMode };
   status: SubscriptionStatus;
+  consumerStatus: SubscriptionConsumerStatus;
   subscribedBy: string;
   application?: { id: string; label: string; name: string; description: string };
   publisherMessage?: string;
@@ -149,6 +151,7 @@ export class ApiGeneralSubscriptionEditComponent implements OnInit {
                 description: subscription.application.description,
               },
               status: subscription.status,
+              consumerStatus: subscription.consumerStatus,
               subscribedBy: subscription.subscribedBy.displayName,
               publisherMessage: subscription.publisherMessage ?? '-',
               subscriberMessage: subscription.consumerMessage ?? '-',

--- a/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/general/subscriptions/edit/api-general-subscription-edit.harness.ts
@@ -44,6 +44,10 @@ export class ApiGeneralSubscriptionEditHarness extends ComponentHarness {
     return this.getSubscriptionDetailText('status');
   }
 
+  public async getConsumerStatus(): Promise<string> {
+    return this.getSubscriptionDetailText('consumer-status');
+  }
+
   public async getSubscribedBy(): Promise<string> {
     return this.getSubscriptionDetailText('subscribed-by');
   }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_1_25/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_1_25/schema.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.1.25
+      author: GraviteeSource Team
+      changes:
+        - dropNotNullConstraint:
+            columnDataType: nvarchar(64)
+            columnName: organization_id
+            tableName: ${gravitee_prefix}commands

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -163,3 +163,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_0_20/schema-dashboards.yml
   - include:
       - file: liquibase/changelogs/v4_0_22/schema-idp.yml
+  - include:
+      - file: liquibase/changelogs/v4_1_25/schema.yml

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <gravitee-entrypoint-http-get.version>1.0.3</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.0.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>4.0.2</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>2.2.0</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>2.2.1</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.10.2</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.1.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6600

## Description

- Bump webhook entrypoint to latest ( https://github.com/gravitee-io/gravitee-entrypoint-webhook/pull/61 ) This one contains a fix about the DLQ for webhook entrypoints.

- Remove not null constraint on command organization ID. When a subscription failure command is created an error occurs on JDBC databases. The gateway is not aware of the environment ID or the orgnization ID linked to the subscription so we should not force the not null constraint on the command.

- Display consumer status in subscription page
<img width="1789" alt="Capture d’écran 2024-09-18 à 12 14 07" src="https://github.com/user-attachments/assets/043845a3-9a6b-4865-ba0e-6041d09c9761">

Linked PRs:
- https://github.com/gravitee-io/gravitee-entrypoint-webhook/pull/61

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ovyuiecgqv.chromatic.com)
<!-- Storybook placeholder end -->
