### PR TITLE
fix: dashboard tenant widget

### DIFF
--- a/gravitee-apim-console-webui/src/services/analytics.service.ts
+++ b/gravitee-apim-console-webui/src/services/analytics.service.ts
@@ -43,7 +43,7 @@ class AnalyticsService {
     const keys = Object.keys(request);
     _.forEach(keys, (key) => {
       const val = request[key];
-      if (val !== undefined) {
+      if (val !== null && val !== undefined && val !== '') {
         url += key + '=' + val + '&';
       }
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6877

## Description

In this PR we check if the value is truthy in the analytics service to avoid to send request like this `http -a "admin:changeMe" GET http://localhost:3000/management/organizations/DEFAULT/environments/DEFAULT/platform/analytics\?type\=group_by\&field\=tenant
\&interval\=60000\&from\=1726577590982\&to\=1726588390982\&query\=\&
`

The problem here is the `query\=\&` when we select a tenant for example



https://github.com/user-attachments/assets/6fa27172-426f-47f0-84da-0ec720030a93





## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ktaeypwlnf.chromatic.com)
<!-- Storybook placeholder end -->
