### PR TITLE
fix(portal-next): remove company name from footer

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/footer/footer.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/footer/footer.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2024 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,4 +16,4 @@
 
 -->
 <app-company-title [title]="title" />
-<p>© 2024 {{ company }}. All rights reserved.</p>
+<p>© {{ currentYear }}. All rights reserved.</p>

--- a/gravitee-apim-portal-webui-next/src/components/footer/footer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/footer/footer.component.ts
@@ -27,6 +27,6 @@ import { CompanyTitleComponent } from '../company-title/company-title.component'
 export class FooterComponent {
   @Input()
   title: string = 'Developer Portal';
-  @Input()
-  company: string = 'Gravitee';
+
+  currentYear = new Date().getFullYear().toString();
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6939

## Description

Need to remove Company name from Portal footer

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



<img width="947" alt="Screenshot 2024-09-24 at 15 38 55" src="https://github.com/user-attachments/assets/8f38113b-c988-4cc3-bd6f-84f8337c3639">
