### PR TITLE
fix: compare decoded certificate with decoded certificate

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -725,6 +725,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             if (updateApplicationEntity.getSettings().getTls() != null) {
                 String existingCertificate = applicationToUpdate.getMetadata().get(METADATA_CLIENT_CERTIFICATE);
                 String newCertificate = updateApplicationEntity.getSettings().getTls().getClientCertificate();
+                existingCertificate = existingCertificate != null ? new String(Base64.getDecoder().decode(existingCertificate)) : null;
                 if (newCertificate != null && !newCertificate.equals(existingCertificate)) {
                     throw new ClientCertificateChangeNotAllowedException();
                 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7023

## Description

Comparing encoded certificate with decoded one always caused exception

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

