### PR TITLE
fix: return first severe error when validating crd po

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/ValidateCRDMembersDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/ValidateCRDMembersDomainService.java
@@ -120,6 +120,7 @@ public class ValidateCRDMembersDomainService implements Validator<ValidateCRDMem
             if (PRIMARY_OWNER.name().equals(member.getRole())) {
                 errors.add(Error.severe("setting a member with the primary owner role is not allowed"));
                 members.remove();
+                return;
             }
 
             log.debug("checking that member {} is not the authenticated user who will be set as a primary owner", member.getSourceId());


### PR DESCRIPTION
not doing this can lead to illegal state exception as we might remove from an empty iterator

see https://gravitee.atlassian.net/browse/GKO-656


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fljhgqxvqd.chromatic.com)
<!-- Storybook placeholder end -->
