### PR TITLE
fix: don't try to access to /settings in user's pages

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -13,10 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PortalSettings } from './portalSettings';
+import { PortalConfiguration, PortalSettings } from './portalSettings';
 
 export function fakePortalSettings(attributes?: Partial<PortalSettings>): PortalSettings {
   const base: PortalSettings = {
+    ...fakePortalConfiguration(),
+    cors: {
+      allowOrigin: ['test.entrypoint.dev', 'test.entrypoint.dev2'],
+      allowHeaders: ['Cache-Control', 'Pragma'],
+      allowMethods: ['GET', 'DELETE'],
+      exposedHeaders: ['ETag', 'X-Xsrf-Token'],
+      maxAge: 1728000,
+    },
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}
+
+export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration>): PortalConfiguration {
+  const base: PortalConfiguration = {
     portal: {
       entrypoint: 'https://api.company.com',
       apikeyHeader: 'X-Gravitee-Api-Key',

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -16,7 +16,11 @@
 /**
  * TODO: to complete, contains only one part used in the Ui console
  */
-export interface PortalSettings {
+export interface PortalSettings extends PortalConfiguration {
+  cors?: PortalSettingsCors;
+}
+
+export interface PortalConfiguration {
   portal?: PortalSettingsPortal;
   metadata?: PortalSettingsMetadata;
   application?: PortalSettingsApplication;
@@ -86,4 +90,12 @@ export interface PortalSettingsPortal {
       enabled: boolean;
     };
   };
+}
+
+export interface PortalSettingsCors {
+  allowOrigin: string[];
+  allowMethods: string[];
+  allowHeaders: string[];
+  exposedHeaders: string[];
+  maxAge: number;
 }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
@@ -32,7 +32,7 @@ import { filter, map, observeOn, startWith, take, takeUntil, tap } from 'rxjs/op
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { asyncScheduler, Observable, of, Subject } from 'rxjs';
 
-import { PortalSettingsService } from '../../../../../services-ngx/portal-settings.service';
+import { PortalConfigurationService } from '../../../../../services-ngx/portal-configuration.service';
 import { PathV4 } from '../../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 
@@ -91,7 +91,7 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
     private readonly fm: FocusMonitor,
     private readonly elRef: ElementRef,
     protected readonly apiV2Service: ApiV2Service,
-    private readonly portalSettingsService: PortalSettingsService,
+    private readonly portalConfigurationService: PortalConfigurationService,
   ) {
     this.mainForm = new FormGroup({
       listeners: this.listenerFormArray,
@@ -99,7 +99,7 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
   }
 
   ngOnInit(): void {
-    this.portalSettingsService
+    this.portalConfigurationService
       .get()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((settings) => {

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.module.spec.ts
@@ -80,7 +80,7 @@ describe('GioFormListenersContextPathModule', () => {
 
   const expectGetPortalSettings = () => {
     const settings: PortalSettings = { portal: { entrypoint: 'localhost' } };
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/portal`, method: 'GET' }).flush(settings);
   };
 
   const expectApiVerify = (inError = false) => {

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.stories.ts
@@ -23,7 +23,7 @@ import { of } from 'rxjs';
 import { GioFormListenersContextPathComponent } from './gio-form-listeners-context-path.component';
 import { GioFormListenersContextPathModule } from './gio-form-listeners-context-path.module';
 
-import { PortalSettingsService } from '../../../../../services-ngx/portal-settings.service';
+import { PortalConfigurationService } from '../../../../../services-ngx/portal-configuration.service';
 import { ApiService } from '../../../../../services-ngx/api.service';
 
 export default {
@@ -33,7 +33,7 @@ export default {
     moduleMetadata({
       imports: [BrowserAnimationsModule, GioFormListenersContextPathModule, FormsModule, ReactiveFormsModule],
       providers: [
-        { provide: PortalSettingsService, useValue: { get: () => of({ portal: { entrypoint: '' } }) } },
+        { provide: PortalConfigurationService, useValue: { get: () => of({ portal: { entrypoint: '' } }) } },
         { provide: ApiService, useValue: { verify: () => of() } },
       ],
     }),

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-virtual-host/gio-form-listeners-virtual-host.stories.ts
@@ -23,7 +23,7 @@ import { of } from 'rxjs';
 import { GioFormListenersVirtualHostComponent } from './gio-form-listeners-virtual-host.component';
 import { GioFormListenersVirtualHostModule } from './gio-form-listeners-virtual-host.module';
 
-import { PortalSettingsService } from '../../../../../services-ngx/portal-settings.service';
+import { PortalConfigurationService } from '../../../../../services-ngx/portal-configuration.service';
 import { ApiService } from '../../../../../services-ngx/api.service';
 export default {
   title: 'Shared / Form listeners virtual host',
@@ -32,7 +32,7 @@ export default {
     moduleMetadata({
       imports: [BrowserAnimationsModule, GioFormListenersVirtualHostModule, FormsModule, ReactiveFormsModule],
       providers: [
-        { provide: PortalSettingsService, useValue: { get: () => of({ portal: { entrypoint: '' } }) } },
+        { provide: PortalConfigurationService, useValue: { get: () => of({ portal: { entrypoint: '' } }) } },
         { provide: ApiService, useValue: { verify: () => of() } },
       ],
     }),

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.spec.ts
@@ -1678,7 +1678,7 @@ describe('ApiCreationV4Component', () => {
         entrypoint: 'entrypoint',
       },
     };
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/portal`, method: 'GET' }).flush(settings);
   }
 
   function expectVerifyContextPathGetRequest() {

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -681,7 +681,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
 
   function expectGetPortalSettings(): void {
     const settings: PortalSettings = { portal: { entrypoint: 'localhost' } };
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/portal`, method: 'GET' }).flush(settings);
   }
 
   function expectApiVerify(): void {

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -469,7 +469,7 @@ describe('ApiProxyEntrypointsComponent', () => {
       },
     };
     httpTestingController
-      .match({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' })
+      .match({ url: `${CONSTANTS_TESTING.env.baseURL}/portal`, method: 'GET' })
       .filter((r) => !r.cancelled)
       .forEach((r) => r.flush(settings));
     fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { PortalConfigurationService } from './portal-configuration.service';
+
+import { fakePortalConfiguration } from '../entities/portal/portalSettings.fixture';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+
+describe('PortalConfigurationService', () => {
+  let service: PortalConfigurationService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(PortalConfigurationService);
+  });
+
+  describe('getEnvConfiguration', () => {
+    it('should call the API', (done) => {
+      const portalConfigurationToGet = fakePortalConfiguration();
+
+      service.get().subscribe((portalSettings) => {
+        expect(portalSettings).toMatchObject(portalConfigurationToGet);
+        done();
+      });
+
+      httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/portal` }).flush(portalConfigurationToGet);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { PortalConfiguration } from '../entities/portal/portalSettings';
+
+/**
+ * Portal Configuration Service is to be used to read Portal settings regardless of user permissions
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class PortalConfigurationService {
+  constructor(
+    private readonly http: HttpClient,
+    @Inject('Constants') private readonly constants: Constants,
+  ) {}
+
+  get(): Observable<PortalConfiguration> {
+    return this.http.get<PortalConfiguration>(`${this.constants.env.baseURL}/portal`);
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-configuration.service.ts
@@ -27,10 +27,7 @@ import { PortalConfiguration } from '../entities/portal/portalSettings';
   providedIn: 'root',
 })
 export class PortalConfigurationService {
-  constructor(
-    private readonly http: HttpClient,
-    @Inject('Constants') private readonly constants: Constants,
-  ) {}
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   get(): Observable<PortalConfiguration> {
     return this.http.get<PortalConfiguration>(`${this.constants.env.baseURL}/portal`);

--- a/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-settings.service.ts
@@ -20,6 +20,11 @@ import { Observable } from 'rxjs';
 import { Constants } from '../entities/Constants';
 import { PortalSettings } from '../entities/portal/portalSettings';
 
+/**
+ *  Portal Settings Service is used to return the settings for users that have the READ permission for settings at the org or env level
+ *
+ *  Use {@link portal-configuration.service.ts} to access settings open to all users.
+ */
 @Injectable({
   providedIn: 'root',
 })


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6929

## Description

We shouldn't use /settings in non admin page

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-winoncbgov.chromatic.com)
<!-- Storybook placeholder end -->
