### PR TITLE
performance ingest

### DIFF
--- a/gravitee-apim-console-webui/yarn.lock
+++ b/gravitee-apim-console-webui/yarn.lock
@@ -23378,7 +23378,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>":
   version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -70,4 +70,15 @@ public interface ApiRepository extends CrudRepository<Api, String> {
     }
 
     Collection<Api> find(Iterable<String> ids) throws TechnicalException;
+
+    /**
+     * DO NOT USE THIS METHOD
+     * @deprecated use {@link #search(ApiCriteria, Sortable, ApiFieldFilter, int)} instead
+     */
+    @Deprecated(forRemoval = false)
+    default Set<Api> findAll() {
+        throw new IllegalStateException(
+            "Too many results, please use search(ApiCriteria, Sortable, ApiFieldFilter, int) returning a Stream instead."
+        );
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.management.model.Api;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -62,4 +63,11 @@ public interface ApiRepository extends CrudRepository<Api, String> {
      * @throws TechnicalException
      */
     List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException;
+
+    @Override
+    default Optional<Api> findById(String id) throws TechnicalException {
+        return find(List.of(id)).stream().findFirst();
+    }
+
+    Collection<Api> find(Iterable<String> ids) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -117,17 +117,6 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
     }
 
     @Override
-    /**
-     * DO NOT USE THIS METHOD
-     * @deprecated use {@link #search(ApiCriteria, Sortable, ApiFieldFilter, int)} instead
-     */
-    public Set<Api> findAll() throws TechnicalException {
-        throw new IllegalStateException(
-            "Too many results, please use search(ApiCriteria, Sortable, ApiFieldFilter, int) returning a Stream instead."
-        );
-    }
-
-    @Override
     public Collection<Api> find(Iterable<String> ids) throws TechnicalException {
         LOGGER.debug("JdbcApiRepository.find({})", ids);
         List<String> allIds = StreamSupport.stream(ids.spliterator(), false).toList();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.mongodb.management.internal.api.ApiMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -60,9 +61,8 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public Optional<Api> findById(String apiId) throws TechnicalException {
-        ApiMongo apiMongo = internalApiRepo.findById(apiId).orElse(null);
-        return Optional.ofNullable(mapApi(apiMongo));
+    public Collection<Api> find(Iterable<String> ids) throws TechnicalException {
+        return internalApiRepo.findAllById(ids).stream().map(this::mapApi).toList();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,11 +53,6 @@ public class MongoApiRepository implements ApiRepository {
 
     @Autowired
     private GraviteeMapper mapper;
-
-    @Override
-    public Set<Api> findAll() throws TechnicalException {
-        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
-    }
 
     @Override
     public Collection<Api> find(Iterable<String> ids) throws TechnicalException {
@@ -160,7 +154,7 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public Optional<String> findIdByEnvironmentIdAndCrossId(final String environmentId, final String crossId) throws TechnicalException {
+    public Optional<String> findIdByEnvironmentIdAndCrossId(final String environmentId, final String crossId) {
         return internalApiRepo.findIdByEnvironmentIdAndCrossId(environmentId, crossId).map(ApiMongo::getId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/crud_service/ApiCrudService.java
@@ -15,12 +15,24 @@
  */
 package io.gravitee.apim.core.api.crud_service;
 
+import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ApiCrudService {
-    Api get(String id);
-    Optional<Api> findById(String id);
+    default Api get(String id) {
+        return findById(id).orElseThrow(() -> new ApiNotFoundException(id));
+    }
+
+    default Optional<Api> findById(String id) {
+        return stream(find(List.of(id))).findFirst();
+    }
+
+    Collection<Api> find(Collection<String> ids);
     boolean existsById(String id);
     Api create(Api api);
     Api update(Api api);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCase.java
@@ -43,7 +43,12 @@ public class UpdateFederatedApiUseCase {
 
         var updating = update(input.apiToUpdate);
 
-        var updated = apiUpdateFederatedApiDomainService.update(input.apiToUpdate.getId(), updating, auditInfo, primaryOwnerEntity);
+        var updated = apiUpdateFederatedApiDomainService.update(
+            UpdateFederatedApiDomainService.Previous.id(input.apiToUpdate.getId()),
+            updating,
+            auditInfo,
+            primaryOwnerEntity
+        );
 
         return new Output(updated, primaryOwnerEntity);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImpl.java
@@ -16,15 +16,12 @@
 package io.gravitee.apim.infra.crud_service.api;
 
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
-import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
-import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
-import io.gravitee.apim.infra.adapter.PlanAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
-import java.util.Optional;
+import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
@@ -41,25 +38,12 @@ public class ApiCrudServiceImpl implements ApiCrudService {
     }
 
     @Override
-    public Api get(String id) {
+    public Collection<Api> find(Collection<String> ids) {
         try {
-            var foundApi = apiRepository.findById(id);
-            if (foundApi.isPresent()) {
-                return ApiAdapter.INSTANCE.toCoreModel(foundApi.get());
-            }
-        } catch (TechnicalException e) {
-            logger.error("An error occurred while finding Api by id {}", id, e);
-        }
-        throw new ApiNotFoundException(id);
-    }
-
-    @Override
-    public Optional<Api> findById(String id) {
-        try {
-            logger.debug("Find an Api by id : {}", id);
-            return apiRepository.findById(id).map(ApiAdapter.INSTANCE::toCoreModel);
+            logger.debug("Find an Api by ids : {}", ids);
+            return apiRepository.find(ids).stream().map(ApiAdapter.INSTANCE::toCoreModel).toList();
         } catch (TechnicalException ex) {
-            throw new TechnicalDomainException(String.format("An error occurs while trying to find an api by id: %s", id), ex);
+            throw new TechnicalDomainException(String.format("An error occurs while trying to find apis by ids: %s", ids), ex);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiCrudServiceInMemory.java
@@ -16,13 +16,11 @@
 package inmemory;
 
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
-import io.gravitee.apim.core.api.exception.ApiNotFoundException;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.plan.model.Plan;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 
 public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternative<Api> {
@@ -30,14 +28,8 @@ public class ApiCrudServiceInMemory implements ApiCrudService, InMemoryAlternati
     final ArrayList<Api> storage = new ArrayList<>();
 
     @Override
-    public Api get(String id) {
-        var foundApi = storage.stream().filter(api -> id.equals(api.getId())).findFirst();
-        return foundApi.orElseThrow(() -> new ApiNotFoundException(id));
-    }
-
-    @Override
-    public Optional<Api> findById(String id) {
-        return storage.stream().filter(api -> id.equals(api.getId())).findFirst();
+    public Collection<Api> find(Collection<String> ids) {
+        return storage.stream().filter(api -> ids.contains(api.getId())).toList();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateFederatedApiDomainServiceTest.java
@@ -182,7 +182,12 @@ class UpdateFederatedApiDomainServiceTest {
         var ownerEntity = buildPrimaryOwnerEntity();
 
         //when
-        var updatedApi = usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity);
+        var updatedApi = usecase.update(
+            UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()),
+            old -> apiToUpdate,
+            auditInfo,
+            ownerEntity
+        );
         //then
         assertThat(apiCrudService.storage()).extracting("federatedApiDefinition").doesNotContainNull();
         SoftAssertions.assertSoftly(soft -> {
@@ -217,7 +222,12 @@ class UpdateFederatedApiDomainServiceTest {
         var ownerEntity = buildPrimaryOwnerEntity();
 
         //when
-        var updatedApi = usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity);
+        var updatedApi = usecase.update(
+            UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()),
+            old -> apiToUpdate,
+            auditInfo,
+            ownerEntity
+        );
         //then
         SoftAssertions.assertSoftly(soft -> {
             assertThat(updatedApi.getName()).isEqualTo("updated-name");
@@ -235,7 +245,9 @@ class UpdateFederatedApiDomainServiceTest {
         var ownerEntity = buildPrimaryOwnerEntity();
 
         assertThatExceptionOfType(ApiNotFoundException.class)
-            .isThrownBy(() -> usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity))
+            .isThrownBy(() ->
+                usecase.update(UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()), old -> apiToUpdate, auditInfo, ownerEntity)
+            )
             .withMessage("Api not found.");
     }
 
@@ -247,7 +259,9 @@ class UpdateFederatedApiDomainServiceTest {
         var ownerEntity = buildPrimaryOwnerEntity();
 
         assertThatExceptionOfType(LifecycleStateChangeNotAllowedException.class)
-            .isThrownBy(() -> usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity))
+            .isThrownBy(() ->
+                usecase.update(UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()), old -> apiToUpdate, auditInfo, ownerEntity)
+            )
             .withMessage("The API lifecycle state cannot be changed to PUBLISHED.");
     }
 
@@ -264,7 +278,9 @@ class UpdateFederatedApiDomainServiceTest {
         var ownerEntity = buildPrimaryOwnerEntity();
 
         assertThatExceptionOfType(InvalidDataException.class)
-            .isThrownBy(() -> usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity))
+            .isThrownBy(() ->
+                usecase.update(UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()), old -> apiToUpdate, auditInfo, ownerEntity)
+            )
             .withMessage("These groupIds [[not-existing-group]] do not exist");
     }
 
@@ -275,7 +291,7 @@ class UpdateFederatedApiDomainServiceTest {
         var apiToUpdate = ApiFixtures.aFederatedApi();
         var ownerEntity = buildPrimaryOwnerEntity();
 
-        usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity);
+        usecase.update(UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()), old -> apiToUpdate, auditInfo, ownerEntity);
 
         assertThat(auditCrudService.storage())
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
@@ -303,7 +319,12 @@ class UpdateFederatedApiDomainServiceTest {
         var apiToUpdate = ApiFixtures.aFederatedApi();
         var ownerEntity = buildPrimaryOwnerEntity();
 
-        var updatedApi = usecase.update(apiToUpdate.getId(), old -> apiToUpdate, auditInfo, ownerEntity);
+        var updatedApi = usecase.update(
+            UpdateFederatedApiDomainService.Previous.id(apiToUpdate.getId()),
+            old -> apiToUpdate,
+            auditInfo,
+            ownerEntity
+        );
 
         assertThat(indexer.storage())
             .isNotEmpty()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5983

## Description

- group queries on APIs
- on update don't make query on APIs 2 times

With this I have 5% of improvement on ingest news APIs.

Ingesto of 600 APIs take less than 1:30 (whe providers takes about 2 minutes)

We can continue to improve it with async/pipelining of updates but APIM isn't ready to this at time.

