### PR TITLE
docs: send groups when user rollback an API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ajs.spec.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { of } from 'rxjs';
+
 import ApiHistoryControllerAjs from './apiHistory.controller.ajs';
 
 describe('ApiHistoryControllerAjs', () => {
@@ -27,6 +29,7 @@ describe('ApiHistoryControllerAjs', () => {
   let ResourceServiceMock;
   let FlowServiceMock;
   let ngApiV2ServiceMock;
+  let ngGroupV2ServiceMock;
   let controller;
 
   enum Modes {
@@ -62,6 +65,7 @@ describe('ApiHistoryControllerAjs', () => {
     ResourceServiceMock = { list: jest.fn().mockResolvedValue({ data: [] }) };
     FlowServiceMock = { getConfigurationSchema: jest.fn().mockResolvedValue({ data: [] }) };
     ngApiV2ServiceMock = jest.fn();
+    ngGroupV2ServiceMock = { list: jest.fn().mockReturnValue(of({ data: [] })) };
 
     controller = new ApiHistoryControllerAjs(
       $mdDialogMock,
@@ -75,6 +79,7 @@ describe('ApiHistoryControllerAjs', () => {
       ResourceServiceMock,
       FlowServiceMock,
       ngApiV2ServiceMock,
+      ngGroupV2ServiceMock,
     );
   });
 
@@ -89,7 +94,14 @@ describe('ApiHistoryControllerAjs', () => {
   test('should trigger $onInit and load API data', async () => {
     await controller.$onInit();
     expect(ApiServiceMock.get).toHaveBeenCalledWith('123');
-    await Promise.resolve();
+    expect(ngGroupV2ServiceMock.list).toHaveBeenCalled();
+
+    await Promise.all([
+      ngGroupV2ServiceMock.list(1, 99999).toPromise(),
+      ApiServiceMock.get('123'),
+      ApiServiceMock.isAPISynchronized('123'),
+    ]);
+
     expect(controller.api).toEqual({ id: '123', name: 'test-api' });
   });
 

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -452,6 +452,7 @@ import { EnvironmentNotificationSettingsDetailsComponent } from './configuration
 import { EnvironmentMetadataComponent } from './configuration/metadata/environment-metadata.component';
 import { ApplicationMetadataComponent } from './application/details/metadata/application-metadata.component';
 import { ApplicationGeneralComponent } from './application/details/general/general-ng/application-general.component';
+import { GroupV2Service } from '../services-ngx/group-v2.service';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -666,6 +667,7 @@ graviteeManagementModule.service('SpelService', SpelService);
 graviteeManagementModule.service('ConnectorService', ConnectorService);
 graviteeManagementModule.factory('ngApiV2Service', downgradeInjectable(ApiV2Service));
 graviteeManagementModule.factory('ngGioPermissionService', downgradeInjectable(GioPermissionService));
+graviteeManagementModule.factory('ngGroupV2Service', downgradeInjectable(GroupV2Service));
 
 graviteeManagementModule.controller('DialogGenerateTokenController', DialogGenerateTokenController);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7125

## Description

Today when a user rollback an API to a previous version deployed it always removes the groups associated to it. In this PR we just add the groups to the payload of the rollback http request. On the backend side everything is already done to make it working.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uaffyhgktz.chromatic.com)
<!-- Storybook placeholder end -->
