### PR TITLE
fix: show sharding tag endpoints with access points in portal

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
@@ -201,7 +201,7 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
 
         if (host == null || !isOverride) {
             List<AccessPoint> accessPoints = this.accessPointQueryService.getGatewayAccessPoints(environmentId);
-            if (accessPoints.isEmpty()) {
+            if (accessPoints.isEmpty() || (tags != null && !tags.isEmpty())) {
                 entrypoints.add(createApiEntrypointEntity(defaultScheme, entrypointValue, path, tags, host));
             } else {
                 for (AccessPoint accessPoint : accessPoints) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-2214

## Description

Recently in https://github.com/gravitee-io/gravitee-api-management/pull/8696 we fixed the access URLs for the new approach to access points (where they are not part of the API definition anymore).

However, we missed sharding tags when have access points present, so this fixes that case. 

Without sharding tags, getting access points:
<img width="1226" alt="Screenshot 2024-09-19 at 11 09 04" src="https://github.com/user-attachments/assets/fab3b3fc-4a03-42fe-9dc1-d76c4427534d">

With sharding tags, using sharding tag entrypoint rather than access points: 

<img width="1217" alt="Screenshot 2024-09-19 at 11 09 10" src="https://github.com/user-attachments/assets/fb3a6b95-2786-45b0-9d8c-4a110d151596">




