### PR TITLE
fix(console): use utc timezone to select From To datetime & use 0-base index page for events

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/components/gio-api-events-table/gio-api-events-table.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-api-events-table/gio-api-events-table.component.spec.ts
@@ -86,7 +86,7 @@ describe('GioApiEventsTableComponent', () => {
     const req = httpTestingController.expectOne({
       method: 'GET',
 
-      url: `${CONSTANTS_TESTING.env.baseURL}/platform/events?type=START_API,STOP_API,PUBLISH_API,UNPUBLISH_API&query=&api_ids=&from=1691565599784&to=1694157599784&page=1&size=5`,
+      url: `${CONSTANTS_TESTING.env.baseURL}/platform/events?type=START_API,STOP_API,PUBLISH_API,UNPUBLISH_API&query=&api_ids=&from=1691565599784&to=1694157599784&page=0&size=5`,
     });
     req.flush(SEARCH_RESPONSE);
   }

--- a/gravitee-apim-console-webui/src/management/home/components/gio-api-events-table/gio-api-events-table.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-api-events-table/gio-api-events-table.component.ts
@@ -65,7 +65,8 @@ export class GioApiEventsTableComponent implements OnChanges {
           filters.searchTerm,
           filters.from,
           filters.to,
-          filters.pagination.index,
+          // Pagination index is 0-based
+          filters.pagination.index - 1,
           filters.pagination.size,
         )
         .pipe(

--- a/gravitee-apim-console-webui/src/management/home/components/gio-quick-time-range/gio-quick-time-range.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-quick-time-range/gio-quick-time-range.component.ts
@@ -16,6 +16,7 @@
 import { Component, EventEmitter, forwardRef, Output } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Subject } from 'rxjs';
+import moment from 'moment';
 
 export type TimeRangeParams = {
   id: string;
@@ -29,10 +30,11 @@ const timeFrameRangesParams: (id: string, interval: number, nbValuesByBucket?: n
   interval: number,
   nbValuesByBucket = 30,
 ) => {
+  const nowUtc = moment.utc().valueOf();
   return {
     id,
-    from: new Date().getTime() - interval,
-    to: Date.now(),
+    from: nowUtc - interval,
+    to: nowUtc,
     interval: interval / nbValuesByBucket,
   };
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6876

## Description

use utc timezone to select From To datetime & use 0-base index page for events

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjbftqjcrc.chromatic.com)
<!-- Storybook placeholder end -->
