### PR TITLE
feat: api-score navigation item display based on settings

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -45,7 +45,7 @@ describe('GioSideNavComponent', () => {
   const expirationDateInOneYear = new Date();
   expirationDateInOneYear.setFullYear(expirationDateInOneYear.getFullYear() + 1);
 
-  const init = async (licenseNotificationEnabled = true, hasLicenseMgmtPermission = true) => {
+  const init = async (licenseNotificationEnabled = true, hasLicenseMgmtPermission = true, scoringEnabled = true) => {
     await TestBed.configureTestingModule({
       declarations: [GioSideNavComponent],
       imports: [NoopAnimationsModule, GioTestingModule, GioSideNavModule, MatIconTestingModule],
@@ -68,8 +68,19 @@ describe('GioSideNavComponent', () => {
           provide: Constants,
           useFactory: () => {
             const constants = CONSTANTS_TESTING;
-            constants.org.settings = { ...constants.org.settings, licenseExpirationNotification: { enabled: licenseNotificationEnabled } };
-            constants.org.environments = [{ id: 'DEFAULT', name: 'default', hrids: [], organizationId: 'organizationId' }];
+            constants.org.settings = {
+              ...constants.org.settings,
+              licenseExpirationNotification: { enabled: licenseNotificationEnabled },
+              scoring: { enabled: scoringEnabled },
+            };
+            constants.org.environments = [
+              {
+                id: 'DEFAULT',
+                name: 'default',
+                hrids: [],
+                organizationId: 'organizationId',
+              },
+            ];
 
             return constants;
           },
@@ -170,6 +181,28 @@ describe('GioSideNavComponent', () => {
           expect.objectContaining({ name: 'Settings', routerLink: expect.not.stringContaining('./') }),
         ]),
       );
+    });
+  });
+
+  describe('settings check', () => {
+    it('should hide scoring elements when feature is disabled', async () => {
+      await init(true, true, false);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      expect(fixture.componentInstance.mainMenuItems.find((item) => item.displayName === 'API Score')).toBeUndefined();
+    });
+
+    it('should show scoring elements when feature is enabled', async () => {
+      await init(true, true, true);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      expect(fixture.componentInstance.mainMenuItems.find((item) => item.displayName === 'API Score')).toEqual({
+        category: 'API Score',
+        displayName: 'API Score',
+        icon: 'gio:shield-check',
+        permissions: ['environment-integration-r'],
+        routerLink: './api-score',
+      });
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -157,13 +157,15 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       });
     }
 
-    mainMenuItems.push({
-      icon: 'gio:shield-check',
-      routerLink: './api-score',
-      displayName: 'API Score',
-      permissions: ['environment-integration-r'],
-      category: 'API Score',
-    });
+    if (this.constants.org.settings?.scoring?.enabled) {
+      mainMenuItems.push({
+        icon: 'gio:shield-check',
+        routerLink: './api-score',
+        displayName: 'API Score',
+        permissions: ['environment-integration-r'],
+        category: 'API Score',
+      });
+    }
 
     mainMenuItems.push(
       {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6808

## Description

Display api-score nav item base on settings

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kkgqxhmumq.chromatic.com)
<!-- Storybook placeholder end -->
