### PR TITLE
fix: set installation id when publishing Alert Event

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/alert/AlertProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/alert/AlertProcessor.java
@@ -118,6 +118,7 @@ public class AlertProcessor implements Processor {
                         .property(PROP_ERROR_KEY, ctx.metrics().getErrorKey())
                         .organization(ctx.getAttribute(ContextAttributes.ATTR_ORGANIZATION))
                         .environment(ctx.getAttribute(ContextAttributes.ATTR_ENVIRONMENT))
+                        .installation((String) node.metadata().get(Node.META_INSTALLATION))
                         .build()
                 )
             )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/alert/AlertProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/alert/AlertProcessor.java
@@ -19,6 +19,7 @@ import io.gravitee.alert.api.event.Event;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,6 +112,7 @@ public class AlertProcessor extends AbstractProcessor<ExecutionContext> {
                     .property(PROP_ERROR_KEY, context.request().metrics().getErrorKey())
                     .organization((String) context.getAttribute(ExecutionContext.ATTR_ORGANIZATION))
                     .environment((String) context.getAttribute(ExecutionContext.ATTR_ENVIRONMENT))
+                    .installation((String) node.metadata().get(Node.META_INSTALLATION))
                     .build()
             );
         } catch (Exception ex) {


### PR DESCRIPTION
## Description

Installation Id was set "automatically" in AE connector. However, since work related to sync of Node Metadata, installation id was not set. That's because the metadata are initialized during the synchronization process that could happens after AE connector is initialized.

To ease the comprehension, we set the installation id when we create the Alert Event like we do with organization & environment

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

