### PR TITLE
Align vert.x versions with Gravitee-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,10 +43,9 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2
              in gravitee-apim-gateway-tests-sdk and gravitee-apim-integration-tests
              along with the grpc libs to create test clients and servers -->
-        <vertx.version>4.5.7</vertx.version>
-        <protobuf-java.version>4.27.2</protobuf-java.version>
-        <grpc-java.version>1.50.2</grpc-java.version>
-
+        <vertx.version>4.5.10</vertx.version>
+        <protobuf-java.version>4.28.2</protobuf-java.version>
+        <grpc-java.version>1.65.0</grpc-java.version>
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.1.16</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>


### PR DESCRIPTION
## Issue

N/A

## Description
- align vert.x version with the one in gravitee bom
- bump protobuf version

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ykcaedvrqh.chromatic.com)
<!-- Storybook placeholder end -->
