### PR TITLE
fix(console): Display only managed apis on console

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -217,7 +217,7 @@ describe('ApisListComponent', () => {
 
         await loader.getHarness(GioTableWrapperHarness).then((tableWrapper) => tableWrapper.setSearchValue('bad-search'));
         await tick(400);
-        const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=25&manageOnly=false`);
+        const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=25`);
         expect(req.request.body).toEqual({ query: 'bad-search' });
 
         req.flush('Internal error', { status: 500, statusText: 'Internal error' });
@@ -424,7 +424,7 @@ describe('ApisListComponent', () => {
     tick(400);
 
     const req = httpTestingController.expectOne(
-      `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=${page}&perPage=25${sortBy ? `&sortBy=${sortBy}` : ''}&manageOnly=false`,
+      `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=${page}&perPage=25${sortBy ? `&sortBy=${sortBy}` : ''}`,
     );
     expect(req.request.method).toEqual('POST');
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -135,7 +135,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
         }),
         switchMap(({ pagination, searchTerm, order }) =>
           this.apiServiceV2
-            .search({ query: searchTerm }, apiSortByParamFromString(order), pagination.index, pagination.size, false)
+            .search({ query: searchTerm }, apiSortByParamFromString(order), pagination.index, pagination.size)
             .pipe(catchError(() => of(new PagedResult<Api>()))),
         ),
         tap((apisPage) => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-5855

## Description
Display only managed apis on console - before we could see apis which user can't manage that's why there was inconsistency in total apis count on dashboard.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vecimgnqdo.chromatic.com)
<!-- Storybook placeholder end -->
