### PR TITLE
 migrate dictionaries event with latest start or stop publish or unpublish state

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
@@ -35,6 +35,8 @@ import java.util.function.Predicate;
  * @author Titouan COMPIEGNE
  */
 public interface EventService {
+    public static final String EVENT_LATEST_DYNAMIC_SUFFIX = "-dynamic";
+
     EventEntity findById(ExecutionContext executionContext, String id);
 
     EventEntity createApiEvent(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
@@ -63,8 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -208,7 +206,7 @@ public class EventServiceImpl extends TransactionalService implements EventServi
             eventProperties.put(Event.EventProperties.DICTIONARY_ID.getValue(), dictionaryId);
         }
         EventEntity event = createEvent(executionContext, environmentsIds, type, null, eventProperties);
-        createOrPatchLatestEvent(dictionaryId + "-dynamic", event);
+        createOrPatchLatestEvent(dictionaryId + EVENT_LATEST_DYNAMIC_SUFFIX, event);
         return event;
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6914

## Description

 Today when we migrate the dictionaries from event to event_latest ( APIM 3.20 to 4.x ) only the last event is migrated. The problem is that if the last event is not a `PUBLISH_DICTIONARY` we can lose a dictionary on gateway side after the migration. For example a dictionary can pass from published and stoped to only stoped.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

