### PR TITLE
fix: update conflicting cloud flag

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -147,7 +147,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       },
     ];
 
-    if (!this.constants?.org?.settings?.cloud?.enabled) {
+    if (!this.constants?.org?.settings?.cloudHosted?.enabled) {
       mainMenuItems.push({
         icon: 'gio:cloud-server',
         displayName: 'Gateways',

--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -33,7 +33,7 @@ export interface ConsoleSettings {
   trialInstance?: ConsoleSettingsTrialInstance;
   federation?: ConsoleSettingsFederation;
   scoring?: ConsoleSettingsScoring;
-  cloud?: ConsoleSettingsCloud;
+  cloudHosted?: ConsoleSettingsCloudHosted;
 }
 
 export interface ConsoleSettingsEmail {
@@ -189,6 +189,6 @@ export interface ConsoleSettingsScoring {
   enabled?: boolean;
 }
 
-export interface ConsoleSettingsCloud {
+export interface ConsoleSettingsCloudHosted {
   enabled?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/cloud-hosted-guard.ts
+++ b/gravitee-apim-console-webui/src/management/cloud-hosted-guard.ts
@@ -21,13 +21,13 @@ import { Constants } from '../entities/Constants';
 @Injectable({
   providedIn: 'root',
 })
-export class CloudGuard implements CanActivate {
+export class CloudHostedGuard implements CanActivate {
   constructor(
     private router: Router,
     @Inject(Constants) private readonly constants: Constants,
   ) {}
 
   canActivate(_route: ActivatedRouteSnapshot): boolean {
-    return !this.constants?.org?.settings?.cloud?.enabled;
+    return !this.constants?.org?.settings?.cloudHosted?.enabled;
   }
 }

--- a/gravitee-apim-console-webui/src/management/management-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/management-routing.module.ts
@@ -24,7 +24,7 @@ import { InstanceDetailsEnvironmentComponent } from './instances/instance-detail
 import { InstanceDetailsMonitoringComponent } from './instances/instance-details/instance-details-monitoring/instance-details-monitoring.component';
 import { EnvAuditComponent } from './audit/env-audit.component';
 import { MessagesComponent } from './messages/messages.component';
-import { CloudGuard } from './cloud-guard';
+import { CloudHostedGuard } from './cloud-hosted-guard';
 
 import { TasksComponent } from '../user/tasks/tasks.component';
 import { UserComponent } from '../user/my-accout/user.component';
@@ -84,7 +84,7 @@ const managementRoutes: Routes = [
       },
       {
         path: 'gateways',
-        canActivate: [CloudGuard],
+        canActivate: [CloudHostedGuard],
         component: InstanceListComponent,
         data: {
           permissions: {
@@ -109,7 +109,7 @@ const managementRoutes: Routes = [
       {
         path: 'gateways/:instanceId',
         component: InstanceDetailsComponent,
-        canActivate: [CloudGuard],
+        canActivate: [CloudHostedGuard],
         data: {
           permissions: {
             anyOf: ['environment-instance-r'],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstanceResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstanceResource.java
@@ -38,8 +38,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import java.util.Set;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -89,7 +87,7 @@ public class InstanceResource {
     private Boolean cloudEnabled() {
         return parameterService.findAsBoolean(
             GraviteeContext.getExecutionContext(),
-            Key.CLOUD_ENABLED,
+            Key.CLOUD_HOSTED_ENABLED,
             GraviteeContext.getCurrentOrganization(),
             ParameterReferenceType.ORGANIZATION
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstancesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstancesResource.java
@@ -39,8 +39,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -86,7 +84,7 @@ public class InstancesResource {
     private Boolean cloudEnabled() {
         return parameterService.findAsBoolean(
             GraviteeContext.getExecutionContext(),
-            Key.CLOUD_ENABLED,
+            Key.CLOUD_HOSTED_ENABLED,
             GraviteeContext.getCurrentOrganization(),
             ParameterReferenceType.ORGANIZATION
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.InstanceEntity;
-import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.model.monitoring.MonitoringData;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -28,7 +27,6 @@ import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.InstanceService;
 import io.gravitee.rest.api.service.MonitoringService;
-import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CloudEnabledException;
@@ -40,11 +38,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -106,7 +100,7 @@ public class MonitoringResource extends AbstractResource {
     private Boolean cloudEnabled() {
         return parameterService.findAsBoolean(
             GraviteeContext.getExecutionContext(),
-            Key.CLOUD_ENABLED,
+            Key.CLOUD_HOSTED_ENABLED,
             GraviteeContext.getCurrentOrganization(),
             ParameterReferenceType.ORGANIZATION
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstanceResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstanceResourceTest.java
@@ -50,7 +50,7 @@ public class InstanceResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )
@@ -70,7 +70,7 @@ public class InstanceResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstancesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/InstancesResourceTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.rest.api.model.InstanceListItem;
 import io.gravitee.rest.api.model.InstanceQuery;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -54,7 +53,7 @@ public class InstancesResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )
@@ -74,7 +73,7 @@ public class InstancesResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/MonitoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/MonitoringResourceTest.java
@@ -55,7 +55,7 @@ public class MonitoringResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )
@@ -75,7 +75,7 @@ public class MonitoringResourceTest extends AbstractResourceTest {
         when(
             parameterService.findAsBoolean(
                 executionContext,
-                Key.CLOUD_ENABLED,
+                Key.CLOUD_HOSTED_ENABLED,
                 GraviteeContext.getCurrentOrganization(),
                 ParameterReferenceType.ORGANIZATION
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -409,7 +409,7 @@ public enum Key {
 
     INSTALLATION_TYPE("installation.type", "standalone", Set.of(SYSTEM)),
     TRIAL_INSTANCE("trialInstance.enabled", "false", Set.of(SYSTEM)),
-    CLOUD_ENABLED("cloud.enabled", "false", Set.of(SYSTEM)),
+    CLOUD_HOSTED_ENABLED("cloud-hosted.enabled", "false", Set.of(SYSTEM)),
 
     EXTERNAL_AUTH_ENABLED("auth.external.enabled", "false", Set.of(SYSTEM)),
     EXTERNAL_AUTH_ACCOUNT_DELETION_ENABLED("auth.external.allowAccountDeletion", "true", Set.of(SYSTEM));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/CloudHosted.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/CloudHosted.java
@@ -22,8 +22,8 @@ import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Cloud {
+public class CloudHosted {
 
-    @ParameterKey(Key.CLOUD_ENABLED)
+    @ParameterKey(Key.CLOUD_HOSTED_ENABLED)
     private Boolean enabled;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
@@ -38,7 +38,7 @@ public class ConsoleConfigEntity {
     private TrialInstance trialInstance;
     private Federation federation;
     private Scoring scoring;
-    private Cloud cloud;
+    private CloudHosted cloudHosted;
 
     public ConsoleConfigEntity() {
         super();
@@ -57,6 +57,6 @@ public class ConsoleConfigEntity {
         trialInstance = new TrialInstance();
         federation = new Federation();
         scoring = new Scoring();
-        cloud = new Cloud();
+        cloudHosted = new CloudHosted();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
@@ -48,7 +48,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
     private TrialInstance trialInstance;
     private Federation federation;
     private Scoring scoring;
-    private Cloud cloud;
+    private CloudHosted cloudHosted;
 
     public ConsoleSettingsEntity() {
         super();
@@ -68,7 +68,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
         trialInstance = new TrialInstance();
         federation = new Federation();
         scoring = new Scoring();
-        cloud = new Cloud();
+        cloudHosted = new CloudHosted();
     }
 
     //Classes

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/CloudEnabledException.java
@@ -33,7 +33,7 @@ public class CloudEnabledException extends AbstractManagementException {
 
     @Override
     public String getTechnicalCode() {
-        return "cloud.enabled";
+        return "cloud-hosted.enabled";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -489,7 +489,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getTrialInstance(),
             consoleConfigEntity.getFederation(),
             consoleConfigEntity.getScoring(),
-            consoleConfigEntity.getCloud(),
+            consoleConfigEntity.getCloudHosted(),
         };
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-2280

## Description

I missed that cloud flag I added https://github.com/gravitee-io/gravitee-api-management/pull/8954 conflicts with existing `cloud.enabled` flag. We may want this flag to be different to whether cockpit/cloud is connected to apim so I renamed the new flag `cloud-hosted.enabled`

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zbtapigefk.chromatic.com)
<!-- Storybook placeholder end -->
