### PR TITLE
feat(integration): pass parameters to (un)subscribe

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationSubscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/model/IntegrationSubscription.java
@@ -29,7 +29,7 @@ public record IntegrationSubscription(String integrationId, Type type, String ap
         return new IntegrationSubscription(integrationId, Type.API_KEY, apiKey, metadata);
     }
 
-    public static IntegrationSubscription oAuth(String integrationId) {
-        return new IntegrationSubscription(integrationId, Type.OAUTH2, null, Map.of());
+    public static IntegrationSubscription oAuth(String integrationId, Map<String, String> metadata) {
+        return new IntegrationSubscription(integrationId, Type.OAUTH2, null, metadata);
     }
 }


### PR DESCRIPTION
**Issue** [APIM-6735](https://gravitee.atlassian.net/browse/APIM-6735)

## Description

- **Subscription**
  - Pass server map to subscription to allow agent set some parameters in ingest needed for subscription
- **Unsubscribe**
  - Pass subscription metadata to unsuscibe command to give parameters to unsubscribe



[APIM-6735]: https://gravitee.atlassian.net/browse/APIM-6735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rbnkxhklwx.chromatic.com)
<!-- Storybook placeholder end -->
