### PR TITLE
Add missing mapstruct in containers

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -387,6 +387,13 @@
             <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Mapstruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-parent/pom.xml
+++ b/gravitee-apim-parent/pom.xml
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
+            <!--
+                Even if MapStruct is required at runtime, it is set as provided to avoid being added in plugin zip files
+                It is however declared as 'runtime' in Rest API & Gateway in:
+                  - Standalone container, to be used with `java -jar` command
+                  - Standalone distribution, to be used with the docker images
+            -->
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -251,6 +251,13 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
+
+        <!-- Mapstruct -->
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7138

## Description

Fix APIM execution with 'java -jar' command by adding mapstruct as a 'runtime' dependency