### PR TITLE
fix(portal-next): fix redoc viewer style

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-redoc/page-redoc.component.ts
@@ -22,7 +22,14 @@ import { RedocService } from '../../../services/redoc.service';
   selector: 'app-page-redoc',
   standalone: true,
   imports: [],
-  template: `<div id="redoc"></div>`,
+  template: `
+    <style>
+      .api-tab-documentation__side-bar {
+        width: 10%;
+      }
+    </style>
+    <div id="redoc"></div>
+  `,
 })
 export class PageRedocComponent implements AfterViewInit {
   @Input()
@@ -37,7 +44,7 @@ export class PageRedocComponent implements AfterViewInit {
     const redocElement = this.element.nativeElement.querySelector('#redoc');
 
     // Force the right-side panel to join into the middle panel
-    const options = { theme: { breakpoints: { medium: '120rem' } } };
+    const options = { theme: { breakpoints: { medium: '150rem' } } };
 
     this.redocService.init(this.page.content, options, redocElement);
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6781

## Description

Redoc viewer shows a right column displayed outside the page border

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



https://github.com/user-attachments/assets/7ef3bbac-8da8-43c8-9fb3-6167f4cedd3f

<img width="897" alt="Screenshot 2024-09-24 at 14 44 40" src="https://github.com/user-attachments/assets/24456cec-8daa-4ddd-a4a3-81f92c1de8f9">

<img width="845" alt="Screenshot 2024-09-24 at 14 44 49" src="https://github.com/user-attachments/assets/38b9da38-a2ae-4010-b26a-9d567e958b92">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flubcnunmr.chromatic.com)
<!-- Storybook placeholder end -->
