### PR TITLE
fix: ensure token used by Federation Agent can manipulate integration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/IntegrationCommandContext.java
@@ -23,23 +23,29 @@ import lombok.Setter;
 public final class IntegrationCommandContext implements ControllerCommandContext {
 
     private final boolean valid;
+    private final String userId;
     private final String organizationId;
 
     @Setter
     private String integrationId;
 
-    public IntegrationCommandContext(boolean valid, String organizationId, String integrationId) {
+    public IntegrationCommandContext(boolean valid, String organizationId, String userId, String integrationId) {
         this.valid = valid;
         this.organizationId = organizationId;
+        this.userId = userId;
         this.integrationId = integrationId;
     }
 
     public IntegrationCommandContext(boolean valid) {
-        this(valid, null, null);
+        this(valid, null, null, null);
     }
 
     public IntegrationCommandContext(boolean valid, String organizationId) {
-        this(valid, organizationId, null);
+        this(valid, organizationId, null, null);
+    }
+
+    public IntegrationCommandContext(boolean valid, String organizationId, String userId) {
+        this(valid, organizationId, userId, null);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/command/hello/HelloCommandHandler.java
@@ -46,6 +46,7 @@ public class HelloCommandHandler implements CommandHandler<HelloCommand, HelloRe
                 var result = checkIntegrationUseCase.execute(
                     new CheckIntegrationUseCase.Input(
                         integrationCommandContext.getOrganizationId(),
+                        integrationCommandContext.getUserId(),
                         payload.getTargetId(),
                         payload.getProvider()
                     )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
@@ -23,9 +23,11 @@ import io.gravitee.integration.controller.command.IntegrationCommandContext;
 import io.gravitee.rest.api.service.TokenService;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -54,9 +56,9 @@ public class IntegrationWebsocketControllerAuthentication implements WebSocketCo
 
                 return userCrudService
                     .findBaseUserById(token.getReferenceId())
-                    .map(BaseUserEntity::getOrganizationId)
-                    .filter(licenseDomainService::isFederationFeatureAllowed)
-                    .map(organizationId -> new IntegrationCommandContext(true, organizationId))
+                    .map(user -> Map.entry(user.getOrganizationId(), user.getId()))
+                    .filter(entry -> licenseDomainService.isFederationFeatureAllowed(entry.getKey()))
+                    .map(entry -> new IntegrationCommandContext(true, entry.getKey(), entry.getValue()))
                     .orElse(new IntegrationCommandContext(false));
             } catch (Exception e) {
                 log.warn("Unable to authenticate incoming websocket controller request");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthenticationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/test/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthenticationTest.java
@@ -50,6 +50,7 @@ class IntegrationWebsocketControllerAuthenticationTest {
 
     private static final String TOKEN_VALUE = "my-token-value";
     private static final String ORGANIZATION_ID = "organization-id";
+    private static final String USER_ID = "user-id";
 
     @Mock
     TokenService tokenService;
@@ -88,12 +89,12 @@ class IntegrationWebsocketControllerAuthenticationTest {
 
     @Test
     void should_return_a_valid_IntegrationCommandContext_when_authentication_succeed() {
-        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId(USER_ID).build());
         givenUser(BaseUserEntity.builder().id(token.getReferenceId()).organizationId(ORGANIZATION_ID).build());
 
         var result = authentication.authenticate(request);
 
-        assertThat(result).isEqualTo(new IntegrationCommandContext(true, ORGANIZATION_ID));
+        assertThat(result).isEqualTo(new IntegrationCommandContext(true, ORGANIZATION_ID, USER_ID));
     }
 
     @Test
@@ -107,7 +108,7 @@ class IntegrationWebsocketControllerAuthenticationTest {
 
     @Test
     void should_return_an_invalid_IntegrationCommandContext_when_no_user_found() {
-        givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+        givenToken(Token.builder().token(TOKEN_VALUE).referenceId(USER_ID).build());
 
         var result = authentication.authenticate(request);
 
@@ -125,7 +126,7 @@ class IntegrationWebsocketControllerAuthenticationTest {
 
     @Test
     void should_return_an_invalid_IntegrationCommandContext_when_no_enterprise_license_found() {
-        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId("user-id").build());
+        var token = givenToken(Token.builder().token(TOKEN_VALUE).referenceId(USER_ID).build());
         givenUser(BaseUserEntity.builder().id(token.getReferenceId()).organizationId(ORGANIZATION_ID).build());
         when(licenseManager.getOrganizationLicenseOrPlatform(ORGANIZATION_ID)).thenReturn(LicenseFixtures.anOssLicense());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -59,6 +59,7 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
@@ -80,6 +81,7 @@ import io.gravitee.apim.core.subscription.use_case.RejectSubscriptionUseCase;
 import io.gravitee.apim.core.user.domain_service.UserDomainService;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.sanitizer.SanitizerSpringConfiguration;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
@@ -576,5 +578,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ValidatePageAccessControlsDomainService validatePageAccessControlsDomainService(GroupQueryService groupQueryService) {
         return new ValidatePageAccessControlsDomainService(groupQueryService);
+    }
+
+    @Bean
+    public PermissionDomainService permissionDomainService(MembershipService membershipService, PermissionService permissionService) {
+        return new PermissionDomainServiceLegacyWrapper(membershipService, permissionService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -48,6 +48,7 @@ import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDoma
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
@@ -68,6 +69,7 @@ import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.sanitizer.SanitizerSpringConfiguration;
 import io.gravitee.apim.infra.spring.CoreServiceSpringConfiguration;
@@ -761,5 +763,10 @@ public class ResourceContextConfiguration {
     @Bean
     public MonitoringService monitoringService() {
         return mock(MonitoringService.class);
+    }
+
+    @Bean
+    public PermissionDomainService permissionDomainService(MembershipService membershipService, PermissionService permissionService) {
+        return new PermissionDomainServiceLegacyWrapper(membershipService, permissionService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -48,6 +48,7 @@ import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainS
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
@@ -67,6 +68,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.permission.PermissionDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.sanitizer.SanitizerSpringConfiguration;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
@@ -740,5 +742,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
         return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), mock(Vertx.class));
+    }
+
+    @Bean
+    public PermissionDomainService permissionDomainService(MembershipService membershipService, PermissionService permissionService) {
+        return new PermissionDomainServiceLegacyWrapper(membershipService, permissionService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/permission/domain_service/PermissionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/permission/domain_service/PermissionDomainService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.permission.domain_service;
+
+import io.gravitee.rest.api.model.permissions.Permission;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import java.util.Arrays;
+import java.util.Map;
+
+public interface PermissionDomainService {
+    boolean hasExactPermissions(
+        String organizationId,
+        String userId,
+        RolePermission permission,
+        String referenceId,
+        RolePermissionAction... acls
+    );
+
+    boolean hasPermission(
+        String organizationId,
+        String userId,
+        RolePermission permission,
+        String referenceId,
+        RolePermissionAction... acls
+    );
+
+    default boolean checkForExactPermissions(Map<String, char[]> userPermissions, Permission permission, RolePermissionAction... acls) {
+        if (userPermissions == null) {
+            return false;
+        }
+
+        char[] permissionAcls = userPermissions.get(permission.getName());
+        if (permissionAcls == null) {
+            return false;
+        }
+
+        var sortedPermissionAcls = new String(permissionAcls).chars().sorted().mapToObj(i -> (char) i).toArray();
+        var aclsToCheck = Arrays.stream(acls).map(RolePermissionAction::getId).sorted().toArray();
+
+        return Arrays.equals(sortedPermissionAcls, aclsToCheck);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/permission/PermissionDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/permission/PermissionDomainServiceLegacyWrapper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.permission;
+
+import static io.gravitee.rest.api.service.impl.PermissionServiceImpl.ROLE_SCOPE_TO_REFERENCE_TYPE;
+import static io.gravitee.rest.api.service.impl.PermissionServiceImpl.isOrganizationAdmin;
+
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.PermissionServiceImpl;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class PermissionDomainServiceLegacyWrapper implements PermissionDomainService {
+
+    private final MembershipService membershipService;
+    private final PermissionService permissionService;
+
+    public PermissionDomainServiceLegacyWrapper(MembershipService membershipService, PermissionService permissionService) {
+        this.membershipService = membershipService;
+        this.permissionService = permissionService;
+    }
+
+    @Override
+    public boolean hasExactPermissions(
+        String organizationId,
+        String userId,
+        io.gravitee.rest.api.model.permissions.RolePermission permission,
+        String referenceId,
+        io.gravitee.rest.api.model.permissions.RolePermissionAction... acls
+    ) {
+        if (isOrganizationAdmin()) {
+            log.debug("User [{}] has full access because of its ORGANIZATION ADMIN role", userId);
+            return true;
+        }
+
+        MembershipReferenceType membershipReferenceType = ROLE_SCOPE_TO_REFERENCE_TYPE.get(permission.getScope());
+
+        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            new ExecutionContext(organizationId),
+            membershipReferenceType,
+            referenceId,
+            userId
+        );
+
+        return checkForExactPermissions(permissions, permission.getPermission(), acls);
+    }
+
+    @Override
+    public boolean hasPermission(
+        String organizationId,
+        String userId,
+        RolePermission permission,
+        String referenceId,
+        RolePermissionAction... acls
+    ) {
+        return this.permissionService.hasPermission(new ExecutionContext(organizationId), userId, permission, referenceId, acls);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -79,6 +79,17 @@ public interface DefaultRoleEntityDefinition {
             .build()
     );
 
+    public static final NewRoleEntity ROLE_ENVIRONMENT_FEDERATION_AGENT = new NewRoleEntity(
+        "FEDERATION_AGENT",
+        "Environment Role used by Federation agents. Created by Gravitee.io.",
+        ENVIRONMENT,
+        false,
+        Maps
+            .<String, char[]>builder()
+            .put(EnvironmentPermission.INTEGRATION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .build()
+    );
+
     public static final NewRoleEntity DEFAULT_ROLE_API_USER = new NewRoleEntity(
         "USER",
         "Default API Role. Created by Gravitee.io.",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -43,9 +43,9 @@ public class PermissionServiceImpl extends AbstractService implements Permission
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PermissionServiceImpl.class);
 
-    private static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
+    public static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
 
-    private static final Map<RoleScope, MembershipReferenceType> ROLE_SCOPE_TO_REFERENCE_TYPE = Map.ofEntries(
+    public static final Map<RoleScope, MembershipReferenceType> ROLE_SCOPE_TO_REFERENCE_TYPE = Map.ofEntries(
         Pair.of(RoleScope.API, MembershipReferenceType.API),
         Pair.of(RoleScope.APPLICATION, MembershipReferenceType.APPLICATION),
         Pair.of(RoleScope.ORGANIZATION, MembershipReferenceType.ORGANIZATION),
@@ -108,7 +108,7 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         return hasOrganizationManagementRole(user) || hasEnvironmentManagementRole(user) || hasApiManagementRole(executionContext, user);
     }
 
-    private static boolean isOrganizationAdmin() {
+    public static boolean isOrganizationAdmin() {
         return (
             SecurityContextHolder.getContext().getAuthentication() != null &&
             SecurityContextHolder

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -62,6 +62,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
     private final List<Map.Entry<String, NewRoleEntity>> initializeRoles = List.of(
         Map.entry("<ORGANIZATION> USER (default)", DEFAULT_ROLE_ORGANIZATION_USER),
         Map.entry("<ENVIRONMENT> API_PUBLISHER", ROLE_ENVIRONMENT_API_PUBLISHER),
+        Map.entry("<ENVIRONMENT> FEDERATION_AGENT", ROLE_ENVIRONMENT_FEDERATION_AGENT),
         Map.entry("<ENVIRONMENT> USER (default)", DEFAULT_ROLE_ENVIRONMENT_USER),
         Map.entry("<API> USER (default)", DEFAULT_ROLE_API_USER),
         Map.entry("<API> OWNER", ROLE_API_OWNER),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentFederationAgentRoleUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentFederationAgentRoleUpgrader.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.API;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class EnvironmentFederationAgentRoleUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public EnvironmentFederationAgentRoleUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() {
+        try {
+            organizationRepository
+                .findAll()
+                .stream()
+                .filter(organization -> shouldCreateEnvironmentFederationAgentRole(organization.getId()))
+                .forEach(organization -> {
+                    roleService.create(new ExecutionContext(organization.getId()), ROLE_ENVIRONMENT_FEDERATION_AGENT);
+                });
+        } catch (Exception e) {
+            log.error("failed to apply {}", getClass().getSimpleName(), e);
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean shouldCreateEnvironmentFederationAgentRole(String organizationId) {
+        return roleService.findByScopeAndName(API, ROLE_ENVIRONMENT_FEDERATION_AGENT.getName(), organizationId).isEmpty();
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.DEFAULT_ROLES_UPGRADER + 1;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/CheckIntegrationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/CheckIntegrationUseCaseTest.java
@@ -16,6 +16,9 @@
 package io.gravitee.apim.core.integration.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.IntegrationFixture;
 import inmemory.EnvironmentCrudServiceInMemory;
@@ -25,7 +28,10 @@ import io.gravitee.apim.core.environment.model.Environment;
 import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.integration.use_case.CheckIntegrationUseCase.Input;
 import io.gravitee.apim.core.integration.use_case.CheckIntegrationUseCase.Output;
+import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -42,6 +48,7 @@ import org.junit.jupiter.api.Test;
 class CheckIntegrationUseCaseTest {
 
     private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String USER_ID = "user-id";
     private static final String ORGANIZATION_1 = "organization-1";
     private static final String ENVIRONMENT_1 = "environment-1";
     private static final String ORGANIZATION_2 = "organization-2";
@@ -58,6 +65,7 @@ class CheckIntegrationUseCaseTest {
 
     IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
     EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    PermissionDomainService permissionDomainService = mock(PermissionDomainService.class);
 
     CheckIntegrationUseCase useCase;
 
@@ -73,7 +81,7 @@ class CheckIntegrationUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new CheckIntegrationUseCase(integrationCrudService, environmentCrudService);
+        useCase = new CheckIntegrationUseCase(integrationCrudService, environmentCrudService, permissionDomainService);
 
         environmentCrudService.initWith(
             List.of(
@@ -91,7 +99,7 @@ class CheckIntegrationUseCaseTest {
     @Test
     void should_fail_when_integration_does_not_exist() {
         // When
-        var result = useCase.execute(new Input(ORGANIZATION_1, "unknown", PROVIDER));
+        var result = useCase.execute(new Input(ORGANIZATION_1, USER_ID, "unknown", PROVIDER));
 
         // Then
         assertThat(result).extracting(Output::success, Output::message).containsExactly(false, "Integration [id=unknown] not found");
@@ -101,9 +109,17 @@ class CheckIntegrationUseCaseTest {
     void should_fail_when_integration_does_not_match_with_agent_connected() {
         // Given
         givenExistingIntegration(INTEGRATION);
+        givenPermission(
+            RolePermission.ENVIRONMENT_INTEGRATION,
+            ENVIRONMENT_1,
+            RolePermissionAction.CREATE,
+            RolePermissionAction.READ,
+            RolePermissionAction.UPDATE,
+            RolePermissionAction.DELETE
+        );
 
         // When
-        var result = useCase.execute(new Input(ORGANIZATION_1, INTEGRATION_ID, "other"));
+        var result = useCase.execute(new Input(ORGANIZATION_1, USER_ID, INTEGRATION_ID, "other"));
 
         // Then
         assertThat(result)
@@ -117,7 +133,7 @@ class CheckIntegrationUseCaseTest {
         givenExistingIntegration(INTEGRATION);
 
         // When
-        var result = useCase.execute(new Input(ORGANIZATION_2, INTEGRATION_ID, PROVIDER));
+        var result = useCase.execute(new Input(ORGANIZATION_2, USER_ID, INTEGRATION_ID, PROVIDER));
 
         // Then
         assertThat(result)
@@ -126,11 +142,46 @@ class CheckIntegrationUseCaseTest {
     }
 
     @Test
-    void should_return_success_response() {
+    void should_fail_when_user_has_not_enough_permission_for_integration() {
         // Given
         givenExistingIntegration(INTEGRATION);
 
-        var result = useCase.execute(new Input(ORGANIZATION_1, INTEGRATION_ID, PROVIDER));
+        // When
+        var result = useCase.execute(new Input(ORGANIZATION_1, USER_ID, INTEGRATION_ID, PROVIDER));
+
+        // Then
+        assertThat(result)
+            .extracting(Output::success, Output::message)
+            .containsExactly(false, "Integration [id=my-integration-id] not found");
+    }
+
+    @Test
+    void should_return_success_response_when_user_has_correct_environment_integration_permissions() {
+        // Given
+        givenExistingIntegration(INTEGRATION);
+        givenPermission(
+            RolePermission.ENVIRONMENT_INTEGRATION,
+            ENVIRONMENT_1,
+            RolePermissionAction.CREATE,
+            RolePermissionAction.READ,
+            RolePermissionAction.UPDATE,
+            RolePermissionAction.DELETE
+        );
+
+        var result = useCase.execute(new Input(ORGANIZATION_1, USER_ID, INTEGRATION_ID, PROVIDER));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result).extracting(Output::success).isEqualTo(true);
+        });
+    }
+
+    @Test
+    void should_return_success_response_when_user_has_correct_integration_permissions() {
+        // Given
+        givenExistingIntegration(INTEGRATION);
+        givenPermission(RolePermission.INTEGRATION_DEFINITION, INTEGRATION_ID, RolePermissionAction.CREATE);
+
+        var result = useCase.execute(new Input(ORGANIZATION_1, USER_ID, INTEGRATION_ID, PROVIDER));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result).extracting(Output::success).isEqualTo(true);
@@ -139,5 +190,10 @@ class CheckIntegrationUseCaseTest {
 
     private void givenExistingIntegration(Integration... integration) {
         integrationCrudService.initWith(Arrays.asList(integration));
+    }
+
+    private void givenPermission(RolePermission rolePermission, String referenceId, RolePermissionAction... acls) {
+        when(permissionDomainService.hasExactPermissions(ORGANIZATION_1, USER_ID, rolePermission, referenceId, acls)).thenReturn(true);
+        when(permissionDomainService.hasPermission(ORGANIZATION_1, USER_ID, rolePermission, referenceId, acls)).thenReturn(true);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/permission/domain_service/PermissionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/permission/domain_service/PermissionDomainServiceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.permission.domain_service;
+
+import static assertions.CoreAssertions.assertThat;
+
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PermissionDomainServiceTest {
+
+    PermissionDomainService permissionDomainService = new PermissionDomainService() {
+        @Override
+        public boolean hasExactPermissions(
+            String organizationId,
+            String userId,
+            RolePermission permission,
+            String referenceId,
+            RolePermissionAction... acls
+        ) {
+            return false;
+        }
+
+        @Override
+        public boolean hasPermission(
+            String organizationId,
+            String userId,
+            RolePermission permission,
+            String referenceId,
+            RolePermissionAction... acls
+        ) {
+            return false;
+        }
+    };
+
+    @Nested
+    class CheckForExactPermissions {
+
+        @Test
+        void should_return_true_when_user_permissions_contains_requested_permission_with_exact_acls() {
+            // Given
+            var requestedPermission = RolePermission.INTEGRATION_DEFINITION.getPermission();
+            var userPermissions = Map.of(requestedPermission.getName(), new char[] { 'C', 'R', 'U', 'D' });
+
+            // When
+            var result = permissionDomainService.checkForExactPermissions(
+                userPermissions,
+                requestedPermission,
+                RolePermissionAction.CREATE,
+                RolePermissionAction.READ,
+                RolePermissionAction.UPDATE,
+                RolePermissionAction.DELETE
+            );
+
+            // Then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void should_return_false_when_user_permissions_contains_requested_permission_but_acls_not_match_exactly() {
+            // Given
+            var requestedPermission = RolePermission.INTEGRATION_DEFINITION.getPermission();
+            var userPermissions = Map.of(requestedPermission.getName(), new char[] { 'C', 'R', 'U', 'D' });
+
+            // When
+            var result = permissionDomainService.checkForExactPermissions(
+                userPermissions,
+                requestedPermission,
+                RolePermissionAction.CREATE,
+                RolePermissionAction.UPDATE
+            );
+
+            // Then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_user_permissions_provide_is_null() {
+            var result = permissionDomainService.checkForExactPermissions(null, null, RolePermissionAction.CREATE);
+
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_user_permissions_does_not_contain_requested_permission() {
+            // Given
+            var userPermissions = Map.of("permission", new char[] { 'C', 'R', 'U', 'D' });
+            var requestedPermission = RolePermission.INTEGRATION_DEFINITION.getPermission();
+
+            // When
+            var result = permissionDomainService.checkForExactPermissions(
+                userPermissions,
+                requestedPermission,
+                RolePermissionAction.CREATE
+            );
+
+            // Then
+            assertThat(result).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7123

## Description

Ensure the token used by the Federation Agent can manipulate integration. The token should be attached to 
- either a user having an Environment Role containing the permissions `INTEGRATION` with CRUD acls
- or a user member of the integration having the permission `INTEGRATION_DEFINITION` with CRUD acls

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cppwwqzyvp.chromatic.com)
<!-- Storybook placeholder end -->
