### PR TITLE
Apim 7152 create native api use case

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeEntrypoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeEntrypoint.java
@@ -23,9 +23,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
-@Builder
+@SuperBuilder
 @Getter
 @Setter
 @ToString

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeEntrypoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeEntrypoint.java
@@ -20,9 +20,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@NoArgsConstructor
 @Builder
 @Getter
 @Setter

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/FlowFixtures.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/fixtures/definition/FlowFixtures.java
@@ -24,8 +24,8 @@ import io.gravitee.definition.model.flow.PathOperator;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.ChannelSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
-import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.flow.step.Step;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -34,7 +34,8 @@ public class FlowFixtures {
 
     private FlowFixtures() {}
 
-    private static final Supplier<Flow.FlowBuilder<?, ?>> BASE_V4 = () -> Flow.builder().name("my-flow");
+    private static final Supplier<Flow.FlowBuilder<?, ?>> BASE_HTTP_V4 = () -> Flow.builder().name("my-flow");
+    private static final Supplier<NativeFlow.NativeFlowBuilder<?, ?>> BASE_NATIVE_V4 = () -> NativeFlow.builder().name("my-flow");
     private static final Supplier<io.gravitee.definition.model.flow.Flow.FlowBuilder> BASE_V2 = () ->
         io.gravitee.definition.model.flow.Flow
             .builder()
@@ -75,7 +76,7 @@ public class FlowFixtures {
     }
 
     public static Flow aProxyFlowV4() {
-        return BASE_V4
+        return BASE_HTTP_V4
             .get()
             .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.STARTS_WITH).build()))
             .request(
@@ -106,7 +107,7 @@ public class FlowFixtures {
     }
 
     public static Flow aMessageFlowV4() {
-        return BASE_V4
+        return BASE_HTTP_V4
             .get()
             .selectors(List.of(ChannelSelector.builder().channel("/").channelOperator(Operator.STARTS_WITH).build()))
             .subscribe(
@@ -122,6 +123,36 @@ public class FlowFixtures {
                 )
             )
             .publish(
+                List.of(
+                    Step
+                        .builder()
+                        .name("my-step-name-2")
+                        .policy("my-policy")
+                        .description("my-step-description")
+                        .messageCondition("my-step-condition")
+                        .configuration("{}")
+                        .build()
+                )
+            )
+            .build();
+    }
+
+    public static NativeFlow aNativeFlowV4() {
+        return BASE_NATIVE_V4
+            .get()
+            .interact(
+                List.of(
+                    Step
+                        .builder()
+                        .name("my-step-name-1")
+                        .policy("my-policy")
+                        .description("my-step-description")
+                        .messageCondition("my-step-condition")
+                        .configuration("{}")
+                        .build()
+                )
+            )
+            .connect(
                 List.of(
                     Step
                         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import static java.util.stream.Collectors.toMap;
 
-import io.gravitee.apim.core.api.model.NewApi;
+import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
 import io.gravitee.apim.core.documentation.model.Page;
@@ -188,7 +188,7 @@ public interface ApiMapper {
     ApiExport toApiExport(ApiV4 api);
 
     @Mapping(target = "listeners", qualifiedByName = "toListeners")
-    NewApi map(CreateApiV4 api);
+    NewHttpApi map(CreateApiV4 api);
 
     @Mapping(target = "listeners", qualifiedByName = "toListeners")
     @Mapping(target = "plans", qualifiedByName = "mapPlanCRD")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -155,14 +155,14 @@ public interface ApiMapper {
 
     @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
-    @Mapping(target = "analytics", source = "source.apiDefinitionV4.analytics")
+    @Mapping(target = "analytics", source = "source.apiDefinitionHttpV4.analytics")
     @Mapping(target = "deploymentState", source = "deploymentState")
-    @Mapping(target = "endpointGroups", source = "source.apiDefinitionV4.endpointGroups")
-    @Mapping(target = "flowExecution", source = "source.apiDefinitionV4.flowExecution")
-    @Mapping(target = "flows", source = "source.apiDefinitionV4.flows")
+    @Mapping(target = "endpointGroups", source = "source.apiDefinitionHttpV4.endpointGroups")
+    @Mapping(target = "flowExecution", source = "source.apiDefinitionHttpV4.flowExecution")
+    @Mapping(target = "flows", source = "source.apiDefinitionHttpV4.flows")
     @Mapping(target = "lifecycleState", source = "source.apiLifecycleState")
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
-    @Mapping(target = "listeners", source = "source.apiDefinitionV4.listeners", qualifiedByName = "fromListeners")
+    @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
     ApiV4 mapToV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapper.java
@@ -17,12 +17,10 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.category.model.ApiCategoryOrder;
-import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
 import io.gravitee.rest.api.management.v2.rest.model.CategoryApi;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -53,9 +51,9 @@ public interface CategoryApiMapper {
 
         switch (api.getDefinitionVersion()) {
             case V4 -> {
-                if (Objects.nonNull(api.getApiDefinitionV4()) && Objects.nonNull(api.getApiDefinitionV4().getListeners())) {
+                if (Objects.nonNull(api.getApiDefinitionHttpV4()) && Objects.nonNull(api.getApiDefinitionHttpV4().getListeners())) {
                     Stream<String> tcpListenerHostsStream = api
-                        .getApiDefinitionV4()
+                        .getApiDefinitionHttpV4()
                         .getListeners()
                         .stream()
                         .filter(listener -> ListenerType.TCP.equals(listener.getType()))
@@ -63,7 +61,7 @@ public interface CategoryApiMapper {
                         .flatMap(listener -> listener.getHosts().stream());
 
                     Stream<String> httpListenerHostsStream = api
-                        .getApiDefinitionV4()
+                        .getApiDefinitionHttpV4()
                         .getListeners()
                         .stream()
                         .filter(listener -> ListenerType.HTTP.equals(listener.getType()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -108,7 +108,7 @@ public interface PlanMapper {
 
     @Mapping(target = "validation", defaultValue = "MANUAL")
     @Mapping(target = "definitionVersion", constant = "V4")
-    @Mapping(target = "planDefinitionV4", source = "source", qualifiedByName = "mapToPlanDefinitionV4")
+    @Mapping(target = "planDefinitionHttpV4", source = "source", qualifiedByName = "mapToPlanDefinitionV4")
     io.gravitee.apim.core.plan.model.Plan map(CreatePlanV4 source);
 
     @Mapping(target = "security", source = "security.type", qualifiedByName = "toV2PlanSecurityType")
@@ -122,7 +122,7 @@ public interface PlanMapper {
 
     @Mapping(target = "definitionVersion", constant = "V4")
     @Mapping(target = "type", constant = "API")
-    @Mapping(target = "planDefinitionV4", source = "plan", qualifiedByName = "mapPlanV4ToPlanDefinitionV4")
+    @Mapping(target = "planDefinitionHttpV4", source = "plan", qualifiedByName = "mapPlanV4ToPlanDefinitionV4")
     PlanWithFlows toPlanWithFlows(PlanV4 plan);
 
     @Named("toPlansWithFlows")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -22,7 +22,7 @@ import com.google.common.base.Strings;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
-import io.gravitee.apim.core.api.use_case.CreateV4ApiUseCase;
+import io.gravitee.apim.core.api.use_case.CreateHttpApiUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
@@ -118,7 +118,7 @@ public class ApisResource extends AbstractResource {
     private ApiStateDomainService apiStateDomainService;
 
     @Inject
-    private CreateV4ApiUseCase createV4ApiUseCase;
+    private CreateHttpApiUseCase createHttpApiUseCase;
 
     @Inject
     private ImportApiCRDUseCase importCRDUseCase;
@@ -154,7 +154,7 @@ public class ApisResource extends AbstractResource {
                     .build()
             )
             .build();
-        var output = createV4ApiUseCase.execute(new CreateV4ApiUseCase.Input(ApiMapper.INSTANCE.map(api), audit));
+        var output = createHttpApiUseCase.execute(new CreateHttpApiUseCase.Input(ApiMapper.INSTANCE.map(api), audit));
 
         boolean isSynchronized = apiStateDomainService.isSynchronized(output.api(), audit);
         return Response

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
@@ -189,7 +189,7 @@ public class PlanFixtures {
             .description("Description")
             .validation(Plan.PlanValidationType.AUTO)
             .type(Plan.PlanType.API)
-            .planDefinitionV4(
+            .planDefinitionHttpV4(
                 fixtures.definition.PlanFixtures
                     .anApiKeyV4()
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CategoryApiMapperTest.java
@@ -139,7 +139,7 @@ public class CategoryApiMapperTest {
             .description(API_DESCRIPTION)
             .version(API_VERSION)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(definition)
+            .apiDefinitionHttpV4(definition)
             .build();
 
         var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
@@ -181,7 +181,7 @@ public class CategoryApiMapperTest {
             .description(API_DESCRIPTION)
             .version(API_VERSION)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(definition)
+            .apiDefinitionHttpV4(definition)
             .build();
 
         var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
@@ -225,7 +225,7 @@ public class CategoryApiMapperTest {
             .description(API_DESCRIPTION)
             .version(API_VERSION)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(definition)
+            .apiDefinitionHttpV4(definition)
             .build();
 
         var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();
@@ -262,7 +262,7 @@ public class CategoryApiMapperTest {
             .description(API_DESCRIPTION)
             .version(API_VERSION)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(definition)
+            .apiDefinitionHttpV4(definition)
             .build();
 
         var apiCategoryOrder = ApiCategoryOrder.builder().apiId(API_ID).categoryId(CAT_ID).order(11).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -362,7 +362,7 @@ class ApisResourceTest extends AbstractResourceTest {
             when(createApiDomainService.create(any(Api.class), any(), any(AuditInfo.class), any(), any()))
                 .thenAnswer(invocation -> {
                     Api api = invocation.getArgument(0);
-                    return new ApiWithFlows(api.toBuilder().id("api-id").build(), api.getApiDefinitionV4().getFlows());
+                    return new ApiWithFlows(api.toBuilder().id("api-id").build(), api.getApiDefinitionHttpV4().getFlows());
                 });
 
             var newApi = aValidV4Api();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageConnectionDurationUseCase.java
@@ -45,7 +45,7 @@ public class SearchAverageConnectionDurationUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionV4());
+        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
         validateApiMultiTenancyAccess(api, input.environmentId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchAverageMessagesPerRequestAnalyticsUseCase.java
@@ -48,7 +48,7 @@ public class SearchAverageMessagesPerRequestAnalyticsUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionV4());
+        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
         validateApiType(api.getType(), input.apiId);
         validateApiMultiTenancyAccess(api, input.environmentId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchRequestsCountAnalyticsUseCase.java
@@ -46,7 +46,7 @@ public class SearchRequestsCountAnalyticsUseCase {
     private void validateApiRequirements(Input input) {
         final Api api = apiCrudService.get(input.apiId);
         validateApiDefinitionVersion(api.getDefinitionVersion(), input.apiId);
-        validateApiIsNotTcp(api.getApiDefinitionV4());
+        validateApiIsNotTcp(api.getApiDefinitionHttpV4());
         validateApiMultiTenancyAccess(api, input.environmentId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusOverTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusOverTimeUseCase.java
@@ -63,7 +63,7 @@ public class SearchResponseStatusOverTimeUseCase {
     }
 
     private void validateApiIsNotTcp(Api api) {
-        if (api.getApiDefinitionV4().isTcpProxy()) {
+        if (api.getApiDefinitionHttpV4().isTcpProxy()) {
             throw new TcpProxyNotSupportedException(api.getId());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusRangesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseStatusRangesUseCase.java
@@ -54,7 +54,7 @@ public class SearchResponseStatusRangesUseCase {
     }
 
     private void validateApiIsNotTcp(Api api) {
-        if (api.getApiDefinitionV4().isTcpProxy()) {
+        if (api.getApiDefinitionHttpV4().isTcpProxy()) {
             throw new TcpProxyNotSupportedException(api.getId());
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCase.java
@@ -60,7 +60,7 @@ public class SearchResponseTimeUseCase {
     }
 
     private static Single<Api> validateApiIsNotTcp(Api api) {
-        return api.getApiDefinitionV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
+        return api.getApiDefinitionHttpV4().isTcpProxy() ? Single.error(new TcpProxyNotSupportedException(api.getId())) : Single.just(api);
     }
 
     private static Single<Api> validateApiMultiTenancyAccess(Api api, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
@@ -35,7 +35,6 @@ import io.gravitee.apim.core.parameters.model.ParameterContext;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
 import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import java.util.Collections;
@@ -158,8 +157,8 @@ public class CreateApiDomainService {
     private List<? extends AbstractFlow> saveApiFlows(Api api) {
         return switch (api.getDefinitionVersion()) {
             case V4 -> switch (api.getType()) {
-                case PROXY, MESSAGE -> flowCrudService.saveApiFlows(api.getId(), api.getApiDefinitionV4().getFlows());
-                case NATIVE -> flowCrudService.saveNativeApiFlows(api.getId(), api.getNativeApiDefinition().getFlows());
+                case PROXY, MESSAGE -> flowCrudService.saveApiFlows(api.getId(), api.getApiDefinitionHttpV4().getFlows());
+                case NATIVE -> flowCrudService.saveNativeApiFlows(api.getId(), api.getApiDefinitionNativeV4().getFlows());
             };
             case V1, V2, FEDERATED -> null;
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CreateApiDomainService.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.notification.model.config.NotificationConfig;
 import io.gravitee.apim.core.parameters.model.ParameterContext;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
 import io.gravitee.apim.core.workflow.crud_service.WorkflowCrudService;
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
@@ -154,9 +155,12 @@ public class CreateApiDomainService {
         }
     }
 
-    private List<Flow> saveApiFlows(Api api) {
+    private List<? extends AbstractFlow> saveApiFlows(Api api) {
         return switch (api.getDefinitionVersion()) {
-            case V4 -> flowCrudService.saveApiFlows(api.getId(), api.getApiDefinitionV4().getFlows());
+            case V4 -> switch (api.getType()) {
+                case PROXY, MESSAGE -> flowCrudService.saveApiFlows(api.getId(), api.getApiDefinitionV4().getFlows());
+                case NATIVE -> flowCrudService.saveNativeApiFlows(api.getId(), api.getNativeApiDefinition().getFlows());
+            };
             case V1, V2, FEDERATED -> null;
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
@@ -119,9 +119,9 @@ public class VerifyApiHostsDomainService {
                 !api.getId().equals(apiId) &&
                 ApiType.PROXY.equals(api.getType()) &&
                 DefinitionVersion.V4.equals(api.getDefinitionVersion()) &&
-                null != api.getApiDefinitionV4()
+                null != api.getApiDefinitionHttpV4()
             )
-            .flatMap(api -> api.getApiDefinitionV4().getListeners().stream())
+            .flatMap(api -> api.getApiDefinitionHttpV4().getListeners().stream())
             .filter(TcpListener.class::isInstance)
             .map(TcpListener.class::cast)
             .map(TcpListener::getHosts)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -30,7 +30,6 @@ import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -211,7 +210,7 @@ public class VerifyApiPathDomainService implements Validator<VerifyApiPathDomain
 
     private static List<Path> getV4Paths(Api api) {
         return api
-            .getApiDefinitionV4()
+            .getApiDefinitionHttpV4()
             .getListeners()
             .stream()
             .filter(HttpListener.class::isInstance)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/exception/ApiInvalidTypeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/exception/ApiInvalidTypeException.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api.exception;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.definition.model.v4.ApiType;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -25,7 +26,23 @@ import java.util.Map;
  */
 public class ApiInvalidTypeException extends ValidationDomainException {
 
+    public static final String ONLY_V_4 = "Only V4 ";
+    public static final String API_DEFINITION_IS_SUPPORTED = " API definition is supported";
+    public static final String API_ID = "apiId";
+
     public ApiInvalidTypeException(String apiId, ApiType expectedType) {
-        super("Only V4 " + expectedType.name() + " API definition is supported", Map.of("apiId", apiId));
+        super(ONLY_V_4 + expectedType.name() + API_DEFINITION_IS_SUPPORTED, Map.of(API_ID, apiId));
+    }
+
+    public ApiInvalidTypeException(String apiId, List<ApiType> expectedTypes) {
+        super(ONLY_V_4 + expectedTypes + API_DEFINITION_IS_SUPPORTED, Map.of(API_ID, apiId));
+    }
+
+    public ApiInvalidTypeException(ApiType expectedType) {
+        super(ONLY_V_4 + expectedType.name() + API_DEFINITION_IS_SUPPORTED);
+    }
+
+    public ApiInvalidTypeException(List<ApiType> expectedTypes) {
+        super(ONLY_V_4 + expectedTypes + API_DEFINITION_IS_SUPPORTED);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractNewApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractNewApi.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@NoArgsConstructor
+@SuperBuilder(toBuilder = true)
+public abstract class AbstractNewApi {
+
+    protected String name;
+
+    protected String apiVersion;
+
+    @Builder.Default
+    protected DefinitionVersion definitionVersion = DefinitionVersion.V4;
+
+    protected ApiType type;
+
+    protected String description;
+
+    @Builder.Default
+    protected Set<String> tags = Set.of();
+
+    @Builder.Default
+    protected Set<String> groups = Set.of();
+
+    /**
+     * @return An instance of {@link Api.ApiBuilder} based on the current state of this NewApi.
+     */
+    public Api.ApiBuilder<?, ?> toApiBuilder() {
+        // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
+        return Api
+            .builder()
+            .name(name)
+            .version(apiVersion)
+            .type(type)
+            .definitionVersion(definitionVersion)
+            .description(description)
+            .groups(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -19,7 +19,6 @@ import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
-import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.rest.api.model.context.OriginContext;
 import java.time.ZonedDateTime;
@@ -74,8 +73,8 @@ public class Api {
      */
     private DefinitionVersion definitionVersion;
 
-    private io.gravitee.definition.model.v4.Api apiDefinitionV4;
-    private io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiDefinition;
+    private io.gravitee.definition.model.v4.Api apiDefinitionHttpV4;
+    private io.gravitee.definition.model.v4.nativeapi.NativeApi apiDefinitionNativeV4;
     private io.gravitee.definition.model.Api apiDefinition;
     private io.gravitee.definition.model.federation.FederatedApi federatedApiDefinition;
 
@@ -164,9 +163,9 @@ public class Api {
         return switch (definitionVersion) {
             case V4 -> {
                 if (type == ApiType.NATIVE) {
-                    yield nativeApiDefinition.getTags();
+                    yield apiDefinitionNativeV4.getTags();
                 }
-                yield apiDefinitionV4.getTags();
+                yield apiDefinitionHttpV4.getTags();
             }
             case V1, V2 -> apiDefinition.getTags();
             case FEDERATED -> Collections.emptySet();
@@ -174,22 +173,22 @@ public class Api {
     }
 
     public Api setTags(Set<String> tags) {
-        if (apiDefinitionV4 != null) {
-            apiDefinitionV4.setTags(tags);
+        if (apiDefinitionHttpV4 != null) {
+            apiDefinitionHttpV4.setTags(tags);
         }
         if (apiDefinition != null) {
             apiDefinition.setTags(tags);
         }
-        if (nativeApiDefinition != null) {
-            nativeApiDefinition.setTags(tags);
+        if (apiDefinitionNativeV4 != null) {
+            apiDefinitionNativeV4.setTags(tags);
         }
         return this;
     }
 
     public Api setId(String id) {
         this.id = id;
-        if (apiDefinitionV4 != null) {
-            apiDefinitionV4.setId(id);
+        if (apiDefinitionHttpV4 != null) {
+            apiDefinitionHttpV4.setId(id);
         }
         if (apiDefinition != null) {
             apiDefinition.setId(id);
@@ -200,9 +199,9 @@ public class Api {
         return this;
     }
 
-    public Api setApiDefinitionV4(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
-        this.apiDefinitionV4 = apiDefinitionV4;
-        this.definitionVersion = apiDefinitionV4.getDefinitionVersion();
+    public Api setApiDefinitionHttpV4(io.gravitee.definition.model.v4.Api apiDefinitionHttpV4) {
+        this.apiDefinitionHttpV4 = apiDefinitionHttpV4;
+        this.definitionVersion = apiDefinitionHttpV4.getDefinitionVersion();
         return this;
     }
 
@@ -221,11 +220,11 @@ public class Api {
     public Api setPlans(List<Plan> plans) {
         switch (definitionVersion) {
             case V4 -> {
-                if (apiDefinitionV4.getType() == ApiType.NATIVE) {
-                    nativeApiDefinition.setPlans(plans.stream().map(Plan::getPlanDefinitionNativeV4).toList());
+                if (apiDefinitionHttpV4.getType() == ApiType.NATIVE) {
+                    apiDefinitionNativeV4.setPlans(plans.stream().map(Plan::getPlanDefinitionNativeV4).toList());
                 }
 
-                apiDefinitionV4.setPlans(plans.stream().map(Plan::getPlanDefinitionHttpV4).toList());
+                apiDefinitionHttpV4.setPlans(plans.stream().map(Plan::getPlanDefinitionHttpV4).toList());
             }
             case V1, V2 -> apiDefinition.setPlans(plans.stream().map(Plan::getPlanDefinitionV2).collect(Collectors.toList()));
             case FEDERATED -> {
@@ -245,10 +244,10 @@ public class Api {
         if (definitionVersion != DefinitionVersion.V4) {
             return false;
         }
-        final ApiProperties apiProperties = new ApiProperties(this.apiDefinitionV4.getProperties());
+        final ApiProperties apiProperties = new ApiProperties(this.apiDefinitionHttpV4.getProperties());
         final ApiProperties.DynamicPropertiesResult properties = apiProperties.updateDynamicProperties(dynamicProperties);
 
-        this.getApiDefinitionV4().setProperties(properties.orderedProperties());
+        this.getApiDefinitionHttpV4().setProperties(properties.orderedProperties());
 
         setUpdatedAt(TimeProvider.now());
 
@@ -265,11 +264,11 @@ public class Api {
     }
 
     public Api rollbackTo(io.gravitee.definition.model.v4.Api source) {
-        final io.gravitee.definition.model.v4.Api currentDefinition = getApiDefinitionV4();
+        final io.gravitee.definition.model.v4.Api currentDefinition = getApiDefinitionHttpV4();
         return toBuilder()
             .name(source.getName())
             .version(source.getApiVersion())
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 currentDefinition
                     .toBuilder()
                     .tags(source.getTags())
@@ -301,8 +300,8 @@ public class Api {
             return self();
         }
 
-        public B apiDefinitionV4(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
-            this.apiDefinitionV4 = apiDefinitionV4;
+        public B apiDefinitionHttpV4(io.gravitee.definition.model.v4.Api apiDefinitionV4) {
+            this.apiDefinitionHttpV4 = apiDefinitionV4;
             if (apiDefinitionV4 != null) {
                 this.definitionVersion = apiDefinitionV4.getDefinitionVersion();
             }
@@ -317,8 +316,8 @@ public class Api {
             return self();
         }
 
-        public B nativeApiDefinition(io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiDefinition) {
-            this.nativeApiDefinition = nativeApiDefinition;
+        public B apiDefinitionNativeV4(io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiDefinition) {
+            this.apiDefinitionNativeV4 = nativeApiDefinition;
             if (nativeApiDefinition != null) {
                 this.definitionVersion = nativeApiDefinition.getDefinitionVersion();
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -173,7 +173,7 @@ public class Api {
         };
     }
 
-    public Api setTag(Set<String> tags) {
+    public Api setTags(Set<String> tags) {
         if (apiDefinitionV4 != null) {
             apiDefinitionV4.setTags(tags);
         }
@@ -288,7 +288,7 @@ public class Api {
                     .build()
             )
             .build()
-            .setTag(source.getTags());
+            .setTags(source.getTags());
     }
 
     public abstract static class ApiBuilder<C extends Api, B extends ApiBuilder<C, B>> {
@@ -313,6 +313,14 @@ public class Api {
             this.federatedApiDefinition = federatedApiDefinition;
             if (federatedApiDefinition != null) {
                 this.definitionVersion = federatedApiDefinition.getDefinitionVersion();
+            }
+            return self();
+        }
+
+        public B nativeApiDefinition(io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiDefinition) {
+            this.nativeApiDefinition = nativeApiDefinition;
+            if (nativeApiDefinition != null) {
+                this.definitionVersion = nativeApiDefinition.getDefinitionVersion();
             }
             return self();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.rest.api.model.context.OriginContext;
 import java.time.ZonedDateTime;
@@ -74,6 +75,7 @@ public class Api {
     private DefinitionVersion definitionVersion;
 
     private io.gravitee.definition.model.v4.Api apiDefinitionV4;
+    private io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiDefinition;
     private io.gravitee.definition.model.Api apiDefinition;
     private io.gravitee.definition.model.federation.FederatedApi federatedApiDefinition;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api.model;
 
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -32,9 +33,9 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public class ApiWithFlows extends Api {
 
-    private List<Flow> flows;
+    private List<? extends AbstractFlow> flows;
 
-    public ApiWithFlows(Api api, List<Flow> flows) {
+    public ApiWithFlows(Api api, List<? extends AbstractFlow> flows) {
         super(
             api.getId(),
             api.getEnvironmentId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -47,6 +47,7 @@ public class ApiWithFlows extends Api {
             api.getApiDefinitionV4(),
             api.getApiDefinition(),
             api.getFederatedApiDefinition(),
+            api.getNativeApiDefinition(),
             api.getType(),
             api.getDeployedAt(),
             api.getCreatedAt(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.core.api.model;
 
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
-import io.gravitee.definition.model.v4.flow.Flow;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -45,10 +44,10 @@ public class ApiWithFlows extends Api {
             api.getVersion(),
             api.getOriginContext(),
             api.getDefinitionVersion(),
-            api.getApiDefinitionV4(),
+            api.getApiDefinitionHttpV4(),
+            api.getApiDefinitionNativeV4(),
             api.getApiDefinition(),
             api.getFederatedApiDefinition(),
-            api.getNativeApiDefinition(),
             api.getType(),
             api.getDeployedAt(),
             api.getCreatedAt(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.apim.core.api.model;
 
-import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.failover.Failover;
@@ -24,33 +22,21 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.listener.Listener;
 import java.util.List;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
-@Builder(toBuilder = true)
+@SuperBuilder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Setter(lombok.AccessLevel.NONE)
-public class NewApi {
-
-    private String name;
-
-    private String apiVersion;
-
-    @Builder.Default
-    private DefinitionVersion definitionVersion = DefinitionVersion.V4;
-
-    private ApiType type;
-
-    private String description;
-
-    @Builder.Default
-    private Set<String> tags = Set.of();
+public class NewHttpApi extends AbstractNewApi {
 
     private List<Listener> listeners;
 
@@ -63,28 +49,10 @@ public class NewApi {
     @Builder.Default
     private List<Flow> flows = List.of();
 
-    @Builder.Default
-    private Set<String> groups = Set.of();
-
     private Failover failover;
 
     /**
-     * @return An instance of {@link Api.ApiBuilder} based on the current state of this NewApi.
-     */
-    public Api.ApiBuilder toApiBuilder() {
-        // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
-        return Api
-            .builder()
-            .name(name)
-            .version(apiVersion)
-            .type(type)
-            .definitionVersion(definitionVersion)
-            .description(description)
-            .groups(groups);
-    }
-
-    /**
-     * @return An instance of {@link io.gravitee.definition.model.v4.Api.ApiBuilder} based on the current state of this NewApi.
+     * @return An instance of {@link io.gravitee.definition.model.v4.Api.ApiBuilder} based on the current state of this NewV4Api.
      */
     public io.gravitee.definition.model.v4.Api.ApiBuilder<?, ?> toApiDefinitionBuilder() {
         // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewNativeApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewNativeApi.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.model;
+
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@SuperBuilder(toBuilder = true)
+@NoArgsConstructor
+@Setter(lombok.AccessLevel.NONE)
+public class NewNativeApi extends AbstractNewApi {
+
+    private List<NativeListener> listeners;
+
+    private List<NativeEndpointGroup> endpointGroups;
+
+    @Builder.Default
+    private List<NativeFlow> flows = List.of();
+
+    /**
+     * @return An instance of {@link NativeApi.NativeApiBuilder} based on the current state of this NewNativeApi.
+     */
+    public NativeApi.NativeApiBuilder<?, ?> toNativeApiDefinitionBuilder() {
+        // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
+        return NativeApi
+            .builder()
+            .name(name)
+            .type(type)
+            .apiVersion(apiVersion)
+            .definitionVersion(definitionVersion)
+            .tags(tags)
+            .listeners(listeners)
+            .endpointGroups(endpointGroups)
+            .flows(flows);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api.model.factory;
 
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.NewHttpApi;
+import io.gravitee.apim.core.api.model.NewNativeApi;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
 import io.gravitee.apim.core.async_job.model.AsyncJob;
@@ -41,6 +42,20 @@ public class ApiModelFactory {
             .createdAt(now)
             .updatedAt(now)
             .apiDefinitionV4(newHttpApi.toApiDefinitionBuilder().id(id).build())
+            .lifecycleState(Api.LifecycleState.STOPPED)
+            .build();
+    }
+
+    public static Api fromNewNativeApi(NewNativeApi newNativeApi, String environmentId) {
+        var id = UuidString.generateRandom();
+        var now = TimeProvider.now();
+        return newNativeApi
+            .toApiBuilder()
+            .id(id)
+            .environmentId(environmentId)
+            .createdAt(now)
+            .updatedAt(now)
+            .nativeApiDefinition(newNativeApi.toNativeApiDefinitionBuilder().id(id).build())
             .lifecycleState(Api.LifecycleState.STOPPED)
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -41,7 +41,7 @@ public class ApiModelFactory {
             .environmentId(environmentId)
             .createdAt(now)
             .updatedAt(now)
-            .apiDefinitionV4(newHttpApi.toApiDefinitionBuilder().id(id).build())
+            .apiDefinitionHttpV4(newHttpApi.toApiDefinitionBuilder().id(id).build())
             .lifecycleState(Api.LifecycleState.STOPPED)
             .build();
     }
@@ -55,7 +55,7 @@ public class ApiModelFactory {
             .environmentId(environmentId)
             .createdAt(now)
             .updatedAt(now)
-            .nativeApiDefinition(newNativeApi.toNativeApiDefinitionBuilder().id(id).build())
+            .apiDefinitionNativeV4(newNativeApi.toNativeApiDefinitionBuilder().id(id).build())
             .lifecycleState(Api.LifecycleState.STOPPED)
             .build();
     }
@@ -70,7 +70,7 @@ public class ApiModelFactory {
             .createdAt(now)
             .updatedAt(now)
             .visibility(Api.Visibility.valueOf(crd.getVisibility()))
-            .apiDefinitionV4(crd.toApiDefinitionBuilder().id(id).build())
+            .apiDefinitionHttpV4(crd.toApiDefinitionBuilder().id(id).build())
             .disableMembershipNotifications(!crd.isNotifyMembers())
             .build();
     }
@@ -87,7 +87,7 @@ public class ApiModelFactory {
             .lifecycleState(Api.LifecycleState.STOPPED)
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)
             .visibility(api.getVisibility() == null ? Api.Visibility.PRIVATE : Api.Visibility.valueOf(api.getVisibility().name()))
-            .apiDefinitionV4(api.toApiDefinitionBuilder().id(id).build())
+            .apiDefinitionHttpV4(api.toApiDefinitionBuilder().id(id).build())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.core.api.model.factory;
 
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.NewApi;
+import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
 import io.gravitee.apim.core.async_job.model.AsyncJob;
@@ -31,16 +31,16 @@ public class ApiModelFactory {
 
     private ApiModelFactory() {}
 
-    public static Api fromNewApi(NewApi newApi, String environmentId) {
+    public static Api fromNewHttpApi(NewHttpApi newHttpApi, String environmentId) {
         var id = UuidString.generateRandom();
         var now = TimeProvider.now();
-        return newApi
+        return newHttpApi
             .toApiBuilder()
             .id(id)
             .environmentId(environmentId)
             .createdAt(now)
             .updatedAt(now)
-            .apiDefinitionV4(newApi.toApiDefinitionBuilder().id(id).build())
+            .apiDefinitionV4(newHttpApi.toApiDefinitionBuilder().id(id).build())
             .lifecycleState(Api.LifecycleState.STOPPED)
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCase.java
@@ -20,20 +20,23 @@ import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.o
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.List;
 
 @UseCase
-public class CreateV4ApiUseCase {
+public class CreateHttpApiUseCase {
 
     private final ValidateApiDomainService validateApiDomainService;
     private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
     private final CreateApiDomainService createApiDomainService;
 
-    public CreateV4ApiUseCase(
+    public CreateHttpApiUseCase(
         ValidateApiDomainService validateApiDomainService,
         ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
         CreateApiDomainService createApiDomainService
@@ -48,6 +51,9 @@ public class CreateV4ApiUseCase {
     public record Output(ApiWithFlows api) {}
 
     public Output execute(Input input) {
+        if (input.newHttpApi == null || (input.newHttpApi.getType() != ApiType.PROXY && input.newHttpApi.getType() != ApiType.MESSAGE)) {
+            throw new ApiInvalidTypeException(List.of(ApiType.PROXY, ApiType.MESSAGE));
+        }
         var auditInfo = input.auditInfo;
 
         var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.oneShotIndexation;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.model.NewNativeApi;
+import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.definition.model.v4.ApiType;
+
+@UseCase
+public class CreateNativeApiUseCase {
+
+    private final ValidateApiDomainService validateApiDomainService;
+    private final ApiPrimaryOwnerFactory apiPrimaryOwnerFactory;
+    private final CreateApiDomainService createApiDomainService;
+
+    public CreateNativeApiUseCase(
+        ValidateApiDomainService validateApiDomainService,
+        ApiPrimaryOwnerFactory apiPrimaryOwnerFactory,
+        CreateApiDomainService createApiDomainService
+    ) {
+        this.validateApiDomainService = validateApiDomainService;
+        this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
+        this.createApiDomainService = createApiDomainService;
+    }
+
+    public record Input(NewNativeApi newApi, AuditInfo auditInfo) {}
+
+    public record Output(ApiWithFlows api) {}
+
+    public Output execute(Input input) {
+        if (input.newApi == null || input.newApi.getType() != ApiType.NATIVE) {
+            throw new ApiInvalidTypeException(ApiType.NATIVE);
+        }
+
+        var auditInfo = input.auditInfo;
+
+        var primaryOwner = apiPrimaryOwnerFactory.createForNewApi(
+            auditInfo.organizationId(),
+            auditInfo.environmentId(),
+            auditInfo.actor().userId()
+        );
+
+        var created = createApiDomainService.create(
+            ApiModelFactory.fromNewNativeApi(input.newApi, auditInfo.environmentId()),
+            primaryOwner,
+            auditInfo,
+            api ->
+                validateApiDomainService.validateAndSanitizeForCreation(
+                    api,
+                    primaryOwner,
+                    auditInfo.environmentId(),
+                    auditInfo.organizationId()
+                ),
+            oneShotIndexation(auditInfo)
+        );
+
+        return new Output(created);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCase.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
-import io.gravitee.apim.core.api.model.NewApi;
+import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
@@ -43,7 +43,7 @@ public class CreateV4ApiUseCase {
         this.createApiDomainService = createApiDomainService;
     }
 
-    public record Input(NewApi newApi, AuditInfo auditInfo) {}
+    public record Input(NewHttpApi newHttpApi, AuditInfo auditInfo) {}
 
     public record Output(ApiWithFlows api) {}
 
@@ -57,7 +57,7 @@ public class CreateV4ApiUseCase {
         );
 
         var created = createApiDomainService.create(
-            ApiModelFactory.fromNewApi(input.newApi, auditInfo.environmentId()),
+            ApiModelFactory.fromNewHttpApi(input.newHttpApi, auditInfo.environmentId()),
             primaryOwner,
             auditInfo,
             api ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
@@ -47,7 +47,7 @@ public class GetApiDefinitionUseCase {
 
         switch (api.getDefinitionVersion()) {
             case V1, V2 -> api.getApiDefinition().setFlows(flowCrudService.getApiV2Flows(api.getId()));
-            case V4 -> api.getApiDefinitionV4().setFlows(flowCrudService.getApiV4Flows(api.getId()));
+            case V4 -> api.getApiDefinitionHttpV4().setFlows(flowCrudService.getApiV4Flows(api.getId()));
         }
 
         List<Plan> plans = planQueryService
@@ -63,6 +63,6 @@ public class GetApiDefinitionUseCase {
             .toList();
         api.setPlans(plans);
 
-        return new Output(api.getDefinitionVersion(), api.getApiDefinitionV4(), api.getApiDefinition());
+        return new Output(api.getDefinitionVersion(), api.getApiDefinitionHttpV4(), api.getApiDefinition());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCase.java
@@ -57,7 +57,7 @@ public class GetApiDefinitionUseCase {
             .peek(plan -> {
                 switch (plan.getDefinitionVersion()) {
                     case V1, V2 -> plan.getPlanDefinitionV2().setFlows(flowCrudService.getPlanV2Flows(plan.getId()));
-                    case V4 -> plan.getPlanDefinitionV4().setFlows(flowCrudService.getPlanV4Flows(plan.getId()));
+                    case V4 -> plan.getPlanDefinitionHttpV4().setFlows(flowCrudService.getPlanV4Flows(plan.getId()));
                 }
             })
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -353,7 +353,7 @@ public class ImportApiCRDUseCase {
             .id(planCRD.getId())
             .name(planCRD.getName())
             .description(planCRD.getDescription())
-            .planDefinitionV4(
+            .planDefinitionHttpV4(
                 io.gravitee.definition.model.v4.plan.Plan
                     .builder()
                     .security(planCRD.getSecurity())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCase.java
@@ -62,7 +62,7 @@ public class RollbackApiUseCase {
             .orElseThrow(() -> new IllegalStateException("Cannot rollback an event that is not a publish event!"));
         ensureApiDefinitionVersionForRollback(api, input.eventId());
 
-        var apiDefinition = api.getApiDefinitionV4();
+        var apiDefinition = api.getApiDefinitionHttpV4();
 
         var toRollback = apiCrudService.get(apiDefinition.getId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCase.java
@@ -123,7 +123,7 @@ public class RollbackApiUseCase {
         plansToAdd.forEach(planToAdd ->
             createPlanDomainService.create(
                 planToAdd,
-                planToAdd.getPlanDefinitionV4().getFlows() == null ? List.of() : planToAdd.getPlanDefinitionV4().getFlows(),
+                planToAdd.getPlanDefinitionHttpV4().getFlows() == null ? List.of() : planToAdd.getPlanDefinitionHttpV4().getFlows(),
                 api,
                 auditInfo
             )
@@ -135,7 +135,7 @@ public class RollbackApiUseCase {
         plansToUpdate.forEach(planToUpdate ->
             updatePlanDomainService.update(
                 planToUpdate,
-                planToUpdate.getPlanDefinitionV4().getFlows() == null ? List.of() : planToUpdate.getPlanDefinitionV4().getFlows(),
+                planToUpdate.getPlanDefinitionHttpV4().getFlows() == null ? List.of() : planToUpdate.getPlanDefinitionHttpV4().getFlows(),
                 existingPlanStatuses,
                 api,
                 auditInfo

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCase.java
@@ -108,22 +108,25 @@ public class UpdateDynamicPropertiesUseCase {
         // Deploy only if
         // - API is not synchronized: no manual changes
         // - properties have changed
-        if (!isApiSynchronized && needRedployment(api.getApiDefinitionV4().getProperties(), previousProperties)) {
+        if (!isApiSynchronized && needRedployment(api.getApiDefinitionHttpV4().getProperties(), previousProperties)) {
             // Get the api from latest deployment event of the api to deploy the api with the same dynamic properties configuration
             // It avoids to deploy changes on the configuration that has not been explicitly deployed by the user
             apiEventQueryService
                 .findLastPublishedApi(auditInfo.organizationId(), auditInfo.environmentId(), api.getId())
                 .ifPresent(deployedApi -> {
                     if (
-                        deployedApi.getApiDefinitionV4().getServices() == null ||
-                        deployedApi.getApiDefinitionV4().getServices().getDynamicProperty() == null
+                        deployedApi.getApiDefinitionHttpV4().getServices() == null ||
+                        deployedApi.getApiDefinitionHttpV4().getServices().getDynamicProperty() == null
                     ) {
                         return;
                     }
-                    final Service deployedDynamicPropertiesService = deployedApi.getApiDefinitionV4().getServices().getDynamicProperty();
+                    final Service deployedDynamicPropertiesService = deployedApi
+                        .getApiDefinitionHttpV4()
+                        .getServices()
+                        .getDynamicProperty();
                     // If the deployed api has the service enabled, then redeploy with the service enabled.
                     if (deployedDynamicPropertiesService.isEnabled()) {
-                        updated.getApiDefinitionV4().getServices().setDynamicProperty(deployedDynamicPropertiesService);
+                        updated.getApiDefinitionHttpV4().getServices().setDynamicProperty(deployedDynamicPropertiesService);
                     }
                 });
             apiStateDomainService.deploy(updated, String.format("%s sync", input.pluginId()), auditInfo);
@@ -148,7 +151,7 @@ public class UpdateDynamicPropertiesUseCase {
      * @return the copy of the list of properties
      */
     private static List<Property> getCurrentProperties(Api api) {
-        return Optional.ofNullable(api.getApiDefinitionV4().getProperties()).orElse(Collections.emptyList()).stream().toList();
+        return Optional.ofNullable(api.getApiDefinitionHttpV4().getProperties()).orElse(Collections.emptyList()).stream().toList();
     }
 
     private AuditInfo buildAuditInfo(Input input, Api apiForUpdate) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplate.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/documentation/model/ApiFreemarkerTemplate.java
@@ -69,8 +69,8 @@ public class ApiFreemarkerTemplate {
             return;
         }
         if (DefinitionVersion.V4.equals(api.getDefinitionVersion())) {
-            if (api.getApiDefinitionV4() != null) {
-                this.tags = api.getApiDefinitionV4().getTags();
+            if (api.getApiDefinitionHttpV4() != null) {
+                this.tags = api.getApiDefinitionHttpV4().getTags();
             }
         } else if (api.getApiDefinition() != null) {
             this.tags = api.getApiDefinition().getTags();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/crud_service/FlowCrudService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.flow.crud_service;
 
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import java.util.List;
 
 public interface FlowCrudService {
@@ -30,4 +31,7 @@ public interface FlowCrudService {
     List<io.gravitee.definition.model.flow.Flow> getApiV2Flows(String apiId);
 
     List<io.gravitee.definition.model.flow.Flow> getPlanV2Flows(String planId);
+
+    //    Native APIs
+    List<NativeFlow> saveNativeApiFlows(String apiId, List<NativeFlow> flows);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -74,10 +74,10 @@ public class CreatePlanDomainService {
             throw new ApiDeprecatedException(plan.getApiId());
         }
 
-        if (api.getApiDefinitionV4().getListeners() != null) {
+        if (api.getApiDefinitionHttpV4().getListeners() != null) {
             planValidatorDomainService.validatePlanSecurityAgainstEntrypoints(
                 plan.getPlanSecurity(),
-                api.getApiDefinitionV4().getListeners().stream().map(Listener::getType).toList()
+                api.getApiDefinitionHttpV4().getListeners().stream().map(Listener::getType).toList()
             );
         }
 
@@ -88,7 +88,7 @@ public class CreatePlanDomainService {
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
         flowValidationDomainService.validatePathParameters(
             api.getType(),
-            api.getApiDefinitionV4().getFlows() != null ? api.getApiDefinitionV4().getFlows().stream() : Stream.empty(),
+            api.getApiDefinitionHttpV4().getFlows() != null ? api.getApiDefinitionHttpV4().getFlows().stream() : Stream.empty(),
             sanitizedFlows.stream()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -85,7 +85,7 @@ public class CreatePlanDomainService {
         planValidatorDomainService.validatePlanTagsAgainstApiTags(plan.getPlanDefinitionHttpV4().getTags(), api.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
 
-        var sanitizedFlows = flowValidationDomainService.validateAndSanitize(api.getType(), flows);
+        var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
         flowValidationDomainService.validatePathParameters(
             api.getType(),
             api.getApiDefinitionV4().getFlows() != null ? api.getApiDefinitionV4().getFlows().stream() : Stream.empty(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -82,7 +82,7 @@ public class CreatePlanDomainService {
         }
 
         planValidatorDomainService.validatePlanSecurity(plan, auditInfo.organizationId(), auditInfo.environmentId());
-        planValidatorDomainService.validatePlanTagsAgainstApiTags(plan.getPlanDefinitionV4().getTags(), api.getTags());
+        planValidatorDomainService.validatePlanTagsAgainstApiTags(plan.getPlanDefinitionHttpV4().getTags(), api.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
 
         var sanitizedFlows = flowValidationDomainService.validateAndSanitize(api.getType(), flows);
@@ -148,7 +148,8 @@ public class CreatePlanDomainService {
             .needRedeployAt(plan.getNeedRedeployAt())
             .validation(plan.getValidation())
             .type(plan.getType())
-            .planDefinitionV4(plan.getPlanDefinitionV4())
+            .planDefinitionHttpV4(plan.getPlanDefinitionHttpV4())
+            .planDefinitionNativeV4(plan.getPlanDefinitionNativeV4())
             .planDefinitionV2(plan.getPlanDefinitionV2())
             .apiId(plan.getApiId())
             .order(plan.getOrder())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -112,7 +112,7 @@ public class UpdatePlanDomainService {
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
         flowValidationDomainService.validatePathParameters(
             api.getType(),
-            api.getApiDefinitionV4().getFlows().stream(),
+            api.getApiDefinitionHttpV4().getFlows().stream(),
             sanitizedFlows.stream()
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -109,7 +109,7 @@ public class UpdatePlanDomainService {
         planValidatorDomainService.validatePlanTagsAgainstApiTags(planToUpdate.getPlanDefinitionV4().getTags(), api.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(planToUpdate);
 
-        var sanitizedFlows = flowValidationDomainService.validateAndSanitize(api.getType(), flows);
+        var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
         flowValidationDomainService.validatePathParameters(
             api.getType(),
             api.getApiDefinitionV4().getFlows().stream(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanWithFlows.java
@@ -54,7 +54,8 @@ public class PlanWithFlows extends Plan {
             plan.isCommentRequired(),
             plan.getCommentMessage(),
             plan.getGeneralConditions(),
-            plan.getPlanDefinitionV4(),
+            plan.getPlanDefinitionHttpV4(),
+            plan.getPlanDefinitionNativeV4(),
             plan.getPlanDefinitionV2(),
             plan.getFederatedPlanDefinition()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
@@ -44,7 +44,7 @@ public class CreatePlanUseCase {
             throw new PlanInvalidException("Can't manually create Federated Plan");
         }
 
-        if (isMtls(api, input) && api.getApiDefinitionV4().isTcpProxy()) {
+        if (isMtls(api, input) && api.getApiDefinitionHttpV4().isTcpProxy()) {
             throw new PlanInvalidException("Cannot create mTLS plan for TCP API");
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -20,10 +20,8 @@ import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.federation.FederatedApi;
-import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
-import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.federation.FederatedApiEntity;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
@@ -46,10 +44,10 @@ public interface ApiAdapter {
     Logger LOGGER = LoggerFactory.getLogger(ApiAdapter.class);
     ApiAdapter INSTANCE = Mappers.getMapper(ApiAdapter.class);
 
-    @Mapping(target = "apiDefinitionV4", expression = "java(deserializeApiDefinitionV4(source))")
+    @Mapping(target = "apiDefinitionHttpV4", expression = "java(deserializeApiDefinitionV4(source))")
     @Mapping(target = "apiDefinition", expression = "java(deserializeApiDefinitionV2(source))")
     @Mapping(target = "federatedApiDefinition", expression = "java(deserializeFederatedApiDefinition(source))")
-    @Mapping(target = "nativeApiDefinition", expression = "java(deserializeNativeApiDefinition(source))")
+    @Mapping(target = "apiDefinitionNativeV4", expression = "java(deserializeNativeApiDefinition(source))")
     Api toCoreModel(io.gravitee.repository.management.model.Api source);
 
     Stream<Api> toCoreModelStream(Stream<io.gravitee.repository.management.model.Api> source);
@@ -60,12 +58,12 @@ public interface ApiAdapter {
     Stream<io.gravitee.repository.management.model.Api> toRepositoryStream(Stream<Api> source);
 
     @Mapping(target = "apiVersion", source = "version")
-    @Mapping(target = "tags", source = "apiDefinitionV4.tags")
-    @Mapping(target = "listeners", source = "apiDefinitionV4.listeners")
-    @Mapping(target = "endpointGroups", source = "apiDefinitionV4.endpointGroups")
-    @Mapping(target = "analytics", source = "apiDefinitionV4.analytics")
-    @Mapping(target = "flowExecution", source = "apiDefinitionV4.flowExecution")
-    @Mapping(target = "flows", source = "apiDefinitionV4.flows")
+    @Mapping(target = "tags", source = "apiDefinitionHttpV4.tags")
+    @Mapping(target = "listeners", source = "apiDefinitionHttpV4.listeners")
+    @Mapping(target = "endpointGroups", source = "apiDefinitionHttpV4.endpointGroups")
+    @Mapping(target = "analytics", source = "apiDefinitionHttpV4.analytics")
+    @Mapping(target = "flowExecution", source = "apiDefinitionHttpV4.flowExecution")
+    @Mapping(target = "flows", source = "apiDefinitionHttpV4.flows")
     NewApiEntity toNewApiEntity(Api source);
 
     @Mapping(target = "apiVersion", source = "version")
@@ -152,8 +150,8 @@ public interface ApiAdapter {
         return switch (api.getDefinitionVersion()) {
             case V1, V2 -> serialize(api.getApiDefinition(), "V2 API");
             case V4 -> switch (api.getType()) {
-                case NATIVE -> serialize(api.getNativeApiDefinition(), "V4 Native API");
-                case PROXY, MESSAGE -> serialize(api.getApiDefinitionV4(), "V4 API");
+                case NATIVE -> serialize(api.getApiDefinitionNativeV4(), "V4 Native API");
+                case PROXY, MESSAGE -> serialize(api.getApiDefinitionHttpV4(), "V4 API");
             };
             case FEDERATED -> serialize(api.getFederatedApiDefinition(), "Federated API");
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
@@ -50,7 +50,7 @@ public interface PlanAdapter {
 
     @Mapping(source = "api", target = "apiId")
     @Mapping(target = "definitionVersion", defaultValue = "V2")
-    @Mapping(target = "planDefinitionV4", expression = "java(deserializeDefinitionV4(plan))")
+    @Mapping(target = "planDefinitionHttpV4", expression = "java(deserializeDefinitionHttpV4(plan))")
     @Mapping(target = "planDefinitionV2", expression = "java(deserializeDefinitionV2(plan))")
     @Mapping(target = "federatedPlanDefinition", expression = "java(deserializeDefinitionFederated(plan))")
     Plan fromRepository(io.gravitee.repository.management.model.Plan plan);
@@ -95,7 +95,7 @@ public interface PlanAdapter {
     @Mapping(target = "security", qualifiedByName = "serializeV2PlanSecurityType")
     io.gravitee.definition.model.Plan toPlanDefinitionV2(io.gravitee.repository.management.model.Plan source);
 
-    default io.gravitee.definition.model.v4.plan.Plan deserializeDefinitionV4(io.gravitee.repository.management.model.Plan source) {
+    default io.gravitee.definition.model.v4.plan.Plan deserializeDefinitionHttpV4(io.gravitee.repository.management.model.Plan source) {
         if (source.getDefinitionVersion() != DefinitionVersion.V4) {
             return null;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -52,7 +52,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
     public Api updateV4(Api api, AuditInfo auditInfo) {
         var executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
 
-        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionV4());
+        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
 
         delegate.update(executionContext, api.getId(), updateApiEntity, false, auditInfo.actor().userId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -81,19 +81,19 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         api.setGroups(newApiEntity.getGroups());
         api.setTags(newApiEntity.getTags());
 
-        api.getApiDefinitionV4().setListeners(newApiEntity.getListeners());
-        api.getApiDefinitionV4().setEndpointGroups(newApiEntity.getEndpointGroups());
-        api.getApiDefinitionV4().setAnalytics(newApiEntity.getAnalytics());
-        api.getApiDefinitionV4().setFlowExecution(newApiEntity.getFlowExecution());
-        api.getApiDefinitionV4().setFailover(newApiEntity.getFailover());
+        api.getApiDefinitionHttpV4().setListeners(newApiEntity.getListeners());
+        api.getApiDefinitionHttpV4().setEndpointGroups(newApiEntity.getEndpointGroups());
+        api.getApiDefinitionHttpV4().setAnalytics(newApiEntity.getAnalytics());
+        api.getApiDefinitionHttpV4().setFlowExecution(newApiEntity.getFlowExecution());
+        api.getApiDefinitionHttpV4().setFailover(newApiEntity.getFailover());
 
-        api.getApiDefinitionV4().setResources(apiValidationService.validateAndSanitize(api.getApiDefinitionV4().getResources()));
+        api.getApiDefinitionHttpV4().setResources(apiValidationService.validateAndSanitize(api.getApiDefinitionHttpV4().getResources()));
 
         var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), newApiEntity.getFlows());
-        api.getApiDefinitionV4().setFlows(sanitizedFlows);
+        api.getApiDefinitionHttpV4().setFlows(sanitizedFlows);
 
         apiValidationService.validateDynamicProperties(
-            api.getApiDefinitionV4().getServices() != null ? api.getApiDefinitionV4().getServices().getDynamicProperty() : null
+            api.getApiDefinitionHttpV4().getServices() != null ? api.getApiDefinitionHttpV4().getServices().getDynamicProperty() : null
         );
     }
 
@@ -119,7 +119,7 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         newApi.setGroups(groupValidationService.validateAndSanitize(Set.of(), newApi.getEnvironmentId(), primaryOwner));
 
         // Validate and clean listeners
-        var apiDefinition = newApi.getNativeApiDefinition();
+        var apiDefinition = newApi.getApiDefinitionNativeV4();
 
         apiDefinition.setListeners(
             listenerValidationService.validateAndSanitizeNativeV4(
@@ -137,8 +137,8 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
         apiDefinition.setFlows(flowValidationDomainService.validateAndSanitizeNativeV4(apiDefinition.getFlows()));
 
         apiValidationService.validateDynamicProperties(
-            newApi.getNativeApiDefinition().getServices() != null
-                ? newApi.getNativeApiDefinition().getServices().getDynamicProperty()
+            newApi.getApiDefinitionNativeV4().getServices() != null
+                ? newApi.getApiDefinitionNativeV4().getServices().getDynamicProperty()
                 : null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
@@ -72,7 +72,7 @@ public class ManagementApiServicesManager extends AbstractService {
             .map(managementApiServiceFactory ->
                 managementApiServiceFactory.createService(
                     // FIXME: Kafka Gateway - Manage properly NativeApi definition
-                    new DefaultManagementDeploymentContext(api.getApiDefinitionV4(), applicationContext)
+                    new DefaultManagementDeploymentContext(api.getApiDefinitionHttpV4(), applicationContext)
                 )
             )
             .filter(Objects::nonNull)
@@ -106,7 +106,7 @@ public class ManagementApiServicesManager extends AbstractService {
                 .concat(
                     managedApi
                         .stream()
-                        .map(managementApiService -> managementApiService.update(api.getApiDefinitionV4()))
+                        .map(managementApiService -> managementApiService.update(api.getApiDefinitionHttpV4()))
                         .collect(Collectors.toList())
                 )
                 .blockingAwait();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.NewApi;
+import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -109,8 +109,8 @@ public class V4ApiServiceCockpitImpl implements V4ApiServiceCockpit {
 
     private Api deserializeApi(JsonNode node, String environmentId) throws JsonProcessingException {
         final String newApiEntityNode = mapper.writeValueAsString(node.at(NEW_API_ENTITY_NODE));
-        var newApi = graviteeMapper.readValue(newApiEntityNode, NewApi.class);
-        return ApiModelFactory.fromNewApi(newApi, environmentId);
+        var newApi = graviteeMapper.readValue(newApiEntityNode, NewHttpApi.class);
+        return ApiModelFactory.fromNewHttpApi(newApi, environmentId);
     }
 
     private UpdateApiEntity getUpdateApiEntity(JsonNode node) throws JsonProcessingException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitImpl.java
@@ -149,12 +149,12 @@ public class V4ApiServiceCockpitImpl implements V4ApiServiceCockpit {
         entity.setDefinitionVersion(api.getDefinitionVersion());
         entity.setType(api.getType());
         entity.setDescription(api.getDescription());
-        entity.setEndpointGroups(api.getApiDefinitionV4().getEndpointGroups());
-        entity.setAnalytics(api.getApiDefinitionV4().getAnalytics());
-        entity.setFlows(api.getApiDefinitionV4().getFlows());
-        entity.setFlowExecution(api.getApiDefinitionV4().getFlowExecution());
-        entity.setResponseTemplates(api.getApiDefinitionV4().getResponseTemplates());
-        entity.setServices(api.getApiDefinitionV4().getServices());
+        entity.setEndpointGroups(api.getApiDefinitionHttpV4().getEndpointGroups());
+        entity.setAnalytics(api.getApiDefinitionHttpV4().getAnalytics());
+        entity.setFlows(api.getApiDefinitionHttpV4().getFlows());
+        entity.setFlowExecution(api.getApiDefinitionHttpV4().getFlowExecution());
+        entity.setResponseTemplates(api.getApiDefinitionHttpV4().getResponseTemplates());
+        entity.setServices(api.getApiDefinitionHttpV4().getServices());
         entity.setGroups(api.getGroups());
         entity.setVisibility(Visibility.PUBLIC);
         entity.setPicture(api.getPicture());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -176,7 +176,7 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
     }
 
     private void transformV4Api(Document doc, IndexableApi api) {
-        var apiDefinitionV4 = api.getApi().getApiDefinitionV4();
+        var apiDefinitionV4 = api.getApi().getApiDefinitionHttpV4();
         if (apiDefinitionV4 != null && apiDefinitionV4.getListeners() != null) {
             final int[] pathIndex = { 0 };
             apiDefinitionV4

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -124,7 +124,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean listeners
         newApiEntity.setListeners(
-            listenerValidationService.validateAndSanitize(
+            listenerValidationService.validateAndSanitizeHttpV4(
                 executionContext,
                 null,
                 newApiEntity.getListeners(),
@@ -133,7 +133,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean endpoints
         newApiEntity.setEndpointGroups(
-            endpointGroupsValidationService.validateAndSanitize(newApiEntity.getType(), newApiEntity.getEndpointGroups())
+            endpointGroupsValidationService.validateAndSanitizeHttpV4(newApiEntity.getType(), newApiEntity.getEndpointGroups())
         );
         // Validate and clean logging
         newApiEntity.setAnalytics(
@@ -179,7 +179,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean listeners
         updateApiEntity.setListeners(
-            listenerValidationService.validateAndSanitize(
+            listenerValidationService.validateAndSanitizeHttpV4(
                 executionContext,
                 updateApiEntity.getId(),
                 updateApiEntity.getListeners(),
@@ -188,7 +188,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean endpoints
         updateApiEntity.setEndpointGroups(
-            endpointGroupsValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getEndpointGroups())
+            endpointGroupsValidationService.validateAndSanitizeHttpV4(updateApiEntity.getType(), updateApiEntity.getEndpointGroups())
         );
         // Validate and clean logging
         updateApiEntity.setAnalytics(
@@ -231,11 +231,16 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         apiEntity.setGroups(groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), primaryOwnerEntity));
         // Validate and clean listeners
         apiEntity.setListeners(
-            listenerValidationService.validateAndSanitize(executionContext, null, apiEntity.getListeners(), apiEntity.getEndpointGroups())
+            listenerValidationService.validateAndSanitizeHttpV4(
+                executionContext,
+                null,
+                apiEntity.getListeners(),
+                apiEntity.getEndpointGroups()
+            )
         );
         // Validate and clean endpoints
         apiEntity.setEndpointGroups(
-            endpointGroupsValidationService.validateAndSanitize(apiEntity.getType(), apiEntity.getEndpointGroups())
+            endpointGroupsValidationService.validateAndSanitizeHttpV4(apiEntity.getType(), apiEntity.getEndpointGroups())
         );
         // Validate and clean logging
         apiEntity.setAnalytics(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
@@ -15,12 +15,9 @@
  */
 package io.gravitee.rest.api.service.v4.validation;
 
-import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
-import io.gravitee.rest.api.model.api.UpdateApiEntity;
-import io.gravitee.rest.api.service.ConnectorService;
-import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import java.util.List;
 
 /**
@@ -28,5 +25,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface EndpointGroupsValidationService {
-    List<EndpointGroup> validateAndSanitize(ApiType apiType, List<EndpointGroup> endpointGroups);
+    List<EndpointGroup> validateAndSanitizeHttpV4(ApiType apiType, List<EndpointGroup> endpointGroups);
+    List<NativeEndpointGroup> validateAndSanitizeNativeV4(List<NativeEndpointGroup> endpointGroups);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/ListenerValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/ListenerValidationService.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.service.v4.validation;
 
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.definition.model.v4.nativeapi.NativeListener;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 
@@ -25,10 +27,17 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface ListenerValidationService {
-    List<Listener> validateAndSanitize(
+    List<Listener> validateAndSanitizeHttpV4(
         ExecutionContext executionContext,
         String apiId,
         List<Listener> listeners,
         List<EndpointGroup> endpointGroups
+    );
+
+    List<NativeListener> validateAndSanitizeNativeV4(
+        ExecutionContext executionContext,
+        String apiId,
+        List<NativeListener> listeners,
+        List<NativeEndpointGroup> endpointGroups
     );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
@@ -78,7 +78,7 @@ public class ApiFixtures {
             .get()
             .type(ApiType.PROXY)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 io.gravitee.definition.model.v4.Api
                     .builder()
                     .id(MY_API)
@@ -175,7 +175,7 @@ public class ApiFixtures {
             .get()
             .type(ApiType.MESSAGE)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 io.gravitee.definition.model.v4.Api
                     .builder()
                     .id("my-api")
@@ -228,7 +228,7 @@ public class ApiFixtures {
             .get()
             .type(ApiType.PROXY)
             .definitionVersion(DefinitionVersion.V4)
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 io.gravitee.definition.model.v4.Api
                     .builder()
                     .id(MY_API)
@@ -281,7 +281,7 @@ public class ApiFixtures {
             .get()
             .crossId(null)
             .lifecycleState(null)
-            .apiDefinitionV4(null)
+            .apiDefinitionHttpV4(null)
             .apiDefinition(null)
             .originContext(new OriginContext.Integration("integration-id"))
             .federatedApiDefinition(FederatedApi.builder().id(MY_API).providerId("provider-id").name("My Api").apiVersion("1.0.0").build())
@@ -293,7 +293,7 @@ public class ApiFixtures {
             .get()
             .type(ApiType.NATIVE)
             .definitionVersion(DefinitionVersion.V4)
-            .nativeApiDefinition(
+            .apiDefinitionNativeV4(
                 NativeApi
                     .builder()
                     .id("my-api")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApiFixtures.java
@@ -32,6 +32,11 @@ import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.model.context.OriginContext;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -280,6 +285,53 @@ public class ApiFixtures {
             .apiDefinition(null)
             .originContext(new OriginContext.Integration("integration-id"))
             .federatedApiDefinition(FederatedApi.builder().id(MY_API).providerId("provider-id").name("My Api").apiVersion("1.0.0").build())
+            .build();
+    }
+
+    public static Api aNativeApi() {
+        return BASE
+            .get()
+            .type(ApiType.NATIVE)
+            .definitionVersion(DefinitionVersion.V4)
+            .nativeApiDefinition(
+                NativeApi
+                    .builder()
+                    .id("my-api")
+                    .name("My message Api")
+                    .type(ApiType.NATIVE)
+                    .tags(Set.of("tag1"))
+                    .listeners(
+                        List.of(
+                            KafkaListener
+                                .builder()
+                                .entrypoints(List.of(NativeEntrypoint.builder().type("native-type").configuration("{}").build()))
+                                .build()
+                        )
+                    )
+                    .endpointGroups(
+                        List.of(
+                            NativeEndpointGroup
+                                .builder()
+                                .name("default-group")
+                                .type("mock")
+                                .sharedConfiguration("{}")
+                                .endpoints(
+                                    List.of(
+                                        NativeEndpoint
+                                            .builder()
+                                            .name("default-endpoint")
+                                            .type("mock")
+                                            .inheritConfiguration(true)
+                                            .configuration("{}")
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        )
+                    )
+                    .flows(List.of())
+                    .build()
+            )
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
@@ -16,6 +16,7 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.api.model.NewHttpApi;
+import io.gravitee.apim.core.api.model.NewNativeApi;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -23,6 +24,10 @@ import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -34,6 +39,8 @@ public class NewApiFixtures {
 
     private static final Supplier<NewHttpApi.NewHttpApiBuilder<?, ?>> BASE_HTTP = () ->
         NewHttpApi.builder().name("My API").apiVersion("1.0");
+    private static final Supplier<NewNativeApi.NewNativeApiBuilder<?, ?>> BASE_NATIVE = () ->
+        NewNativeApi.builder().name("My API").apiVersion("1.0");
 
     public static NewHttpApi aProxyApiV4() {
         return BASE_HTTP
@@ -59,6 +66,43 @@ public class NewApiFixtures {
                         .endpoints(
                             List.of(
                                 Endpoint
+                                    .builder()
+                                    .name("default-endpoint")
+                                    .type("http-proxy")
+                                    .inheritConfiguration(true)
+                                    .configuration("{\"target\":\"https://api.gravitee.io/echo\"}")
+                                    .build()
+                            )
+                        )
+                        .build()
+                )
+            )
+            .build();
+    }
+
+    public static NewNativeApi aNativeApiV4() {
+        return BASE_NATIVE
+            .get()
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.NATIVE)
+            .listeners(
+                List.of(
+                    KafkaListener
+                        .builder()
+                        .entrypoints(List.of(NativeEntrypoint.builder().type("native-entrypoint-type").configuration("{}").build()))
+                        .build()
+                )
+            )
+            .endpointGroups(
+                List.of(
+                    NativeEndpointGroup
+                        .builder()
+                        .name("default-group")
+                        .type("http-proxy")
+                        .sharedConfiguration("{}")
+                        .endpoints(
+                            List.of(
+                                NativeEndpoint
                                     .builder()
                                     .name("default-endpoint")
                                     .type("http-proxy")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/NewApiFixtures.java
@@ -15,7 +15,7 @@
  */
 package fixtures.core.model;
 
-import io.gravitee.apim.core.api.model.NewApi;
+import io.gravitee.apim.core.api.model.NewHttpApi;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -31,10 +31,12 @@ public class NewApiFixtures {
     private NewApiFixtures() {}
 
     public static final String MY_API = "my-api";
-    private static final Supplier<NewApi.NewApiBuilder> BASE = () -> NewApi.builder().name("My API").apiVersion("1.0");
 
-    public static NewApi aProxyApiV4() {
-        return BASE
+    private static final Supplier<NewHttpApi.NewHttpApiBuilder<?, ?>> BASE_HTTP = () ->
+        NewHttpApi.builder().name("My API").apiVersion("1.0");
+
+    public static NewHttpApi aProxyApiV4() {
+        return BASE_HTTP
             .get()
             .definitionVersion(DefinitionVersion.V4)
             .type(ApiType.PROXY)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanFixtures.java
@@ -48,7 +48,11 @@ public class PlanFixtures {
             .validation(Plan.PlanValidationType.AUTO);
 
     public static Plan aPlanV4() {
-        return BASE.get().definitionVersion(DefinitionVersion.V4).planDefinitionV4(fixtures.definition.PlanFixtures.aKeylessV4()).build();
+        return BASE
+            .get()
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(fixtures.definition.PlanFixtures.aKeylessV4())
+            .build();
     }
 
     public static Plan aPlanV2() {
@@ -56,15 +60,15 @@ public class PlanFixtures {
     }
 
     public static Plan aKeylessV4() {
-        return BASE.get().id("keyless").name("Keyless").planDefinitionV4(fixtures.definition.PlanFixtures.aKeylessV4()).build();
+        return BASE.get().id("keyless").name("Keyless").planDefinitionHttpV4(fixtures.definition.PlanFixtures.aKeylessV4()).build();
     }
 
     public static Plan anApiKeyV4() {
-        return BASE.get().id("apikey").name("API Key").planDefinitionV4(fixtures.definition.PlanFixtures.anApiKeyV4()).build();
+        return BASE.get().id("apikey").name("API Key").planDefinitionHttpV4(fixtures.definition.PlanFixtures.anApiKeyV4()).build();
     }
 
     public static Plan aPushPlan() {
-        return BASE.get().id("push").name("Push Plan").planDefinitionV4(fixtures.definition.PlanFixtures.aPushPlan()).build();
+        return BASE.get().id("push").name("Push Plan").planDefinitionHttpV4(fixtures.definition.PlanFixtures.aPushPlan()).build();
     }
 
     public static Plan anMtlsPlanV4() {
@@ -73,7 +77,7 @@ public class PlanFixtures {
             .id("mtls")
             .name("mTLS Plan")
             .definitionVersion(DefinitionVersion.V4)
-            .planDefinitionV4(fixtures.definition.PlanFixtures.anMtlsPlanV4())
+            .planDefinitionHttpV4(fixtures.definition.PlanFixtures.anMtlsPlanV4())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanWithFlowsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PlanWithFlowsFixtures.java
@@ -36,7 +36,7 @@ public class PlanWithFlowsFixtures {
             .description("Description")
             .validation(Plan.PlanValidationType.AUTO)
             .type(Plan.PlanType.API)
-            .planDefinitionV4(
+            .planDefinitionHttpV4(
                 fixtures.definition.PlanFixtures
                     .anApiKeyV4()
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchResponseTimeUseCaseTest.java
@@ -67,7 +67,7 @@ class SearchResponseTimeUseCaseTest {
             .type(ApiType.MESSAGE)
             .definitionVersion(DefinitionVersion.V4)
             .build();
-        apiCrudServiceInMemory.initWith(List.of(Api.builder().id("MyApiID").apiDefinitionV4(definition).environmentId(ENV_ID).build()));
+        apiCrudServiceInMemory.initWith(List.of(Api.builder().id("MyApiID").apiDefinitionHttpV4(definition).environmentId(ENV_ID).build()));
         // the order of keys is important
         analyticsQueryService.averageAggregate = new LinkedHashMap<>();
         analyticsQueryService.averageAggregate.put("1970-01-01T00:00:00", 1.2D);
@@ -92,7 +92,7 @@ class SearchResponseTimeUseCaseTest {
             .type(ApiType.MESSAGE)
             .definitionVersion(DefinitionVersion.V4)
             .build();
-        apiCrudServiceInMemory.initWith(List.of(Api.builder().id("MyApiID").apiDefinitionV4(definition).environmentId(ENV_ID).build()));
+        apiCrudServiceInMemory.initWith(List.of(Api.builder().id("MyApiID").apiDefinitionHttpV4(definition).environmentId(ENV_ID).build()));
 
         // When
         SearchResponseTimeUseCase.Output output = cut.execute(new ExecutionContext(), input).blockingGet();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiPathDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiPathDomainServiceTest.java
@@ -491,6 +491,6 @@ class VerifyApiPathDomainServiceTest {
                 )
             )
             .build();
-        return Api.builder().id(apiId).environmentId(environmentId).apiDefinitionV4(apiDefV4).build();
+        return Api.builder().id(apiId).environmentId(environmentId).apiDefinitionHttpV4(apiDefV4).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/ApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/ApiTest.java
@@ -40,20 +40,20 @@ class ApiTest {
     void does_not_need_to_update() {
         final Api api = ApiFixtures.aProxyApiV4();
         api
-            .getApiDefinitionV4()
+            .getApiDefinitionHttpV4()
             .setProperties(List.of(new Property("key", "value", false, false), new Property("dynamic", "value", false, true)));
         assertThat(
             api.updateDynamicProperties(List.of(new Property("key", "value", false, true), new Property("dynamic", "value", false, true)))
         )
             .isFalse();
         // keys must be sorted by natural order
-        assertThat(api.getApiDefinitionV4().getProperties()).extracting(Property::getKey).containsExactly("dynamic", "key");
+        assertThat(api.getApiDefinitionHttpV4().getProperties()).extracting(Property::getKey).containsExactly("dynamic", "key");
     }
 
     @Test
     void needs_to_update() {
         final Api api = ApiFixtures.aProxyApiV4();
-        api.getApiDefinitionV4().setProperties(List.of(new Property("key", "value", false, false)));
+        api.getApiDefinitionHttpV4().setProperties(List.of(new Property("key", "value", false, false)));
         assertThat(
             api.updateDynamicProperties(
                 List.of(
@@ -65,6 +65,6 @@ class ApiTest {
         )
             .isTrue();
         // keys must be sorted by natural order
-        assertThat(api.getApiDefinitionV4().getProperties()).extracting(Property::getKey).containsExactly("X-Other", "dynamic", "key");
+        assertThat(api.getApiDefinitionHttpV4().getProperties()).extracting(Property::getKey).containsExactly("X-Other", "dynamic", "key");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
@@ -246,7 +246,7 @@ class CreateHttpApiUseCaseTest {
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)
             .lifecycleState(Api.LifecycleState.STOPPED)
             .visibility(Api.Visibility.PRIVATE)
-            .apiDefinitionV4(newApi.toApiDefinitionBuilder().id("generated-id").build())
+            .apiDefinitionHttpV4(newApi.toApiDefinitionBuilder().id("generated-id").build())
             .build();
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(output.api()).isEqualTo(new ApiWithFlows(expectedApi, newApi.getFlows()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.RoleFixtures.apiPrimaryOwnerRoleId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.NewApiFixtures;
+import inmemory.ApiCategoryQueryServiceInMemory;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.ApiMetadataQueryServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.IndexerInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.MetadataCrudServiceInMemory;
+import inmemory.NotificationConfigCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import inmemory.WorkflowCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.CreateNativeApiUseCase.Input;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.audit.model.event.MembershipAuditEvent;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.metadata.model.Metadata;
+import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.apim.core.search.model.IndexableApi;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.impl.NotifierServiceImpl;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class CreateNativeApiUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2023-10-22T10:15:30Z");
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String GROUP_ID = "group-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    ValidateApiDomainService validateApiDomainService;
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
+    ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    MetadataCrudServiceInMemory metadataCrudService = new MetadataCrudServiceInMemory();
+    ApiMetadataQueryServiceInMemory apiMetadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    WorkflowCrudServiceInMemory workflowCrudService = new WorkflowCrudServiceInMemory();
+    IndexerInMemory indexer = new IndexerInMemory();
+
+    CreateNativeApiUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        validateApiDomainService = mock(ValidateApiDomainService.class);
+
+        var metadataQueryService = new ApiMetadataQueryServiceInMemory(metadataCrudService);
+        var membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var apiPrimaryOwnerFactory = new ApiPrimaryOwnerFactory(
+            groupQueryService,
+            membershipQueryService,
+            parametersQueryService,
+            roleQueryService,
+            userCrudService
+        );
+        var apiPrimaryOwnerDomainService = new ApiPrimaryOwnerDomainService(
+            auditService,
+            groupQueryService,
+            membershipCrudService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
+        var createApiDomainService = new CreateApiDomainService(
+            apiCrudService,
+            auditService,
+            new ApiIndexerDomainService(
+                new ApiMetadataDecoderDomainService(metadataQueryService, new FreemarkerTemplateProcessor()),
+                apiPrimaryOwnerDomainService,
+                new ApiCategoryQueryServiceInMemory(),
+                indexer
+            ),
+            new ApiMetadataDomainService(metadataCrudService, apiMetadataQueryService, auditService),
+            apiPrimaryOwnerDomainService,
+            flowCrudService,
+            notificationConfigCrudService,
+            parametersQueryService,
+            workflowCrudService
+        );
+        useCase = new CreateNativeApiUseCase(validateApiDomainService, apiPrimaryOwnerFactory, createApiDomainService);
+
+        when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode.USER);
+        roleQueryService.resetSystemRoles(ORGANIZATION_ID);
+        givenExistingUsers(
+            List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream
+            .of(
+                apiCrudService,
+                auditCrudService,
+                flowCrudService,
+                groupQueryService,
+                membershipCrudService,
+                metadataCrudService,
+                notificationConfigCrudService,
+                parametersQueryService,
+                userCrudService,
+                workflowCrudService
+            )
+            .forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_throw_when_api_is_invalid() {
+        // Given
+        when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any()))
+            .thenThrow(new ValidationDomainException("Definition version is unsupported, should be V4 or higher"));
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        var throwable = catchThrowable(() -> useCase.execute(new Input(newApi, AUDIT_INFO)));
+
+        // Then
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+    }
+
+    @Test
+    void should_create_and_index_a_new_api() {
+        // Given
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        var output = useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        var expectedApi = newApi
+            .toApiBuilder()
+            .id("generated-id")
+            .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+            .environmentId(ENVIRONMENT_ID)
+            .apiLifecycleState(Api.ApiLifecycleState.CREATED)
+            .lifecycleState(Api.LifecycleState.STOPPED)
+            .visibility(Api.Visibility.PRIVATE)
+            .nativeApiDefinition(newApi.toNativeApiDefinitionBuilder().id("generated-id").build())
+            .build();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(output.api()).isEqualTo(new ApiWithFlows(expectedApi, newApi.getFlows()));
+            soft.assertThat(apiCrudService.storage()).contains(expectedApi);
+            soft
+                .assertThat(indexer.storage())
+                .containsExactly(
+                    new IndexableApi(
+                        expectedApi,
+                        new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER),
+                        Map.ofEntries(Map.entry("email-support", "jane.doe@gravitee.io")),
+                        Collections.emptySet()
+                    )
+                );
+        });
+    }
+
+    @Test
+    void should_create_an_audit() {
+        // Given
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+            .containsExactly(
+                // API Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId("generated-id")
+                    .user(USER_ID)
+                    .properties(Collections.emptyMap())
+                    .event(ApiAuditEvent.API_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build(),
+                // Membership Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId("generated-id")
+                    .user(USER_ID)
+                    .properties(Map.of("USER", USER_ID))
+                    .event(MembershipAuditEvent.MEMBERSHIP_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build(),
+                // Metadata Audit
+                AuditEntity
+                    .builder()
+                    .id("generated-id")
+                    .organizationId(ORGANIZATION_ID)
+                    .environmentId(ENVIRONMENT_ID)
+                    .referenceType(AuditEntity.AuditReferenceType.API)
+                    .referenceId("generated-id")
+                    .user(USER_ID)
+                    .properties(Map.of("METADATA", "email-support"))
+                    .event(ApiAuditEvent.METADATA_CREATED.name())
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ApiPrimaryOwnerMode.class, mode = EnumSource.Mode.INCLUDE, names = { "USER", "HYBRID" })
+    void should_create_primary_owner_membership_when_user_or_hybrid_mode_is_enabled(ApiPrimaryOwnerMode mode) {
+        // Given
+        enableApiPrimaryOwnerMode(mode);
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(membershipCrudService.storage())
+            .contains(
+                Membership
+                    .builder()
+                    .id("generated-id")
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceId("generated-id")
+                    .referenceType(Membership.ReferenceType.API)
+                    .source("system")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_primary_owner_membership_when_group_mode_is_enabled() {
+        // Given
+        enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode.GROUP);
+        givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("Group name").apiPrimaryOwner(USER_ID).build()));
+        givenExistingMemberships(
+            List.of(
+                Membership
+                    .builder()
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(GROUP_ID)
+                    .memberType(Membership.Type.USER)
+                    .memberId(USER_ID)
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .build()
+            )
+        );
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(membershipCrudService.storage())
+            .contains(
+                Membership
+                    .builder()
+                    .id("generated-id")
+                    .roleId(apiPrimaryOwnerRoleId(ORGANIZATION_ID))
+                    .memberId(GROUP_ID)
+                    .memberType(Membership.Type.GROUP)
+                    .referenceId("generated-id")
+                    .referenceType(Membership.ReferenceType.API)
+                    .source("system")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_default_email_notification_configuration() {
+        // Given
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(notificationConfigCrudService.storage())
+            .containsExactly(
+                NotificationConfig
+                    .builder()
+                    .id("generated-id")
+                    .type(NotificationConfig.Type.GENERIC)
+                    .name("Default Mail Notifications")
+                    .referenceType("API")
+                    .referenceId("generated-id")
+                    .hooks(
+                        List.of(
+                            "APIKEY_EXPIRED",
+                            "APIKEY_RENEWED",
+                            "APIKEY_REVOKED",
+                            "API_DEPLOYED",
+                            "API_DEPRECATED",
+                            "API_STARTED",
+                            "API_STOPPED",
+                            "API_UPDATED",
+                            "ASK_FOR_REVIEW",
+                            "MESSAGE",
+                            "NEW_RATING",
+                            "NEW_RATING_ANSWER",
+                            "NEW_SUPPORT_TICKET",
+                            "REQUEST_FOR_CHANGES",
+                            "REVIEW_OK",
+                            "SUBSCRIPTION_ACCEPTED",
+                            "SUBSCRIPTION_CLOSED",
+                            "SUBSCRIPTION_NEW",
+                            "SUBSCRIPTION_PAUSED",
+                            "SUBSCRIPTION_REJECTED",
+                            "SUBSCRIPTION_RESUMED",
+                            "SUBSCRIPTION_TRANSFERRED"
+                        )
+                    )
+                    .notifier(NotifierServiceImpl.DEFAULT_EMAIL_NOTIFIER_ID)
+                    .config("${(api.primaryOwner.email)!''}")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_create_default_api_metadata() {
+        // Given
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(metadataCrudService.storage())
+            .containsExactly(
+                Metadata
+                    .builder()
+                    .key("email-support")
+                    .format(Metadata.MetadataFormat.MAIL)
+                    .name(MetadataService.METADATA_EMAIL_SUPPORT_KEY)
+                    .value("${(api.primaryOwner.email)!''}")
+                    .referenceType(Metadata.ReferenceType.API)
+                    .referenceId("generated-id")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    @Test
+    void should_save_all_flows() {
+        // Given
+        List<NativeFlow> flows = List.of(NativeFlow.builder().name("flow").build());
+        var newApi = NewApiFixtures.aNativeApiV4().toBuilder().flows(flows).build();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(flowCrudService.storage()).containsExactlyElementsOf(flows);
+    }
+
+    @Test
+    void should_create_an_api_review_workflow_when_api_review_is_enabled() {
+        // Given
+        enableApiReview();
+        var newApi = NewApiFixtures.aNativeApiV4();
+
+        // When
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        // Then
+        assertThat(workflowCrudService.storage())
+            .contains(
+                Workflow
+                    .builder()
+                    .id("generated-id")
+                    .referenceType(Workflow.ReferenceType.API)
+                    .referenceId("generated-id")
+                    .type(Workflow.Type.REVIEW)
+                    .state(Workflow.State.DRAFT)
+                    .user(USER_ID)
+                    .comment("")
+                    .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                    .build()
+            );
+    }
+
+    private void enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode mode) {
+        parametersQueryService.initWith(
+            List.of(new Parameter(Key.API_PRIMARY_OWNER_MODE.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, mode.name()))
+        );
+    }
+
+    private void enableApiReview() {
+        parametersQueryService.define(
+            new Parameter(Key.API_REVIEW_ENABLED.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, "true")
+        );
+    }
+
+    private void givenExistingUsers(List<BaseUserEntity> users) {
+        userCrudService.initWith(users);
+    }
+
+    private void givenExistingMemberships(List<Membership> memberships) {
+        membershipCrudService.initWith(memberships);
+    }
+
+    private void givenExistingGroup(List<Group> groups) {
+        groupQueryService.initWith(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateNativeApiUseCaseTest.java
@@ -233,7 +233,7 @@ class CreateNativeApiUseCaseTest {
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)
             .lifecycleState(Api.LifecycleState.STOPPED)
             .visibility(Api.Visibility.PRIVATE)
-            .nativeApiDefinition(newApi.toNativeApiDefinitionBuilder().id("generated-id").build())
+            .apiDefinitionNativeV4(newApi.toNativeApiDefinitionBuilder().id("generated-id").build())
             .build();
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(output.api()).isEqualTo(new ApiWithFlows(expectedApi, newApi.getFlows()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateV4ApiUseCaseTest.java
@@ -452,7 +452,7 @@ class CreateV4ApiUseCaseTest {
     @Test
     void should_save_all_flows() {
         // Given
-        var flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
+        List<Flow> flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
         var newApi = NewApiFixtures.aProxyApiV4().toBuilder().flows(flows).build();
 
         // When

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
@@ -77,7 +77,7 @@ class GetApiDefinitionUseCaseTest {
         void should_return_api_definition_with_flows() {
             // Given
             //   Api flow
-            var flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
+            List<Flow> flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
             flowCrudServiceInMemory.saveApiFlows(API_ID, flows);
 
             //   Plan flow
@@ -89,7 +89,7 @@ class GetApiDefinitionUseCaseTest {
             planStaging.setPlanStatus(PlanStatus.STAGING);
             planQueryServiceInMemory.initWith(List.of(planPublished, planDeprecated, planStaging));
 
-            var planFlows = List.of(Flow.builder().name("plan-flow").selectors(List.of(new HttpSelector())).build());
+            List<Flow> planFlows = List.of(Flow.builder().name("plan-flow").selectors(List.of(new HttpSelector())).build());
             flowCrudServiceInMemory.savePlanFlows(planPublished.getId(), planFlows);
             flowCrudServiceInMemory.savePlanFlows(planDeprecated.getId(), planFlows);
             flowCrudServiceInMemory.savePlanFlows(planStaging.getId(), planFlows);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiDefinitionUseCaseTest.java
@@ -19,15 +19,12 @@ import static fixtures.core.model.ApiFixtures.aMessageApiV4;
 import static fixtures.core.model.ApiFixtures.aProxyApiV2;
 import static fixtures.core.model.PlanFixtures.aPlanV2;
 import static fixtures.core.model.PlanFixtures.aPlanV4;
-import static fixtures.core.model.PlanFixtures.aPushPlan;
 import static org.junit.jupiter.api.Assertions.*;
 
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.plan.model.Plan;
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -70,7 +67,7 @@ class GetApiDefinitionUseCaseTest {
 
             // Then
             assertNotNull(output);
-            assertEquals(API.getApiDefinitionV4(), output.apiDefinitionV4());
+            assertEquals(API.getApiDefinitionHttpV4(), output.apiDefinitionV4());
         }
 
         @Test
@@ -103,7 +100,7 @@ class GetApiDefinitionUseCaseTest {
 
             // Then
             assertNotNull(output);
-            assertEquals(API.getApiDefinitionV4(), output.apiDefinitionV4());
+            assertEquals(API.getApiDefinitionHttpV4(), output.apiDefinitionV4());
             assertEquals(flows, output.apiDefinitionV4().getFlows());
             assertEquals(2, output.apiDefinitionV4().getPlans().size());
             assertEquals(planFlows, output.apiDefinitionV4().getPlans().get(0).getFlows());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -1273,7 +1273,7 @@ class ImportApiCRDUseCaseTest {
             .background(null)
             .groups(null)
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 ApiDefinitionFixtures
                     .aHttpProxyApiV4(API_ID)
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -133,6 +133,7 @@ import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -519,7 +520,7 @@ class ImportApiCRDUseCaseTest {
                 .hasSize(1)
                 .extracting(Plan::getId, Plan::getName, Plan::getPublishedAt)
                 .containsExactly(tuple("keyless-id", "Keyless", INSTANT_NOW.atZone(ZoneId.systemDefault())));
-            assertThat(flowCrudService.storage()).extracting(Flow::getName).containsExactly("plan-flow");
+            assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).containsExactly("plan-flow");
         }
 
         @Test
@@ -906,7 +907,7 @@ class ImportApiCRDUseCaseTest {
                 .extracting(Plan::getId, Plan::getName)
                 .containsExactly(tuple("keyless", "Keyless"), tuple("generated-id", "API Key"));
 
-            assertThat(flowCrudService.storage()).extracting(Flow::getName).contains("apikey-flow");
+            assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).contains("apikey-flow");
         }
 
         @Test
@@ -941,7 +942,7 @@ class ImportApiCRDUseCaseTest {
                 .hasSize(1)
                 .extracting(Plan::getId, Plan::getName, Plan::getDescription)
                 .containsExactly(tuple("keyless", "Updated Keyless", "Updated description"));
-            assertThat(flowCrudService.storage()).extracting(Flow::getName).containsExactly("updated flow");
+            assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).containsExactly("updated flow");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -41,9 +41,6 @@ import io.gravitee.apim.core.api.model.import_definition.ApiMember;
 import io.gravitee.apim.core.api.model.import_definition.ApiMemberRole;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.documentation.exception.InvalidPageContentException;
-import io.gravitee.apim.core.documentation.exception.InvalidPageNameException;
-import io.gravitee.apim.core.documentation.exception.InvalidPageParentException;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -70,7 +67,6 @@ import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
-import io.gravitee.rest.api.service.exceptions.PageContentUnsafeException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -348,7 +344,7 @@ class ImportApiDefinitionUseCaseTest {
                 .aPlanWithFlows()
                 .toBuilder()
                 .apiId(API_ID)
-                .planDefinitionV4(PlanWithFlowsFixtures.aPlanWithFlows().getPlanDefinitionV4().toBuilder().tags(TAGS).build())
+                .planDefinitionHttpV4(PlanWithFlowsFixtures.aPlanWithFlows().getPlanDefinitionHttpV4().toBuilder().tags(TAGS).build())
                 .build();
             var importDefinition = anImportDefinition().toBuilder().plans(Set.of(plan)).build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionUseCaseTest.java
@@ -572,7 +572,7 @@ class ImportApiDefinitionUseCaseTest {
     private Api expectedApi() {
         return aProxyApiV4()
             .toBuilder()
-            .apiDefinitionV4(
+            .apiDefinitionHttpV4(
                 ApiDefinitionFixtures
                     .anApiV4()
                     .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -27,31 +27,18 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import fixtures.core.model.AuditInfoFixtures;
 import initializers.ImportDefinitionCreateDomainServiceTestInitializer;
-import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
-import inmemory.MembershipCrudServiceInMemory;
-import inmemory.MembershipQueryServiceInMemory;
-import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PolicyPluginCrudServiceInMemory;
-import inmemory.RoleQueryServiceInMemory;
 import inmemory.TagQueryServiceInMemory;
-import inmemory.UserCrudServiceInMemory;
-import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
-import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
-import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
-import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
 import io.gravitee.apim.core.api.exception.InvalidImportWithOASValidationPolicyException;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.model.Group;
-import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerFactory;
 import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.apim.core.tag.model.Tag;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
-import io.gravitee.apim.infra.domain_service.api.ApiImportDomainServiceLegacyWrapper;
 import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.plugin.EndpointConnectorPluginLegacyWrapper;
-import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
@@ -191,7 +178,7 @@ class OAIToImportApiUseCaseTest {
 
         var importDefinition = output.apiWithFlows();
         assertThat(importDefinition).isNotNull();
-        assertThat(importDefinition.getApiDefinitionV4().getEndpointGroups())
+        assertThat(importDefinition.getApiDefinitionHttpV4().getEndpointGroups())
             .hasSize(1)
             .extracting(EndpointGroup::getSharedConfiguration)
             .containsExactly(SHARED_CONFIGURATION);
@@ -279,7 +266,7 @@ class OAIToImportApiUseCaseTest {
             var importDefinition = output.apiWithFlows();
             assertThat(importDefinition).isNotNull();
             // Check that the OAS validation policy is added
-            assertThat(importDefinition.getApiDefinitionV4().getFlows())
+            assertThat(importDefinition.getApiDefinitionHttpV4().getFlows())
                 .first()
                 .satisfies(flow -> {
                     assertThat(flow.getName()).isEqualTo("OpenAPI Specification Validation");
@@ -292,7 +279,7 @@ class OAIToImportApiUseCaseTest {
                 });
 
             // Check that the Resource is added
-            assertThat(importDefinition.getApiDefinitionV4().getResources())
+            assertThat(importDefinition.getApiDefinitionHttpV4().getResources())
                 .hasSize(1)
                 .first()
                 .satisfies(resource1 -> {
@@ -354,10 +341,10 @@ class OAIToImportApiUseCaseTest {
             var importDefinition = output.apiWithFlows();
             assertThat(importDefinition).isNotNull();
             // Check that the OAS validation policy is not added
-            assertThat(importDefinition.getApiDefinitionV4().getFlows())
+            assertThat(importDefinition.getApiDefinitionHttpV4().getFlows())
                 .noneMatch(flow -> flow.getName().equals("OpenAPI Specification Validation"));
             // Check that the Resource is not added
-            assertThat(importDefinition.getApiDefinitionV4().getResources()).isEmpty();
+            assertThat(importDefinition.getApiDefinitionHttpV4().getResources()).isEmpty();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/RollbackApiUseCaseTest.java
@@ -367,7 +367,7 @@ class RollbackApiUseCaseTest {
                 .id("plan-to-republish")
                 .apiId(existingApi.getId())
                 .name("plan-to-republish-name")
-                .planDefinitionV4(PlanFixtures.aPlanV4().getPlanDefinitionV4().toBuilder().status(PlanStatus.CLOSED).build())
+                .planDefinitionHttpV4(PlanFixtures.aPlanV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.CLOSED).build())
                 .build()
         );
 
@@ -494,7 +494,7 @@ class RollbackApiUseCaseTest {
         // Check updated plan
         var updatedPlan = planCrudService.getById(existingPlanToUpdate.getId());
         assertThat(updatedPlan.getName()).isEqualTo("plan-to-update-name-UPDATED");
-        assertThat(updatedPlan.getPlanDefinitionV4().getFlows().get(0).getName()).isEqualTo("plan-to-update-new-flow");
+        assertThat(updatedPlan.getPlanDefinitionHttpV4().getFlows().get(0).getName()).isEqualTo("plan-to-update-new-flow");
         assertThat(updatedPlan.getDescription()).isEqualTo("Description not updated");
         assertThat(updatedPlan.getCommentMessage()).isEqualTo("Comment message not updated");
 
@@ -502,10 +502,10 @@ class RollbackApiUseCaseTest {
         var createdPlan = planCrudService.getById("plan-to-add");
         assertThat(createdPlan.getId()).isEqualTo("plan-to-add");
         assertThat(createdPlan.getName()).isEqualTo("plan-to-add-name");
-        assertThat(createdPlan.getPlanDefinitionV4().getFlows().get(0).getName()).isEqualTo("flow-name");
-        assertThat(createdPlan.getPlanDefinitionV4().getTags()).containsExactly("tag");
-        assertThat(createdPlan.getPlanDefinitionV4().getSelectionRule()).isEqualTo("selection-rule");
-        assertThat(createdPlan.getPlanDefinitionV4().getSecurity().getType()).isEqualTo("KEY_LESS");
+        assertThat(createdPlan.getPlanDefinitionHttpV4().getFlows().get(0).getName()).isEqualTo("flow-name");
+        assertThat(createdPlan.getPlanDefinitionHttpV4().getTags()).containsExactly("tag");
+        assertThat(createdPlan.getPlanDefinitionHttpV4().getSelectionRule()).isEqualTo("selection-rule");
+        assertThat(createdPlan.getPlanDefinitionHttpV4().getSecurity().getType()).isEqualTo("KEY_LESS");
 
         assertClosePlanAuditHasBeenCreated(existingPlanToClose);
         assertRollbackAuditHasBeenCreated();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateDynamicPropertiesUseCaseTest.java
@@ -170,7 +170,7 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionV4().getProperties())
+            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties())
                 .containsExactlyInAnyOrder(
                     Property.builder().key("user-prop").value("value").dynamic(false).build(),
                     Property.builder().key("key").value("value").dynamic(true).build()
@@ -194,7 +194,7 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionV4().getProperties())
+            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties())
                 .containsExactlyInAnyOrder(
                     Property.builder().key("user-prop").value("value").dynamic(false).build(),
                     Property.builder().key("key").value("value").dynamic(true).build()
@@ -245,7 +245,7 @@ class UpdateDynamicPropertiesUseCaseTest {
                 )
             );
 
-            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionV4().getProperties())
+            assertThat(apiCrudServiceInMemory.get(api.getId()).getApiDefinitionHttpV4().getProperties())
                 .containsExactlyInAnyOrder(
                     Property.builder().key("user-prop").value("value").dynamic(false).build(),
                     Property.builder().key("key").value("value").dynamic(true).build()
@@ -272,7 +272,7 @@ class UpdateDynamicPropertiesUseCaseTest {
             verify(apiStateDomainService).deploy(apiCaptor.capture(), any(String.class), auditInfoCaptor.capture());
             assertSoftly(softly -> {
                 softly
-                    .assertThat(apiCaptor.getValue().getApiDefinitionV4().getProperties())
+                    .assertThat(apiCaptor.getValue().getApiDefinitionHttpV4().getProperties())
                     .containsExactlyInAnyOrder(
                         Property.builder().key("user-prop").value("value").dynamic(false).build(),
                         Property.builder().key("key").value("value").dynamic(true).build()
@@ -294,11 +294,11 @@ class UpdateDynamicPropertiesUseCaseTest {
         void should_redeploy_using_the_last_deployed_api_definition() {
             // Case were a user disable and save the API, but without deploying it
             var api = givenApi(buildApiWithProperties(List.of(Property.builder().key("user-prop").value("value").dynamic(false).build())));
-            api.getApiDefinitionV4().getServices().getDynamicProperty().setEnabled(false);
+            api.getApiDefinitionHttpV4().getServices().getDynamicProperty().setEnabled(false);
 
             // Last event of the deployed api is with the service enabled
             final Api lastDeployedApi = api.toBuilder().build();
-            lastDeployedApi.getApiDefinitionV4().getServices().getDynamicProperty().setEnabled(true);
+            lastDeployedApi.getApiDefinitionHttpV4().getServices().getDynamicProperty().setEnabled(true);
             apiEventQueryServiceInMemory.initWith(List.of(lastDeployedApi));
 
             cut.execute(
@@ -315,7 +315,7 @@ class UpdateDynamicPropertiesUseCaseTest {
 
             verify(apiStateDomainService).deploy(apiCaptor.capture(), any(String.class), auditInfoCaptor.capture());
             assertSoftly(softly -> {
-                var definition = api.getApiDefinitionV4();
+                var definition = api.getApiDefinitionHttpV4();
                 softly.assertThat(definition.getServices().getDynamicProperty().isEnabled()).isTrue();
                 softly
                     .assertThat(definition.getProperties())
@@ -345,7 +345,7 @@ class UpdateDynamicPropertiesUseCaseTest {
 
     @NotNull
     private static Api buildApiWithProperties(List<Property> properties) {
-        return ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).apiDefinitionV4(anApiDefinitionWithProperties(properties)).build();
+        return ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).apiDefinitionHttpV4(anApiDefinitionWithProperties(properties)).build();
     }
 
     private static io.gravitee.definition.model.v4.Api anApiDefinitionWithProperties(List<Property> properties) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateFederatedApiUseCaseTest.java
@@ -228,7 +228,7 @@ class UpdateFederatedApiUseCaseTest {
             .version("input")
             .originContext(new OriginContext.Integration("input"))
             .definitionVersion(DefinitionVersion.V1)
-            .apiDefinitionV4(io.gravitee.definition.model.v4.Api.builder().build())
+            .apiDefinitionHttpV4(io.gravitee.definition.model.v4.Api.builder().build())
             .apiDefinition(io.gravitee.definition.model.Api.builder().build())
             .federatedApiDefinition(null)
             .type(ApiType.MESSAGE)
@@ -257,7 +257,7 @@ class UpdateFederatedApiUseCaseTest {
             .version("old")
             .originContext(new OriginContext.Integration("old"))
             .definitionVersion(DefinitionVersion.FEDERATED)
-            .apiDefinitionV4(null)
+            .apiDefinitionHttpV4(null)
             .apiDefinition(null)
             .federatedApiDefinition(FederatedApi.builder().build())
             .type(ApiType.PROXY)
@@ -283,7 +283,7 @@ class UpdateFederatedApiUseCaseTest {
         assertThat(result.getCrossId()).isEqualTo("old");
         assertThat(result.getOriginContext()).isEqualTo(new OriginContext.Integration("old"));
         assertThat(result.getDefinitionVersion()).isEqualTo(DefinitionVersion.FEDERATED);
-        assertThat(result.getApiDefinitionV4()).isEqualTo(null);
+        assertThat(result.getApiDefinitionHttpV4()).isEqualTo(null);
         assertThat(result.getApiDefinition()).isEqualTo(null);
         assertThat(result.getFederatedApiDefinition()).isEqualTo(FederatedApi.builder().build());
         assertThat(result.getType()).isEqualTo(ApiType.PROXY);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/integration/use_case/IngestFederatedApisUseCaseTest.java
@@ -1754,7 +1754,7 @@ class IngestFederatedApisUseCaseTest {
             .version("input")
             .originContext(new OriginContext.Integration("input"))
             .definitionVersion(DefinitionVersion.V1)
-            .apiDefinitionV4(io.gravitee.definition.model.v4.Api.builder().build())
+            .apiDefinitionHttpV4(io.gravitee.definition.model.v4.Api.builder().build())
             .apiDefinition(io.gravitee.definition.model.Api.builder().build())
             .federatedApiDefinition(FederatedApi.builder().id("input").build())
             .type(ApiType.MESSAGE)
@@ -1783,7 +1783,7 @@ class IngestFederatedApisUseCaseTest {
             .version("old")
             .originContext(new OriginContext.Integration("old"))
             .definitionVersion(DefinitionVersion.FEDERATED)
-            .apiDefinitionV4(null)
+            .apiDefinitionHttpV4(null)
             .apiDefinition(null)
             .federatedApiDefinition(FederatedApi.builder().id("old").build())
             .type(ApiType.PROXY)
@@ -1809,7 +1809,7 @@ class IngestFederatedApisUseCaseTest {
         assertThat(result.getCrossId()).isEqualTo("old");
         assertThat(result.getOriginContext()).isEqualTo(new OriginContext.Integration("old"));
         assertThat(result.getDefinitionVersion()).isEqualTo(DefinitionVersion.FEDERATED);
-        assertThat(result.getApiDefinitionV4()).isEqualTo(null);
+        assertThat(result.getApiDefinitionHttpV4()).isEqualTo(null);
         assertThat(result.getApiDefinition()).isEqualTo(null);
         assertThat(result.getType()).isEqualTo(ApiType.PROXY);
         assertThat(result.getDeployedAt()).isEqualTo(oldDate);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainServiceTest.java
@@ -109,10 +109,10 @@ class ClosePlanDomainServiceTest {
                 PlanFixtures
                     .anApiKeyV4()
                     .toBuilder()
-                    .planDefinitionV4(
+                    .planDefinitionHttpV4(
                         PlanFixtures
                             .anApiKeyV4()
-                            .getPlanDefinitionV4()
+                            .getPlanDefinitionHttpV4()
                             .toBuilder()
                             .status(io.gravitee.definition.model.v4.plan.PlanStatus.CLOSED)
                             .build()
@@ -188,10 +188,10 @@ class ClosePlanDomainServiceTest {
             PlanFixtures
                 .anApiKeyV4()
                 .toBuilder()
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     PlanFixtures
                         .anApiKeyV4()
-                        .getPlanDefinitionV4()
+                        .getPlanDefinitionHttpV4()
                         .toBuilder()
                         .status(io.gravitee.definition.model.v4.plan.PlanStatus.CLOSED)
                         .build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
@@ -191,7 +191,7 @@ class CreatePlanDomainServiceTest {
             // Given
             var plan = aPushPlan()
                 .toBuilder()
-                .planDefinitionV4(PlanFixtures.aPushPlan().toBuilder().security(PlanSecurity.builder().build()).build())
+                .planDefinitionHttpV4(PlanFixtures.aPushPlan().toBuilder().security(PlanSecurity.builder().build()).build())
                 .build();
 
             // When
@@ -206,7 +206,7 @@ class CreatePlanDomainServiceTest {
         @Test
         void should_throw_when_security_configuration_is_missing() {
             // Given
-            var plan = aPlanV4().toBuilder().planDefinitionV4(PlanFixtures.anApiKeyV4().toBuilder().security(null).build()).build();
+            var plan = aPlanV4().toBuilder().planDefinitionHttpV4(PlanFixtures.anApiKeyV4().toBuilder().security(null).build()).build();
 
             // When
             var throwable = Assertions.catchThrowable(() -> service.create(plan, List.of(), HTTP_PROXY_API_V4, AUDIT_INFO));
@@ -253,7 +253,7 @@ class CreatePlanDomainServiceTest {
         @MethodSource("plans")
         void should_throw_when_flows_are_invalid(Api api, Plan plan) {
             // Given
-            var invalidFlows = List.of(
+            List<Flow> invalidFlows = List.of(
                 Flow.builder().name("invalid").selectors(List.of(new HttpSelector(), new ChannelSelector())).build()
             );
 
@@ -428,7 +428,7 @@ class CreatePlanDomainServiceTest {
         void should_allow_keyless_plan_creation_to_tcp_api() {
             // Given
             var plan = aKeylessV4().toBuilder().apiId(API_ID).build().setPlanStatus(PlanStatus.PUBLISHED).setPlanTags(Set.of(TAG));
-            var flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
+            List<Flow> flows = List.of(Flow.builder().name("flow").selectors(List.of(new HttpSelector())).build());
 
             // When
             var result = service.create(plan, flows, TCP_PROXY_API_V4, AUDIT_INFO);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
@@ -238,7 +238,7 @@ class CreatePlanDomainServiceTest {
         @MethodSource("plans")
         void should_throw_when_plan_tags_mismatch_with_tags_defined_in_api(Api api, Plan plan, List<Flow> flows) {
             // Given
-            api.getApiDefinitionV4().setTags(Set.of());
+            api.getApiDefinitionHttpV4().setTags(Set.of());
 
             // When
             var throwable = Assertions.catchThrowable(() -> service.create(plan, flows, api, AUDIT_INFO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -307,9 +307,9 @@ class UpdatePlanDomainServiceTest {
                 .description("updated description")
                 .commentRequired(true)
                 .commentMessage("updated comment")
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     plan
-                        .getPlanDefinitionV4()
+                        .getPlanDefinitionHttpV4()
                         .toBuilder()
                         .status(PlanStatus.PUBLISHED)
                         .tags(Set.of("tag1"))
@@ -347,7 +347,7 @@ class UpdatePlanDomainServiceTest {
         void should_throw_when_flows_are_invalid(Api api, Plan plan) {
             // Given
             givenExistingPlan(plan);
-            var invalidFlows = List.of(
+            List<Flow> invalidFlows = List.of(
                 Flow.builder().name("invalid").selectors(List.of(new HttpSelector(), new ChannelSelector())).build()
             );
 
@@ -417,7 +417,7 @@ class UpdatePlanDomainServiceTest {
             // When
             var toUpdate = plan
                 .toBuilder()
-                .planDefinitionV4(plan.getPlanDefinitionV4().toBuilder().selectionRule("updated rule").build())
+                .planDefinitionHttpV4(plan.getPlanDefinitionHttpV4().toBuilder().selectionRule("updated rule").build())
                 .build();
             var result = service.update(toUpdate, flows, null, api, AUDIT_INFO);
 
@@ -511,7 +511,7 @@ class UpdatePlanDomainServiceTest {
                 anApiKeyV4()
                     .toBuilder()
                     .apiId(API_ID)
-                    .planDefinitionV4(
+                    .planDefinitionHttpV4(
                         fixtures.definition.PlanFixtures.anApiKeyV4().toBuilder().tags(Set.of(TAG)).status(PlanStatus.STAGING).build()
                     )
                     .build(),
@@ -522,7 +522,7 @@ class UpdatePlanDomainServiceTest {
                 aPushPlan()
                     .toBuilder()
                     .apiId(API_ID)
-                    .planDefinitionV4(
+                    .planDefinitionHttpV4(
                         fixtures.definition.PlanFixtures.anApiKeyV4().toBuilder().tags(Set.of(TAG)).status(PlanStatus.STAGING).build()
                     )
                     .build(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -333,7 +333,7 @@ class UpdatePlanDomainServiceTest {
         void should_throw_when_a_plan_have_no_tag_matching_api_tags(Api api, Plan plan, List<Flow> flows) {
             // Given
             givenExistingPlan(plan);
-            api.getApiDefinitionV4().setTags(Set.of("tag1", "tag2"));
+            api.getApiDefinitionHttpV4().setTags(Set.of("tag1", "tag2"));
 
             // When
             var throwable = Assertions.catchThrowable(() -> service.update(plan.setPlanTags(Set.of("tag3")), flows, null, api, AUDIT_INFO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -39,7 +39,6 @@ import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import lombok.SneakyThrows;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -70,7 +69,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
                 soft.assertThat(api.getApiDefinition()).isNull();
                 soft
-                    .assertThat(api.getApiDefinitionV4())
+                    .assertThat(api.getApiDefinitionHttpV4())
                     .isEqualTo(
                         io.gravitee.definition.model.v4.Api
                             .builder()
@@ -157,7 +156,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V4);
                 soft.assertThat(api.getApiDefinition()).isNull();
-                soft.assertThat(api.getApiDefinitionV4()).isNull();
+                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
                 soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
                 soft.assertThat(api.getName()).isEqualTo("api-name");
                 soft.assertThat(api.getDeployedAt()).isEqualTo(Instant.parse("2020-02-03T20:22:02.00Z").atZone(ZoneOffset.UTC));
@@ -188,7 +187,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isEqualTo(DefinitionVersion.V2);
-                soft.assertThat(api.getApiDefinitionV4()).isNull();
+                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
                 soft
                     .assertThat(api.getApiDefinition())
                     // V2 Api definition is defining a equals/hashcode checking only the id
@@ -223,7 +222,7 @@ class ApiAdapterTest {
                 soft.assertThat(api.getDescription()).isEqualTo("api-description");
                 soft.assertThat(api.getVersion()).isEqualTo("1.0.0");
                 soft.assertThat(api.getDefinitionVersion()).isNull();
-                soft.assertThat(api.getApiDefinitionV4()).isNull();
+                soft.assertThat(api.getApiDefinitionHttpV4()).isNull();
                 soft.assertThat(api.getApiDefinition()).isNull();
                 soft.assertThat(api.getType()).isEqualTo(ApiType.PROXY);
                 soft.assertThat(api.getName()).isEqualTo("api-name");
@@ -257,7 +256,7 @@ class ApiAdapterTest {
         void should_convert_v4_api_to_repository() {
             var model = ApiFixtures.aProxyApiV4();
             model
-                .getApiDefinitionV4()
+                .getApiDefinitionHttpV4()
                 .setFailover(
                     Failover
                         .builder()
@@ -281,7 +280,7 @@ class ApiAdapterTest {
                 try {
                     soft
                         .assertThat(api.getDefinition())
-                        .isEqualTo(GraviteeJacksonMapper.getInstance().writeValueAsString(model.getApiDefinitionV4()));
+                        .isEqualTo(GraviteeJacksonMapper.getInstance().writeValueAsString(model.getApiDefinitionHttpV4()));
                 } catch (JsonProcessingException e) {
                     soft.fail(e.getMessage());
                 }
@@ -375,7 +374,7 @@ class ApiAdapterTest {
                 .apiLifecycleState(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.PUBLISHED)
                 .build();
 
-            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, model.getApiDefinitionV4());
+            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, model.getApiDefinitionHttpV4());
 
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(updateApiEntity.getId()).isEqualTo("my-api");
@@ -395,9 +394,9 @@ class ApiAdapterTest {
                 soft.assertThat(updateApiEntity.getEndpointGroups()).hasSize(1);
                 soft
                     .assertThat(updateApiEntity.getEndpointGroups().get(0))
-                    .isEqualTo(model.getApiDefinitionV4().getEndpointGroups().get(0));
+                    .isEqualTo(model.getApiDefinitionHttpV4().getEndpointGroups().get(0));
                 soft.assertThat(updateApiEntity.getListeners()).hasSize(1);
-                soft.assertThat(updateApiEntity.getListeners().get(0)).isEqualTo(model.getApiDefinitionV4().getListeners().get(0));
+                soft.assertThat(updateApiEntity.getListeners().get(0)).isEqualTo(model.getApiDefinitionHttpV4().getListeners().get(0));
             });
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
@@ -171,7 +171,7 @@ class PlanAdapterTest {
                 .characteristics(List.of("characteristic1", "characteristic2"))
                 .commentMessage("Comment message")
                 .generalConditions("General conditions")
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     io.gravitee.definition.model.v4.plan.Plan
                         .builder()
                         .security(PlanSecurity.builder().type("key-less").configuration("{\"nice\": \"config\"}").build())
@@ -409,7 +409,7 @@ class PlanAdapterTest {
             var plan = PlanFixtures
                 .anApiKeyV4()
                 .toBuilder()
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     fixtures.definition.PlanFixtures
                         .anApiKeyV4()
                         .toBuilder()
@@ -427,7 +427,7 @@ class PlanAdapterTest {
             assertThat(planEntity.getPlanStatus().name()).isEqualTo(plan.getPlanStatus().name());
             assertThat(planEntity.getApiId()).isEqualTo(plan.getApiId());
             assertThat(planEntity.getGeneralConditions()).isEqualTo(plan.getGeneralConditions());
-            assertThat(planEntity.getTags()).isEqualTo(plan.getPlanDefinitionV4().getTags());
+            assertThat(planEntity.getTags()).isEqualTo(plan.getPlanDefinitionHttpV4().getTags());
             assertThat(planEntity.getSelectionRule()).isEqualTo(plan.getPlanDefinitionV4().getSelectionRule());
             assertThat(planEntity.getPlanSecurity().getType()).isEqualTo(PlanSecurityType.API_KEY.getLabel());
             assertThat(planEntity.getPlanSecurity().getConfiguration())
@@ -462,7 +462,7 @@ class PlanAdapterTest {
             var plan = PlanFixtures
                 .anApiKeyV4()
                 .toBuilder()
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     fixtures.definition.PlanFixtures
                         .anApiKeyV4()
                         .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/api/ApiCrudServiceImplTest.java
@@ -209,7 +209,9 @@ public class ApiCrudServiceImplTest {
                         .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
                         .deployedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
                         .definitionVersion(DefinitionVersion.V4)
-                        .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionV4()))
+                        .definition(
+                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4())
+                        )
                         .build()
                 );
         }
@@ -374,7 +376,9 @@ public class ApiCrudServiceImplTest {
                         .updatedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")))
                         .deployedAt(Date.from(Instant.parse("2020-02-03T20:22:02.00Z")))
                         .definitionVersion(DefinitionVersion.V4)
-                        .definition(GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionV4()))
+                        .definition(
+                            GraviteeJacksonMapper.getInstance().writeValueAsString(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4())
+                        )
                         .build()
                 );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/plan/PlanCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/plan/PlanCrudServiceImplTest.java
@@ -324,7 +324,7 @@ public class PlanCrudServiceImplTest {
                 .commentMessage("Comment message")
                 .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
                 .generalConditions("General conditions")
-                .planDefinitionV4(
+                .planDefinitionHttpV4(
                     fixtures.definition.PlanFixtures
                         .aKeylessV4()
                         .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -33,7 +33,6 @@ import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
@@ -130,7 +129,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             .when(apiValidationService)
             .validateDynamicProperties(any());
 
-        doAnswer(invocation -> invocation.<List<Flow>>getArgument(1)).when(flowValidationDomainService).validateAndSanitize(any(), any());
+        doAnswer(invocation -> invocation.<List<Flow>>getArgument(1))
+            .when(flowValidationDomainService)
+            .validateAndSanitizeHttpV4(any(), any());
 
         var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -39,8 +39,6 @@ import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint;
-import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
-import io.gravitee.definition.model.v4.nativeapi.NativeListener;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
@@ -119,10 +117,10 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             var api = ApiFixtures
                 .aProxyApiV4()
                 .toBuilder()
-                .apiDefinitionV4(
+                .apiDefinitionHttpV4(
                     ApiFixtures
                         .aProxyApiV4()
-                        .getApiDefinitionV4()
+                        .getApiDefinitionHttpV4()
                         .toBuilder()
                         .services(
                             ApiServices
@@ -176,12 +174,14 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .hasOnlyTags(Set.of("sanitized"));
 
             SoftAssertions.assertSoftly(soft -> {
-                soft.assertThat(result.getApiDefinitionV4().getListeners()).isEmpty();
-                soft.assertThat(result.getApiDefinitionV4().getEndpointGroups()).isEmpty();
-                soft.assertThat(result.getApiDefinitionV4().getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
-                soft.assertThat(result.getApiDefinitionV4().getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
-                soft.assertThat(result.getApiDefinitionV4().getFlowExecution()).isNull();
-                soft.assertThat(result.getApiDefinitionV4().getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
+                soft.assertThat(result.getApiDefinitionHttpV4().getListeners()).isEmpty();
+                soft.assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEmpty();
+                soft.assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
+                soft.assertThat(result.getApiDefinitionHttpV4().getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
+                soft.assertThat(result.getApiDefinitionHttpV4().getFlowExecution()).isNull();
+                soft
+                    .assertThat(result.getApiDefinitionHttpV4().getServices().getDynamicProperty().getConfiguration())
+                    .isEqualTo("sanitized");
             });
         }
 
@@ -214,10 +214,10 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .aNativeApi()
                 .toBuilder()
                 .description("sani<img src=\"../../../image.png\">tized")
-                .nativeApiDefinition(
+                .apiDefinitionNativeV4(
                     ApiFixtures
                         .aNativeApi()
-                        .getNativeApiDefinition()
+                        .getApiDefinitionNativeV4()
                         .toBuilder()
                         .services(
                             NativeApiServices
@@ -276,7 +276,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             SoftAssertions.assertSoftly(soft -> {
                 soft
-                    .assertThat(result.getNativeApiDefinition().getListeners())
+                    .assertThat(result.getApiDefinitionNativeV4().getListeners())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(KafkaListener.class)
@@ -284,7 +284,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .extracting(l -> l.getEntrypoints().get(0))
                     .hasFieldOrPropertyWithValue("type", "sanitized");
                 soft
-                    .assertThat(result.getNativeApiDefinition().getEndpointGroups())
+                    .assertThat(result.getApiDefinitionNativeV4().getEndpointGroups())
                     .hasSize(1)
                     .first()
                     .isInstanceOf(NativeEndpointGroup.class)
@@ -293,9 +293,9 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                     .isInstanceOf(NativeEndpoint.class)
                     .hasFieldOrPropertyWithValue("name", "sanitized")
                     .hasFieldOrPropertyWithValue("type", "sanitized");
-                soft.assertThat(result.getNativeApiDefinition().getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
+                soft.assertThat(result.getApiDefinitionNativeV4().getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
                 soft
-                    .assertThat(result.getNativeApiDefinition().getServices().getDynamicProperty().getConfiguration())
+                    .assertThat(result.getApiDefinitionNativeV4().getServices().getDynamicProperty().getConfiguration())
                     .isEqualTo("sanitized");
             });
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -25,6 +25,7 @@ import assertions.CoreAssertions;
 import fixtures.core.model.ApiFixtures;
 import fixtures.definition.FlowFixtures;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
+import io.gravitee.apim.core.api.domain_service.GroupValidationService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -33,15 +34,27 @@ import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
+import io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
+import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
+import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -70,98 +83,232 @@ class ValidateApiDomainServiceLegacyWrapperTest {
     @Mock
     FlowValidationDomainService flowValidationDomainService;
 
+    @Mock
+    TagsValidationService tagsValidationService;
+
+    @Mock
+    GroupValidationService groupValidationService;
+
+    @Mock
+    ListenerValidationService listenerValidationService;
+
+    @Mock
+    EndpointGroupsValidationService endpointGroupsValidationService;
+
     @InjectMocks
     ValidateApiDomainServiceLegacyWrapper service;
 
-    @Test
-    void should_call_legacy_service() {
-        Api api = ApiFixtures.aProxyApiV4();
-        service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
+    @Nested
+    class ApiHttpV4 {
 
-        verify(apiValidationService)
-            .validateAndSanitizeNewApi(
-                eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
-                eq(ApiAdapter.INSTANCE.toNewApiEntity(api)),
-                eq(PrimaryOwnerAdapter.INSTANCE.toRestEntity(PRIMARY_OWNER))
+        @Test
+        void should_call_legacy_service() {
+            Api api = ApiFixtures.aProxyApiV4();
+            service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
+
+            verify(apiValidationService)
+                .validateAndSanitizeNewApi(
+                    eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
+                    eq(ApiAdapter.INSTANCE.toNewApiEntity(api)),
+                    eq(PrimaryOwnerAdapter.INSTANCE.toRestEntity(PRIMARY_OWNER))
+                );
+        }
+
+        @Test
+        void should_update_api_with_sanitized_value() {
+            var api = ApiFixtures
+                .aProxyApiV4()
+                .toBuilder()
+                .apiDefinitionV4(
+                    ApiFixtures
+                        .aProxyApiV4()
+                        .getApiDefinitionV4()
+                        .toBuilder()
+                        .services(
+                            ApiServices
+                                .builder()
+                                .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+            doAnswer(invocation -> {
+                    NewApiEntity entity = invocation.getArgument(1);
+                    entity.setName("sanitized");
+                    entity.setApiVersion("sanitized");
+                    entity.setType(ApiType.MESSAGE);
+                    entity.setDescription("sanitized");
+                    entity.setGroups(Set.of("sanitized"));
+                    entity.setTags(Set.of("sanitized"));
+                    entity.setListeners(List.of());
+                    entity.setEndpointGroups(List.of());
+                    entity.setAnalytics(Analytics.builder().enabled(true).build());
+                    entity.setFlowExecution(null);
+                    entity.setFlows(List.of(FlowFixtures.aSimpleFlowV4()));
+
+                    return null;
+                })
+                .when(apiValidationService)
+                .validateAndSanitizeNewApi(any(), any(), any());
+
+            doAnswer(invocation -> {
+                    Service dynamicProperties = invocation.getArgument(0);
+                    dynamicProperties.setConfiguration("sanitized");
+                    return null;
+                })
+                .when(apiValidationService)
+                .validateDynamicProperties(any());
+
+            doAnswer(invocation -> invocation.<List<Flow>>getArgument(1))
+                .when(flowValidationDomainService)
+                .validateAndSanitizeHttpV4(any(), any());
+
+            var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
+
+            CoreAssertions
+                .assertThat(result)
+                .hasName("sanitized")
+                .hasVersion("sanitized")
+                .hasType(ApiType.MESSAGE)
+                .hasDescription("sanitized")
+                .hasOnlyGroups(Set.of("sanitized"))
+                .hasOnlyTags(Set.of("sanitized"));
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getApiDefinitionV4().getListeners()).isEmpty();
+                soft.assertThat(result.getApiDefinitionV4().getEndpointGroups()).isEmpty();
+                soft.assertThat(result.getApiDefinitionV4().getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
+                soft.assertThat(result.getApiDefinitionV4().getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
+                soft.assertThat(result.getApiDefinitionV4().getFlowExecution()).isNull();
+                soft.assertThat(result.getApiDefinitionV4().getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
+            });
+        }
+
+        @Test
+        void should_throw_when_validation_fails() {
+            doThrow(new RuntimeException("error")).when(apiValidationService).validateAndSanitizeNewApi(any(), any(), any());
+
+            var throwable = Assertions.catchThrowable(() ->
+                service.validateAndSanitizeForCreation(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)
             );
+
+            Assertions.assertThat(throwable).isInstanceOf(RuntimeException.class);
+        }
     }
 
-    @Test
-    void should_update_api_with_sanitized_value() {
-        var api = ApiFixtures
-            .aProxyApiV4()
-            .toBuilder()
-            .apiDefinitionV4(
-                ApiFixtures
-                    .aProxyApiV4()
-                    .getApiDefinitionV4()
-                    .toBuilder()
-                    .services(
-                        ApiServices.builder().dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build()).build()
+    @Nested
+    class ApiNativeV4 {
+
+        @Test
+        void should_call_legacy_service() {
+            Api api = ApiFixtures.aNativeApi();
+            service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
+
+            verify(apiValidationService).validateDynamicProperties(any());
+        }
+
+        @Test
+        void should_update_api_with_sanitized_value() {
+            var api = ApiFixtures
+                .aNativeApi()
+                .toBuilder()
+                .description("sani<img src=\"../../../image.png\">tized")
+                .nativeApiDefinition(
+                    ApiFixtures
+                        .aNativeApi()
+                        .getNativeApiDefinition()
+                        .toBuilder()
+                        .services(
+                            NativeApiServices
+                                .builder()
+                                .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+
+            doAnswer(invocation -> Set.of("sanitized")).when(tagsValidationService).validateAndSanitize(any(), any(), any());
+
+            doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any());
+
+            doAnswer(invocation ->
+                    List.of(KafkaListener.builder().entrypoints(List.of(NativeEntrypoint.builder().type("sanitized").build())).build())
+                )
+                .when(listenerValidationService)
+                .validateAndSanitizeNativeV4(any(), any(), any(), any());
+
+            doAnswer(invocation ->
+                    List.of(
+                        NativeEndpointGroup
+                            .builder()
+                            .type("sanitized")
+                            .endpoints(List.of(NativeEndpoint.builder().name("sanitized").type("sanitized").build()))
+                            .build()
                     )
-                    .build()
-            )
-            .build();
-        doAnswer(invocation -> {
-                NewApiEntity entity = invocation.getArgument(1);
-                entity.setName("sanitized");
-                entity.setApiVersion("sanitized");
-                entity.setType(ApiType.MESSAGE);
-                entity.setDescription("sanitized");
-                entity.setGroups(Set.of("sanitized"));
-                entity.setTags(Set.of("sanitized"));
-                entity.setListeners(List.of());
-                entity.setEndpointGroups(List.of());
-                entity.setAnalytics(Analytics.builder().enabled(true).build());
-                entity.setFlowExecution(null);
-                entity.setFlows(List.of(FlowFixtures.aSimpleFlowV4()));
+                )
+                .when(endpointGroupsValidationService)
+                .validateAndSanitizeNativeV4(any());
 
-                return null;
-            })
-            .when(apiValidationService)
-            .validateAndSanitizeNewApi(any(), any(), any());
+            doAnswer(invocation -> {
+                    Service dynamicProperties = invocation.getArgument(0);
+                    dynamicProperties.setConfiguration("sanitized");
+                    return null;
+                })
+                .when(apiValidationService)
+                .validateDynamicProperties(any());
 
-        doAnswer(invocation -> {
-                Service dynamicProperties = invocation.getArgument(0);
-                dynamicProperties.setConfiguration("sanitized");
-                return null;
-            })
-            .when(apiValidationService)
-            .validateDynamicProperties(any());
+            doAnswer(invocation -> List.of(FlowFixtures.aNativeFlowV4()))
+                .when(flowValidationDomainService)
+                .validateAndSanitizeNativeV4(any());
 
-        doAnswer(invocation -> invocation.<List<Flow>>getArgument(1))
-            .when(flowValidationDomainService)
-            .validateAndSanitizeHttpV4(any(), any());
+            var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
 
-        var result = service.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID);
+            CoreAssertions
+                .assertThat(result)
+                .hasName(api.getName())
+                .hasVersion(api.getVersion())
+                .hasType(ApiType.NATIVE)
+                .hasDescription("sanitized")
+                .hasOnlyGroups(Set.of("sanitized"))
+                .hasOnlyTags(Set.of("sanitized"));
 
-        CoreAssertions
-            .assertThat(result)
-            .hasName("sanitized")
-            .hasVersion("sanitized")
-            .hasType(ApiType.MESSAGE)
-            .hasDescription("sanitized")
-            .hasOnlyGroups(Set.of("sanitized"))
-            .hasOnlyTags(Set.of("sanitized"));
+            SoftAssertions.assertSoftly(soft -> {
+                soft
+                    .assertThat(result.getNativeApiDefinition().getListeners())
+                    .hasSize(1)
+                    .first()
+                    .isInstanceOf(KafkaListener.class)
+                    .hasFieldOrPropertyWithValue("type", ListenerType.KAFKA)
+                    .extracting(l -> l.getEntrypoints().get(0))
+                    .hasFieldOrPropertyWithValue("type", "sanitized");
+                soft
+                    .assertThat(result.getNativeApiDefinition().getEndpointGroups())
+                    .hasSize(1)
+                    .first()
+                    .isInstanceOf(NativeEndpointGroup.class)
+                    .hasFieldOrPropertyWithValue("type", "sanitized")
+                    .extracting(ls -> ls.getEndpoints().get(0))
+                    .isInstanceOf(NativeEndpoint.class)
+                    .hasFieldOrPropertyWithValue("name", "sanitized")
+                    .hasFieldOrPropertyWithValue("type", "sanitized");
+                soft.assertThat(result.getNativeApiDefinition().getFlows()).containsExactly(FlowFixtures.aNativeFlowV4());
+                soft
+                    .assertThat(result.getNativeApiDefinition().getServices().getDynamicProperty().getConfiguration())
+                    .isEqualTo("sanitized");
+            });
+        }
 
-        SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(result.getApiDefinitionV4().getListeners()).isEmpty();
-            soft.assertThat(result.getApiDefinitionV4().getEndpointGroups()).isEmpty();
-            soft.assertThat(result.getApiDefinitionV4().getAnalytics()).isEqualTo(Analytics.builder().enabled(true).build());
-            soft.assertThat(result.getApiDefinitionV4().getFlows()).containsExactly(FlowFixtures.aSimpleFlowV4());
-            soft.assertThat(result.getApiDefinitionV4().getFlowExecution()).isNull();
-            soft.assertThat(result.getApiDefinitionV4().getServices().getDynamicProperty().getConfiguration()).isEqualTo("sanitized");
-        });
-    }
+        @Test
+        void should_throw_when_validation_fails() {
+            doThrow(new RuntimeException("error")).when(apiValidationService).validateAndSanitizeNewApi(any(), any(), any());
 
-    @Test
-    void should_throw_when_validation_fails() {
-        doThrow(new RuntimeException("error")).when(apiValidationService).validateAndSanitizeNewApi(any(), any(), any());
+            var throwable = Assertions.catchThrowable(() ->
+                service.validateAndSanitizeForCreation(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)
+            );
 
-        var throwable = Assertions.catchThrowable(() ->
-            service.validateAndSanitizeForCreation(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)
-        );
-
-        Assertions.assertThat(throwable).isInstanceOf(RuntimeException.class);
+            Assertions.assertThat(throwable).isInstanceOf(RuntimeException.class);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/json/jackson/JacksonJsonDiffProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/json/jackson/JacksonJsonDiffProcessorTest.java
@@ -46,7 +46,7 @@ class JacksonJsonDiffProcessorTest {
         var oldPlan = PlanFixtures
             .aPlanV4()
             .toBuilder()
-            .planDefinitionV4(
+            .planDefinitionHttpV4(
                 Plan
                     .builder()
                     .security(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiEventQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiEventQueryServiceImplTest.java
@@ -95,7 +95,7 @@ class ApiEventQueryServiceImplTest {
         final Optional<Api> lastPublishedApi = cut.findLastPublishedApi("org-id", "env-id", "api-id");
         assertThat(lastPublishedApi)
             .hasValueSatisfying(result -> {
-                assertThat(result.getApiDefinitionV4()).isEqualTo(api.getApiDefinitionV4());
+                assertThat(result.getApiDefinitionHttpV4()).isEqualTo(api.getApiDefinitionHttpV4());
             });
         verifyEventCriteria();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -231,7 +231,7 @@ public class V4ApiServiceCockpitTest {
             soft.assertThat(created.getDescription()).isEqualTo("Original from Cockpit - HTTP");
             // Resources and Properties are currently not handle by NewApi
             soft
-                .assertThat(created.getApiDefinitionV4())
+                .assertThat(created.getApiDefinitionHttpV4())
                 .isEqualTo(
                     Api
                         .builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -160,8 +160,8 @@ public class ApiValidationServiceImplTest {
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, Set.of());
         verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
-        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
+        verify(endpointGroupsValidationService, times(1)).validateAndSanitizeHttpV4(apiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -138,8 +138,8 @@ public class ApiValidationServiceImplTest {
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null);
         verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
-        verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
-        verify(endpointGroupsValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
+        verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
+        verify(endpointGroupsValidationService, times(1)).validateAndSanitizeHttpV4(newApiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), newApiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(resourcesValidationService, never()).validateAndSanitize(any());
@@ -160,8 +160,8 @@ public class ApiValidationServiceImplTest {
 
         verify(tagsValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, Set.of());
         verify(groupValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, primaryOwnerEntity);
-        verify(listenerValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), null, null, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
+        verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -45,6 +45,9 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeEntrypoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
@@ -65,6 +68,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -117,578 +121,687 @@ class ListenerValidationServiceImplTest {
             );
     }
 
-    @Test
-    void should_ignore_empty_list() {
-        List<Listener> emptyListeners = List.of();
-        List<Listener> validatedListeners = listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            emptyListeners,
-            emptyList()
-        );
-        assertThat(validatedListeners).isEmpty();
-    }
+    @Nested
+    class ValidateAndSanitizeHttpV4 {
 
-    @Test
-    void should_throw_duplicated_exception_with_duplicated_type() {
-        // Given
-        Listener httpListener1 = new HttpListener();
-        Entrypoint e1 = new Entrypoint();
-        e1.setType("e1");
-        httpListener1.setEntrypoints(List.of(e1));
-        Listener httpListener2 = new HttpListener();
-        Entrypoint e2 = new Entrypoint();
-        e2.setType("e2");
-        httpListener1.setEntrypoints(List.of(e2));
-        List<Listener> listeners = List.of(httpListener1, httpListener2);
-        // When
-        assertThatExceptionOfType(ListenersDuplicatedException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(GraviteeContext.getExecutionContext(), null, listeners, emptyList())
+        @Test
+        void should_ignore_empty_list() {
+            List<Listener> emptyListeners = List.of();
+            List<Listener> validatedListeners = listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                emptyListeners,
+                emptyList()
             );
-    }
+            assertThat(validatedListeners).isEmpty();
+        }
 
-    @Test
-    void should_return_validated_listeners() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        httpListener.setEntrypoints(List.of(entrypoint));
-        List<Listener> listeners = List.of(httpListener);
-        when(entrypointService.findById("type")).thenReturn(mock(ConnectorPluginEntity.class));
-        // When
-        List<Listener> validatedListeners = listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            listeners,
-            emptyList()
-        );
-        // Then
-        assertThat(validatedListeners).hasSize(1);
-        Listener actual = validatedListeners.get(0);
-        assertThat(actual).isInstanceOf(HttpListener.class);
-        HttpListener actualHttpListener = (HttpListener) actual;
-        assertThat(actualHttpListener.getPaths()).hasSize(1);
-        Path path = actualHttpListener.getPaths().get(0);
-        assertThat(path.getHost()).isNull();
-        assertThat(path.getPath()).isEqualTo("/path/");
-    }
+        @Test
+        void should_throw_duplicated_exception_with_duplicated_type() {
+            // Given
+            Listener httpListener1 = new HttpListener();
+            Entrypoint e1 = new Entrypoint();
+            e1.setType("e1");
+            httpListener1.setEntrypoints(List.of(e1));
+            Listener httpListener2 = new HttpListener();
+            Entrypoint e2 = new Entrypoint();
+            e2.setType("e2");
+            httpListener1.setEntrypoints(List.of(e2));
+            List<Listener> listeners = List.of(httpListener1, httpListener2);
+            // When
+            assertThatExceptionOfType(ListenersDuplicatedException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, listeners, emptyList())
+                );
+        }
 
-    @Test
-    void should_return_validated_listeners_with_qos_validation() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        httpListener.setEntrypoints(List.of(entrypoint));
-        List<Listener> listeners = List.of(httpListener);
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AUTO));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        // When
-        List<Listener> validatedListeners = listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            listeners,
-            emptyList()
-        );
-        // Then
-        assertThat(validatedListeners).hasSize(1);
-        Listener actual = validatedListeners.get(0);
-        assertThat(actual).isInstanceOf(HttpListener.class);
-        HttpListener actualHttpListener = (HttpListener) actual;
-        assertThat(actualHttpListener.getPaths()).hasSize(1);
-        Path path = actualHttpListener.getPaths().get(0);
-        assertThat(path.getHost()).isNull();
-        assertThat(path.getPath()).isEqualTo("/path/");
-    }
-
-    @Test
-    void should_throw_missing_path_exception_without_path() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        // When
-        assertThatExceptionOfType(InvalidPathsException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
+        @Test
+        void should_return_validated_listeners() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            httpListener.setEntrypoints(List.of(entrypoint));
+            List<Listener> listeners = List.of(httpListener);
+            when(entrypointService.findById("type")).thenReturn(mock(ConnectorPluginEntity.class));
+            // When
+            List<Listener> validatedListeners = listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                listeners,
+                emptyList()
             );
-    }
+            // Then
+            assertThat(validatedListeners).hasSize(1);
+            Listener actual = validatedListeners.get(0);
+            assertThat(actual).isInstanceOf(HttpListener.class);
+            HttpListener actualHttpListener = (HttpListener) actual;
+            assertThat(actualHttpListener.getPaths()).hasSize(1);
+            Path path = actualHttpListener.getPaths().get(0);
+            assertThat(path.getHost()).isNull();
+            assertThat(path.getPath()).isEqualTo("/path/");
+        }
 
-    @Test
-    void should_throw_missing_entrypoint_exception_without_entrypoints() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("/path")));
-        // When
-        assertThatExceptionOfType(ListenerEntrypointMissingException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
+        @Test
+        void should_return_validated_listeners_with_qos_validation() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            httpListener.setEntrypoints(List.of(entrypoint));
+            List<Listener> listeners = List.of(httpListener);
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AUTO));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            // When
+            List<Listener> validatedListeners = listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                listeners,
+                emptyList()
             );
-    }
+            // Then
+            assertThat(validatedListeners).hasSize(1);
+            Listener actual = validatedListeners.get(0);
+            assertThat(actual).isInstanceOf(HttpListener.class);
+            HttpListener actualHttpListener = (HttpListener) actual;
+            assertThat(actualHttpListener.getPaths()).hasSize(1);
+            Path path = actualHttpListener.getPaths().get(0);
+            assertThat(path.getHost()).isNull();
+            assertThat(path.getPath()).isEqualTo("/path/");
+        }
 
-    @Test
-    void should_throw_missing_entrypoint_type_exception_with_no_type() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("/path")));
-        httpListener.setEntrypoints(List.of(new Entrypoint()));
-        // When
-        assertThatExceptionOfType(ListenerEntrypointMissingTypeException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
+        @Test
+        void should_throw_missing_path_exception_without_path() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            // When
+            assertThatExceptionOfType(InvalidPathsException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_missing_entrypoint_exception_without_entrypoints() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("/path")));
+            // When
+            assertThatExceptionOfType(ListenerEntrypointMissingException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_missing_entrypoint_type_exception_with_no_type() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("/path")));
+            httpListener.setEntrypoints(List.of(new Entrypoint()));
+            // When
+            assertThatExceptionOfType(ListenerEntrypointMissingTypeException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_duplicated_entrypoints_exception_with_duplicated() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("/path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            httpListener.setEntrypoints(List.of(entrypoint, entrypoint));
+            // When
+            assertThatExceptionOfType(ListenerEntrypointDuplicatedException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_return_validated_subscription_listeners() {
+            // Given
+            SubscriptionListener subscriptionListener = new SubscriptionListener();
+            subscriptionListener.setType(ListenerType.SUBSCRIPTION);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            subscriptionListener.setEntrypoints(List.of(entrypoint));
+            List<Listener> listeners = List.of(subscriptionListener);
+
+            when(entrypointService.findById("type")).thenReturn(mock(ConnectorPluginEntity.class));
+            // When
+            List<Listener> validatedListeners = listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                listeners,
+                emptyList()
             );
-    }
+            // Then
+            assertThat(validatedListeners).hasSize(1);
+            Listener actual = validatedListeners.get(0);
+            assertThat(actual).isInstanceOf(SubscriptionListener.class);
+        }
 
-    @Test
-    void should_throw_duplicated_entrypoints_exception_with_duplicated() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("/path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        httpListener.setEntrypoints(List.of(entrypoint, entrypoint));
-        // When
-        assertThatExceptionOfType(ListenerEntrypointDuplicatedException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
+        @Test
+        void should_throw_missing_entrypoint_exception_without_entrypoints_on_subscription_listener() {
+            // Given
+            SubscriptionListener subscriptionListener = new SubscriptionListener();
+            // When
+            assertThatExceptionOfType(ListenerEntrypointMissingException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(subscriptionListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_missing_entrypoint_type_exception_with_not_type_on_subscription_listener() {
+            // Given
+            SubscriptionListener subscriptionListener = new SubscriptionListener();
+            Entrypoint entrypoint = new Entrypoint();
+            subscriptionListener.setEntrypoints(List.of(entrypoint));
+
+            // When
+            assertThatExceptionOfType(ListenerEntrypointMissingTypeException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(subscriptionListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_duplicated_entrypoints_exception_with_duplicated_on_subscription_listener() {
+            // Given
+            SubscriptionListener subscriptionListener = new SubscriptionListener();
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            subscriptionListener.setEntrypoints(List.of(entrypoint, entrypoint));
+
+            // When
+            assertThatExceptionOfType(ListenerEntrypointDuplicatedException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(subscriptionListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_unsupported_qos_exception_with_wrong_qos() {
+            // Given
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setQos(Qos.AT_LEAST_ONCE);
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            // When
+            assertThatExceptionOfType(ListenerEntrypointUnsupportedQosException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_invalid_qos_exception_when_target_endpoint_does_not_support_at_least_once_qos() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setQos(Qos.AT_LEAST_ONCE);
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+            ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AUTO));
+            when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        List.of(endpointGroup)
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_invalid_qos_exception_when_target_endpoint_does_not_have_connector() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setQos(Qos.AT_LEAST_ONCE);
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            when(endpointService.findById("endpoint-test")).thenReturn(null);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        List.of(endpointGroup)
+                    )
+                );
+        }
+
+        @Test
+        void should_validate_qos_config_when_targeting_endpoint() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setQos(Qos.AT_LEAST_ONCE);
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+            ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
+            when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE));
+            when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                List.of(httpListener),
+                List.of(endpointGroup)
             );
-    }
+        }
 
-    @Test
-    void should_return_validated_subscription_listeners() {
-        // Given
-        SubscriptionListener subscriptionListener = new SubscriptionListener();
-        subscriptionListener.setType(ListenerType.SUBSCRIPTION);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        subscriptionListener.setEntrypoints(List.of(entrypoint));
-        List<Listener> listeners = List.of(subscriptionListener);
+        @Test
+        void should_throw_unsupported_dlq_exception_when_connector_does_not_support_dlq_feature() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("target"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(emptySet());
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
 
-        when(entrypointService.findById("type")).thenReturn(mock(ConnectorPluginEntity.class));
-        // When
-        List<Listener> validatedListeners = listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            listeners,
-            emptyList()
-        );
-        // Then
-        assertThat(validatedListeners).hasSize(1);
-        Listener actual = validatedListeners.get(0);
-        assertThat(actual).isInstanceOf(SubscriptionListener.class);
-    }
+            assertThatExceptionOfType(ListenerEntrypointUnsupportedDlqException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
 
-    @Test
-    void should_throw_missing_entrypoint_exception_without_entrypoints_on_subscription_listener() {
-        // Given
-        SubscriptionListener subscriptionListener = new SubscriptionListener();
-        // When
-        assertThatExceptionOfType(ListenerEntrypointMissingException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(subscriptionListener),
-                    emptyList()
-                )
+        @Test
+        void should_throw_invalid_dlq_exception_when_null_target_endpoint() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq(null));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_unsupported_dlq_exception_when_unknown_target_endpoint() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("unknown"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_invalid_dlq_exception_when_target_endpoint_does_not_support_publish() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("endpoint2"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+            ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.SUBSCRIBE));
+            when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        List.of(endpointGroup)
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_invalid_dlq_exception_when_target_endpoint_does_not_have_connector() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("endpoint2"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+            when(endpointService.findById("endpoint-test")).thenReturn(null);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        List.of(endpointGroup)
+                    )
+                );
+        }
+
+        @Test
+        void should_validate_dlq_config_when_targeting_endpoint() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("endpoint2"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+
+            ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.PUBLISH));
+            when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                List.of(httpListener),
+                List.of(endpointGroup)
             );
-    }
+        }
 
-    @Test
-    void should_throw_missing_entrypoint_type_exception_with_not_type_on_subscription_listener() {
-        // Given
-        SubscriptionListener subscriptionListener = new SubscriptionListener();
-        Entrypoint entrypoint = new Entrypoint();
-        subscriptionListener.setEntrypoints(List.of(entrypoint));
+        @Test
+        void should_validate_dlq_config_when_targeting_endpoint_group() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("type");
+            entrypoint.setDlq(new Dlq("endpoint-group"));
+            httpListener.setEntrypoints(List.of(entrypoint));
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
+            when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
 
-        // When
-        assertThatExceptionOfType(ListenerEntrypointMissingTypeException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(subscriptionListener),
-                    emptyList()
-                )
+            ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.PUBLISH));
+            when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            listenerValidationService.validateAndSanitizeHttpV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                List.of(httpListener),
+                List.of(endpointGroup)
             );
+        }
+
+        @Test
+        void should_throw_listener_entrypoint_unsupported_listener_type_exception_when_target_endpoint_does_not_match_listener_type() {
+            HttpListener httpListener = new HttpListener();
+            httpListener.setPaths(List.of(new Path("path")));
+            httpListener.setType(ListenerType.HTTP);
+            Entrypoint entrypoint = new Entrypoint();
+            entrypoint.setType("webhook");
+            httpListener.setEntrypoints(List.of(entrypoint));
+
+            ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
+            when(connectorPluginEntity.getSupportedListenerType()).thenReturn(ListenerType.SUBSCRIPTION);
+            when(entrypointService.findById("webhook")).thenReturn(connectorPluginEntity);
+
+            final EndpointGroup endpointGroup = buildEndpointGroup();
+
+            assertThatExceptionOfType(ListenerEntrypointUnsupportedListenerTypeException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(httpListener),
+                        List.of(endpointGroup)
+                    )
+                );
+        }
+
+        @Test
+        void should_throw_error_when_tcp_listener_hosts_are_not_valid() {
+            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any())).thenThrow(new InvalidHostException("invalid hosts"));
+
+            assertThatExceptionOfType(InvalidHostException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeHttpV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(TcpListener.builder().hosts(List.of("")).build()),
+                        emptyList()
+                    )
+                );
+        }
     }
 
-    @Test
-    void should_throw_duplicated_entrypoints_exception_with_duplicated_on_subscription_listener() {
-        // Given
-        SubscriptionListener subscriptionListener = new SubscriptionListener();
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        subscriptionListener.setEntrypoints(List.of(entrypoint, entrypoint));
+    @Nested
+    class ValidateAndSanitizeNativeV4 {
 
-        // When
-        assertThatExceptionOfType(ListenerEntrypointDuplicatedException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(subscriptionListener),
-                    emptyList()
-                )
+        @Test
+        void should_ignore_empty_list() {
+            List<NativeListener> emptyListeners = List.of();
+            List<NativeListener> validatedListeners = listenerValidationService.validateAndSanitizeNativeV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                emptyListeners,
+                emptyList()
             );
-    }
+            assertThat(validatedListeners).isEmpty();
+        }
 
-    @Test
-    void should_throw_unsupported_qos_exception_with_wrong_qos() {
-        // Given
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setQos(Qos.AT_LEAST_ONCE);
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        // When
-        assertThatExceptionOfType(ListenerEntrypointUnsupportedQosException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
+        @Test
+        void should_throw_duplicated_exception_with_duplicated_type() {
+            // Given
+            NativeListener kafkaListener1 = new KafkaListener();
+            NativeEntrypoint e1 = new NativeEntrypoint();
+            e1.setType("e1");
+            kafkaListener1.setEntrypoints(List.of(e1));
+            NativeListener kafkaListener2 = new KafkaListener();
+            NativeEntrypoint e2 = new NativeEntrypoint();
+            e2.setType("e2");
+            kafkaListener1.setEntrypoints(List.of(e2));
+            List<NativeListener> listeners = List.of(kafkaListener1, kafkaListener2);
+            // When
+            assertThatExceptionOfType(ListenersDuplicatedException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeNativeV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        listeners,
+                        emptyList()
+                    )
+                );
+        }
+
+        @Test
+        void should_return_validated_kafka_listeners() {
+            // Given
+            NativeEntrypoint entrypoint = new NativeEntrypoint();
+            entrypoint.setType("type");
+
+            KafkaListener kafkaListener = new KafkaListener();
+            kafkaListener.setHost("kafka-host");
+            kafkaListener.setPort(9000);
+            kafkaListener.setEntrypoints(List.of(entrypoint));
+
+            List<NativeListener> listeners = List.of(kafkaListener);
+            when(entrypointService.findById("type")).thenReturn(mock(ConnectorPluginEntity.class));
+            // When
+            List<NativeListener> validatedListeners = listenerValidationService.validateAndSanitizeNativeV4(
+                GraviteeContext.getExecutionContext(),
+                null,
+                listeners,
+                emptyList()
             );
-    }
+            // Then
+            assertThat(validatedListeners).hasSize(1);
+            NativeListener actual = validatedListeners.get(0);
+            assertThat(actual).isInstanceOf(KafkaListener.class);
+            KafkaListener actualHttpListener = (KafkaListener) actual;
+            assertThat(actualHttpListener.getHost()).isEqualTo(kafkaListener.getHost());
+            assertThat(actualHttpListener.getPort()).isEqualTo(kafkaListener.getPort());
+        }
 
-    @Test
-    void should_throw_invalid_qos_exception_when_target_endpoint_does_not_support_at_least_once_qos() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setQos(Qos.AT_LEAST_ONCE);
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
+        @Test
+        void should_throw_error_when_kafka_listener_host_is_not_valid() {
+            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any())).thenThrow(new InvalidHostException("invalid hosts"));
 
-        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AUTO));
-        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
+            assertThatExceptionOfType(InvalidHostException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeNativeV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(KafkaListener.builder().host("").build()),
+                        emptyList()
+                    )
+                );
+        }
 
-        final EndpointGroup endpointGroup = buildEndpointGroup();
+        @Test
+        void should_throw_duplicated_entrypoints_exception_with_duplicated() {
+            // Given
+            KafkaListener kafkaListener = new KafkaListener();
 
-        assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    List.of(endpointGroup)
-                )
-            );
-    }
+            NativeEntrypoint entrypoint = new NativeEntrypoint();
+            entrypoint.setType("type");
+            kafkaListener.setEntrypoints(List.of(entrypoint, entrypoint));
 
-    @Test
-    void should_throw_invalid_qos_exception_when_target_endpoint_does_not_have_connector() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setQos(Qos.AT_LEAST_ONCE);
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        when(endpointService.findById("endpoint-test")).thenReturn(null);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        assertThatExceptionOfType(ListenerEntrypointInvalidQosException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    List.of(endpointGroup)
-                )
-            );
-    }
-
-    @Test
-    void should_validate_qos_config_when_targeting_endpoint() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setQos(Qos.AT_LEAST_ONCE);
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(connectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE, Qos.AUTO));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-
-        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(endpointConnectorPluginEntity.getSupportedApiType()).thenReturn(ApiType.MESSAGE);
-        when(endpointConnectorPluginEntity.getSupportedQos()).thenReturn(Set.of(Qos.AT_LEAST_ONCE));
-        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            List.of(httpListener),
-            List.of(endpointGroup)
-        );
-    }
-
-    @Test
-    void should_throw_unsupported_dlq_exception_when_connector_does_not_support_dlq_feature() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("target"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(emptySet());
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-
-        assertThatExceptionOfType(ListenerEntrypointUnsupportedDlqException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
-            );
-    }
-
-    @Test
-    void should_throw_invalid_dlq_exception_when_null_target_endpoint() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq(null));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-
-        assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
-            );
-    }
-
-    @Test
-    void should_throw_unsupported_dlq_exception_when_unknown_target_endpoint() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("unknown"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-
-        assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    emptyList()
-                )
-            );
-    }
-
-    @Test
-    void should_throw_invalid_dlq_exception_when_target_endpoint_does_not_support_publish() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("endpoint2"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-
-        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.SUBSCRIBE));
-        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    List.of(endpointGroup)
-                )
-            );
-    }
-
-    @Test
-    void should_throw_invalid_dlq_exception_when_target_endpoint_does_not_have_connector() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("endpoint2"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-        when(endpointService.findById("endpoint-test")).thenReturn(null);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        assertThatExceptionOfType(ListenerEntrypointInvalidDlqException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    List.of(endpointGroup)
-                )
-            );
-    }
-
-    @Test
-    void should_validate_dlq_config_when_targeting_endpoint() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("endpoint2"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-
-        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.PUBLISH));
-        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            List.of(httpListener),
-            List.of(endpointGroup)
-        );
-    }
-
-    @Test
-    void should_validate_dlq_config_when_targeting_endpoint_group() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("type");
-        entrypoint.setDlq(new Dlq("endpoint-group"));
-        httpListener.setEntrypoints(List.of(entrypoint));
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getAvailableFeatures()).thenReturn(Set.of(ConnectorFeature.DLQ));
-        when(entrypointService.findById("type")).thenReturn(connectorPluginEntity);
-
-        ConnectorPluginEntity endpointConnectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(endpointConnectorPluginEntity.getSupportedModes()).thenReturn(Set.of(ConnectorMode.PUBLISH));
-        when(endpointService.findById("endpoint-test")).thenReturn(endpointConnectorPluginEntity);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        listenerValidationService.validateAndSanitize(
-            GraviteeContext.getExecutionContext(),
-            null,
-            List.of(httpListener),
-            List.of(endpointGroup)
-        );
-    }
-
-    @Test
-    void should_throw_listener_entrypoint_unsupported_listener_type_exception_when_target_endpoint_does_not_match_listener_type() {
-        HttpListener httpListener = new HttpListener();
-        httpListener.setPaths(List.of(new Path("path")));
-        httpListener.setType(ListenerType.HTTP);
-        Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setType("webhook");
-        httpListener.setEntrypoints(List.of(entrypoint));
-
-        ConnectorPluginEntity connectorPluginEntity = mock(ConnectorPluginEntity.class);
-        when(connectorPluginEntity.getSupportedListenerType()).thenReturn(ListenerType.SUBSCRIPTION);
-        when(entrypointService.findById("webhook")).thenReturn(connectorPluginEntity);
-
-        final EndpointGroup endpointGroup = buildEndpointGroup();
-
-        assertThatExceptionOfType(ListenerEntrypointUnsupportedListenerTypeException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(httpListener),
-                    List.of(endpointGroup)
-                )
-            );
-    }
-
-    @Test
-    void should_throw_error_when_tcp_listener_hosts_are_not_valid() {
-        when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any())).thenThrow(new InvalidHostException("invalid hosts"));
-
-        assertThatExceptionOfType(InvalidHostException.class)
-            .isThrownBy(() ->
-                listenerValidationService.validateAndSanitize(
-                    GraviteeContext.getExecutionContext(),
-                    null,
-                    List.of(TcpListener.builder().hosts(List.of("")).build()),
-                    emptyList()
-                )
-            );
+            // When
+            assertThatExceptionOfType(ListenerEntrypointDuplicatedException.class)
+                .isThrownBy(() ->
+                    listenerValidationService.validateAndSanitizeNativeV4(
+                        GraviteeContext.getExecutionContext(),
+                        null,
+                        List.of(kafkaListener),
+                        emptyList()
+                    )
+                );
+        }
     }
 
     private io.gravitee.definition.model.v4.endpointgroup.EndpointGroup buildEndpointGroup() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7192

## Description

- Create abstract class `AbstractNewApi` for creating v4 + native APIs
- Add `planDefinitionNativeV4` to core `Plan`
- Add `nativeApiDefinition` to core `Api`
- Add http vs native methods to services used during creation
- Add `CreateNativeApiUseCase` for creating native apis

Next Steps:
1. Add `NativeApi` to `openapi-apis.yaml` and handle creating a native API on `POST /apis`


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

