### PR TITLE
chore: use java image with latest version of alpine

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17 as base
+FROM graviteeio/java:17-alpine-3.20 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
 
 RUN apk update  \

--- a/gravitee-apim-gateway/docker/Dockerfile-from-download
+++ b/gravitee-apim-gateway/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17 as base
+FROM graviteeio/java:17-alpine-3.20 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-management-api
 
 RUN addgroup -g 1000 graviteeio \

--- a/gravitee-apim-rest-api/docker/Dockerfile-from-download
+++ b/gravitee-apim-rest-api/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7000

## Description

Use latest version of Gravitee java image, to use alpine 3.20.
A fix regarding the DNS issue has been provided in 3.18, and 3.20 is the latest version available
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rkhyngmfuv.chromatic.com)
<!-- Storybook placeholder end -->
