### PR TITLE
chore(deps): bump rate limit policy to 2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-policy-quota.version>2.1.1</gravitee-policy-quota.version>    -->
         <!--    <gravitee-policy-spikearrest.version>2.1.1</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>2.1.2</gravitee-policy-ratelimit.version>
+        <gravitee-policy-ratelimit.version>2.1.3</gravitee-policy-ratelimit.version>
         <gravitee-policy-regex-threat-protection.version>1.5.0</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.1</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.15.1</gravitee-policy-request-validation.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-409

## Description

Bump rate limit policy to 2.1.3

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yfqxvoslcp.chromatic.com)
<!-- Storybook placeholder end -->
