### PR TITLE
fix: update token permissions to 2500

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
@@ -37,7 +37,7 @@ public enum OrganizationPermission implements Permission {
     ENTRYPOINT("ENTRYPOINT", 2100),
     POLICIES("POLICIES", 2200),
     AUDIT("AUDIT", 2300),
-    USER_TOKEN("USER_TOKEN", 2400);
+    USER_TOKEN("USER_TOKEN", 2500);
 
     String name;
     int mask;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6960

## Description

The mask 2400 is already used on 4.3.x and upper version so we need to use the 2500. I'll update the database manually when this pr is merged

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pccijnjlar.chromatic.com)
<!-- Storybook placeholder end -->
