### PR TITLE
fix(console): add applys to both portals in console settings

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -167,16 +167,23 @@
     <mat-card class="portal__form__card">
       <mat-card-content formGroupName="portal">
         <h3>General</h3>
-        <mat-form-field
-          [matTooltip]="'Configuration provided by the system'"
-          [matTooltipDisabled]="!isReadonly('portal.apikey.header')"
-          class="portal__form__card__form-field"
-        >
-          <mat-label
-            >Api-key Header (Used by portal to display the CURL command, change the YAML configuration to impact the gateway)
-          </mat-label>
-          <input formControlName="apikeyHeader" matInput type="text" />
-        </mat-form-field>
+        <div class="form-field-container">
+          <mat-form-field
+            [matTooltip]="'Configuration provided by the system'"
+            [matTooltipDisabled]="!isReadonly('portal.apikey.header')"
+            class="portal__form__card__form-field api-key-header"
+          >
+            <mat-label
+              >Api-key Header (Used by portal to display the CURL command, change the YAML configuration to impact the gateway)
+            </mat-label>
+            <input formControlName="apikeyHeader" matInput type="text" />
+          </mat-form-field>
+          @if (isPortalNextEnabled) {
+            <span class="gio-badge-warning" data-testid="badge-warning-1">
+              <mat-icon svgIcon="gio:chat-lines" data-testid="badge-icon-1"> </mat-icon>&nbsp;Applies to both portals
+            </span>
+          }
+        </div>
         <mat-form-field
           [matTooltip]="'Configuration provided by the system'"
           [matTooltipDisabled]="!isReadonly('portal.url')"
@@ -283,7 +290,7 @@
           [matTooltipDisabled]="!isReadonly('portal.analytics.enabled')"
           class="portal__form__card__form-field"
         >
-          <gio-form-label>Add Google Analytics</gio-form-label>
+          <gio-form-label> Add Google Analytics</gio-form-label>
           <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Add Google Analytics"></mat-slide-toggle>
         </gio-form-slide-toggle>
         <mat-form-field

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.scss
@@ -68,3 +68,13 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 }
+
+.form-field-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.api-key-header {
+  width: 80%;
+}

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -178,6 +178,7 @@ export class PortalSettingsComponent implements OnInit {
   hasEnterpriseLicense$: Observable<boolean> = of(false);
   portalUrl: string = undefined;
   environmentRootRouterLink: string;
+  isPortalNextEnabled: boolean = false;
 
   constructor(
     private readonly portalSettingsService: PortalSettingsService,
@@ -198,12 +199,12 @@ export class PortalSettingsComponent implements OnInit {
         tap(([portalSettings]) => {
           this.settings = portalSettings;
           this.initialPortalForm();
-          const isPortalNextEnabled = portalSettings?.portalNext?.access?.enabled;
+          this.isPortalNextEnabled = portalSettings?.portalNext?.access?.enabled;
           this.portalUrl = isEmpty(portalSettings.portal.url)
             ? undefined
             : this.constants.env.baseURL.replace('{:envId}', this.constants.org.currentEnv.id) +
               '/portal/redirect' +
-              (isPortalNextEnabled ? '?version=next' : '');
+              (this.isPortalNextEnabled ? '?version=next' : '');
         }),
         takeUntilDestroyed(this.destroyRef),
       )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6853

## Description

The warning message "Apply to Both Portals" should also be displayed for API Key Header field in Portal->General section
