### PR TITLE
APIM-6599: handle EL dynamic limit for portal api mapping

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiTemplateVariables.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiTemplateVariables.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import io.gravitee.common.util.TemplatedValueHashMap;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Serialization of an API to be used with the TemplateEngine
+ * An equivalent to ApiProperties and ApiVariables classes in the Gateway.
+ */
+public class ApiTemplateVariables {
+
+    private final GenericApiEntity api;
+
+    public ApiTemplateVariables(final GenericApiEntity api) {
+        this.api = api;
+    }
+
+    public String getId() {
+        return this.api.getId();
+    }
+
+    public String getName() {
+        return this.api.getName();
+    }
+
+    public String getVersion() {
+        return this.api.getApiVersion();
+    }
+
+    public Map<String, String> getProperties() {
+        if (this.api != null) {
+            if (DefinitionVersion.V4.equals(this.api.getDefinitionVersion())) {
+                var v4Api = (io.gravitee.rest.api.model.v4.api.ApiEntity) api;
+                if (v4Api.getProperties() != null) {
+                    return v4Api
+                        .getProperties()
+                        .stream()
+                        .collect(
+                            Collectors.toMap(
+                                io.gravitee.definition.model.v4.property.Property::getKey,
+                                io.gravitee.definition.model.v4.property.Property::getValue,
+                                (v1, v2) -> {
+                                    throw new IllegalArgumentException(String.format("Duplicate key for values %s and %s", v1, v2));
+                                },
+                                TemplatedValueHashMap::new
+                            )
+                        );
+                }
+            } else {
+                var v2Api = (io.gravitee.rest.api.model.api.ApiEntity) api;
+                if (v2Api.getProperties() != null) {
+                    return v2Api.getProperties().getValues();
+                }
+            }
+        }
+
+        return Map.of();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResource.java
@@ -78,7 +78,7 @@ public class ApiPlansResource extends AbstractResource {
             .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
             .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))
             .sorted(Comparator.comparingInt(GenericPlanEntity::getOrder))
-            .map(p -> planMapper.convert(p))
+            .map(p -> planMapper.convert(p, genericApiEntity))
             .collect(Collectors.toList());
 
         return createListResponse(executionContext, plans, paginationParam);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -115,7 +115,7 @@ public class ApiResource extends AbstractResource {
                     .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
                     .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))
                     .sorted(Comparator.comparingInt(GenericPlanEntity::getOrder))
-                    .map(p -> planMapper.convert(p))
+                    .map(p -> planMapper.convert(p, genericApiEntity))
                     .collect(Collectors.toList());
                 api.setPlans(plans);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPlansResourceTest.java
@@ -87,7 +87,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
         when(planSearchService.findByApi(GraviteeContext.getExecutionContext(), API)).thenReturn(Set.of(plan1, plan2, planWrongStatus));
 
-        when(planMapper.convert(any(GenericPlanEntity.class))).thenCallRealMethod();
+        when(planMapper.convert(any(GenericPlanEntity.class), any())).thenCallRealMethod();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
@@ -89,7 +89,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
 
         doReturn(new Api()).when(apiMapper).convert(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(new Page()).when(pageMapper).convert(any());
-        doReturn(new Plan()).when(planMapper).convert(any());
+        doReturn(new Plan()).when(planMapper).convert(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -73,7 +73,7 @@ public class ApiResourceTest extends AbstractResourceTest {
         api.setId(API);
         doReturn(api).when(apiMapper).convert(eq(GraviteeContext.getExecutionContext()), any());
         doReturn(new Page()).when(pageMapper).convert(any());
-        doReturn(new Plan()).when(planMapper).convert(any());
+        doReturn(new Plan()).when(planMapper).convert(any(), any());
         doReturn(new Rating()).when(ratingMapper).convert(eq(GraviteeContext.getExecutionContext()), any(), any());
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6599

## Description

When mapping a plan in the Portal API, the dynamic limit was not being calculated if it contained Gravitee Expression Language. 

The mapper can now lookup these values and handle if the EL is invalid. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pwwnhofxvb.chromatic.com)
<!-- Storybook placeholder end -->
