### PR TITLE
fix: handle DefaultOrganizationAdminRoleInitializer error by getting existing role value

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -615,7 +615,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                     Collections.singletonMap(ROLE, systemRole.getScope() + ":" + systemRole.getName()),
                     ROLE_UPDATED,
                     systemRole.getCreatedAt(),
-                    existingRole,
+                    existingRole.get(),
                     systemRole
                 );
             } else if (!existingRole.isPresent()) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7036

## Description

Avoid  error `Unable to apply the initializer DefaultOrganizationAdminRoleInitializer` at APIM Rest API start 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uekyaohujj.chromatic.com)
<!-- Storybook placeholder end -->
