### PR TITLE
fix: manage groups dialog miss proper css class

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.scss
@@ -4,7 +4,7 @@
 @use '../../../../scss/gio-layout' as gio-layout;
 $typography: map.get(gio.$mat-theme, typography);
 
-.integration-access-groups {
+.api-portal-access-groups {
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
## Description

While working on the integration groups module I accidentally renamed the CSS class for managing API groups. 

## Additional context

Before:
![image](https://github.com/user-attachments/assets/92aca057-bf20-4d33-9035-d2294cf43ac0)

After:
<img width="2036" alt="image" src="https://github.com/user-attachments/assets/f559234e-ce6a-4ac6-8924-63541e80e679">
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bcysmfitvp.chromatic.com)
<!-- Storybook placeholder end -->
