### PR TITLE
chore: use java image with version 3.18 of alpine

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -15,8 +15,8 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17 as base
-ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
+FROM graviteeio/java:17-alpine-3.18 AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 RUN apk update  \
     && apk add --no-cache libc6-compat  \
@@ -27,7 +27,7 @@ RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
 
 # Second stage to add the folder and change the permissions and ownership
-FROM base as builder
+FROM base AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
 
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \

--- a/gravitee-apim-gateway/docker/Dockerfile-from-download
+++ b/gravitee-apim-gateway/docker/Dockerfile-from-download
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17
+FROM graviteeio/java:17-alpine-3.18
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0
 ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-apim/distributions
 ARG GRAVITEEIO_PACKAGE_NAME=graviteeio-full
-ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
+ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,14 +15,14 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17 as base
-ENV GRAVITEEIO_HOME /opt/graviteeio-management-api
+FROM graviteeio/java:17-alpine-3.18 AS base
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
 
 # Second stage to add the folder and change the permissions and ownership
-FROM base as builder
+FROM base AS builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
 
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \

--- a/gravitee-apim-rest-api/docker/Dockerfile-from-download
+++ b/gravitee-apim-rest-api/docker/Dockerfile-from-download
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17
+FROM graviteeio/java:17-alpine-3.18
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0
 ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-apim/distributions
 ARG GRAVITEEIO_PACKAGE_NAME=graviteeio-full
-ENV GRAVITEEIO_HOME /opt/graviteeio-management-api
+ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7000

## Description

Use version 3.18 of Alpine which brings the fix to the DNS issue, without removing libc6-compat library.