### PR TITLE
ci: use new version of aqua orb (1.0.4)

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -84,7 +84,7 @@ const maven = {
 };
 
 const orbs = {
-  aquasec: '1.0.3',
+  aquasec: '1.0.4',
   artifactory: '1.0.1',
   awsCli: '2.0.6',
   awsS3: '3.0.0',

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-dry-run.yml
@@ -133,4 +133,4 @@ workflows:
           name: Build and push RPM packages for APIM 4.1.0-alpha.1 - Dry Run
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-prerelease-no-dry-run.yml
@@ -133,4 +133,4 @@ workflows:
           name: Build and push RPM packages for APIM 4.1.0-alpha.1
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-dry-run.yml
@@ -133,4 +133,4 @@ workflows:
           name: Build and push RPM packages for APIM 4.1.0 - Dry Run
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run-as-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run-as-latest.yml
@@ -133,4 +133,4 @@ workflows:
           name: Build and push RPM packages for APIM 4.1.0
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/build-rpm-and-docker-images/build-rpm-and-docker-images-release-no-dry-run.yml
@@ -133,4 +133,4 @@ workflows:
           name: Build and push RPM packages for APIM 4.1.0
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -717,7 +717,7 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@3.0.0
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -707,7 +707,7 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@3.0.0
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -719,7 +719,7 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@3.0.0
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -719,7 +719,7 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1
   aws-s3: circleci/aws-s3@3.0.0
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-4-1-x.yml
@@ -397,5 +397,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/publish-docker-images/publish-docker-images-master.yml
@@ -397,5 +397,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -1257,7 +1257,7 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-distribution-only.yml
@@ -184,5 +184,5 @@ workflows:
             - Validate backend
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -334,5 +334,5 @@ workflows:
             - Test gateway
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -238,5 +238,5 @@ workflows:
             - Build backend
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -520,5 +520,5 @@ workflows:
             - Test repository
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -335,5 +335,5 @@ workflows:
             - Test plugins
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -280,5 +280,5 @@ workflows:
             - Test rest-api
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -390,6 +390,6 @@ workflows:
             - Build APIM Console and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
@@ -83,5 +83,5 @@ workflows:
             - Helm Chart - Lint & Test
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-portal-only.yml
@@ -312,5 +312,5 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -826,7 +826,7 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -1257,7 +1257,7 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -826,7 +826,7 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -1048,7 +1048,7 @@ workflows:
             - Build APIM Portal and publish image
 orbs:
   keeper: gravitee-io/keeper@0.6.3
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   helm: circleci/helm@3.0.0
   slack: circleci/slack@4.12.5
   gh: circleci/github-cli@1.0.5

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -429,5 +429,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -431,5 +431,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-snapshot.yml
@@ -431,5 +431,5 @@ workflows:
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5
-  aquasec: gravitee-io/aquasec@1.0.3
+  aquasec: gravitee-io/aquasec@1.0.4
   artifactory-orb: jfrog/artifactory-orb@1.0.1


### PR DESCRIPTION
## Issue

N/A

## Description

Use latest version of aquasec orb to avoir ratelimit errors.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lwofzwsndb.chromatic.com)
<!-- Storybook placeholder end -->
