### PR TITLE
fix: push plan subscription failure command not created for JDBC

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -44,6 +44,13 @@
             {{ subscription.status || '-' }}
           </dd>
 
+          <ng-container *ngIf="subscription.consumerStatus">
+            <dt>Consumer status</dt>
+            <dd gioClipboardCopyWrapper [contentToCopy]="subscription.consumerStatus" data-testId="subscription-consumer-status">
+              {{ subscription.consumerStatus }}
+            </dd>
+          </ng-container>
+
           <dt>Subscribed by</dt>
           <dd gioClipboardCopyWrapper [contentToCopy]="subscription.subscribedBy" data-testId="subscription-subscribed-by">
             {{ subscription.subscribedBy || '-' }}

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.spec.ts
@@ -141,6 +141,21 @@ describe('ApiSubscriptionEditComponent', () => {
       expect(await harness.rejectBtnIsVisible()).toEqual(false);
     });
 
+    it('should load accepted subscription with consumer status', async () => {
+      await initComponent({
+        subscription: {
+          ...BASIC_SUBSCRIPTION(),
+          consumerStatus: 'FAILURE',
+          plan: { ...BASIC_SUBSCRIPTION().plan, mode: 'PUSH', security: null },
+        },
+      });
+      expectApiKeyListGet();
+
+      const harness = await loader.getHarness(ApiSubscriptionEditHarness);
+
+      expect(await harness.getConsumerStatus()).toEqual('FAILURE');
+    });
+
     it('should load federated subscription', async () => {
       await initComponent({ api: fakeApiFederated({ id: API_ID }) });
       expectApiKeyListGet();

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
@@ -21,7 +21,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { PlanMode, PlanSecurityType, SubscriptionConsumerConfiguration, SubscriptionStatus } from '../../../../entities/management-api-v2';
+import {
+  PlanMode,
+  PlanSecurityType,
+  SubscriptionConsumerConfiguration,
+  SubscriptionConsumerStatus,
+  SubscriptionStatus,
+} from '../../../../entities/management-api-v2';
 import { ApiSubscriptionV2Service } from '../../../../services-ngx/api-subscription-v2.service';
 import {
   ApiPortalSubscriptionTransferDialogComponent,
@@ -62,6 +68,7 @@ interface SubscriptionDetailVM {
   id: string;
   plan: { id: string; label: string; securityType: PlanSecurityType; mode: PlanMode };
   status: SubscriptionStatus;
+  consumerStatus: SubscriptionConsumerStatus;
   subscribedBy: string;
   application?: { id: string; label: string; name: string; description: string };
   publisherMessage?: string;
@@ -159,6 +166,7 @@ export class ApiSubscriptionEditComponent implements OnInit {
                 description: subscription.application.description,
               },
               status: subscription.status,
+              consumerStatus: subscription.consumerStatus,
               subscribedBy: subscription.subscribedBy.displayName,
               publisherMessage: subscription.publisherMessage,
               subscriberMessage: subscription.consumerMessage,

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
@@ -45,6 +45,10 @@ export class ApiSubscriptionEditHarness extends ComponentHarness {
     return this.getSubscriptionDetailText('status');
   }
 
+  public async getConsumerStatus(): Promise<string> {
+    return this.getSubscriptionDetailText('consumer-status');
+  }
+
   public async getSubscribedBy(): Promise<string> {
     return this.getSubscriptionDetailText('subscribed-by');
   }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/SubscriptionDeployer.java
@@ -178,6 +178,7 @@ public class SubscriptionDeployer implements Deployer<SubscriptionDeployable> {
                 command.setTags(List.of(CommandTags.SUBSCRIPTION_FAILURE.name()));
                 command.setCreatedAt(Date.from(now));
                 command.setUpdatedAt(Date.from(now));
+                command.setEnvironmentId(subscription.getEnvironmentId());
 
                 convertSubscriptionCommand(subscription, command, throwable.getMessage());
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapper.java
@@ -52,6 +52,7 @@ public class SubscriptionMapper {
                 );
             }
             subscription.setMetadata(subscriptionModel.getMetadata());
+            subscription.setEnvironmentId(subscriptionModel.getEnvironmentId());
             return subscription;
         } catch (Exception e) {
             log.error("Unable to map subscription from model [{}].", subscriptionModel.getId(), e);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_1_25/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_1_25/schema.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.1.25
+      author: GraviteeSource Team
+      changes:
+        - dropNotNullConstraint:
+            columnDataType: nvarchar(64)
+            columnName: organization_id
+            tableName: ${gravitee_prefix}commands

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -164,6 +164,8 @@ databaseChangeLog:
   - include:
       - file: liquibase/changelogs/v4_0_22/schema-idp.yml
   - include:
+      - file: liquibase/changelogs/v4_1_25/schema.yml
+  - include:
       - file: liquibase/changelogs/v4_2_0/schema.yml
   - include:
       - file: liquibase/changelogs/v4_2_0/schema-quality-rules.yml

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.5.3</gravitee-gateway-api.version>
         <gravitee-integration-api.version>1.1.0</gravitee-integration-api.version>
         <gravitee-node.version>6.0.7</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <gravitee-entrypoint-http-get.version>1.2.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>1.2.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>4.1.0</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>3.0.0</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>3.0.1</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.10.2</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.2.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6600

## Description

This PR follow this one https://github.com/gravitee-io/gravitee-api-management/pull/9042 it's simply a cherry pick of the commit and we use a different versions for the webhook dependency.

In 4.4.x we have introduced the environmentId in the subscription that's why here I map it in the command as it can be a usefull data which become accessible in this version 

Linked PRs:
- https://github.com/gravitee-io/gravitee-api-management/pull/9042
- https://github.com/gravitee-io/gravitee-entrypoint-webhook/pull/62
- https://github.com/gravitee-io/gravitee-gateway-api/pull/236 ( for 4.4.x )
- https://github.com/gravitee-io/gravitee-gateway-api/pull/235 ( for master )

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-reduicavej.chromatic.com)
<!-- Storybook placeholder end -->
