### PR TITLE
Console: make etag / if-match work with angular & angularJs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v2/steps/api-creation-v2.controller.ajs.ts
@@ -268,9 +268,8 @@ class ApiCreationV2ControllerAjs {
         })
         .then((api) => {
           if (readyForReview) {
-            this.ApiService.askForReview(api.data).then((response) => {
+            this.ApiService.askForReview(api.data).then(() => {
               api.data.workflow_state = 'IN_REVIEW';
-              this.ngIfMatchEtagInterceptor.updateLastEtag('api', response.headers('etag'));
               this.api = api.data;
             });
           }
@@ -278,8 +277,7 @@ class ApiCreationV2ControllerAjs {
         })
         .then((api) => {
           if (deployAndStart) {
-            this.ApiService.deploy(api.data.id).then((response) => {
-              this.ngIfMatchEtagInterceptor.updateLastEtag('api', response.headers('etag'));
+            this.ApiService.deploy(api.data.id).then(() => {
               this.ApiService.start(api.data).then(() => {
                 this.NotificationService.show('API created, deployed and started');
                 this.ngRouter.navigate(['../..', api.data.id], { relativeTo: this.activatedRoute });

--- a/gravitee-apim-console-webui/src/management/api/properties-v1/properties.controller.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties-v1/properties.controller.ajs.ts
@@ -164,7 +164,6 @@ class ApiV1PropertiesControllerAjs {
     this.api.services['dynamic-property'] = this.dynamicPropertyService;
     return this.ApiService.update(this.api).then((updatedApi) => {
       this.api = updatedApi.data;
-      this.ngIfMatchEtagInterceptor.updateLastEtag('api', updatedApi.headers('etag'));
       this.$rootScope.$broadcast('apiChangeSuccess', { api: this.api });
       this.NotificationService.show("API '" + this.api.name + "' saved");
     });

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -187,19 +187,11 @@ export class ApiService {
   }
 
   start(api: { id: string }): IHttpPromise<any> {
-    return this.$http.post(
-      `${this.Constants.env.baseURL}/apis/` + api.id + '?action=START',
-      {},
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/` + api.id + '?action=START', {});
   }
 
   stop(api: { id: string }): IHttpPromise<any> {
-    return this.$http.post(
-      `${this.Constants.env.baseURL}/apis/` + api.id + '?action=STOP',
-      {},
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/` + api.id + '?action=STOP', {});
   }
 
   reload(name: string): IHttpPromise<any> {
@@ -211,39 +203,35 @@ export class ApiService {
   }
 
   update(api): IHttpPromise<any> {
-    return this.$http.put(
-      `${this.Constants.env.baseURL}/apis/` + api.id,
-      {
-        version: api.version,
-        description: api.description,
-        proxy: api.proxy,
-        paths: api.paths,
-        flows: api.flows,
-        plans: api.plans,
-        private: api.private,
-        visibility: api.visibility,
-        name: api.name,
-        services: api.services,
-        properties: api.properties,
-        tags: api.tags,
-        picture: api.picture,
-        picture_url: api.picture_url,
-        background: api.background,
-        background_url: api.background_url,
-        resources: api.resources,
-        categories: api.categories,
-        groups: api.groups,
-        labels: api.labels,
-        path_mappings: api.path_mappings,
-        response_templates: api.response_templates,
-        lifecycle_state: api.lifecycle_state,
-        disable_membership_notifications: api.disable_membership_notifications,
-        flow_mode: api.flow_mode,
-        gravitee: api.gravitee,
-        execution_mode: api.execution_mode,
-      },
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.put(`${this.Constants.env.baseURL}/apis/` + api.id, {
+      version: api.version,
+      description: api.description,
+      proxy: api.proxy,
+      paths: api.paths,
+      flows: api.flows,
+      plans: api.plans,
+      private: api.private,
+      visibility: api.visibility,
+      name: api.name,
+      services: api.services,
+      properties: api.properties,
+      tags: api.tags,
+      picture: api.picture,
+      picture_url: api.picture_url,
+      background: api.background,
+      background_url: api.background_url,
+      resources: api.resources,
+      categories: api.categories,
+      groups: api.groups,
+      labels: api.labels,
+      path_mappings: api.path_mappings,
+      response_templates: api.response_templates,
+      lifecycle_state: api.lifecycle_state,
+      disable_membership_notifications: api.disable_membership_notifications,
+      flow_mode: api.flow_mode,
+      gravitee: api.gravitee,
+      execution_mode: api.execution_mode,
+    });
   }
 
   delete(name: string): IHttpPromise<any> {
@@ -766,27 +754,15 @@ export class ApiService {
   }
 
   askForReview(api: { id: string }, message?: any): IHttpPromise<any> {
-    return this.$http.post(
-      `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ASK`,
-      { message },
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ASK`, { message });
   }
 
   acceptReview(api: { id: string }, message: any): IHttpPromise<any> {
-    return this.$http.post(
-      `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ACCEPT`,
-      { message },
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ACCEPT`, { message });
   }
 
   rejectReview(api: { id: string }, message: any): IHttpPromise<any> {
-    return this.$http.post(
-      `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=REJECT`,
-      { message: message },
-      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
-    );
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=REJECT`, { message: message });
   }
 
   /*

--- a/gravitee-apim-console-webui/src/shared/interceptors/if-match-etag.interceptor.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/interceptors/if-match-etag.interceptor.spec.ts
@@ -45,7 +45,7 @@ describe('IfMatchEtagInterceptor', () => {
     const testUrl = 'https://test.com/management/organizations/DEFAULT/environments/DEFAULT/apis/f35505ff-ac3f-45d6-b134-e4406e8e0165';
 
     let expectedSteps = 0;
-    // First request with etag
+    // First request to get etag
     httpClient.get<unknown>(testUrl).subscribe(() => {
       expectedSteps++;
     });
@@ -68,5 +68,42 @@ describe('IfMatchEtagInterceptor', () => {
     req2.flush('', { headers: { etag: '9012' } });
 
     expect(expectedSteps).toEqual(3);
+  });
+
+  it('should set if-match with last etag different api urls', () => {
+    const apiAUrl = 'https://test.com/management/v2/environments/DEFAULT/apis/a35505ff-ac3f-45d6-b134-e4406e8e0165';
+    const apiBUrl = 'https://test.com/management/organizations/DEFAULT/environments/DEFAULT/apis/b35505ff-ac3f-45d6-b134-e4406e8e0166';
+
+    let expectedSteps = 0;
+    // First request api A to get etag
+    httpClient.get<unknown>(apiAUrl).subscribe(() => {
+      expectedSteps++;
+    });
+    httpTestingController.expectOne(apiAUrl).flush('', { headers: { etag: '1000' } });
+
+    // Second request api B to get etag
+    httpClient.get<unknown>(apiBUrl).subscribe(() => {
+      expectedSteps++;
+    });
+
+    httpTestingController.expectOne(apiBUrl).flush('', { headers: { etag: '2000' } });
+
+    // Put request with if-match for api A
+    httpClient.put<unknown>(apiAUrl, '').subscribe(() => {
+      expectedSteps++;
+    });
+    const req = httpTestingController.expectOne(apiAUrl);
+    expect(req.request.headers.get('if-match')).toEqual('1000');
+    req.flush('', { headers: { etag: '1001' } });
+
+    // Post request with if-match for api B
+    httpClient.post<unknown>(apiBUrl, '').subscribe(() => {
+      expectedSteps++;
+    });
+    const req2 = httpTestingController.expectOne(apiBUrl);
+    expect(req2.request.headers.get('if-match')).toEqual('2000');
+    req2.flush('', { headers: { etag: '2001' } });
+
+    expect(expectedSteps).toEqual(4);
   });
 });

--- a/gravitee-apim-console-webui/src/shared/interceptors/if-match-etag.interceptor.ts
+++ b/gravitee-apim-console-webui/src/shared/interceptors/if-match-etag.interceptor.ts
@@ -17,6 +17,7 @@ import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } fr
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { isEmpty } from 'lodash';
 
 /**
  * Add the If-Match header to the request if the response contains an ETag header for specific resources.
@@ -26,53 +27,72 @@ import { map } from 'rxjs/operators';
   providedIn: 'platform',
 })
 export class IfMatchEtagInterceptor implements HttpInterceptor {
-  private activatedFor: {
-    key: 'api';
-    urlToMatch: RegExp;
-  }[] = [
-    {
-      key: 'api',
-      urlToMatch: new RegExp(`/management/organizations/(.*)/environments/(.*)/apis`),
+  public static ETAG_HEADER = 'etag';
+  public static ETAG_HEADER_IF_MATCH = 'If-Match';
+
+  private urlToKeyMatchers: ((url: string) => string | undefined)[] = [
+    (url) => {
+      const matchArray = url.match(new RegExp(`/management/organizations/(.*)/environments/(.*)/apis/(.*)`));
+      if (matchArray) {
+        return `api-${matchArray[3]}`;
+      }
+    },
+    (url) => {
+      const matchArray = url.match(new RegExp(`/management/v2/environments/(.*)/apis/(.*)`));
+      if (matchArray) {
+        return `api-${matchArray[2]}`;
+      }
     },
   ];
   public lastEtag: Record<string, string> = {};
 
-  public updateLastEtag(key: string, etag: string) {
-    this.lastEtag[key] = etag;
+  interceptRequest(method: string, url: string, setIfMatchHeaderFn: (etagValue: string) => void): void {
+    if (method === 'PUT' || method === 'POST') {
+      const matchingKey = this.getMatchingKey(url);
+      if (matchingKey) {
+        const etag = this.lastEtag[matchingKey];
+        if (etag) {
+          setIfMatchHeaderFn(etag);
+        }
+      }
+    }
   }
 
-  public getLastEtag(key: string): string {
-    return this.lastEtag[key];
+  interceptResponse(url: string, etagHeaderValue: string): void {
+    const matchingKey = this.getMatchingKey(url);
+    if (matchingKey) {
+      if (!isEmpty(etagHeaderValue)) {
+        this.lastEtag[matchingKey] = etagHeaderValue;
+      }
+    }
   }
 
   intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     req = req.clone();
 
-    if (req.method === 'PUT' || req.method === 'POST') {
-      const activated = this.activatedFor.find((a) => req.url.match(a.urlToMatch));
-
-      if (activated) {
-        const etag = this.getLastEtag(activated.key);
-        if (etag) {
-          req = req.clone({
-            headers: req.headers.set('If-Match', etag),
-          });
-        }
-      }
-    }
+    this.interceptRequest(req.method, req.url, (etagValue) => {
+      req = req.clone({
+        headers: req.headers.set(IfMatchEtagInterceptor.ETAG_HEADER_IF_MATCH, etagValue),
+      });
+    });
 
     return next.handle(req).pipe(
       map((event) => {
         if (event instanceof HttpResponse) {
-          const activated = this.activatedFor.find((a) => event.url.match(a.urlToMatch));
-          if (activated) {
-            if (event.headers.has('etag')) {
-              this.updateLastEtag(activated.key, event.headers.get('etag'));
-            }
-          }
+          this.interceptResponse(event.url, event.headers.get(IfMatchEtagInterceptor.ETAG_HEADER));
         }
         return event;
       }),
     );
+  }
+
+  private getMatchingKey(url: string): string | null {
+    for (const matcher of this.urlToKeyMatchers) {
+      const key = matcher(url);
+      if (key) {
+        return key;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6060

## Description

Add angularJs interceptor and remove unnecessary get / update etag
Add api mapiV2 url pattern to ad etag / if match for mapiV2 😱 
Make api etag key linked to apiId

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kswgbckuna.chromatic.com)
<!-- Storybook placeholder end -->
