### PR TITLE
fix: update api alert and refresh data

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ajs.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ajs.ts
@@ -16,7 +16,7 @@
 import { IScope } from 'angular';
 
 import { Router } from '@angular/router';
-import { cloneDeep, find } from 'lodash';
+import { cloneDeep, find, isEqual } from 'lodash';
 
 import { Alert, Scope } from '../../../entities/alert';
 import { Rule } from '../../../entities/alerts/rule.metrics';
@@ -94,6 +94,16 @@ const AlertComponentAjs: ng.IComponentOptions = {
 
         this.selectedTab = indexOfTab > -1 ? indexOfTab : 1;
         this.currentTab = this.tabs[this.selectedTab];
+      };
+
+      this.$onChanges = (changes) => {
+        const currentAlert = find(this.alerts, { id: this.activatedRoute.snapshot.params.alertId });
+        if (this.updateMode && (!isEqual(this.alerts, changes.alerts.currentValue) || !isEqual(currentAlert, this.alert))) {
+          this.alerts = changes.alerts.currentValue;
+          this.alert = find(this.alerts, { id: this.activatedRoute.snapshot.params.alertId }) || this.alerts[0];
+          this.alert.type = (this.alert.source + '@' + this.alert.type).toUpperCase();
+          this.alert.reference_type = this.referenceType;
+        }
       };
 
       this.selectTab = (idx: number) => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6583

## Description

The goal of this pr is to update api alert and refresh data. The update has been broken when we changed the router I think. Today there is an issue between the child that save the data and the parent that reload it after the save. 


https://github.com/user-attachments/assets/b336e868-0ce7-4a16-8aa3-bce09f57eba9


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ekblwbowvh.chromatic.com)
<!-- Storybook placeholder end -->
