### PR TITLE
feat: add endpoint to get environment scoring overview

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ScoringReportRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ScoringReportRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.ScoringEnvironmentSummary;
 import io.gravitee.repository.management.model.ScoringReport;
 import java.util.Collection;
 import java.util.Optional;
@@ -26,4 +27,6 @@ public interface ScoringReportRepository {
     Optional<ScoringReport> findLatestFor(String apiId) throws TechnicalException;
     Stream<ScoringReport> findLatestReports(Collection<String> apiIds) throws TechnicalException;
     void deleteByApi(String api) throws TechnicalException;
+
+    ScoringEnvironmentSummary getScoringEnvironmentSummary(String environmentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringEnvironmentSummary.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringEnvironmentSummary.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Getter
+@Setter
+@ToString
+public final class ScoringEnvironmentSummary {
+
+    private String environmentId;
+
+    @Builder.Default
+    private Long errors = 0L;
+
+    @Builder.Default
+    private Long warnings = 0L;
+
+    @Builder.Default
+    private Long infos = 0L;
+
+    @Builder.Default
+    private Long hints = 0L;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoScoringReportRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoScoringReportRepository.java
@@ -17,12 +17,12 @@ package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ScoringReportRepository;
+import io.gravitee.repository.management.model.ScoringEnvironmentSummary;
 import io.gravitee.repository.management.model.ScoringReport;
 import io.gravitee.repository.mongodb.management.internal.model.ScoringReportMongo;
 import io.gravitee.repository.mongodb.management.internal.score.ScoringReportMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -70,6 +70,14 @@ public class MongoScoringReportRepository implements ScoringReportRepository {
         logger.debug("Delete scoring reports of API [{}]", apiId);
         internalRepository.deleteByApiId(apiId);
         logger.debug("Delete scoring reports of API [{}] - Done", apiId);
+    }
+
+    @Override
+    public ScoringEnvironmentSummary getScoringEnvironmentSummary(String environmentId) throws TechnicalException {
+        logger.debug("Get Environment Scoring Summary of {}", environmentId);
+        var result = internalRepository.getScoringEnvironmentSummary(environmentId);
+        logger.debug("Get Environment Scoring Summary of {} - DONE", environmentId);
+        return result;
     }
 
     private ScoringReport map(ScoringReportMongo source) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/scorings/EnvironmentIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/scorings/EnvironmentIdIndexUpgrader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.scorings;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("ScoringReportEnvironmentIdIndexUpgrader")
+public class EnvironmentIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("scoring_reports")
+            .name("ei1")
+            .key("environmentId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ScoringReportReportRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ScoringReportReportRepositoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.ScoringEnvironmentSummary;
 import io.gravitee.repository.management.model.ScoringReport;
 import java.util.Date;
 import java.util.List;
@@ -177,6 +178,21 @@ public class ScoringReportReportRepositoryTest extends AbstractManagementReposit
 
         var reportAfter = scoringReportRepository.findLatestFor("api1");
         assertThat(reportAfter).isEmpty();
+    }
+
+    // getScoringEnvironmentSummary
+    @Test
+    public void getScoringEnvironmentSummary_should_return_environment_summary() throws Exception {
+        var result = scoringReportRepository.getScoringEnvironmentSummary("env1");
+
+        Assertions.assertThat(result).isEqualTo(new ScoringEnvironmentSummary("env1", 5L, 5L, 5L, 5L));
+    }
+
+    @Test
+    public void getScoringEnvironmentSummary_should_return_empty_summary_when_no_data() throws Exception {
+        var result = scoringReportRepository.getScoringEnvironmentSummary("env4");
+
+        Assertions.assertThat(result).isEqualTo(new ScoringEnvironmentSummary("env4", 0L, 0L, 0L, 0L));
     }
 
     private static ScoringReport aScoring() {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/scoring-tests/scoringReports.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/scoring-tests/scoringReports.json
@@ -75,5 +75,95 @@
             "hints": 0
         },
         "assets": []
+    },
+    {
+        "id": "c6bfb040-b185-4f11-880a-5ed1add052bc",
+        "apiId": "api4",
+        "environmentId": "env1",
+        "createdAt": 1470157767000,
+        "summary": {
+            "errors": 4,
+            "warnings": 3,
+            "infos": 2,
+            "hints": 1
+        },
+        "assets": [
+            {
+                "pageId": "e0abd870-cb65-4be0-a65e-001f07c5d980",
+                "type": "SWAGGER",
+                "diagnostics": [
+                    {
+                        "severity": "WARN",
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 1
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 1
+                            }
+                        },
+                        "rule": "operation-operationId",
+                        "message": "Operation must have \"operationId\".",
+                        "path": "paths./echo.options"
+                    }
+                ]
+            },
+            {
+                "pageId": "a5fd25a3-73d7-4338-b027-f24029cfa582",
+                "type": "ASYNCAPI",
+                "diagnostics": []
+            },
+            {
+                "type": "GRAVITEE_DEFINITION",
+                "diagnostics": []
+            }
+        ]
+    },
+    {
+        "id": "26a590f2-05fa-433e-a982-d64c0a274ee9",
+        "apiId": "api5",
+        "environmentId": "env2",
+        "createdAt": 1470157767000,
+        "summary": {
+            "errors": 0,
+            "warnings": 1,
+            "infos": 0,
+            "hints": 0
+        },
+        "assets": [
+            {
+                "pageId": "9a2803c3-6467-49ff-840e-981fb391df94",
+                "type": "SWAGGER",
+                "diagnostics": [
+                    {
+                        "severity": "WARN",
+                        "range": {
+                            "start": {
+                                "line": 1,
+                                "character": 1
+                            },
+                            "end": {
+                                "line": 1,
+                                "character": 1
+                            }
+                        },
+                        "rule": "operation-operationId",
+                        "message": "Operation must have \"operationId\".",
+                        "path": "paths./echo.options"
+                    }
+                ]
+            },
+            {
+                "pageId": "a89bfa49-65ac-4529-abf6-0efdb8415a99",
+                "type": "ASYNCAPI",
+                "diagnostics": []
+            },
+            {
+                "type": "GRAVITEE_DEFINITION",
+                "diagnostics": []
+            }
+        ]
     }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ScoringReportMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ScoringReportMapper.java
@@ -16,9 +16,11 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.scoring.model.EnvironmentApiScoringReport;
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
 import io.gravitee.apim.core.scoring.model.ScoringReportView;
 import io.gravitee.rest.api.management.v2.rest.model.ApiScoring;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentApiScore;
+import io.gravitee.rest.api.management.v2.rest.model.EnvironmentScoringOverview;
 import io.gravitee.rest.api.management.v2.rest.utils.ManagementApiLinkHelper;
 import jakarta.ws.rs.core.UriInfo;
 import org.mapstruct.Mapper;
@@ -43,6 +45,9 @@ public interface ScoringReportMapper {
     @Mapping(target = "hints", source = "source.summary.hints")
     @Mapping(target = "pictureUrl", expression = "java(computePictureUrl(source, uriInfo))")
     EnvironmentApiScore map(EnvironmentApiScoringReport source, UriInfo uriInfo);
+
+    @Mapping(target = "id", source = "source.environmentId")
+    EnvironmentScoringOverview map(EnvironmentOverview source);
 
     @Named("computeApiLinks")
     default String computePictureUrl(EnvironmentApiScoringReport report, UriInfo uriInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
@@ -16,9 +16,11 @@
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
 import io.gravitee.apim.core.scoring.use_case.GetEnvironmentReportsUseCase;
+import io.gravitee.apim.core.scoring.use_case.GetEnvironmentScoringOverviewUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ScoringReportMapper;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentApisScoringResponse;
+import io.gravitee.rest.api.management.v2.rest.model.EnvironmentScoringOverview;
 import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
@@ -43,6 +45,9 @@ public class EnvironmentScoringResource extends AbstractResource {
     @Inject
     private GetEnvironmentReportsUseCase getEnvironmentReportsUseCase;
 
+    @Inject
+    private GetEnvironmentScoringOverviewUseCase getEnvironmentScoringOverviewUseCase;
+
     @Path("apis")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -63,5 +68,16 @@ public class EnvironmentScoringResource extends AbstractResource {
             .pagination(PaginationInfo.computePaginationInfo(totalElements, Math.toIntExact(page.getPageElements()), paginationParam))
             .links(computePaginationLinks(totalElements, paginationParam))
             .build();
+    }
+
+    @Path("overview")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public EnvironmentScoringOverview getScoringEnvironmentOverview() {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var overview = getEnvironmentScoringOverviewUseCase
+            .execute(new GetEnvironmentScoringOverviewUseCase.Input(executionContext.getEnvironmentId()))
+            .overview();
+        return ScoringReportMapper.INSTANCE.map(overview);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -225,6 +225,22 @@ paths:
                     $ref: "#/components/responses/EnvironmentApisScoringResponse"
                 default:
                     $ref: "#/components/responses/Error"
+    /scoring/overview:
+        get:
+            tags:
+                - Scoring
+            summary: Get Scoring Environment Overview
+            operationId: getScoringEnvironmentOverview
+            responses:
+                "200":
+                  description: Scoring overview of the environment
+                  content:
+                    application/json:
+                      schema:
+                        $ref: "#/components/schemas/EnvironmentScoringOverview"
+                default:
+                    $ref: "#/components/responses/Error"
+
 components:
     schemas:
         # Shared policy group
@@ -412,6 +428,30 @@ components:
                 hints:
                     type: integer
                     description: The total number of violated rules with severity HINT for all assets.
+                    example: 40
+
+        EnvironmentScoringOverview:
+            type: object
+            description: The scoring overview of an Environment
+            properties:
+                id:
+                    type: string
+                    description: Environment identifier
+                errors:
+                    type: integer
+                    description: The total number of violated rules with severity ERROR for all APIs.
+                    example: 10
+                warnings:
+                    type: integer
+                    description: The total number of violated rules with severity WARN for all APIs.
+                    example: 20
+                infos:
+                    type: integer
+                    description: The total number of violated rules with severity INFO for all APIs.
+                    example: 30
+                hints:
+                    type: integer
+                    description: The total number of violated rules with severity HINT for all APIs.
                     example: 40
 
         Error:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/EnvironmentOverview.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/EnvironmentOverview.java
@@ -13,17 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.repository.mongodb.management.internal.score;
+package io.gravitee.apim.core.scoring.model;
 
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.ScoringEnvironmentSummary;
-import io.gravitee.repository.mongodb.management.internal.model.ScoringReportMongo;
-import java.util.Collection;
-import java.util.List;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ScoringReportMongoRepositoryCustom {
-    List<ScoringReportMongo> findLatestReports(Collection<String> apiIds);
-    ScoringEnvironmentSummary getScoringEnvironmentSummary(String environmentId);
-}
+public record EnvironmentOverview(String environmentId, Long errors, Long warnings, Long infos, Long hints) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/query_service/ScoringReportQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/query_service/ScoringReportQueryService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.scoring.query_service;
 
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
 import java.util.Collection;
 import java.util.Optional;
@@ -23,4 +24,5 @@ import java.util.stream.Stream;
 public interface ScoringReportQueryService {
     Optional<ScoringReport> findLatestByApiId(String apiId);
     Stream<ScoringReport> findLatestReportsByApiId(Collection<String> apiId);
+    EnvironmentOverview getEnvironmentScoringSummary(String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentScoringOverviewUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentScoringOverviewUseCase.java
@@ -13,19 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra.adapter;
+package io.gravitee.apim.core.scoring.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
-import io.gravitee.apim.core.scoring.model.ScoringReport;
-import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
+import io.gravitee.apim.core.scoring.query_service.ScoringReportQueryService;
+import lombok.RequiredArgsConstructor;
 
-@Mapper
-public interface ScoringReportAdapter {
-    ScoringReportAdapter INSTANCE = Mappers.getMapper(ScoringReportAdapter.class);
+@RequiredArgsConstructor
+@UseCase
+public class GetEnvironmentScoringOverviewUseCase {
 
-    ScoringReport toEntity(io.gravitee.repository.management.model.ScoringReport source);
-    EnvironmentOverview toEntity(io.gravitee.repository.management.model.ScoringEnvironmentSummary source);
+    private final ScoringReportQueryService scoringReportQueryService;
 
-    io.gravitee.repository.management.model.ScoringReport toRepository(ScoringReport source);
+    public Output execute(Input input) {
+        var summary = scoringReportQueryService.getEnvironmentScoringSummary(input.environmentId);
+        return new Output(summary);
+    }
+
+    public record Input(String environmentId) {}
+
+    public record Output(EnvironmentOverview overview) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/scoring/ScoringReportQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/scoring/ScoringReportQueryServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.query_service.scoring;
 
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
 import io.gravitee.apim.core.scoring.query_service.ScoringReportQueryService;
 import io.gravitee.apim.infra.adapter.ScoringReportAdapter;
@@ -55,6 +56,16 @@ public class ScoringReportQueryServiceImpl implements ScoringReportQueryService 
         } catch (TechnicalException e) {
             log.error("An error occurred while finding Scoring Reports by API id", e);
             throw new TechnicalManagementException("An error occurred while finding Scoring Report of API: " + apiIds, e);
+        }
+    }
+
+    @Override
+    public EnvironmentOverview getEnvironmentScoringSummary(String environmentId) {
+        try {
+            return ScoringReportAdapter.INSTANCE.toEntity(scoringReportRepository.getScoringEnvironmentSummary(environmentId));
+        } catch (TechnicalException e) {
+            log.error("An error occurred while getting Scoring Environment Summary of {}", environmentId, e);
+            throw new TechnicalManagementException("An error occurred while getting Scoring Environment Summary of " + environmentId, e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringReportFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringReportFixture.java
@@ -31,6 +31,7 @@ public class ScoringReportFixture {
             .builder()
             .id("report-id")
             .apiId("api-id")
+            .environmentId("environment-id")
             .summary(new ScoringReport.Summary(0L, 1L, 0L, 0L))
             .assets(
                 List.of(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringReportQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringReportQueryServiceInMemory.java
@@ -15,6 +15,7 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
 import io.gravitee.apim.core.scoring.query_service.ScoringReportQueryService;
 import java.util.ArrayList;
@@ -45,6 +46,32 @@ public class ScoringReportQueryServiceInMemory implements ScoringReportQueryServ
     @Override
     public Stream<ScoringReport> findLatestReportsByApiId(Collection<String> apiIds) {
         return storage.stream().filter(report -> apiIds.contains(report.apiId()));
+    }
+
+    @Override
+    public EnvironmentOverview getEnvironmentScoringSummary(String environmentId) {
+        return storage
+            .stream()
+            .filter(report -> report.environmentId().equals(environmentId))
+            .reduce(
+                new EnvironmentOverview(environmentId, 0L, 0L, 0L, 0L),
+                (summary, report) ->
+                    new EnvironmentOverview(
+                        environmentId,
+                        summary.errors() + report.summary().errors(),
+                        summary.warnings() + report.summary().warnings(),
+                        summary.infos() + report.summary().infos(),
+                        summary.hints() + report.summary().hints()
+                    ),
+                (summary1, summary2) ->
+                    new EnvironmentOverview(
+                        environmentId,
+                        summary1.errors() + summary2.errors(),
+                        summary1.warnings() + summary2.warnings(),
+                        summary1.infos() + summary2.infos(),
+                        summary1.hints() + summary2.hints()
+                    )
+            );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentScoringOverviewUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentScoringOverviewUseCaseTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import fixtures.core.model.ScoringReportFixture;
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringReportQueryServiceInMemory;
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
+import io.gravitee.apim.core.scoring.model.ScoringAssetType;
+import io.gravitee.apim.core.scoring.model.ScoringReport;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetEnvironmentScoringOverviewUseCaseTest {
+
+    private static final ZonedDateTime UPDATED_AT = Instant.parse("2023-10-22T10:15:30Z").atZone(ZoneId.systemDefault());
+    private static final String REPORT_ID = "report-id";
+    private static final String ENVIRONMENT_1 = "environment-1";
+    private static final String ENVIRONMENT_2 = "environment-2";
+    private static final String API_ID_1 = "api-1";
+    private static final String API_ID_2 = "api-2";
+    private static final String API_ID_3 = "api-3";
+
+    private static final String PAGE_ID = "page-id";
+    private static final ScoringReport.Asset ASSET = new ScoringReport.Asset(
+        PAGE_ID,
+        ScoringAssetType.SWAGGER,
+        List.of(
+            new ScoringReport.Diagnostic(
+                ScoringReport.Severity.WARN,
+                new ScoringReport.Range(new ScoringReport.Position(17, 12), new ScoringReport.Position(38, 25)),
+                "operation-operationId",
+                "Operation must have \"operationId\".",
+                "paths./echo.options"
+            ),
+            new ScoringReport.Diagnostic(
+                ScoringReport.Severity.ERROR,
+                new ScoringReport.Range(new ScoringReport.Position(10, 4), new ScoringReport.Position(10, 10)),
+                "error-rule",
+                "Error rule message",
+                "paths./error"
+            ),
+            new ScoringReport.Diagnostic(
+                ScoringReport.Severity.INFO,
+                new ScoringReport.Range(new ScoringReport.Position(11, 4), new ScoringReport.Position(11, 10)),
+                "info-rule",
+                "Info rule message",
+                "paths./info"
+            ),
+            new ScoringReport.Diagnostic(
+                ScoringReport.Severity.HINT,
+                new ScoringReport.Range(new ScoringReport.Position(12, 4), new ScoringReport.Position(12, 10)),
+                "hint-rule",
+                "Hint rule message",
+                "paths./hint"
+            )
+        )
+    );
+
+    ScoringReportQueryServiceInMemory scoringReportQueryService = new ScoringReportQueryServiceInMemory();
+
+    GetEnvironmentScoringOverviewUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetEnvironmentScoringOverviewUseCase(scoringReportQueryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(scoringReportQueryService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_return_environment_summary() {
+        // Given
+        givenExistingScoringReports(
+            aReport().toBuilder().apiId(API_ID_1).environmentId(ENVIRONMENT_1).build(),
+            aReport().toBuilder().apiId(API_ID_2).environmentId(ENVIRONMENT_1).build(),
+            aReport().toBuilder().apiId(API_ID_3).environmentId(ENVIRONMENT_2).build()
+        );
+
+        // When
+        var report = useCase.execute(new GetEnvironmentScoringOverviewUseCase.Input(ENVIRONMENT_1));
+
+        // Then
+        Assertions
+            .assertThat(report)
+            .extracting(GetEnvironmentScoringOverviewUseCase.Output::overview)
+            .isEqualTo(new EnvironmentOverview(ENVIRONMENT_1, 2L, 2L, 2L, 2L));
+    }
+
+    private static ScoringReport aReport() {
+        return ScoringReportFixture
+            .aScoringReport()
+            .toBuilder()
+            .id(REPORT_ID)
+            .summary(new ScoringReport.Summary(1L, 1L, 1L, 1L))
+            .assets(List.of(ASSET))
+            .build();
+    }
+
+    private void givenExistingScoringReports(ScoringReport... reports) {
+        givenExistingScoringReports(List.of(reports));
+    }
+
+    private void givenExistingScoringReports(List<ScoringReport> reports) {
+        scoringReportQueryService.initWith(reports);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/scoring/ScoringReportQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/scoring/ScoringReportQueryServiceImplTest.java
@@ -21,10 +21,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
 import io.gravitee.apim.core.scoring.model.ScoringAssetType;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ScoringReportRepository;
+import io.gravitee.repository.management.model.ScoringEnvironmentSummary;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -180,6 +182,37 @@ public class ScoringReportQueryServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalManagementException.class)
                 .hasMessage("An error occurred while finding Scoring Report of API: [api-id]");
+        }
+    }
+
+    @Nested
+    class GetEnvironmentOverview {
+
+        @Test
+        @SneakyThrows
+        void should_find_scoring_report() {
+            when(scoringReportRepository.getScoringEnvironmentSummary(any()))
+                .thenAnswer(invocation -> ScoringEnvironmentSummary.builder().environmentId("environment-id").warnings(1L).build());
+
+            // When
+            var result = service.getEnvironmentScoringSummary("environment-id");
+
+            // Then
+            assertThat(result).isEqualTo(new EnvironmentOverview("environment-id", 0L, 1L, 0L, 0L));
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(scoringReportRepository.getScoringEnvironmentSummary(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.getEnvironmentScoringSummary("environment-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurred while getting Scoring Environment Summary of environment-id");
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5419

## Description

Add endpoint to get environment scoring overview

```
{
  "id": "DEFAULT",
  "errors": 0,
  "warnings": 15,
  "infos": 0,
  "hints": 0
}
```

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

