### PR TITLE
fix: update conflicting cloud flag

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -409,7 +409,7 @@ public enum Key {
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
     TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
-    CLOUD_ENABLED("cloud.enabled", "false", Set.of(SYSTEM)),
+    CLOUD_ENABLED("cloud-hosted.enabled", "false", Set.of(SYSTEM)),
 
     EXTERNAL_AUTH_ENABLED("auth.external.enabled", "false", Set.of(SYSTEM)),
     EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED("auth.external.allowAccountDeletion", "true", Set.of(SYSTEM));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
@@ -33,7 +33,7 @@ public class CloudEnabledException extends AbstractManagementException {
 
     @Override
     public String getTechnicalCode() {
-        return "cloud.enabled";
+        return "cloud-hosted.enabled";
     }
 
     @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-2280

## Description

I missed that cloud flag I added https://github.com/gravitee-io/gravitee-api-management/pull/8954 conflicts with existing `cloud.enabled` flag. We may want this flag to be different to whether cockpit/cloud is connected to apim so I renamed the new flag `cloud-hosted.enabled`

