### PR TITLE
Console: allow to see HealthCheck config with read only permission

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -630,7 +630,7 @@ const apisRoutes: Routes = [
         component: ApiHealthCheckComponent,
         data: {
           permissions: {
-            anyOf: ['api-health-c'],
+            anyOf: ['api-health-r'],
           },
           docs: {
             page: 'management-api-health-check-configure',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6057

## Description

allow to see HealthCheck config with read only permission


![image](https://github.com/user-attachments/assets/59546b35-a06f-4663-9b24-9001f36b4213)
![image](https://github.com/user-attachments/assets/6f17c64f-72e3-42d0-ba9e-fa0f134d4b7c)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcdqpvoldk.chromatic.com)
<!-- Storybook placeholder end -->
