### PR TITLE
feat: Endpoint to delete portal media

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/media/api/MediaRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/media/api/MediaRepository.java
@@ -44,6 +44,8 @@ public interface MediaRepository {
 
     void deleteByHashAndApi(String hash, String api) throws TechnicalException;
 
+    void deleteByHashAndEnvironment(String hash, String environment) throws TechnicalException;
+
     /**
      * Delete by environment
      * @param environment

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMediaRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMediaRepository.java
@@ -93,19 +93,11 @@ public class JdbcMediaRepository extends JdbcAbstractRepository<Media> implement
     @Override
     public Media create(Media media) throws TechnicalException {
         LOGGER.debug("JdbcMediaRepository.create({})", media);
-
         media.setCreatedAt(new Date());
-
         try {
-            Connection conn = DataSourceUtils.getConnection(jdbcTemplate.getDataSource());
-            conn.setAutoCommit(false);
-            PreparedStatement ps = getOrm().buildInsertPreparedStatementCreator(media).createPreparedStatement(conn);
-
-            ps.execute();
-            conn.commit();
-
+            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(media));
             return media;
-        } catch (final Exception ex) {
+        } catch (Exception ex) {
             LOGGER.error("Failed to create media", ex);
             throw new TechnicalException("Failed to create media", ex);
         }
@@ -124,6 +116,16 @@ public class JdbcMediaRepository extends JdbcAbstractRepository<Media> implement
 
         try {
             jdbcTemplate.update("delete from " + this.tableName + " where hash = ? and api = ?", hash, api);
+        } catch (Exception e) {
+            throw new TechnicalException(e);
+        }
+    }
+
+    public void deleteByHashAndEnvironment(String hash, String environment) throws TechnicalException {
+        LOGGER.debug("JdbcMediaRepository.deleteByHashAndEnvironment({}, {})", hash, environment);
+
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where hash = ? and environment = ?", hash, environment);
         } catch (Exception e) {
             throw new TechnicalException(e);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMediaRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMediaRepository.java
@@ -224,6 +224,14 @@ public class MongoMediaRepository implements MediaRepository {
         }
     }
 
+    public void deleteByHashAndEnvironment(String hash, String environment) throws TechnicalException {
+        if (hash == null || environment == null) {
+            LOGGER.warn("Skipping media deletion because the [{}/{}] given as an argument is null", hash, environment);
+        } else {
+            deleteWithQuery(and(eq("metadata.environment", environment), eq("metadata.hash", hash)));
+        }
+    }
+
     @Override
     public List<String> deleteByEnvironment(String environment) throws TechnicalException {
         return deleteWithMetadata("metadata.environment", environment);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MediaService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MediaService.java
@@ -46,4 +46,6 @@ public interface MediaService {
     void deleteAllByApi(String apiId);
 
     void deleteByHashAndApi(String hash, String apiId);
+
+    void deletePortalMediaByHash(ExecutionContext executionContext, String hash);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -119,4 +119,6 @@ public interface PageService {
     Optional<PageEntity> attachMedia(String pageId, String mediaId, String mediaName);
 
     boolean folderHasPublishedChildren(String folderId);
+
+    boolean isMediaUsedInPages(ExecutionContext executionContext, String mediaHash);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
@@ -26,7 +26,9 @@ import io.gravitee.rest.api.model.MediaEntity;
 import io.gravitee.rest.api.model.PageMediaEntity;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.MediaService;
+import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiMediaNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -258,6 +260,24 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             mediaRepository.deleteByHashAndApi(media.getHash(), apiId);
         } catch (TechnicalException e) {
             LOGGER.error("An error has occurred trying to delete media for API " + apiId + " with hash " + hash, e);
+            throw new TechnicalManagementException("An error has occurred trying to delete media");
+        }
+    }
+
+    @Override
+    public void deletePortalMediaByHash(ExecutionContext executionContext, String hash) {
+        try {
+            final MediaCriteria mediaCriteria = MediaCriteria
+                .builder()
+                .organization(executionContext.getOrganizationId())
+                .environment(executionContext.getEnvironmentId())
+                .build();
+
+            Media media = mediaRepository.findByHash(hash, mediaCriteria).orElseThrow(() -> new TechnicalManagementException(hash));
+
+            mediaRepository.deleteByHashAndEnvironment(media.getHash(), executionContext.getEnvironmentId());
+        } catch (TechnicalException e) {
+            LOGGER.error("An error has occurred trying to delete media with hash " + hash, e);
             throw new TechnicalManagementException("An error has occurred trying to delete media");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MediaServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MediaServiceTest.java
@@ -458,6 +458,62 @@ public class MediaServiceTest extends TestCase {
         mediaService.deleteByHashAndApi(MEDIA_HASH, API_ID);
     }
 
+    @Test
+    public void shouldDeletePortalMediaByHashSuccessfully() throws Exception {
+        Media media = newMedia();
+        media.setId("media-id");
+        when(
+            mediaRepository.findByHash(
+                MEDIA_HASH,
+                MediaCriteria
+                    .builder()
+                    .organization(GraviteeContext.getExecutionContext().getOrganizationId())
+                    .environment(GraviteeContext.getExecutionContext().getEnvironmentId())
+                    .build()
+            )
+        )
+            .thenReturn(Optional.of(media));
+
+        mediaService.deletePortalMediaByHash(GraviteeContext.getExecutionContext(), MEDIA_HASH);
+
+        verify(mediaRepository, times(1))
+            .deleteByHashAndEnvironment(media.getHash(), GraviteeContext.getExecutionContext().getEnvironmentId());
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldThrowMediaNotFoundExceptionWhenDeletingNonExistingMedia() throws Exception {
+        when(
+            mediaRepository.findByHash(
+                MEDIA_HASH,
+                MediaCriteria
+                    .builder()
+                    .organization(GraviteeContext.getExecutionContext().getOrganizationId())
+                    .environment(GraviteeContext.getExecutionContext().getEnvironmentId())
+                    .build()
+            )
+        )
+            .thenReturn(Optional.empty());
+
+        mediaService.deletePortalMediaByHash(GraviteeContext.getExecutionContext(), MEDIA_HASH);
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldThrowTechnicalManagementExceptionWhenDeletingMedia() throws Exception {
+        when(
+            mediaRepository.findByHash(
+                MEDIA_HASH,
+                MediaCriteria
+                    .builder()
+                    .organization(GraviteeContext.getExecutionContext().getOrganizationId())
+                    .environment(GraviteeContext.getExecutionContext().getEnvironmentId())
+                    .build()
+            )
+        )
+            .thenThrow(TechnicalException.class);
+
+        mediaService.deletePortalMediaByHash(GraviteeContext.getExecutionContext(), MEDIA_HASH);
+    }
+
     private static MediaEntity newMediaEntity() throws Exception {
         return newMediaEntity(true);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
@@ -15,10 +15,25 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PageRepository;
+import io.gravitee.repository.management.model.Page;
+import io.gravitee.repository.management.model.PageMedia;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.converter.PageConverter;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -27,7 +42,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PageServiceImplTests {
 
-    private PageServiceImpl pageService = new PageServiceImpl();
+    @InjectMocks
+    private PageServiceImpl pageService;
+
+    @Mock
+    private PageRepository pageRepository;
 
     @Test
     public void getParentPathFromFilePath_should_return_correct_path() {
@@ -45,5 +64,102 @@ public class PageServiceImplTests {
     public void getParentPathFromFilePath_with_empty_path_should_return_slash() {
         String parentPath = pageService.getParentPathFromFilePath("");
         assertEquals("/", parentPath);
+    }
+
+    @Test
+    public void isMediaUsedInPages_shouldReturnTrueWhenMediaIsUsedInAttachedMedia() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        var page = createPage("page-id", List.of(new PageMedia(mediaHash, "media-name", null)), null);
+        var pages = new io.gravitee.common.data.domain.Page<>(List.of(page), 0, 1, 1);
+
+        when(pageRepository.findAll(any())).thenReturn(pages);
+
+        var result = pageService.isMediaUsedInPages(executionContext, mediaHash);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void isMediaUsedInPages_shouldReturnTrueWhenMediaIsUsedInContent() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        var page = createPage("page-id", null, "This is a sample content with media hash: " + mediaHash);
+        var pages = new io.gravitee.common.data.domain.Page<>(List.of(page), 0, 1, 1);
+
+        when(pageRepository.findAll(any())).thenReturn(pages);
+
+        var result = pageService.isMediaUsedInPages(executionContext, mediaHash);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void isMediaUsedInPages_shouldReturnFalseWhenMediaIsNotUsed() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        var page = createPage("page-id", List.of(new PageMedia("other-media-hash", "media-name", null)), "Content without the media hash");
+
+        var pages = new io.gravitee.common.data.domain.Page<>(List.of(page), 0, 1, 1);
+        io.gravitee.common.data.domain.Page<Page> emptyPages = new io.gravitee.common.data.domain.Page<>(List.of(), 0, 0, 0);
+
+        when(pageRepository.findAll(any())).thenReturn(pages).thenReturn(emptyPages);
+
+        var result = pageService.isMediaUsedInPages(executionContext, mediaHash);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void isMediaUsedInPages_shouldReturnFalseWhenNoPagesFound() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        io.gravitee.common.data.domain.Page<Page> pages = new io.gravitee.common.data.domain.Page<>(List.of(), 0, 0, 0);
+
+        when(pageRepository.findAll(any())).thenReturn(pages);
+
+        var result = pageService.isMediaUsedInPages(executionContext, mediaHash);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void isMediaUsedInPages_shouldThrowTechnicalManagementExceptionOnError() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        when(pageRepository.findAll(any())).thenThrow(TechnicalException.class);
+
+        pageService.isMediaUsedInPages(executionContext, mediaHash);
+    }
+
+    @Test
+    public void isMediaUsedInPages_shouldHandlePagination() throws Exception {
+        var mediaHash = "media-hash";
+        var executionContext = new ExecutionContext("org-id", "env-id");
+
+        var page1 = createPage("page-id-1", null, "Content without media hash");
+        var page2 = createPage("page-id-2", null, "Content with media hash " + mediaHash);
+
+        var pages1 = new io.gravitee.common.data.domain.Page<>(List.of(page1), 0, 1, 2);
+        var pages2 = new io.gravitee.common.data.domain.Page<>(List.of(page2), 1, 1, 2);
+
+        when(pageRepository.findAll(any())).thenReturn(pages1).thenReturn(pages2);
+
+        var result = pageService.isMediaUsedInPages(executionContext, mediaHash);
+
+        assertThat(result).isTrue();
+    }
+
+    private Page createPage(String id, List<PageMedia> mediaList, String content) {
+        Page page = new Page();
+        page.setId(id);
+        page.setAttachedMedia(mediaList);
+        page.setContent(content);
+        return page;
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6302

## Description

As an API publisher

I want to delete portal media using the portal API

so that I can clean up media that isn’t attached to a page.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->



https://github.com/user-attachments/assets/57d51631-a690-4129-a254-28b253fbd3a9


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pzawuzsrct.chromatic.com)
<!-- Storybook placeholder end -->
