### PR TITLE
chore: bump gateway-api to 3.9.0-alpha.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.9.0-alpha.3</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.9.0-alpha.4</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
         <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
         <gravitee-node.version>6.4.6</gravitee-node.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7109

## Description

Bump gravitee-gateway-api to to 3.9.0-alpha.4 to fix e2e issues

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vksjinithk.chromatic.com)
<!-- Storybook placeholder end -->
