### PR TITLE
fix: ditionaries upgraders ids

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
@@ -167,12 +167,7 @@ public class EventsLatestUpgrader implements Upgrader {
         );
         if (eventPage.getPageElements() > 0) {
             Event event = eventPage.getContent().get(0);
-            processEvent(
-                event,
-                DictionaryType.DYNAMIC.equals(dictionary.getType())
-                    ? dictionary.getId() + EventService.EVENT_LATEST_DYNAMIC_SUFFIX
-                    : dictionary.getId()
-            );
+            processEvent(event, dictionary.getId());
         }
 
         if (DictionaryType.DYNAMIC.equals(dictionary.getType())) {
@@ -184,7 +179,7 @@ public class EventsLatestUpgrader implements Upgrader {
                 );
             if (eventPage.getPageElements() > 0) {
                 Event event = eventPage.getContent().get(0);
-                processEvent(event, dictionary.getId());
+                processEvent(event, dictionary.getId() + EventService.EVENT_LATEST_DYNAMIC_SUFFIX);
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
@@ -251,8 +251,8 @@ public class EventsLatestUpgraderTest {
         assertThat(eventsSaved)
             .extracting(Event::getId, Event::getType)
             .containsExactlyInAnyOrder(
-                tuple("dictionary1" + EventService.EVENT_LATEST_DYNAMIC_SUFFIX, EventType.PUBLISH_DICTIONARY),
-                tuple("dictionary1", EventType.STOP_DICTIONARY),
+                tuple("dictionary1", EventType.PUBLISH_DICTIONARY),
+                tuple("dictionary1" + EventService.EVENT_LATEST_DYNAMIC_SUFFIX, EventType.STOP_DICTIONARY),
                 tuple("dictionary2", EventType.UNPUBLISH_DICTIONARY)
             );
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6914

## Description

A small mistake has ben done when we fixed the EventLatestUpgrader. The ids has been reversed on start/stop and publish/unpublish events. The dictionary is well deployed at the end but here we do a fix to use the proper ids for dictionaries events during migration.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

