### PR TITLE
feat(console): Propagate error-key field when using response template

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/responseTemplate.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/responseTemplate.ts
@@ -18,4 +18,5 @@ export interface ResponseTemplate {
   statusCode?: number;
   headers?: { [key: string]: string };
   body?: string;
+  propagateErrorKeyToLogs?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/response-templates/api-response-templates.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/api-response-templates.module.ts
@@ -21,7 +21,14 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
-import { GioFormHeadersModule, GioIconsModule, GioSaveBarModule, GioFormFocusInvalidModule } from '@gravitee/ui-particles-angular';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import {
+  GioFormHeadersModule,
+  GioIconsModule,
+  GioSaveBarModule,
+  GioFormFocusInvalidModule,
+  GioFormSlideToggleModule,
+} from '@gravitee/ui-particles-angular';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -59,6 +66,8 @@ import { GioGoBackButtonModule } from '../../../shared/components/gio-go-back-bu
     GioFormHeadersModule,
     GioFormFocusInvalidModule,
     GioGoBackButtonModule,
+    GioFormSlideToggleModule,
+    MatSlideToggle,
   ],
 })
 export class ApiResponseTemplatesModule {}

--- a/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.html
@@ -41,7 +41,7 @@
             </mat-option>
           </mat-autocomplete>
 
-          <mat-error *ngIf="responseTemplatesForm.get('key').hasError('required')"> Status code is required. </mat-error>
+          <mat-error *ngIf="responseTemplatesForm.get('key').hasError('required')"> Status code is required.</mat-error>
         </mat-form-field>
       </div>
 
@@ -102,6 +102,12 @@
           <textarea matInput formControlName="body" rows="8"> </textarea>
         </mat-form-field>
       </div>
+
+      <!--      Propagate error key to logs-->
+      <gio-form-slide-toggle>
+        <gio-form-label>Add template key to logs</gio-form-label>
+        <mat-slide-toggle gioFormSlideToggle formControlName="propagateErrorKeyToLogs"></mat-slide-toggle>
+      </gio-form-slide-toggle>
     </mat-card-content>
   </mat-card>
 

--- a/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/edit/api-response-templates-edit.component.ts
@@ -102,6 +102,10 @@ export class ApiResponseTemplatesEditComponent implements OnInit, OnDestroy {
               value: this.responseTemplateToEdit?.body ?? '',
               disabled: this.isReadOnly,
             }),
+            propagateErrorKeyToLogs: new UntypedFormControl({
+              value: this.responseTemplateToEdit?.propagateErrorKeyToLogs ?? false,
+              disabled: this.isReadOnly,
+            }),
           });
           this.initialResponseTemplatesFormValue = this.responseTemplatesForm.getRawValue();
 
@@ -147,6 +151,7 @@ export class ApiResponseTemplatesEditComponent implements OnInit, OnDestroy {
       statusCode: parseInt(responseTemplateFormValue.statusCode, 10),
       headers: !isEmpty(headers) ? Object.fromEntries(headers.map((h) => [h.key, h.value])) : undefined,
       body: responseTemplateFormValue.body,
+      propagateErrorKeyToLogs: responseTemplateFormValue.propagateErrorKeyToLogs,
     };
 
     return this.apiService

--- a/gravitee-apim-console-webui/src/management/api/response-templates/response-templates.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/response-templates/response-templates.adapter.ts
@@ -24,6 +24,7 @@ export type ResponseTemplate = {
   statusCode?: number;
   body?: string;
   headers?: Record<string, string>;
+  propagateErrorKeyToLogs?: boolean;
 };
 
 export const toResponseTemplates = (responseTemplates: (ApiV1 | ApiV2)['responseTemplates']): ResponseTemplate[] => {
@@ -40,6 +41,7 @@ export const toResponseTemplates = (responseTemplates: (ApiV1 | ApiV2)['response
         statusCode: responseTemplate.statusCode,
         body: responseTemplate.body,
         headers: responseTemplate.headers,
+        propagateErrorKeyToLogs: responseTemplate.propagateErrorKeyToLogs,
       })),
     ];
   });
@@ -48,7 +50,7 @@ export const toResponseTemplates = (responseTemplates: (ApiV1 | ApiV2)['response
 export const fromResponseTemplates = (responseTemplates: ResponseTemplate[]): (ApiV1 | ApiV2)['responseTemplates'] => {
   return responseTemplates.reduce(
     (acc, responseTemplate) => {
-      const { key, contentType, statusCode, body, headers } = responseTemplate;
+      const { key, contentType, statusCode, body, headers, propagateErrorKeyToLogs } = responseTemplate;
       if (!acc[key]) {
         acc[key] = {};
       }
@@ -56,6 +58,7 @@ export const fromResponseTemplates = (responseTemplates: ResponseTemplate[]): (A
         statusCode,
         body,
         headers,
+        propagateErrorKeyToLogs,
       };
       return acc;
     },

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ResponseTemplateDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ResponseTemplateDeserializer.java
@@ -43,6 +43,7 @@ public class ResponseTemplateDeserializer extends StdScalarDeserializer<Response
 
         template.setStatusCode(node.path("status").asInt());
         template.setBody(node.path("body").asText());
+        template.setPropagateErrorKeyToLogs(node.path("propagateErrorKeyToLogs").asBoolean());
 
         JsonNode headersNode = node.get("headers");
         if (headersNode != null && !headersNode.isEmpty(null)) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/ResponseTemplateSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/ResponseTemplateSerializer.java
@@ -39,6 +39,7 @@ public class ResponseTemplateSerializer extends StdScalarSerializer<ResponseTemp
             jgen.writeObjectField("headers", responseTemplate.getHeaders());
         }
         jgen.writeStringField("body", responseTemplate.getBody());
+        jgen.writeBooleanField("propagateErrorKeyToLogs", responseTemplate.isPropagateErrorKeyToLogs());
         jgen.writeEndObject();
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ResponseTemplate.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ResponseTemplate.java
@@ -44,4 +44,5 @@ public class ResponseTemplate implements Serializable {
 
     private Map<String, String> headers;
     private String body;
+    private boolean propagateErrorKeyToLogs;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessor.java
@@ -114,6 +114,9 @@ public class ResponseTemplateBasedFailureProcessor extends SimpleFailureProcesso
         context.response().status(template.getStatusCode());
         context.response().reason(HttpResponseStatus.valueOf(template.getStatusCode()).reasonPhrase());
         context.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+        if (template.isPropagateErrorKeyToLogs()) {
+            context.request().metrics().setErrorKey(failure.key());
+        }
 
         if (template.getBody() != null && !template.getBody().isEmpty()) {
             context.response().headers().set(HttpHeaderNames.CONTENT_TYPE, context.request().headers().getFirst(HttpHeaderNames.ACCEPT));
@@ -132,7 +135,6 @@ public class ResponseTemplateBasedFailureProcessor extends SimpleFailureProcesso
             if (failure.parameters() != null && !failure.parameters().isEmpty()) {
                 context.getTemplateEngine().getTemplateContext().setVariable("parameters", failure.parameters());
             }
-
             // Apply templating
             String body = context.getTemplateEngine().getValue(template.getBody(), String.class);
             Buffer payload = Buffer.buffer(body);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
@@ -139,6 +139,9 @@ public class ResponseTemplateBasedFailureProcessor extends AbstractFailureProces
         context.response().status(template.getStatusCode());
         context.response().reason(HttpResponseStatus.valueOf(template.getStatusCode()).reasonPhrase());
         context.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+        if (template.isPropagateErrorKeyToLogs()) {
+            context.metrics().setErrorKey(executionFailure.key());
+        }
 
         if (template.getBody() != null && !template.getBody().isEmpty()) {
             context.response().headers().set(HttpHeaderNames.CONTENT_TYPE, context.request().headers().get(HttpHeaderNames.ACCEPT));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4759,6 +4759,8 @@ components:
                         type: string
                 body:
                     type: string
+                propagateErrorKeyToLogs:
+                    type: boolean
         Sampling:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsCustomResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsCustomResourceTest.java
@@ -176,6 +176,7 @@ public class ApiExportService_ExportAsCustomResourceTest extends ApiExportServic
         ResponseTemplate responseTemplate = new ResponseTemplate();
         responseTemplate.setStatusCode(400);
         responseTemplate.setBody("{\"bad\":\"news\"}");
+        responseTemplate.setPropagateErrorKeyToLogs(false);
         apiEntity.setResponseTemplates(Collections.singletonMap("API_KEY_MISSING", Collections.singletonMap("*/*", responseTemplate)));
 
         when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
@@ -160,6 +160,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
         ResponseTemplate responseTemplate = new ResponseTemplate();
         responseTemplate.setStatusCode(400);
         responseTemplate.setBody("{\"bad\":\"news\"}");
+        responseTemplate.setPropagateErrorKeyToLogs(false);
         apiEntity.setResponseTemplates(Collections.singletonMap("API_KEY_MISSING", Collections.singletonMap("*/*", responseTemplate)));
 
         when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_gRPC_ExportAsJsonTestSetup.java
@@ -179,6 +179,7 @@ public class ApiExportService_gRPC_ExportAsJsonTestSetup {
         ResponseTemplate responseTemplate = new ResponseTemplate();
         responseTemplate.setStatusCode(400);
         responseTemplate.setBody("{\"bad\":\"news\"}");
+        responseTemplate.setPropagateErrorKeyToLogs(false);
         apiEntity.setResponseTemplates(Collections.singletonMap("API_KEY_MISSING", Collections.singletonMap("*/*", responseTemplate)));
 
         apiEntity.setPaths(null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextPath.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextPath.yml
@@ -79,4 +79,5 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
+        propagateErrorKeyToLogs: false
   notifyMembers: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
@@ -79,6 +79,7 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
+        propagateErrorKeyToLogs: false
   contextRef:
     name: "apim-dev-ctx"
     namespace: "default"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-noIds.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-noIds.yml
@@ -74,4 +74,5 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
+        propagateErrorKeyToLogs: false
   notifyMembers: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-version.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-version.yml
@@ -79,5 +79,6 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
+        propagateErrorKeyToLogs: false
   version: "1.0.0-alpha"
   notifyMembers: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource.yml
@@ -79,4 +79,5 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
+        propagateErrorKeyToLogs: false
   notifyMembers: true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
@@ -204,7 +204,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
@@ -204,7 +204,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v4-emulation-engine.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v4-emulation-engine.json
@@ -204,7 +204,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
@@ -204,7 +204,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
@@ -195,7 +195,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
@@ -194,7 +194,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
@@ -118,7 +118,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
@@ -168,7 +168,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
@@ -219,7 +219,8 @@
     "API_KEY_MISSING": {
       "*/*": {
         "status": 400,
-        "body": "{\"bad\":\"news\"}"
+        "body": "{\"bad\":\"news\"}",
+        "propagateErrorKeyToLogs": false
       }
     }
   },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6311

## Description
Error key can be propagated to logs when using response template

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/9236/console](https://pr.team-apim.gravitee.dev/9236/console)
      Portal: [https://pr.team-apim.gravitee.dev/9236/portal](https://pr.team-apim.gravitee.dev/9236/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/9236/api/management](https://pr.team-apim.gravitee.dev/9236/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/9236](https://pr.team-apim.gravitee.dev/9236)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/9236](https://pr.gateway-v3.team-apim.gravitee.dev/9236)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-efpehuwpti.chromatic.com)
<!-- Storybook placeholder end -->
