### PR TITLE
chore: downgrade gravitee-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <protobuf-java.version>4.27.2</protobuf-java.version>
         <grpc-java.version>1.50.2</grpc-java.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>8.1.14</gravitee-bom.version>
+        <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.2.3</gravitee-cockpit-api.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>


### PR DESCRIPTION
## Issue

N/A

## Description

Gravitee-bom >= 8.1.3 depends on Vert.X  4.5.10 which makes some Grpc Integration tests failing. On top of that, we have upgraded gravite-bom only 6 days ago. So we lack perspective on the changes introduced between Vert.X 4.5.7 and 4.5.10.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iwuhzxhhih.chromatic.com)
<!-- Storybook placeholder end -->
