### PR TITLE
fix(portal-next): allow rectangular company logos in header + footer

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.html
@@ -16,6 +16,6 @@
 
 -->
 <a class="company-logo" [routerLink]="['']">
-  <img i18n-alt="@@logo" [src]="logo" height="36" width="36" alt="Company logo" (error)="updateLogo()" />
+  <img i18n-alt="@@logo" [src]="logo" alt="Company logo" (error)="updateLogo()" />
 </a>
 <div class="m3-title-medium">{{ title }}</div>

--- a/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/company-title/company-title.component.scss
@@ -21,6 +21,7 @@
   white-space: nowrap;
 }
 
-.company-logo {
-  height: 36px;
+.company-logo > img {
+  display: flex;
+  max-height: 36px;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Before when the logo was being squashed if it was a rectangle: 
[redacted]


With the fix:
<img width="1154" alt="Screenshot 2024-10-17 at 13 53 55" src="https://github.com/user-attachments/assets/0bd1c6c7-d8ec-40d9-ac10-f95b38056d3c">


Fix with a logo that has a height < 36px:

<img width="1166" alt="Screenshot 2024-10-17 at 13 51 13" src="https://github.com/user-attachments/assets/12c2c679-270d-45b8-8c8b-d2628a963635">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

