### PR TITLE
fix(console): hide add link for read permissions

### DIFF
--- a/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.html
+++ b/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.html
@@ -22,7 +22,10 @@
         <h3>Menu Links</h3>
         <div class="menu-link-list__content__header__description">Customize the Developer Portal top bar menu with up to 5 links</div>
       </div>
-      <div class="menu-link-list__header__action">
+      <div
+        class="menu-link-list__header__action"
+        *gioPermission="{ anyOf: ['environment-settings-c', 'environment-settings-u', 'environment-settings-d'] }"
+      >
         <button
           [disabled]="!canAddLink"
           (click)="onAddLinkClick()"
@@ -85,7 +88,10 @@
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef data-testid="link_actions">Actions</th>
         <td mat-cell *matCellDef="let element">
-          <div class="menu-link-list__actions">
+          <div
+            class="menu-link-list__actions"
+            *gioPermission="{ anyOf: ['environment-settings-c', 'environment-settings-u', 'environment-settings-d'] }"
+          >
             <button
               mat-icon-button
               type="button"

--- a/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.spec.ts
@@ -30,6 +30,7 @@ import { MenuLinkAddDialogHarness } from '../menu-link-dialog/menu-link-add-dial
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { fakePortalMenuLink, PortalMenuLink } from '../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 describe('MenuLinkListComponent', () => {
   const fakeSnackBarService = {
@@ -46,7 +47,13 @@ describe('MenuLinkListComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MatIconTestingModule, NoopAnimationsModule, GioTestingModule],
-      providers: [{ provide: SnackBarService, useValue: fakeSnackBarService }],
+      providers: [
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        {
+          provide: GioTestingPermissionProvider,
+          useValue: ['environment-settings-u', 'environment-settings-d', 'environment-settings-c'],
+        },
+      ],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {

--- a/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.ts
+++ b/gravitee-apim-console-webui/src/portal/customization/top-bar/menu-link-list/menu-link-list.component.ts
@@ -42,6 +42,7 @@ import {
   UpdatePortalMenuLink,
 } from '../../../../entities/management-api-v2';
 import { UiPortalMenuLinksService } from '../../../../services-ngx/ui-portal-menu-links.service';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 
 type PortalMenuLinkListVM = PortalMenuLink & {
   readableType: string;
@@ -67,6 +68,7 @@ type PortalMenuLinkListVM = PortalMenuLink & {
     RouterLink,
     CdkDropList,
     CdkDrag,
+    GioPermissionModule,
   ],
 })
 export class MenuLinkListComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6979

## Description

User should NOT see “Add Link” when they don’t have the required permissions.

“delete” option should be hidden.

“update” i.e. pencil icon should be hidden.


<img width="1718" alt="Screenshot 2024-09-27 at 18 02 50" src="https://github.com/user-attachments/assets/ffb05705-b91d-449b-ba8c-29a481543691">



https://github.com/user-attachments/assets/cf77ab55-1856-4469-a0b6-4310f8330683

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uqkoggzchv.chromatic.com)
<!-- Storybook placeholder end -->
