### PR TITLE
Provide Kafka libraries in gateway & improve maven configuration

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -537,6 +537,24 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-metadata</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-server-common</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
                 <version>${lucene.version}</version>

--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -232,6 +232,24 @@
             </dependency>
 
             <dependency>
+                <groupId>com.bazaarvoice.jolt</groupId>
+                <artifactId>jolt-core</artifactId>
+                <version>${jolt.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.bazaarvoice.jolt</groupId>
+                <artifactId>json-utils</artifactId>
+                <version>${jolt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>com.github.dozermapper</groupId>
                 <artifactId>dozer-core</artifactId>
                 <version>${dozer.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -105,6 +105,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Provided by the gravitee-node-license lib -->
+        <!-- FIXME: should we explicitly declare it in gateway container ? -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.kubernetes</groupId>
             <artifactId>gravitee-kubernetes-client</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -252,6 +252,22 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Kafka -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-metadata</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+        </dependency>
+
         <!-- Mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -33,19 +33,6 @@
         <reactiverse-junit5-rx-java2-web-client.version>0.3.0</reactiverse-junit5-rx-java2-web-client.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Gravitee.io -->
         <dependency>

--- a/gravitee-apim-integration-tests/pom.xml
+++ b/gravitee-apim-integration-tests/pom.xml
@@ -38,21 +38,7 @@
         <reactor-rabbitmq.version>1.5.6</reactor-rabbitmq.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
-
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>

--- a/gravitee-apim-parent/pom.xml
+++ b/gravitee-apim-parent/pom.xml
@@ -179,7 +179,6 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>${maven-assembly-plugin.version}</version>
                     <inherited>true</inherited>
                     <executions>
                         <execution>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/pom.xml
@@ -30,10 +30,6 @@
     <artifactId>gravitee-apim-plugin-apiservice-dynamicproperties-http</artifactId>
     <name>Gravitee.io APIM - Plugin - Dynamic Properties - Api Service Dynamic Properties Http</name>
     <description>Api Service dedicated to manage dynamic properties for apis</description>
-    <properties>
-        <jolt-core.version>0.1.8</jolt-core.version>
-        <json-utils.version>0.1.8</json-utils.version>
-    </properties>
 
     <dependencies>
         <!-- Gravitee dependencies -->
@@ -57,12 +53,10 @@
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
-            <version>${jolt-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
-            <version>${json-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-servicediscovery-consul/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-servicediscovery-consul/pom.xml
@@ -71,22 +71,12 @@
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-core</artifactId>
+            <artifactId>vertx-web-client</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-consul-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-web</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.vertx</groupId>
-                    <artifactId>vertx-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/pom.xml
@@ -31,19 +31,6 @@
     <name>Gravitee.io APIM - Plugin - Endpoint HTTP proxy</name>
     <description>Endpoint that allows exposing HTTP SyncApi.</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Gravitee dependencies -->
         <dependency>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/pom.xml
@@ -31,18 +31,6 @@
     <name>Gravitee.io APIM - Plugin - Endpoint mock</name>
     <description>Use a Mock backend to emulate the behaviour of a typical HTTP server and test processes</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee dependencies -->

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-tcp-proxy/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-tcp-proxy/pom.xml
@@ -30,18 +30,6 @@
     <name>Gravitee.io APIM - Plugin - Endpoint TCP proxy</name>
     <description>Endpoint that allows exposing TCP API</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee dependencies -->

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-proxy/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-proxy/pom.xml
@@ -31,19 +31,6 @@
     <name>Gravitee.io APIM - Plugin - Entrypoint HTTP Proxy</name>
     <description>Web APIs can be accessed using the HTTP protocol. Defines endpoints, valid request and response formats.</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Gravitee dependencies -->
         <dependency>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-tcp-proxy/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-tcp-proxy/pom.xml
@@ -30,19 +30,6 @@
     <name>Gravitee.io APIM - Plugin - Entrypoint TCP Proxy</name>
     <description>APIs can be accessed using the TCP protocol.</description>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Import bom to properly inherit all dependencies -->
-            <dependency>
-                <groupId>io.gravitee.apim</groupId>
-                <artifactId>gravitee-apim-bom</artifactId>
-                <version>${project.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Gravitee dependencies -->
         <dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
@@ -47,10 +47,12 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-license</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -45,31 +45,6 @@
         <module>gravitee-apim-rest-api-services-subscription-pre-expiration-notif</module>
     </modules>
 
-    <properties>
-        <jolt.version>0.1.8</jolt.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.bazaarvoice.jolt</groupId>
-                <artifactId>jolt-core</artifactId>
-                <version>${jolt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.bazaarvoice.jolt</groupId>
-                <artifactId>json-utils</artifactId>
-                <version>${jolt.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>io.gravitee.apim.rest.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
         <json-smart.version>2.5.1</json-smart.version>
         <json-unit.version>3.3.0</json-unit.version>
         <jsoup.version>1.17.2</jsoup.version>
+        <kafka.version>3.7.1</kafka.version>
         <lucene.version>9.11.1</lucene.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.0.Beta2</mapstruct.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
         <awaitility.version>4.2.2</awaitility.version>
         <jmh.version>1.37</jmh.version>
         <jcstress.version>0.15</jcstress.version>
+        <jolt.version>0.1.8</jolt.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <json-unit.version>3.3.0</json-unit.version>
         <json-patch.version>1.13</json-patch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.2.3</gravitee-cockpit-api.version>
+        <gravitee-cloud-initializer.version>2.0.2</gravitee-cloud-initializer.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
@@ -58,34 +59,36 @@
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.9.0-alpha.4</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>
-        <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
+        <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
+        <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
         <gravitee-node.version>6.4.6</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
+        <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.31.1</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
-        <gravitee-kubernetes.version>3.4.1</gravitee-kubernetes.version>
-        <gravitee-json-validation.version>2.0.1</gravitee-json-validation.version>
-        <gravitee-cloud-initializer.version>2.0.2</gravitee-cloud-initializer.version>
+
         <!-- Other dependencies version -->
-        <angus-mail.version>2.0.3</angus-mail.version>
         <angus-activation.version>2.0.2</angus-activation.version>
+        <angus-mail.version>2.0.3</angus-mail.version>
+        <archunit-junit5.version>1.3.0</archunit-junit5.version>
         <asm.version>9.7</asm.version>
+        <awaitility.version>4.2.2</awaitility.version>
         <batik-transcoder.version>1.17</batik-transcoder.version>
         <classgraph.version>4.8.174</classgraph.version>
+        <commons-email.version>1.6.0</commons-email.version>
         <commons-io.version>2.16.1</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-pool2.version>2.12.0</commons-pool2.version>
         <commons-text.version>1.12.0</commons-text.version>
-        <commons-email.version>1.6.0</commons-email.version>
         <dozer.version>7.0.0</dozer.version>
         <flexmark.version>0.64.8</flexmark.version>
         <freemarker.version>2.3.33</freemarker.version>
@@ -95,55 +98,51 @@
         <hibernate-validator.version>8.0.1.Final</hibernate-validator.version>
         <httpclient.version>4.5.14</httpclient.version>
         <imageio.version>3.11.0</imageio.version>
-        <java-jwt.version>4.4.0</java-jwt.version>
-        <javassist.version>3.30.2-GA</javassist.version>
-        <jakarta.validation-api.version>3.1.0</jakarta.validation-api.version>
+        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
         <jakarta.inject-api.version>2.0.1.MR</jakarta.inject-api.version>
-        <javax.inject.version>1</javax.inject.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
-        <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
+        <jakarta.validation-api.version>3.1.0</jakarta.validation-api.version>
         <jakarta.xml.bind-api.version>4.0.2</jakarta.xml.bind-api.version>
+        <java-jwt.version>4.4.0</java-jwt.version>
+        <javassist.version>3.30.2-GA</javassist.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <spring-data-mongodb.version>4.3.1</spring-data-mongodb.version>
-
+        <javax.inject.version>1</javax.inject.version>
+        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <!-- javax dependencies still required for compatibility or test -->
         <jaxb-impl.version>4.0.5</jaxb-impl.version>
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
-        <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
-
-        <archunit-junit5.version>1.3.0</archunit-junit5.version>
-        <awaitility.version>4.2.2</awaitility.version>
-        <jmh.version>1.37</jmh.version>
         <jcstress.version>0.15</jcstress.version>
+        <jmh.version>1.37</jmh.version>
         <jolt.version>0.1.8</jolt.version>
         <jsonassert.version>1.5.3</jsonassert.version>
-        <json-unit.version>3.3.0</json-unit.version>
         <json-patch.version>1.13</json-patch.version>
         <json-path.version>2.9.0</json-path.version>
         <json-smart.version>2.5.1</json-smart.version>
+        <json-unit.version>3.3.0</json-unit.version>
         <jsoup.version>1.17.2</jsoup.version>
-        <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <lucene.version>9.11.1</lucene.version>
+        <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.0.Beta2</mapstruct.version>
         <netty-tcnative-boringssl-static.version>2.0.65.Final</netty-tcnative-boringssl-static.version>
         <nimbus-jose-jwt.version>9.40</nimbus-jose-jwt.version>
         <owasp-java-html-sanitizer.version>20240325.1</owasp-java-html-sanitizer.version>
-        <reactor-core.version>3.6.7</reactor-core.version>
         <reactor-adapter.version>3.5.1</reactor-adapter.version>
+        <reactor-core.version>3.6.7</reactor-core.version>
         <slf4j2-mock.version>2.3.0</slf4j2-mock.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <swagger-jaxrs2.version>2.2.22</swagger-jaxrs2.version>
-        <swagger-core.version>2.2.22</swagger-core.version>
-        <swagger-parser.version>2.1.22</swagger-parser.version>
+        <spring-data-mongodb.version>4.3.1</spring-data-mongodb.version>
         <resilience4j-rxjava3.version>2.2.0</resilience4j-rxjava3.version>
         <!-- !! Transitive dependency !! need to remove when swagger parser will include a version higher than 1.7.12 -->
         <rhino.version>1.7.15</rhino.version>
+        <swagger-core.version>2.2.22</swagger-core.version>
+        <swagger-jaxrs2.version>2.2.22</swagger-jaxrs2.version>
+        <swagger-parser.version>2.1.22</swagger-parser.version>
         <testcontainers.version>1.19.8</testcontainers.version>
-        <xmlbeans.version>5.2.1</xmlbeans.version>
         <wiremock.version>3.8.0</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
+        <xmlbeans.version>5.2.1</xmlbeans.version>
 
         <!-- Plugins version -->
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.1.14</version>
+        <version>22.2.0</version>
     </parent>
 
     <groupId>io.gravitee.apim</groupId>
@@ -145,7 +145,6 @@
         <wsdl4j.version>1.6.3</wsdl4j.version>
 
         <!-- Plugins version -->
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7138

## Description

- Provide kafka libraries in the gateway for the kafka gateway project.
- Use gravitee-parent 22.2.0 to force maven-assembly 3.6.0 (version 3.7.0 has a bug) (https://github.com/gravitee-io/gravitee-parent/pull/62)
- Clean poms
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-opjyujmopn.chromatic.com)
<!-- Storybook placeholder end -->
