### PR TITLE
feat: score assets using Environment rulesets when defined

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ScoringRulesetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ScoringRulesetRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.ScoringRuleset;
+import java.util.List;
+import java.util.Optional;
+
+public interface ScoringRulesetRepository {
+    ScoringRuleset create(ScoringRuleset report) throws TechnicalException;
+    Optional<ScoringRuleset> findById(String id) throws TechnicalException;
+    List<ScoringRuleset> findAllByReferenceId(String referenceId, String referenceType) throws TechnicalException;
+    void delete(String id) throws TechnicalException;
+    List<String> deleteByReferenceId(String referenceId, String referenceType) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringRuleset.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringRuleset.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@Getter
+@Setter
+@ToString
+public final class ScoringRuleset {
+
+    @EqualsAndHashCode.Include
+    private String id;
+
+    private String name;
+    private String description;
+    private String referenceId;
+    private String referenceType;
+    private Date createdAt;
+    private String payload;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcScoringRulesetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcScoringRulesetRepository.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.repository.management.model.ScoringRuleset;
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+public class JdbcScoringRulesetRepository extends JdbcAbstractCrudRepository<ScoringRuleset, String> implements ScoringRulesetRepository {
+
+    JdbcScoringRulesetRepository(@Value("${management.jdbc.prefix:}") String prefix) {
+        super(prefix, "scoring_rulesets");
+    }
+
+    @Override
+    protected String getId(ScoringRuleset item) {
+        return item.getId();
+    }
+
+    @Override
+    protected JdbcObjectMapper<ScoringRuleset> buildOrm() {
+        return JdbcObjectMapper
+            .builder(ScoringRuleset.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("name", Types.NVARCHAR, String.class)
+            .addColumn("description", Types.NVARCHAR, String.class)
+            .addColumn("payload", Types.NCLOB, String.class)
+            .addColumn("reference_id", Types.NVARCHAR, String.class)
+            .addColumn("reference_type", Types.NVARCHAR, String.class)
+            .addColumn("created_at", Types.TIMESTAMP, Date.class)
+            .build();
+    }
+
+    @Override
+    public List<ScoringRuleset> findAllByReferenceId(String referenceId, String referenceType) throws TechnicalException {
+        var query = "select * from %s where reference_id = ? and reference_type = ?".formatted(this.tableName);
+        return jdbcTemplate.query(query, getOrm().getRowMapper(), referenceId, referenceType);
+    }
+
+    @Override
+    public List<String> deleteByReferenceId(String referenceId, String referenceType) throws TechnicalException {
+        var rows = jdbcTemplate.queryForList(
+            "select id from %s where reference_id = ? and reference_type = ?".formatted(this.tableName),
+            String.class,
+            referenceId,
+            referenceType
+        );
+        if (!rows.isEmpty()) {
+            jdbcTemplate.update(
+                "delete from %s where reference_id = ? and reference_type = ?".formatted(this.tableName),
+                referenceId,
+                referenceType
+            );
+        }
+        return rows;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/08_add_scoring_ruleset_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/08_add_scoring_ruleset_table.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.5.0_add_scoring_rulesets
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}scoring_rulesets
+            columns:
+              - column: { name: id, type: nvarchar(64), constraints: { primaryKey: true, nullable: false } }
+              - column: { name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: name, type: nvarchar(512), constraints: { nullable: false } }
+              - column: { name: description, type: nvarchar(1024) }
+              - column: { name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
+              - column: { name: payload, type: nclob, constraints: { nullable: true } }
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}ref_id_ref_type
+            tableName: ${gravitee_prefix}scoring_rulesets
+            columns:
+              - column:
+                  name: reference_id
+                  type: nvarchar(64)
+              - column:
+                  name: reference_type
+                  type: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -209,3 +209,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_0/06_add_scoring_table.yml
     - include:
           - file: liquibase/changelogs/v4_5_0/07_add_media_org_env.yml
+    - include:
+          - file: liquibase/changelogs/v4_5_0/08_add_scoring_ruleset_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -146,6 +146,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "sharedpolicygrouphistories",
         "scoring_reports",
         "scoring_report_summary",
+        "scoring_rulesets",
         "portal_menu_links"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoScoringRulesetRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoScoringRulesetRepository.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.IntegrationRepository;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.model.Integration;
+import io.gravitee.repository.management.model.ScoringRuleset;
+import io.gravitee.repository.mongodb.management.internal.integration.IntegrationMongoRepository;
+import io.gravitee.repository.mongodb.management.internal.model.IntegrationMongo;
+import io.gravitee.repository.mongodb.management.internal.model.ScoringRulesetMongo;
+import io.gravitee.repository.mongodb.management.internal.score.ScoringRulesetMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MongoScoringRulesetRepository implements ScoringRulesetRepository {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ScoringRulesetMongoRepository internalRepository;
+    private final GraviteeMapper mapper;
+
+    @Override
+    public Optional<ScoringRuleset> findById(String s) throws TechnicalException {
+        logger.debug("Find ruleset by id [{}]", s);
+        var result = internalRepository.findById(s).map(this::map);
+        logger.debug("Find ruleset by id [{}] - Done", s);
+        return result;
+    }
+
+    @Override
+    public ScoringRuleset create(ScoringRuleset ruleset) throws TechnicalException {
+        logger.debug("Create ruleset [{}]", ruleset.getId());
+        var created = map(internalRepository.insert(map(ruleset)));
+        logger.debug("Create ruleset [{}] - Done", created.getId());
+        return created;
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        logger.debug("Delete ruleset [{}]", id);
+        internalRepository.deleteById(id);
+        logger.debug("Delete ruleset [{}] - Done", id);
+    }
+
+    @Override
+    public List<ScoringRuleset> findAllByReferenceId(String referenceId, String referenceType) {
+        logger.debug("Search by reference [{}={}]", referenceType, referenceId);
+
+        var result = internalRepository.findByReferenceIdAndReferenceType(referenceId, referenceType).stream().map(mapper::map).toList();
+
+        logger.debug("Search by reference [{}={}] - Done", referenceType, referenceId);
+        return result;
+    }
+
+    @Override
+    public List<String> deleteByReferenceId(String referenceId, String referenceType) throws TechnicalException {
+        logger.debug("Delete by reference: [{}={}]", referenceType, referenceId);
+        try {
+            List<String> all = internalRepository
+                .deleteByReferenceIdAAndReferenceType(referenceId, referenceType)
+                .stream()
+                .map(ScoringRulesetMongo::getId)
+                .toList();
+            logger.debug("Delete by reference: [{}={}] - Done", referenceType, referenceId);
+            return all;
+        } catch (Exception ex) {
+            logger.error("Failed to delete ruleset by Reference: [{}={}]", referenceType, referenceId, ex);
+            throw new TechnicalException("Failed to delete ruleset by Reference");
+        }
+    }
+
+    private ScoringRuleset map(ScoringRulesetMongo source) {
+        return mapper.map(source);
+    }
+
+    private ScoringRulesetMongo map(ScoringRuleset source) {
+        return mapper.map(source);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}scoring_rulesets")
+public class ScoringRulesetMongo extends Auditable {
+
+    @Id
+    private String id;
+
+    private String name;
+    private String description;
+    private String payload;
+    private String referenceId;
+    private String referenceType;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringRulesetMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringRulesetMongoRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.score;
+
+import io.gravitee.repository.mongodb.management.internal.model.ScoringRulesetMongo;
+import java.util.List;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScoringRulesetMongoRepository extends MongoRepository<ScoringRulesetMongo, String> {
+    @Query(value = "{ referenceId: ?0, referenceType: ?1 }", fields = "{ _id : 1 }", delete = true)
+    List<ScoringRulesetMongo> deleteByReferenceIdAAndReferenceType(String referenceId, String referenceType);
+
+    @Query(value = "{ referenceId: ?0, referenceType: ?1 }")
+    List<ScoringRulesetMongo> findByReferenceIdAndReferenceType(String referenceId, String referenceType);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -339,4 +339,6 @@ public interface GraviteeMapper {
     List<ScoringReport> map(List<ScoringReportMongo> source);
 
     ScoringReportMongo map(ScoringReport source);
+    ScoringRuleset map(ScoringRulesetMongo source);
+    ScoringRulesetMongo map(ScoringRuleset source);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/scoringrulesets/scorings/ReferenceIdReferenceTypeIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/scoringrulesets/scorings/ReferenceIdReferenceTypeIndexUpgrader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.scoringrulesets.scorings;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("ScoringRulesetReferenceIdReferenceTypeIndexUpgrader")
+public class ReferenceIdReferenceTypeIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("scoring_rulesets")
+            .name("ri1rt1")
+            .key("referenceId", ascending())
+            .key("referenceType", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -146,6 +146,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected ScoringReportRepository scoringReportRepository;
 
     @Inject
+    protected ScoringRulesetRepository scoringRulesetRepository;
+
+    @Inject
     protected DashboardRepository dashboardRepository;
 
     @Inject
@@ -283,6 +286,8 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             apiQualityRuleRepository.create(apiQualityRule);
         } else if (object instanceof ScoringReport scoringReport) {
             scoringReportRepository.create(scoringReport);
+        } else if (object instanceof ScoringRuleset scoringRuleset) {
+            scoringRulesetRepository.create(scoringRuleset);
         } else if (object instanceof Dashboard apiQualityRule) {
             dashboardRepository.create(apiQualityRule);
         } else if (object instanceof AlertEvent alertEvent) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ScoringRulesetRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ScoringRulesetRepositoryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.common.utils.UUID;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.model.Integration;
+import io.gravitee.repository.management.model.ScoringRuleset;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+public class ScoringRulesetRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/scoringruleset-tests/";
+    }
+
+    // create
+    @Test
+    public void create_should_create_ruleset() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        var ruleset = aRuleset(uuid, date);
+
+        var created = scoringRulesetRepository.create(ruleset);
+
+        assertThat(created).usingRecursiveComparison().isEqualTo(ruleset);
+    }
+
+    @Test
+    public void create_should_throw_when_creating_same_id() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        var ruleset = aRuleset(uuid, date);
+
+        scoringRulesetRepository.create(ruleset);
+        assertThatThrownBy(() -> scoringRulesetRepository.create(ruleset)).isInstanceOf(Exception.class);
+    }
+
+    // findById
+    @Test
+    public void findById_should_return_found_ruleset() throws TechnicalException {
+        var found = scoringRulesetRepository.findById("ruleset1");
+
+        assertThat(found).isPresent().get().extracting(ScoringRuleset::getId).isEqualTo("ruleset1");
+    }
+
+    @Test
+    public void findById_should_return_empty_when_not_found() throws TechnicalException {
+        var found = scoringRulesetRepository.findById("unknown");
+
+        assertThat(found).isEmpty();
+    }
+
+    // findAllByReferenceId
+    @Test
+    public void findAllByReferenceId_should_return_found_rulesets() throws TechnicalException {
+        var found = scoringRulesetRepository.findAllByReferenceId("my-env", "ENVIRONMENT");
+
+        assertThat(found).hasSize(2).are(anyOf(haveId("ruleset1"), haveId("ruleset2")));
+    }
+
+    @Test
+    public void findAllByReferenceId_should_return_empty_list_when_no_result() throws TechnicalException {
+        var result = scoringRulesetRepository.findAllByReferenceId("unknown", "ENVIRONMENT");
+
+        assertThat(result).isEmpty();
+    }
+
+    // delete
+    @Test
+    public void delete_should_delete_ruleset() throws TechnicalException {
+        var id = "to-delete";
+
+        integrationRepository.delete(id);
+
+        assertThat(integrationRepository.findById(id)).isEmpty();
+    }
+
+    // deleteByReferenceId
+    @Test
+    public void should_delete_by_reference_id() throws TechnicalException {
+        int nbBeforeDeletion = scoringRulesetRepository.findAllByReferenceId("ToBeDeleted", "ENVIRONMENT").size();
+        int deleted = scoringRulesetRepository.deleteByReferenceId("ToBeDeleted", "ENVIRONMENT").size();
+        int nbAfterDeletion = scoringRulesetRepository.findAllByReferenceId("ToBeDeleted", "ENVIRONMENT").size();
+
+        assertThat(nbBeforeDeletion).isEqualTo(2);
+        assertThat(deleted).isEqualTo(2);
+        assertThat(nbAfterDeletion).isZero();
+    }
+
+    private static ScoringRuleset aRuleset(String uuid, Date date) {
+        return ScoringRuleset
+            .builder()
+            .id(uuid)
+            .name("ruleset-name")
+            .description("ruleset-description")
+            .referenceType("ENVIRONMENT")
+            .referenceId("my-env")
+            .createdAt(date)
+            .payload("ruleset-payload")
+            .build();
+    }
+
+    Condition<ScoringRuleset> haveId(String id) {
+        return new Condition<>(e -> id.equals(e.getId()), "have the id " + id);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/scoringruleset-tests/scoringRulesets.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/scoringruleset-tests/scoringRulesets.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": "ruleset1",
+        "referenceId": "my-env",
+        "referenceType": "ENVIRONMENT",
+        "name": "Ruleset 1",
+        "description": "description 1",
+        "payload": "payload 1",
+        "createdAt": 1470157767000
+    },
+    {
+        "id": "ruleset2",
+        "referenceId": "my-env",
+        "referenceType": "ENVIRONMENT",
+        "name": "Ruleset 2",
+        "description": "description 2",
+        "payload": "payload 2",
+        "createdAt": 1470157767000
+    },
+    {
+        "id": "to-delete",
+        "referenceId": "env1",
+        "referenceType": "ENVIRONMENT",
+        "name": "Ruleset",
+        "description": "description",
+        "payload": "payload",
+        "createdAt": 1470157767000
+    },
+    {
+        "id": "86adbd41-8a3f-45f3-b1ca-f980042db19d",
+        "referenceId": "ToBeDeleted",
+        "referenceType": "ENVIRONMENT",
+        "name": "Ruleset",
+        "description": "description",
+        "payload": "payload",
+        "createdAt": 1470157767000
+    },
+    {
+        "id": "b8c2ef52-ebb5-4d0f-be1e-a41cc5579fc8",
+        "referenceId": "ToBeDeleted",
+        "referenceType": "ENVIRONMENT",
+        "name": "Ruleset",
+        "description": "description",
+        "payload": "payload",
+        "createdAt": 1470157767000
+    }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ScoringRulesetMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ScoringRulesetMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Mapper(uses = { ConfigurationSerializationMapper.class, DateMapper.class })
+public interface ScoringRulesetMapper {
+    Logger logger = LoggerFactory.getLogger(ScoringRulesetMapper.class);
+    ScoringRulesetMapper INSTANCE = Mappers.getMapper(ScoringRulesetMapper.class);
+
+    ScoringRuleset map(io.gravitee.apim.core.scoring.model.ScoringRuleset source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
 import io.gravitee.apim.core.scoring.use_case.GetEnvironmentReportsUseCase;
 import io.gravitee.apim.core.scoring.use_case.GetEnvironmentScoringOverviewUseCase;
+import io.gravitee.apim.core.scoring.use_case.ImportEnvironmentRulesetUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ScoringReportMapper;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentApisScoringResponse;
@@ -32,6 +33,7 @@ import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.UriInfo;
 import lombok.extern.slf4j.Slf4j;
@@ -42,11 +44,17 @@ public class EnvironmentScoringResource extends AbstractResource {
     @Context
     protected UriInfo uriInfo;
 
+    @Context
+    private ResourceContext resourceContext;
+
     @Inject
     private GetEnvironmentReportsUseCase getEnvironmentReportsUseCase;
 
     @Inject
     private GetEnvironmentScoringOverviewUseCase getEnvironmentScoringOverviewUseCase;
+
+    @Inject
+    private ImportEnvironmentRulesetUseCase importEnvironmentRulesetUseCase;
 
     @Path("apis")
     @GET
@@ -79,5 +87,10 @@ public class EnvironmentScoringResource extends AbstractResource {
             .execute(new GetEnvironmentScoringOverviewUseCase.Input(executionContext.getEnvironmentId()))
             .overview();
         return ScoringReportMapper.INSTANCE.map(overview);
+    }
+
+    @Path("rulesets")
+    public EnvironmentScoringRulesetsResource getEnvironmentScoringRulesetsResource() {
+        return resourceContext.getResource(EnvironmentScoringRulesetsResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.scoring.use_case.DeleteEnvironmentRulesetUseCase;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnvironmentScoringRulesetResource extends AbstractResource {
+
+    @PathParam("rulesetId")
+    String rulesetId;
+
+    @Inject
+    private DeleteEnvironmentRulesetUseCase deleteEnvironmentRulesetUseCase;
+
+    @DELETE
+    public Response deleteRuleset() {
+        deleteEnvironmentRulesetUseCase.execute(new DeleteEnvironmentRulesetUseCase.Input(rulesetId, getAuditInfo()));
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import io.gravitee.apim.core.scoring.use_case.ImportEnvironmentRulesetUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.model.ImportScoringRuleset;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnvironmentScoringRulesetsResource extends AbstractResource {
+
+    @Context
+    protected UriInfo uriInfo;
+
+    @Inject
+    private ImportEnvironmentRulesetUseCase importEnvironmentRulesetUseCase;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response importRuleset(@Valid ImportScoringRuleset request) {
+        var result = importEnvironmentRulesetUseCase.execute(
+            new ImportEnvironmentRulesetUseCase.Input(
+                new ImportEnvironmentRulesetUseCase.NewRuleset(request.getName(), request.getDescription(), request.getPayload()),
+                getAuditInfo()
+            )
+        );
+
+        return Response.created(uriInfo.getRequestUri().resolve(result.rulesetId())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
@@ -28,7 +28,9 @@ import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
@@ -39,6 +41,9 @@ public class EnvironmentScoringRulesetsResource extends AbstractResource {
 
     @Context
     protected UriInfo uriInfo;
+
+    @Context
+    private ResourceContext resourceContext;
 
     @Inject
     private ImportEnvironmentRulesetUseCase importEnvironmentRulesetUseCase;
@@ -66,5 +71,10 @@ public class EnvironmentScoringRulesetsResource extends AbstractResource {
         var executionContext = GraviteeContext.getExecutionContext();
         var result = getEnvironmentRulesetsUseCase.execute(new GetEnvironmentRulesetsUseCase.Input(executionContext.getEnvironmentId()));
         return ScoringRulesetsResponse.builder().data(result.reports().stream().map(ScoringRulesetMapper.INSTANCE::map).toList()).build();
+    }
+
+    @Path("{rulesetId}")
+    public EnvironmentScoringRulesetResource getEnvironmentScoringRulesetResource() {
+        return resourceContext.getResource(EnvironmentScoringRulesetResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
@@ -15,13 +15,18 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
+import io.gravitee.apim.core.scoring.use_case.GetEnvironmentRulesetsUseCase;
 import io.gravitee.apim.core.scoring.use_case.ImportEnvironmentRulesetUseCase;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.ScoringRulesetMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ImportScoringRuleset;
+import io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetsResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
@@ -38,6 +43,9 @@ public class EnvironmentScoringRulesetsResource extends AbstractResource {
     @Inject
     private ImportEnvironmentRulesetUseCase importEnvironmentRulesetUseCase;
 
+    @Inject
+    private GetEnvironmentRulesetsUseCase getEnvironmentRulesetsUseCase;
+
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
@@ -50,5 +58,13 @@ public class EnvironmentScoringRulesetsResource extends AbstractResource {
         );
 
         return Response.created(uriInfo.getRequestUri().resolve(result.rulesetId())).build();
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public ScoringRulesetsResponse listRulesets() {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var result = getEnvironmentRulesetsUseCase.execute(new GetEnvironmentRulesetsUseCase.Input(executionContext.getEnvironmentId()));
+        return ScoringRulesetsResponse.builder().data(result.reports().stream().map(ScoringRulesetMapper.INSTANCE::map).toList()).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -269,6 +269,20 @@ paths:
                     $ref: "#/components/responses/ScoringRulesetsResponse"
                 default:
                     $ref: "#/components/responses/Error"
+    /scoring/rulesets/{rulesetId}:
+        delete:
+            tags:
+                - Scoring
+                - Rulesets
+            summary: Delete a ruleset
+            operationId: deleteEnvironmentRuleset
+            parameters:
+                - $ref: "#/components/parameters/rulesetId"
+            responses:
+                "204":
+                    description: Ruleset deleted
+                default:
+                    $ref: "#/components/responses/Error"
 
 components:
     schemas:
@@ -683,6 +697,15 @@ components:
                     - -updatedAt
                     - deployedAt
                     - -deployedAt
+
+        # Scoring
+        rulesetId:
+            name: rulesetId
+            in: path
+            description: The unique ID of ruleset
+            required: true
+            schema:
+                type: string
     responses:
         SchemaFormResponse:
             description: Schema form of a plugin

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -258,6 +258,17 @@ paths:
                     description: Ruleset created
                 default:
                     $ref: "#/components/responses/Error"
+        get:
+            tags:
+                - Scoring
+                - Rulesets
+            summary: Get all rulesets at environment level
+            operationId: getEnvironmentRulesets
+            responses:
+                "200":
+                    $ref: "#/components/responses/ScoringRulesetsResponse"
+                default:
+                    $ref: "#/components/responses/Error"
 
 components:
     schemas:
@@ -491,6 +502,36 @@ components:
                 payload:
                     type: string
                     description: The ruleset payload
+        ScoringRuleset:
+            type: object
+            description: A scoring ruleset
+            properties:
+                id:
+                    type: string
+                    description: The id of ruleset
+                name:
+                    type: string
+                    description: The name of ruleset
+                description:
+                    type: string
+                    description: The description of ruleset
+                payload:
+                    type: string
+                    description: The ruleset payload
+                createdAt:
+                    type: string
+                    format: date-time
+                    description: The date at which the ruleset was created
+                    example: 2020-01-01T00:00:00Z
+                referenceId:
+                    type: string
+                    description: The reference Id of ruleset
+                referenceType:
+                    $ref: "#/components/schemas/ScoringRulesetReferenceType"
+        ScoringRulesetReferenceType:
+            type: string
+            enum:
+                - ENVIRONMENT
 
         Error:
             type: object
@@ -705,6 +746,18 @@ components:
                                 $ref: "#/components/schemas/Pagination"
                             links:
                                 $ref: "#/components/schemas/Links"
+        ScoringRulesetsResponse:
+            description: Scoring rulesets list
+            content:
+                application/json:
+                    schema:
+                        title: "ScoringRulesetsResponse"
+                        properties:
+                            data:
+                                description: List of rulesets.
+                                type: array
+                                items:
+                                    $ref: "#/components/schemas/ScoringRuleset"
 
     securitySchemes:
         BasicAuth:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -233,11 +233,29 @@ paths:
             operationId: getScoringEnvironmentOverview
             responses:
                 "200":
-                  description: Scoring overview of the environment
-                  content:
+                    description: Scoring overview of the environment
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/EnvironmentScoringOverview"
+                default:
+                    $ref: "#/components/responses/Error"
+    /scoring/rulesets:
+        post:
+            tags:
+                - Scoring
+                - Rulesets
+            summary: Create a new ruleset at environment level
+            operationId: createEnvironmentRuleset
+            requestBody:
+                content:
                     application/json:
-                      schema:
-                        $ref: "#/components/schemas/EnvironmentScoringOverview"
+                        schema:
+                            $ref: "#/components/schemas/ImportScoringRuleset"
+                required: true
+            responses:
+                "201":
+                    description: Ruleset created
                 default:
                     $ref: "#/components/responses/Error"
 
@@ -433,7 +451,6 @@ components:
                     type: integer
                     description: The total number of violated rules with severity HINT for all assets.
                     example: 40
-
         EnvironmentScoringOverview:
             type: object
             description: The scoring overview of an Environment
@@ -442,9 +459,9 @@ components:
                     type: string
                     description: Environment identifier
                 score:
-                  type: number
-                  description: The average score of all APIs
-                  example: 0.74
+                    type: number
+                    description: The average score of all APIs
+                    example: 0.74
                 errors:
                     type: integer
                     description: The total number of violated rules with severity ERROR for all APIs.
@@ -461,6 +478,19 @@ components:
                     type: integer
                     description: The total number of violated rules with severity HINT for all APIs.
                     example: 40
+        ImportScoringRuleset:
+            type: object
+            description: The scoring ruleset to import
+            properties:
+                name:
+                    type: string
+                    description: The name of ruleset
+                description:
+                    type: string
+                    description: The description of ruleset
+                payload:
+                    type: string
+                    description: The ruleset payload
 
         Error:
             type: object
@@ -595,23 +625,23 @@ components:
                 type: string
                 example: my shared policy group
         sharedPolicyGroupHistoriesSortByParam:
-                name: sortBy
-                in: query
-                required: false
-                description: |-
-                    Possibility to sort Shared Policy Group history results by field.
-                    Can be ascending or descending with minus '-' prefix.
-                    By default, no sort is applied.
-                schema:
-                    type: string
-                    example: name
-                    enum:
-                        - version
-                        - -version
-                        - updatedAt
-                        - -updatedAt
-                        - deployedAt
-                        - -deployedAt
+            name: sortBy
+            in: query
+            required: false
+            description: |-
+                Possibility to sort Shared Policy Group history results by field.
+                Can be ascending or descending with minus '-' prefix.
+                By default, no sort is applied.
+            schema:
+                type: string
+                example: name
+                enum:
+                    - version
+                    - -version
+                    - updatedAt
+                    - -updatedAt
+                    - deployedAt
+                    - -deployedAt
     responses:
         SchemaFormResponse:
             description: Schema form of a plugin

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/assertions/ResponseAssert.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/assertions/ResponseAssert.java
@@ -15,6 +15,8 @@
  */
 package assertions;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import jakarta.ws.rs.core.Response;
 import org.assertj.core.api.AbstractObjectAssert;
@@ -32,6 +34,12 @@ public class ResponseAssert extends AbstractObjectAssert<ResponseAssert, Respons
         if (actual.getStatus() != status) {
             failWithMessage("Expected response status to be <%s> but was <%s>", status, actual.getStatus());
         }
+        return this;
+    }
+
+    public ResponseAssert hasHeader(String name, String value) {
+        isNotNull();
+        assertThat(actual.getHeaderString(name)).isEqualTo(value);
         return this;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringResourceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.doReturn;
 import fixtures.core.model.ScoringReportFixture;
 import inmemory.InMemoryAlternative;
 import inmemory.ScoringReportQueryServiceInMemory;
+import inmemory.ScoringRulesetCrudServiceInMemory;
 import io.gravitee.apim.core.scoring.model.ScoringReport;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentApiScore;
@@ -31,6 +32,7 @@ import io.gravitee.rest.api.management.v2.rest.model.Pagination;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
@@ -57,6 +59,9 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
     @Inject
     ScoringReportQueryServiceInMemory scoringReportQueryService;
 
+    @Inject
+    ScoringRulesetCrudServiceInMemory scoringRulesetCrudService;
+
     @Override
     protected String contextPath() {
         return "/environments/" + ENVIRONMENT;
@@ -80,9 +85,10 @@ class EnvironmentScoringResourceTest extends AbstractResourceTest {
     @Override
     public void tearDown() {
         super.tearDown();
+        UuidString.reset();
         GraviteeContext.cleanContext();
 
-        Stream.of(scoringReportQueryService).forEach(InMemoryAlternative::reset);
+        Stream.of(scoringReportQueryService, scoringRulesetCrudService).forEach(InMemoryAlternative::reset);
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetResourceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+
+import assertions.MAPIAssertions;
+import assertions.RestApiAssertions;
+import fixtures.core.model.ScoringRulesetFixture;
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringRulesetCrudServiceInMemory;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentScoringRulesetResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+
+    WebTarget rootTarget;
+
+    @Inject
+    ScoringRulesetCrudServiceInMemory scoringRulesetCrudService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/scoring/rulesets";
+    }
+
+    @BeforeEach
+    void setup() {
+        rootTarget = rootTarget();
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        doReturn(environmentEntity).when(environmentService).findById(ENVIRONMENT);
+        doReturn(environmentEntity).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        UuidString.reset();
+        GraviteeContext.cleanContext();
+
+        Stream.of(scoringRulesetCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class DeleteEnvironmentRuleset {
+
+        @Test
+        void should_delete_a_ruleset() {
+            // Given
+            scoringRulesetCrudService.initWith(List.of(ScoringRulesetFixture.aRuleset("ruleset-id").withReferenceId(ENVIRONMENT)));
+
+            // When
+            var response = rootTarget.path("ruleset-id").request().delete();
+
+            // Then
+            assertThat(response).hasStatus(HttpStatusCode.NO_CONTENT_204);
+            assertThat(scoringRulesetCrudService.storage()).isEmpty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.doReturn;
+
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringRulesetCrudServiceInMemory;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.v2.rest.model.ImportScoringRuleset;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+
+    WebTarget target;
+
+    @Inject
+    ScoringRulesetCrudServiceInMemory scoringRulesetCrudService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/scoring/rulesets";
+    }
+
+    @BeforeEach
+    void setup() {
+        target = rootTarget();
+
+        EnvironmentEntity environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        doReturn(environmentEntity).when(environmentService).findById(ENVIRONMENT);
+        doReturn(environmentEntity).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        UuidString.reset();
+        GraviteeContext.cleanContext();
+
+        Stream.of(scoringRulesetCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Nested
+    class ImportEnvironmentRuleset {
+
+        @Test
+        void should_create_ruleset() {
+            // Given
+            var request = ImportScoringRuleset
+                .builder()
+                .name("ruleset-name")
+                .description("ruleset-description")
+                .payload("ruleset-payload")
+                .build();
+
+            // When
+            target.request().post(json(request));
+
+            // Then
+            assertThat(scoringRulesetCrudService.storage())
+                .extracting(ScoringRuleset::name, ScoringRuleset::description, ScoringRuleset::payload)
+                .containsExactly(tuple("ruleset-name", "ruleset-description", "ruleset-payload"));
+        }
+
+        @Test
+        void should_set_location_header_with_created_ruleset_url() {
+            // Given
+            UuidString.overrideGenerator(() -> "generated-id");
+            var request = ImportScoringRuleset
+                .builder()
+                .name("ruleset-name")
+                .description("ruleset-description")
+                .payload("ruleset-payload")
+                .build();
+
+            // When
+            Response response = target.request().post(json(request));
+
+            // Then
+            assertThat(response)
+                .hasStatus(HttpStatusCode.CREATED_201)
+                .hasHeader("Location", target.path("generated-id").getUri().toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResourceTest.java
@@ -20,11 +20,13 @@ import static jakarta.ws.rs.client.Entity.json;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.doReturn;
 
+import fixtures.core.model.ScoringRulesetFixture;
 import inmemory.InMemoryAlternative;
 import inmemory.ScoringRulesetCrudServiceInMemory;
 import io.gravitee.apim.core.scoring.model.ScoringRuleset;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.v2.rest.model.ImportScoringRuleset;
+import io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetsResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -32,7 +34,11 @@ import io.gravitee.rest.api.service.common.UuidString;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -114,6 +120,53 @@ class EnvironmentScoringRulesetsResourceTest extends AbstractResourceTest {
             assertThat(response)
                 .hasStatus(HttpStatusCode.CREATED_201)
                 .hasHeader("Location", target.path("generated-id").getUri().toString());
+        }
+    }
+
+    @Nested
+    class ListEnvironmentRulesets {
+
+        @Test
+        void should_return_rulesets() {
+            // Given
+            scoringRulesetCrudService.initWith(
+                List.of(
+                    ScoringRulesetFixture.aRuleset().toBuilder().id("ruleset1").referenceId(ENVIRONMENT).build(),
+                    ScoringRulesetFixture.aRuleset().toBuilder().id("ruleset2").referenceId(ENVIRONMENT).build()
+                )
+            );
+
+            // When
+            var response = target.request().get();
+
+            // Then
+            assertThat(response)
+                .hasStatus(HttpStatusCode.OK_200)
+                .asEntity(ScoringRulesetsResponse.class)
+                .extracting(ScoringRulesetsResponse::getData)
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
+                .containsExactly(
+                    io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset
+                        .builder()
+                        .id("ruleset1")
+                        .name("ruleset-name")
+                        .description("ruleset-description")
+                        .payload("ruleset-payload")
+                        .referenceId(ENVIRONMENT)
+                        .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetReferenceType.ENVIRONMENT)
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
+                        .build(),
+                    io.gravitee.rest.api.management.v2.rest.model.ScoringRuleset
+                        .builder()
+                        .id("ruleset2")
+                        .name("ruleset-name")
+                        .description("ruleset-description")
+                        .payload("ruleset-payload")
+                        .referenceId(ENVIRONMENT)
+                        .referenceType(io.gravitee.rest.api.management.v2.rest.model.ScoringRulesetReferenceType.ENVIRONMENT)
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atOffset(ZoneOffset.UTC))
+                        .build()
+                );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/crud_service/ScoringRulesetCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/crud_service/ScoringRulesetCrudService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.crud_service;
+
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import java.util.Optional;
+
+public interface ScoringRulesetCrudService {
+    ScoringRuleset create(ScoringRuleset ruleset);
+    Optional<ScoringRuleset> findById(String id);
+    void delete(String id);
+    void deleteByReference(String referenceId, ScoringRuleset.ReferenceType referenceType);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoreRequest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoreRequest.java
@@ -15,8 +15,21 @@
  */
 package io.gravitee.apim.core.scoring.model;
 
+import static java.util.Collections.emptyList;
+
 import java.util.List;
 
-public record ScoreRequest(String jobId, String organizationId, String environmentId, String apiId, List<AssetToScore> assets) {
+public record ScoreRequest(
+    String jobId,
+    String organizationId,
+    String environmentId,
+    String apiId,
+    List<AssetToScore> assets,
+    List<String> customRulesets
+) {
+    public ScoreRequest(String jobId, String organizationId, String environmentId, String apiId, List<AssetToScore> assets) {
+        this(jobId, organizationId, environmentId, apiId, assets, emptyList());
+    }
+
     public record AssetToScore(String assetId, ScoringAssetType assetType, String assetName, String content) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoringRuleset.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoringRuleset.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.model;
+
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.With;
+
+@Builder(toBuilder = true)
+public record ScoringRuleset(
+    String id,
+    String name,
+    String description,
+    @With String referenceId,
+    ReferenceType referenceType,
+    String payload,
+    ZonedDateTime createdAt
+) {
+    public enum ReferenceType {
+        ENVIRONMENT,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/query_service/ScoringRulesetQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/query_service/ScoringRulesetQueryService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.query_service;
+
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import java.util.List;
+
+public interface ScoringRulesetQueryService {
+    List<ScoringRuleset> findByReference(String referenceId, ScoringRuleset.ReferenceType referenceType);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/DeleteEnvironmentRulesetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/DeleteEnvironmentRulesetUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.scoring.crud_service.ScoringRulesetCrudService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class DeleteEnvironmentRulesetUseCase {
+
+    private final ScoringRulesetCrudService scoringRulesetCrudService;
+
+    public void execute(Input input) {
+        var found = scoringRulesetCrudService
+            .findById(input.rulesetId)
+            .filter(ruleset -> ruleset.referenceId().equals(input.auditInfo.environmentId()));
+
+        if (found.isPresent()) {
+            scoringRulesetCrudService.delete(input.rulesetId);
+        }
+    }
+
+    public record Input(String rulesetId, AuditInfo auditInfo) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentRulesetsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetEnvironmentRulesetsUseCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.apim.core.scoring.query_service.ScoringRulesetQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class GetEnvironmentRulesetsUseCase {
+
+    private final ScoringRulesetQueryService scoringRulesetQueryService;
+
+    public Output execute(Input input) {
+        var result = scoringRulesetQueryService.findByReference(input.environmentId(), ScoringRuleset.ReferenceType.ENVIRONMENT);
+        return new Output(result);
+    }
+
+    public record Input(String environmentId) {}
+
+    public record Output(List<ScoringRuleset> reports) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ImportEnvironmentRulesetUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ImportEnvironmentRulesetUseCase.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.scoring.crud_service.ScoringRulesetCrudService;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class ImportEnvironmentRulesetUseCase {
+
+    private final ScoringRulesetCrudService scoringRulesetCrudService;
+
+    public Output execute(Input input) {
+        var created = scoringRulesetCrudService.create(
+            new ScoringRuleset(
+                UuidString.generateRandom(),
+                input.newRuleset.name(),
+                input.newRuleset.description(),
+                input.auditInfo.environmentId(),
+                ScoringRuleset.ReferenceType.ENVIRONMENT,
+                input.newRuleset.payload(),
+                TimeProvider.now()
+            )
+        );
+        return new Output(created.id());
+    }
+
+    public record Input(NewRuleset newRuleset, AuditInfo auditInfo) {}
+
+    public record NewRuleset(String name, String description, String payload) {}
+
+    public record Output(String rulesetId) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ScoringRulesetAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ScoringRulesetAdapter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ScoringRulesetAdapter {
+    ScoringRulesetAdapter INSTANCE = Mappers.getMapper(ScoringRulesetAdapter.class);
+
+    ScoringRuleset toEntity(io.gravitee.repository.management.model.ScoringRuleset source);
+    io.gravitee.repository.management.model.ScoringRuleset toRepository(ScoringRuleset source);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/scoring/ScoringRulesetCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/scoring/ScoringRulesetCrudServiceImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.scoring;
+
+import io.gravitee.apim.core.scoring.crud_service.ScoringRulesetCrudService;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.apim.infra.adapter.ScoringReportAdapter;
+import io.gravitee.apim.infra.adapter.ScoringRulesetAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ScoringRulesetCrudServiceImpl extends AbstractService implements ScoringRulesetCrudService {
+
+    private final ScoringRulesetRepository scoringRulesetRepository;
+
+    public ScoringRulesetCrudServiceImpl(@Lazy ScoringRulesetRepository scoringRulesetRepository) {
+        this.scoringRulesetRepository = scoringRulesetRepository;
+    }
+
+    @Override
+    public ScoringRuleset create(ScoringRuleset ruleset) {
+        try {
+            var created = scoringRulesetRepository.create(ScoringRulesetAdapter.INSTANCE.toRepository(ruleset));
+            return ScoringRulesetAdapter.INSTANCE.toEntity(created);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when creating Scoring Ruleset: " + ruleset.id(), e);
+        }
+    }
+
+    @Override
+    public Optional<ScoringRuleset> findById(String id) {
+        try {
+            return scoringRulesetRepository.findById(id).map(ScoringRulesetAdapter.INSTANCE::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when searching for Scoring Ruleset: " + id, e);
+        }
+    }
+
+    @Override
+    public void delete(String id) {
+        try {
+            scoringRulesetRepository.delete(id);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Error when deleting Scoring Ruleset: %s".formatted(id), e);
+        }
+    }
+
+    @Override
+    public void deleteByReference(String referenceId, ScoringRuleset.ReferenceType referenceType) {
+        try {
+            scoringRulesetRepository.deleteByReferenceId(referenceId, referenceType.name());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException(
+                "Error when deleting Scoring Ruleset for [%s:%s]".formatted(referenceType, referenceId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/scoring/ScoringRulesetQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/scoring/ScoringRulesetQueryServiceImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.scoring;
+
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.apim.core.scoring.query_service.ScoringRulesetQueryService;
+import io.gravitee.apim.infra.adapter.ScoringRulesetAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ScoringRulesetQueryServiceImpl extends AbstractService implements ScoringRulesetQueryService {
+
+    private final ScoringRulesetRepository scoringRulesetRepository;
+
+    public ScoringRulesetQueryServiceImpl(@Lazy ScoringRulesetRepository scoringRulesetRepository) {
+        this.scoringRulesetRepository = scoringRulesetRepository;
+    }
+
+    @Override
+    public List<ScoringRuleset> findByReference(String referenceId, ScoringRuleset.ReferenceType referenceType) {
+        try {
+            return scoringRulesetRepository
+                .findAllByReferenceId(referenceId, referenceType.name())
+                .stream()
+                .map(ScoringRulesetAdapter.INSTANCE::toEntity)
+                .toList();
+        } catch (TechnicalException e) {
+            log.error("An error occurred while finding Scoring ruleset [{}:{}]", referenceType, referenceId, e);
+            throw new TechnicalManagementException(
+                "An error occurred while finding Scoring ruleset [%s:%s] ".formatted(referenceType, referenceId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/scoring/ScoringProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/scoring/ScoringProviderImpl.java
@@ -70,7 +70,8 @@ public class ScoringProviderImpl implements ScoringProvider {
                                 detectContentType(a.content())
                             )
                         )
-                        .toList()
+                        .toList(),
+                    request.customRulesets()
                 )
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.cockpit.command.handler;
 
 import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
 import io.gravitee.apim.core.access_point.model.AccessPoint;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
 import io.gravitee.apim.core.workflow.model.Workflow;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.environment.DeleteEnvironmentCommand;
@@ -55,6 +56,7 @@ import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.api.RatingRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.api.ScoringReportRepository;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
 import io.gravitee.repository.management.api.SharedPolicyGroupHistoryRepository;
 import io.gravitee.repository.management.api.SharedPolicyGroupRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
@@ -144,6 +146,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final RatingRepository ratingRepository;
     private final RoleRepository roleRepository;
     private final ScoringReportRepository scoringReportRepository;
+    private final ScoringRulesetRepository scoringRulesetRepository;
     private final SearchEngineService searchEngineService;
     private final SharedPolicyGroupRepository sharedPolicyGroupRepository;
     private final SharedPolicyGroupHistoryRepository sharedPolicyGroupHistoryRepository;
@@ -185,6 +188,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         @Lazy RatingRepository ratingRepository,
         @Lazy RoleRepository roleRepository,
         @Lazy ScoringReportRepository scoringReportRepository,
+        @Lazy ScoringRulesetRepository scoringRulesetRepository,
         @Lazy SharedPolicyGroupRepository sharedPolicyGroupRepository,
         @Lazy SharedPolicyGroupHistoryRepository sharedPolicyGroupHistoryRepository,
         @Lazy SubscriptionRepository subscriptionRepository,
@@ -241,6 +245,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.ratingRepository = ratingRepository;
         this.roleRepository = roleRepository;
         this.scoringReportRepository = scoringReportRepository;
+        this.scoringRulesetRepository = scoringRulesetRepository;
         this.searchEngineService = searchEngineService;
         this.sharedPolicyGroupRepository = sharedPolicyGroupRepository;
         this.sharedPolicyGroupHistoryRepository = sharedPolicyGroupHistoryRepository;
@@ -344,6 +349,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         dashboardRepository.deleteByReferenceIdAndReferenceType(environment.getId(), DashboardReferenceType.ENVIRONMENT);
         dictionaryRepository.deleteByEnvironmentId(environment.getId());
         eventService.deleteOrUpdateEventsByEnvironment(environment.getId());
+        scoringRulesetRepository.deleteByReferenceId(environment.getId(), ScoringRuleset.ReferenceType.ENVIRONMENT.name());
 
         // Always default for environment
         portalNotificationConfigRepository.deleteByReferenceIdAndReferenceType(environment.getId(), NotificationReferenceType.ENVIRONMENT);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringRulesetFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringRulesetFixture.java
@@ -31,6 +31,8 @@ public class ScoringRulesetFixture {
             .name("ruleset-name")
             .description("ruleset-description")
             .payload("ruleset-payload")
+            .referenceId("environment-id")
+            .referenceType(ScoringRuleset.ReferenceType.ENVIRONMENT)
             .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()));
 
     public static ScoringRuleset aRuleset() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringRulesetFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ScoringRulesetFixture.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.function.Supplier;
+
+public class ScoringRulesetFixture {
+
+    private ScoringRulesetFixture() {}
+
+    public static final Supplier<ScoringRuleset.ScoringRulesetBuilder> BASE = () ->
+        ScoringRuleset
+            .builder()
+            .id("ruleset-id")
+            .name("ruleset-name")
+            .description("ruleset-description")
+            .payload("ruleset-payload")
+            .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()));
+
+    public static ScoringRuleset aRuleset() {
+        return BASE.get().build();
+    }
+
+    public static ScoringRuleset aRuleset(String id) {
+        return BASE.get().id(id).payload("payload-" + id).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/ScoringRulesetFixture.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/ScoringRulesetFixture.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.repository;
+
+import io.gravitee.repository.management.model.ScoringRuleset;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Supplier;
+
+public class ScoringRulesetFixture {
+
+    private ScoringRulesetFixture() {}
+
+    public static final Supplier<ScoringRuleset.ScoringRulesetBuilder> BASE = () ->
+        ScoringRuleset
+            .builder()
+            .id("ruleset-id")
+            .name("ruleset-name")
+            .description("ruleset-description")
+            .payload("ruleset-payload")
+            .referenceId("reference-id")
+            .referenceType("ENVIRONMENT")
+            .createdAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")));
+
+    public static ScoringRuleset aRuleset() {
+        return BASE.get().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringRulesetCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringRulesetCrudServiceInMemory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.scoring.crud_service.ScoringRulesetCrudService;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class ScoringRulesetCrudServiceInMemory implements ScoringRulesetCrudService, InMemoryAlternative<ScoringRuleset> {
+
+    final ArrayList<ScoringRuleset> storage = new ArrayList<>();
+
+    @Override
+    public ScoringRuleset create(ScoringRuleset ruleset) {
+        storage.add(ruleset);
+        return ruleset;
+    }
+
+    @Override
+    public Optional<ScoringRuleset> findById(String id) {
+        return storage.stream().filter(i -> i.id().equals(id)).findFirst();
+    }
+
+    @Override
+    public void delete(String id) {
+        OptionalInt index = this.findIndex(this.storage, i -> i.id().equals(id));
+        if (index.isPresent()) {
+            storage.remove(index.getAsInt());
+        }
+    }
+
+    @Override
+    public void deleteByReference(String referenceId, ScoringRuleset.ReferenceType referenceType) {
+        OptionalInt index =
+            this.findIndex(this.storage, i -> i.referenceId().equals(referenceId) && i.referenceType().equals(referenceType));
+        if (index.isPresent()) {
+            storage.remove(index.getAsInt());
+        }
+    }
+
+    @Override
+    public void initWith(List<ScoringRuleset> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ScoringRuleset> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringRulesetQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ScoringRulesetQueryServiceInMemory.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.scoring.model.EnvironmentApiScoringReport;
+import io.gravitee.apim.core.scoring.model.EnvironmentOverview;
+import io.gravitee.apim.core.scoring.model.ScoringReport;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.apim.core.scoring.query_service.ScoringReportQueryService;
+import io.gravitee.apim.core.scoring.query_service.ScoringRulesetQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+public class ScoringRulesetQueryServiceInMemory implements ScoringRulesetQueryService, InMemoryAlternative<ScoringRuleset> {
+
+    private final List<ScoringRuleset> storage;
+
+    public ScoringRulesetQueryServiceInMemory() {
+        storage = new ArrayList<>();
+    }
+
+    public ScoringRulesetQueryServiceInMemory(ScoringRulesetCrudServiceInMemory integrationCrudServiceInMemory) {
+        storage = integrationCrudServiceInMemory.storage;
+    }
+
+    @Override
+    public List<ScoringRuleset> findByReference(String referenceId, ScoringRuleset.ReferenceType referenceType) {
+        return storage
+            .stream()
+            .filter(report -> report.referenceId().equals(referenceId) && report.referenceType().equals(referenceType))
+            .toList();
+    }
+
+    @Override
+    public void initWith(List<ScoringRuleset> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<ScoringRuleset> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -74,6 +74,8 @@ import inmemory.RoleQueryServiceInMemory;
 import inmemory.ScoringProviderInMemory;
 import inmemory.ScoringReportCrudServiceInMemory;
 import inmemory.ScoringReportQueryServiceInMemory;
+import inmemory.ScoringRulesetCrudServiceInMemory;
+import inmemory.ScoringRulesetQueryServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.TagQueryServiceInMemory;
@@ -459,5 +461,15 @@ public class InMemoryConfiguration {
     @Bean
     public ScoringReportQueryServiceInMemory scoringReportQueryService() {
         return new ScoringReportQueryServiceInMemory();
+    }
+
+    @Bean
+    public ScoringRulesetCrudServiceInMemory scoringRulesetCrudService() {
+        return new ScoringRulesetCrudServiceInMemory();
+    }
+
+    @Bean
+    public ScoringRulesetQueryServiceInMemory scoringRulesetQueryService(ScoringRulesetCrudServiceInMemory scoringRulesetCrudService) {
+        return new ScoringRulesetQueryServiceInMemory(scoringRulesetCrudService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/DeleteEnvironmentRulesetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/DeleteEnvironmentRulesetUseCaseTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import static assertions.CoreAssertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.ScoringRulesetFixture;
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringRulesetCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeleteEnvironmentRulesetUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    ScoringRulesetCrudServiceInMemory scoringRulesetCrudService = new ScoringRulesetCrudServiceInMemory();
+
+    DeleteEnvironmentRulesetUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeleteEnvironmentRulesetUseCase(scoringRulesetCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(scoringRulesetCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_delete_a_ruleset() {
+        // Given
+        var rulesetId = "ruleset-id";
+        givenExistingRulesets(ScoringRulesetFixture.aRuleset(rulesetId).withReferenceId(ENVIRONMENT_ID));
+
+        // When
+        useCase.execute(new DeleteEnvironmentRulesetUseCase.Input(rulesetId, AUDIT_INFO));
+
+        // Then
+        assertThat(scoringRulesetCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_do_nothing_when_no_ruleset() {
+        // When
+        useCase.execute(new DeleteEnvironmentRulesetUseCase.Input("unknown", AUDIT_INFO));
+
+        // Then
+        assertThat(scoringRulesetCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_do_nothing_when_ruleset_found_is_from_another_env() {
+        // Given
+        var rulesetId = "ruleset-id";
+        givenExistingRulesets(ScoringRulesetFixture.aRuleset(rulesetId).withReferenceId("other"));
+
+        // When
+        useCase.execute(new DeleteEnvironmentRulesetUseCase.Input(rulesetId, AUDIT_INFO));
+
+        // Then
+        assertThat(scoringRulesetCrudService.storage()).hasSize(1);
+    }
+
+    private void givenExistingRulesets(ScoringRuleset... rulesets) {
+        scoringRulesetCrudService.initWith(List.of(rulesets));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ImportEnvironmentRulesetUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ImportEnvironmentRulesetUseCaseTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.scoring.use_case;
+
+import static assertions.CoreAssertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.InMemoryAlternative;
+import inmemory.ScoringRulesetCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ImportEnvironmentRulesetUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String USER_ID = "user-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    ScoringRulesetCrudServiceInMemory scoringRulesetCrudService = new ScoringRulesetCrudServiceInMemory();
+
+    ImportEnvironmentRulesetUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ImportEnvironmentRulesetUseCase(scoringRulesetCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(scoringRulesetCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_create_ruleset() {
+        // Given
+        ImportEnvironmentRulesetUseCase.Input input = new ImportEnvironmentRulesetUseCase.Input(
+            new ImportEnvironmentRulesetUseCase.NewRuleset("name", "description", "payload"),
+            AUDIT_INFO
+        );
+
+        // When
+        useCase.execute(input);
+
+        // Then
+        assertThat(scoringRulesetCrudService.storage())
+            .contains(
+                ScoringRuleset
+                    .builder()
+                    .id("generated-id")
+                    .name("name")
+                    .description("description")
+                    .payload("payload")
+                    .referenceId(ENVIRONMENT_ID)
+                    .referenceType(ScoringRuleset.ReferenceType.ENVIRONMENT)
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_ruleset_id() {
+        // Given
+        ImportEnvironmentRulesetUseCase.Input input = new ImportEnvironmentRulesetUseCase.Input(
+            new ImportEnvironmentRulesetUseCase.NewRuleset("name", "description", "payload"),
+            AUDIT_INFO
+        );
+
+        // When
+        ImportEnvironmentRulesetUseCase.Output output = useCase.execute(input);
+
+        // Then
+        assertThat(output.rulesetId()).isEqualTo("generated-id");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/scoring/ScoringRulesetCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/scoring/ScoringRulesetCrudServiceImplTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ScoringRulesetFixture;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ScoringRulesetCrudServiceImplTest {
+
+    ScoringRulesetRepository scoringRulesetRepository;
+
+    ScoringRulesetCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        scoringRulesetRepository = mock(ScoringRulesetRepository.class);
+        service = new ScoringRulesetCrudServiceImpl(scoringRulesetRepository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_scoring_ruleset() {
+            // Given
+            var ruleset = ScoringRulesetFixture.aRuleset();
+            when(scoringRulesetRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            var created = service.create(ruleset);
+
+            // Then
+            assertThat(created).isEqualTo(ruleset);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            var ruleset = ScoringRulesetFixture.aRuleset();
+            when(scoringRulesetRepository.create(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.create(ruleset));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when creating Scoring Ruleset: ruleset-id");
+        }
+    }
+
+    @Nested
+    class FindById {
+
+        @Test
+        @SneakyThrows
+        void should_find_a_ruleset_by_id() {
+            // Given
+            var ruleset = ScoringRulesetFixture.aRuleset();
+            when(scoringRulesetRepository.findById("ruleset-id"))
+                .thenReturn(Optional.of(fixtures.repository.ScoringRulesetFixture.aRuleset()));
+
+            // When
+            var found = service.findById("ruleset-id");
+
+            // Then
+            assertThat(found)
+                .contains(
+                    ScoringRuleset
+                        .builder()
+                        .id("ruleset-id")
+                        .name("ruleset-name")
+                        .description("ruleset-description")
+                        .payload("ruleset-payload")
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                        .referenceType(ScoringRuleset.ReferenceType.ENVIRONMENT)
+                        .referenceId("reference-id")
+                        .build()
+                );
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(scoringRulesetRepository.findById(any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findById("ruleset-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when searching for Scoring Ruleset: ruleset-id");
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        @SneakyThrows
+        void should_delete_a_ruleset() {
+            // Given
+
+            // When
+            service.delete("ruleset-id");
+
+            // Then
+            verify(scoringRulesetRepository).delete("ruleset-id");
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            doThrow(TechnicalException.class).when(scoringRulesetRepository).delete(any());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.delete("ruleset-id"));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when deleting Scoring Ruleset: ruleset-id");
+        }
+    }
+
+    @Nested
+    class DeleteByReference {
+
+        @Test
+        @SneakyThrows
+        void should_delete_all_rulesets_of_an_environment() {
+            // Given
+
+            // When
+            service.deleteByReference("env-id", ScoringRuleset.ReferenceType.ENVIRONMENT);
+
+            // Then
+            verify(scoringRulesetRepository).deleteByReferenceId("env-id", "ENVIRONMENT");
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            doThrow(TechnicalException.class).when(scoringRulesetRepository).deleteByReferenceId(any(), any());
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.deleteByReference("env-id", ScoringRuleset.ReferenceType.ENVIRONMENT));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("Error when deleting Scoring Ruleset for [ENVIRONMENT:env-id]");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/scoring/ScoringRulesetQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/scoring/ScoringRulesetQueryServiceImplTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.scoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.repository.ScoringRulesetFixture;
+import io.gravitee.apim.core.scoring.model.ScoringRuleset;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ScoringRulesetQueryServiceImplTest {
+
+    ScoringRulesetRepository scoringRulesetRepository;
+
+    ScoringRulesetQueryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        scoringRulesetRepository = mock(ScoringRulesetRepository.class);
+        service = new ScoringRulesetQueryServiceImpl(scoringRulesetRepository);
+    }
+
+    @Nested
+    class FindByReference {
+
+        @Test
+        @SneakyThrows
+        void should_find_rulesets() {
+            when(scoringRulesetRepository.findAllByReferenceId(any(), any()))
+                .thenAnswer(invocation ->
+                    List.of(
+                        ScoringRulesetFixture
+                            .aRuleset()
+                            .toBuilder()
+                            .referenceId(invocation.getArgument(0))
+                            .referenceType(invocation.getArgument(1))
+                            .build()
+                    )
+                );
+
+            // When
+            var result = service.findByReference("ref-id", ScoringRuleset.ReferenceType.ENVIRONMENT);
+
+            // Then
+            assertThat(result)
+                .contains(
+                    ScoringRuleset
+                        .builder()
+                        .id("ruleset-id")
+                        .name("ruleset-name")
+                        .description("ruleset-description")
+                        .payload("ruleset-payload")
+                        .createdAt(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneId.systemDefault()))
+                        .referenceType(ScoringRuleset.ReferenceType.ENVIRONMENT)
+                        .referenceId("ref-id")
+                        .build()
+                );
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            // Given
+            when(scoringRulesetRepository.findAllByReferenceId(any(), any())).thenThrow(TechnicalException.class);
+
+            // When
+            Throwable throwable = catchThrowable(() -> service.findByReference("env-id", ScoringRuleset.ReferenceType.ENVIRONMENT));
+
+            // Then
+            assertThat(throwable)
+                .isInstanceOf(TechnicalManagementException.class)
+                .hasMessage("An error occurred while finding Scoring ruleset [ENVIRONMENT:env-id] ");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/scoring/ScoringProviderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/scoring/ScoringProviderImplTest.java
@@ -107,7 +107,8 @@ class ScoringProviderImplTest {
                         ENVIRONMENT_ID,
                         INSTALLATION_ID,
                         new ScoringRequest(
-                            List.of(new AssetToAnalyze("page-id", AssetType.OPEN_API, "echo-oas.json", "{}", ContentType.JSON))
+                            List.of(new AssetToAnalyze("page-id", AssetType.OPEN_API, "echo-oas.json", "{}", ContentType.JSON)),
+                            List.of("custom-ruleset-payload")
                         )
                     )
                 );
@@ -133,7 +134,8 @@ class ScoringProviderImplTest {
                 ORGANIZATION_ID,
                 ENVIRONMENT_ID,
                 API_ID,
-                List.of(new ScoreRequest.AssetToScore("page-id", ScoringAssetType.SWAGGER, "echo-oas.json", "{}"))
+                List.of(new ScoreRequest.AssetToScore("page-id", ScoringAssetType.SWAGGER, "echo-oas.json", "{}")),
+                List.of("custom-ruleset-payload")
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -60,6 +60,7 @@ import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.api.RatingRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.api.ScoringReportRepository;
+import io.gravitee.repository.management.api.ScoringRulesetRepository;
 import io.gravitee.repository.management.api.SharedPolicyGroupHistoryRepository;
 import io.gravitee.repository.management.api.SharedPolicyGroupRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
@@ -273,6 +274,9 @@ public class DeleteEnvironmentCommandHandlerTest {
     private ScoringReportRepository scoringReportRepository;
 
     @Mock
+    private ScoringRulesetRepository scoringRulesetRepository;
+
+    @Mock
     private SearchEngineService searchEngineService;
 
     private DeleteEnvironmentCommandHandler cut;
@@ -363,6 +367,7 @@ public class DeleteEnvironmentCommandHandlerTest {
                 ratingRepository,
                 roleRepository,
                 scoringReportRepository,
+                scoringRulesetRepository,
                 sharedPolicyGroupRepository,
                 sharedPolicyGroupHistoryRepository,
                 subscriptionRepository,
@@ -459,6 +464,7 @@ public class DeleteEnvironmentCommandHandlerTest {
         verify(mediaRepository).deleteByEnvironment(ENV_ID);
         verify(portalMenuLinkRepository).deleteByEnvironmentId(ENV_ID);
         verify(metadataRepository).deleteByReferenceIdAndReferenceType(ENV_ID, MetadataReferenceType.ENVIRONMENT);
+        verify(scoringRulesetRepository).deleteByReferenceId(ENV_ID, "ENVIRONMENT");
         verify(environmentService).delete(ENV_ID);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.1.14</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.2.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>3.2.3</gravitee-cockpit-api.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
-        <gravitee-scoring-api.version>0.2.0</gravitee-scoring-api.version>
+        <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
         <gravitee-node.version>6.4.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>4.1.0</gravitee-plugin.version>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-6648

## Description

Add endpoints to manage rulesets at environment level (Import, List All and delete)
Update the scoring request use case to score assets using Environment rulesets when defined

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ovvngxxany.chromatic.com)
<!-- Storybook placeholder end -->
