### PR TITLE
fix(portal-next): handle api plan permissions for user in subscription details

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -20,23 +20,29 @@
   Manage subscriptions
 </div>
 
-@if (subscriptionDetails$ | async; as details) {
-  <div class="subscriptions-details__container">
-    <app-subscription-info
-      class="subscriptions-details__subscription-info"
-      [applicationName]="details.applicationName"
-      [planName]="details.planName"
-      [planSecurity]="details.planSecurity"
-      [subscriptionStatus]="details.subscriptionStatus"
-      [planUsageConfiguration]="details.planUsageConfiguration" />
-    <app-api-access
-      [planSecurity]="details.planSecurity"
-      [subscriptionStatus]="details.subscriptionStatus"
-      [entrypointUrl]="details.entrypointUrl"
-      [apiKey]="details.apiKey"
-      [clientId]="details.clientId"
-      [clientSecret]="details.clientSecret" />
-  </div>
+@if (subscriptionDetails$ | async; as detailsVM) {
+  @if (detailsVM.error) {
+    <div i18n="@@subscriptionDetailsError" class="m3-body-medium subscriptions-details__error">
+      An error occurred. Try again later or contact your Portal administrator.
+    </div>
+  } @else if (detailsVM.result) {
+    <div class="subscriptions-details__container">
+      <app-subscription-info
+        class="subscriptions-details__subscription-info"
+        [applicationName]="detailsVM.result.applicationName"
+        [planName]="detailsVM.result.planName"
+        [planSecurity]="detailsVM.result.planSecurity"
+        [subscriptionStatus]="detailsVM.result.subscriptionStatus"
+        [planUsageConfiguration]="detailsVM.result.planUsageConfiguration" />
+      <app-api-access
+        [planSecurity]="detailsVM.result.planSecurity"
+        [subscriptionStatus]="detailsVM.result.subscriptionStatus"
+        [entrypointUrl]="detailsVM.result.entrypointUrl"
+        [apiKey]="detailsVM.result.apiKey"
+        [clientId]="detailsVM.result.clientId"
+        [clientSecret]="detailsVM.result.clientSecret" />
+    </div>
+  }
 } @else {
   <app-loader />
 }

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.scss
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+:host {
+  display: flex;
+  flex-flow: column;
+}
+
 .subscriptions-details {
   &__navigate-back {
     display: flex;
@@ -36,5 +41,10 @@
 
   &__subscription-info {
     min-width: 38%;
+  }
+
+  &__error {
+    align-self: center;
+    padding: 36px 0;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6858

## Description

- Show error message when an unexpected error occurs:

<img width="1210" alt="Screenshot 2024-09-18 at 08 24 55" src="https://github.com/user-attachments/assets/2fa8f24c-e023-44a0-877f-7f44c632a6f6">


- If a user does not have permissions to read an API's plans, then plan information comes from the subscription list metadata.
- If a user does have permission, then plans are retrieved.
- If an error occurs during the plans call (related to https://github.com/gravitee-io/gravitee-api-management/pull/9062), then plan information is fetched from the subscription list metadata.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oidwctromw.chromatic.com)
<!-- Storybook placeholder end -->
