### PR TITLE
helm: fix changelog

### DIFF
--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -24,6 +24,20 @@ import { CircleCIEnvironment } from '../pipelines';
 export class ReleaseCommitAndPrepareNextVersionJob {
   private static jobName = 'job-release-commit-and-prepare-next-version';
 
+  private static buildHelmCommand(nextVersion: string, nextQualifier: string) {
+    let command = `sed -e "0,/^version:/{s/version:.*/version: ${nextVersion}${nextQualifier}/}" \\
+    -e "0,/^appVersion:/{ s/appVersion.*/appVersion: ${nextVersion}${nextQualifier}/ }" \\`;
+    // Do not clean the helm changelog when building pre-release
+    if (!nextQualifier) {
+      command += `
+    -e '/artifacthub.io\\/changes/,\${ s/|// }' \\
+    -e '/artifacthub.io\\/changes:/q0'`;
+    }
+    command += `
+    -i helm/Chart.yaml`;
+    return command;
+  }
+
   public static create(dynamicConfig: Config, environment: CircleCIEnvironment): Job {
     const parsedVersion = parse(environment.graviteeioVersion);
 
@@ -80,10 +94,7 @@ sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#'
 sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
 
 # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
-sed -e "0,/^version:/{s/version:.*/version: ${nextVersion}${nextQualifier}/}" \\
-    -e "0,/^appVersion:/{ s/appVersion.*/appVersion: ${nextVersion}${nextQualifier}/ }" \\
-    -e '/artifacthub.io\\/changes/,\${ s/|//; /^[ ]*\\- /d }' \\
-    -i helm/Chart.yaml
+${this.buildHelmCommand(nextVersion, nextQualifier)}
 
 git add --update
 git commit -m 'chore: prepare next version [skip ci]'

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -362,7 +362,6 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.0-alpha.2/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.0-alpha.2/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -362,7 +362,8 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.1/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
+                -e '/artifacthub.io\/changes/,${ s/|// }' \
+                -e '/artifacthub.io\/changes:/q0'
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -362,7 +362,8 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.1/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
+                -e '/artifacthub.io\/changes/,${ s/|// }' \
+                -e '/artifacthub.io\/changes:/q0'
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -362,7 +362,8 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.1/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
+                -e '/artifacthub.io\/changes/,${ s/|// }' \
+                -e '/artifacthub.io\/changes:/q0'
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -362,7 +362,6 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.0-alpha.2/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.0-alpha.2/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -362,7 +362,8 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.1/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
+                -e '/artifacthub.io\/changes/,${ s/|// }' \
+                -e '/artifacthub.io\/changes:/q0'
                 -i helm/Chart.yaml
 
             git add --update

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -362,7 +362,8 @@ jobs:
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \
                 -e "0,/^appVersion:/{ s/appVersion.*/appVersion: 4.2.1/ }" \
-                -e '/artifacthub.io\/changes/,${ s/|//; /^[ ]*\- /d }' \
+                -e '/artifacthub.io\/changes/,${ s/|// }' \
+                -e '/artifacthub.io\/changes:/q0'
                 -i helm/Chart.yaml
 
             git add --update

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,8 +17,10 @@ keywords:
 kubeVersion: ">=1.14.0-0"
 annotations:
   # List of changes for the release in artifacthub.io
-  # https://artifacthub.io/packages/helm/graviteeio/apim?modal=changelog
+  # https://artifacthub.io/packages/  helm/graviteeio/apim?modal=changelog
+  ###########
+  # WARNING #
+  ###########
+  # "changes" must be the last section in this file, because a CI job clean it after each release
+  ###########
   artifacthub.io/changes: 
-      description: 'Add support of SSL keystore secret'
-      links:
-          url: https://github.com/gravitee-io/issues/issues/9854

--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -1048,8 +1048,7 @@ helm install \
 |===
 |Parameter |Description |Default
 
-|license.key |string |license.key file encoded in base64 |
-
+|license.key |string |license.key file encoded in base64
 |===
 
 


### PR DESCRIPTION
## Issue

N/A

## Description

Changelog should not be reset during a pre-release.

And when the changelog has to be deleted, the sed command now removes all lines, and not only the one starting with '-'

NOTE: It has already been done on 4.5.x and master (see https://github.com/gravitee-io/gravitee-api-management/pull/9018)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oyenvymfzo.chromatic.com)
<!-- Storybook placeholder end -->
