### PR TITLE
fix: avoid duplicates keys for categories

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
@@ -137,7 +137,8 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
         final List<CategoryEntity> categories = findAll(executionContext.getEnvironmentId());
         final Optional<CategoryEntity> optionalCategory = categories
             .stream()
-            .filter(v -> v.getName().equals((newCategory.getName())))
+            .filter(v -> v.getName().equalsIgnoreCase((newCategory.getName())))
+            .filter(v -> v.getKey().equalsIgnoreCase(IdGenerator.generate((newCategory.getName()))))
             .findAny();
 
         if (optionalCategory.isPresent()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/CategoryService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/CategoryService_CreateTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.utils.IdGenerator;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Category;
@@ -93,7 +94,26 @@ public class CategoryService_CreateTest {
         Category v1 = new Category();
         NewCategoryEntity nv1 = new NewCategoryEntity();
         v1.setName("v1");
+        v1.setKey(IdGenerator.generate(v1.getName()));
         nv1.setName("v1");
+        when(mockCategoryRepository.findAllByEnvironment(any())).thenReturn(Collections.singleton(v1));
+
+        try {
+            categoryService.create(GraviteeContext.getExecutionContext(), nv1);
+        } catch (DuplicateCategoryNameException e) {
+            verify(mockCategoryRepository, never()).create(any());
+            throw e;
+        }
+        Assert.fail("should throw DuplicateCategoryNameException");
+    }
+
+    @Test(expected = DuplicateCategoryNameException.class)
+    public void shouldNotCreateExistingCategoryBecauseSameName() throws TechnicalException {
+        Category v1 = new Category();
+        NewCategoryEntity nv1 = new NewCategoryEntity();
+        v1.setName("A Name With Capital Letters");
+        v1.setKey(IdGenerator.generate(v1.getName()));
+        nv1.setName("A name with CAPITAL letters");
         when(mockCategoryRepository.findAllByEnvironment(any())).thenReturn(Collections.singleton(v1));
 
         try {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6819

## Description

Avoid duplicates keys for categories