### PR TITLE
fix: increase integration provider column length

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_12/00_increase_length_integration_provider_column.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_12/00_increase_length_integration_provider_column.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.4.11_increase_length_integration_provider_column
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}integrations
+            columnName: provider
+            newDataType: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -195,3 +195,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v4_4_4/00_drop_not_null_constraint.yml
   - include:
       - file: liquibase/changelogs/v4_4_10/00_add_media_org_env.yml
+  - include:
+      - file: liquibase/changelogs/v4_4_12/00_increase_length_integration_provider_column.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7264

## Description

Increase integration provider column length: 16 char was to small

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

