### PR TITLE
fix(console): Set reference id with execution context environment id whenever permission is Scope Environment

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/settings/mapi-v1/notification-setting.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/settings/mapi-v1/notification-setting.spec.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { API_USER, forManagementAsAdminUser } from '@gravitee/utils/configuration';
+import { RolesApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/RolesApi';
+import { UsersApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/UsersApi';
+import { RoleScope, UserEntity } from '../../../../../lib/management-webclient-sdk/src/lib/models';
+import { describe, expect } from '@jest/globals';
+import { noContent, succeed } from '@lib/jest-utils';
+import { ConfigurationApi } from '../../../../../lib/management-webclient-sdk/src/lib/apis/ConfigurationApi';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const managementRolesResourceAsAdminUser = new RolesApi(forManagementAsAdminUser());
+const managementUserResourceAsAdminUser = new UsersApi(forManagementAsAdminUser());
+const configurationResourceAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
+
+describe('Notification settings tests', () => {
+  let apiUser: UserEntity;
+
+  describe('Create', () => {
+    it('should create a notification setting', async () => {
+      const users = await managementUserResourceAsAdminUser.getAllUsers({ orgId, envId });
+      apiUser = users.data.find((user) => user.displayName === API_USER.username);
+
+      const userOrganizationRole = await succeed(
+        managementRolesResourceAsAdminUser.getRole1Raw({
+          scope: RoleScope.ORGANIZATION,
+          role: 'USER',
+          envId,
+          orgId,
+        }),
+      );
+
+      await succeed(
+        managementUserResourceAsAdminUser.updateUserRolesRaw({
+          userId: apiUser.id,
+          userReferenceRoleEntity: {
+            referenceId: orgId,
+            referenceType: 'ORGANIZATION',
+            roles: [userOrganizationRole.id],
+            user: apiUser.id,
+          },
+          orgId,
+          envId,
+        }),
+      );
+
+      const adminEnvironmentRole = await succeed(
+        managementRolesResourceAsAdminUser.getRole1Raw({
+          scope: RoleScope.ENVIRONMENT,
+          role: 'ADMIN',
+          envId,
+          orgId,
+        }),
+      );
+
+      await succeed(
+        managementUserResourceAsAdminUser.updateUserRolesRaw({
+          userId: apiUser.id,
+          userReferenceRoleEntity: {
+            referenceId: envId,
+            referenceType: 'ENVIRONMENT',
+            roles: [adminEnvironmentRole.id],
+            user: apiUser.id,
+          },
+          orgId,
+          envId,
+        }),
+      );
+
+      const notification = JSON.parse(
+        await succeed(
+          configurationResourceAsAdmin.createPortalNotificationSetting1Raw({
+            envId,
+            orgId,
+            genericNotificationConfigEntity: {
+              name: 'test',
+              referenceType: 'PORTAL',
+              referenceId: 'DEFAULT',
+              notifier: 'default-email',
+              config_type: 'GENERIC',
+            },
+          }),
+        ),
+      );
+
+      expect(notification).toBeTruthy();
+
+      await noContent(
+        configurationResourceAsAdmin.deleteNotificationSettings1Raw({
+          notificationId: notification.id,
+          envId,
+          orgId,
+        }),
+      );
+    });
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
@@ -117,10 +117,6 @@ public abstract class AbstractResource {
         return securityContext.isUserInRole(role);
     }
 
-    protected boolean hasPermission(final ExecutionContext executionContext, RolePermission permission, RolePermissionAction... acls) {
-        return hasPermission(executionContext, permission, null, acls);
-    }
-
     protected boolean hasPermission(
         ExecutionContext executionContext,
         RolePermission permission,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
@@ -65,6 +65,7 @@ public class CategoriesResource extends AbstractCategoryResource {
         boolean hasAllPermissions = hasPermission(
             executionContext,
             RolePermission.ENVIRONMENT_CATEGORY,
+            executionContext.getEnvironmentId(),
             RolePermissionAction.UPDATE,
             RolePermissionAction.CREATE,
             RolePermissionAction.DELETE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
@@ -85,7 +85,12 @@ public class CategoryResource extends AbstractCategoryResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public CategoryEntity getCategory() {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        boolean canShowCategory = hasPermission(executionContext, RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
+        boolean canShowCategory = hasPermission(
+            executionContext,
+            RolePermission.ENVIRONMENT_CATEGORY,
+            executionContext.getEnvironmentId(),
+            RolePermissionAction.READ
+        );
         CategoryEntity category = categoryService.findById(categoryId, executionContext.getEnvironmentId());
 
         if (!canShowCategory && category.isHidden()) {
@@ -135,7 +140,12 @@ public class CategoryResource extends AbstractCategoryResource {
     }
 
     private Response getImageResponse(final ExecutionContext executionContext, Request request, InlinePictureEntity image) {
-        boolean canShowCategory = hasPermission(executionContext, RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
+        boolean canShowCategory = hasPermission(
+            executionContext,
+            RolePermission.ENVIRONMENT_CATEGORY,
+            executionContext.getEnvironmentId(),
+            RolePermissionAction.READ
+        );
         CategoryEntity category = categoryService.findById(categoryId, GraviteeContext.getCurrentEnvironment());
 
         if (!canShowCategory && category.isHidden()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalNotificationSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalNotificationSettingsResource.java
@@ -65,7 +65,8 @@ public class PortalNotificationSettingsResource extends AbstractResource {
                 GraviteeContext.getCurrentEnvironment()
             )
         );
-        if (hasPermission(GraviteeContext.getExecutionContext(), ENVIRONMENT_NOTIFICATION, CREATE, UPDATE, DELETE)) {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        if (hasPermission(executionContext, ENVIRONMENT_NOTIFICATION, executionContext.getEnvironmentId(), CREATE, UPDATE, DELETE)) {
             settings.addAll(
                 genericNotificationConfigService.findByReference(NotificationReferenceType.PORTAL, GraviteeContext.getCurrentEnvironment())
             );
@@ -84,11 +85,12 @@ public class PortalNotificationSettingsResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
             config.getConfigType().equals(NotificationConfigType.GENERIC) &&
-            hasPermission(executionContext, ENVIRONMENT_NOTIFICATION, CREATE)
+            hasPermission(executionContext, ENVIRONMENT_NOTIFICATION, executionContext.getEnvironmentId(), CREATE)
         ) {
             return genericNotificationConfigService.create(config);
         } else if (
-            config.getConfigType().equals(NotificationConfigType.PORTAL) && hasPermission(executionContext, ENVIRONMENT_NOTIFICATION, READ)
+            config.getConfigType().equals(NotificationConfigType.PORTAL) &&
+            hasPermission(executionContext, ENVIRONMENT_NOTIFICATION, executionContext.getEnvironmentId(), READ)
         ) {
             return portalNotificationConfigService.save(convert(config));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRulesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRulesResource.java
@@ -69,7 +69,12 @@ public class QualityRulesResource extends AbstractResource {
     public List<QualityRuleEntity> getQualityRules() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
-            !hasPermission(executionContext, RolePermission.ENVIRONMENT_QUALITY_RULE, RolePermissionAction.READ) &&
+            !hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_QUALITY_RULE,
+                executionContext.getEnvironmentId(),
+                RolePermissionAction.READ
+            ) &&
             !canReadAPIConfiguration()
         ) {
             throw new ForbiddenAccessException();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7104

## Description
Set reference id with execution context environment id whenever permission is Scope Environment

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xvhhxbjdcb.chromatic.com)
<!-- Storybook placeholder end -->
