### PR TITLE
Rest-api & Repository: replace all the use of MESSAGE_REQUEST & MESSAGE_RESPONSE with FlowPhase

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/SharedPolicyGroup.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/SharedPolicyGroup.java
@@ -138,8 +138,6 @@ public class SharedPolicyGroup {
     public enum FlowPhase {
         REQUEST,
         RESPONSE,
-        MESSAGE_REQUEST,
-        MESSAGE_RESPONSE,
         INTERACT,
         CONNECT,
         PUBLISH,

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_6_0/00_migrate_spg_phase.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_6_0/00_migrate_spg_phase.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.6.0_migrate_spg_phase
+      author: GraviteeSource Team
+      changes:
+        # Update the phase of shared policy groups and shared policy group histories from MESSAGE_REQUEST to PUBLISH
+        - sql:
+            sql: update ${gravitee_prefix}sharedpolicygroups set phase='PUBLISH' where phase='MESSAGE_REQUEST'
+        - sql:
+            sql: update ${gravitee_prefix}sharedpolicygrouphistories set phase='PUBLISH' where phase='MESSAGE_REQUEST'
+        # Update the phase of shared policy groups and shared policy group histories from MESSAGE_RESPONSE to SUBSCRIBE
+        - sql:
+            sql: update ${gravitee_prefix}sharedpolicygroups set phase='SUBSCRIBE' where phase='MESSAGE_RESPONSE'
+        - sql:
+            sql: update ${gravitee_prefix}sharedpolicygrouphistories set phase='SUBSCRIBE' where phase='MESSAGE_RESPONSE'

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -213,3 +213,5 @@ databaseChangeLog:
           - file: liquibase/changelogs/v4_5_0/06_add_scoring_table.yml
     - include:
           - file: liquibase/changelogs/v4_5_0/07_add_scoring_ruleset_table.yml
+    - include:
+          - file: liquibase/changelogs/v4_6_0/00_migrate_spg_phase.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/keys/ApiKeyFederatedUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/keys/ApiKeyFederatedUpgrader.java
@@ -15,10 +15,8 @@
  */
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.keys;
 
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import io.gravitee.repository.mongodb.management.upgrade.upgrader.environment.MissingEnvironmentUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.organization.MissingOrganizationsOnEventsUpgrader;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +26,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class ApiKeyFederatedUpgrader extends MongoUpgrader {
 
-    public static final int API_KEY_FEDERATED_UPGRADER_ORDER = MissingEnvironmentUpgrader.MISSING_ENVIRONMENT_UPGRADER_ORDER + 1;
+    public static final int API_KEY_FEDERATED_UPGRADER_ORDER =
+        MissingOrganizationsOnEventsUpgrader.MISSING_ORGANIZATION_ON_EVENT_UPGRADER_ORDER + 1;
 
     @Override
     public String version() {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/organization/MissingOrganizationsOnEventsUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/organization/MissingOrganizationsOnEventsUpgrader.java
@@ -23,8 +23,8 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.UpdateManyModel;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.accessPoints.AccessPointsStatusAndUpdatedUpgrader;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import io.gravitee.repository.mongodb.management.upgrade.upgrader.themes.ThemeTypeUpgrader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +38,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MissingOrganizationsOnEventsUpgrader extends MongoUpgrader {
 
-    public static final int MISSING_ENVIRONMENT_UPGRADER_ORDER = ThemeTypeUpgrader.THEME_TYPE_UPGRADER_ORDER + 1;
+    public static final int MISSING_ORGANIZATION_ON_EVENT_UPGRADER_ORDER =
+        AccessPointsStatusAndUpdatedUpgrader.ACCESSPOINTS_STATUS_AND_UPDATED_UPGRADER_ORDER + 1;
 
     @Override
     public boolean upgrade() {
@@ -71,6 +72,6 @@ public class MissingOrganizationsOnEventsUpgrader extends MongoUpgrader {
 
     @Override
     public int getOrder() {
-        return MISSING_ENVIRONMENT_UPGRADER_ORDER;
+        return MISSING_ORGANIZATION_ON_EVENT_UPGRADER_ORDER;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/sharedpolicygroups/SharedPolicyGroupHistoriesPhaseUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/sharedpolicygroups/SharedPolicyGroupHistoriesPhaseUpgrader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.sharedpolicygroups;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.UpdateManyModel;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.keys.ApiKeyFederatedUpgrader;
+import java.util.ArrayList;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+/**
+ * Update the phase of shared policy groups histories from MESSAGE_REQUEST to PUBLISH and MESSAGE_RESPONSE to SUBSCRIBE
+ */
+@Component
+public class SharedPolicyGroupHistoriesPhaseUpgrader extends MongoUpgrader {
+
+    public static final int SHARED_POLICY_GROUP_HISTORIES_PHASE_UPGRADER_ORDER =
+        SharedPolicyGroupPhaseUpgrader.SHARED_POLICY_GROUP_PHASE_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var projection = Projections.fields(Projections.include("_id", "phase"));
+        var bulkActions = new ArrayList<UpdateManyModel<Document>>();
+        this.getCollection("sharedpolicygrouphistories")
+            .find()
+            .projection(projection)
+            .forEach(spg -> {
+                if (spg.getString("phase").equals("MESSAGE_REQUEST")) {
+                    bulkActions.add(new UpdateManyModel<>(Filters.eq("_id", spg.getObjectId("_id")), Updates.set("phase", "PUBLISH")));
+                }
+                if (spg.getString("phase").equals("MESSAGE_RESPONSE")) {
+                    bulkActions.add(new UpdateManyModel<>(Filters.eq("_id", spg.getObjectId("_id")), Updates.set("phase", "SUBSCRIBE")));
+                }
+            });
+        if (!bulkActions.isEmpty()) {
+            this.getCollection("sharedpolicygrouphistories").bulkWrite(bulkActions).wasAcknowledged();
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return SHARED_POLICY_GROUP_HISTORIES_PHASE_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/sharedpolicygroups/SharedPolicyGroupPhaseUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/sharedpolicygroups/SharedPolicyGroupPhaseUpgrader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.sharedpolicygroups;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.UpdateManyModel;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.keys.ApiKeyFederatedUpgrader;
+import java.util.ArrayList;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+/**
+ * Update the phase of shared policy groups from MESSAGE_REQUEST to PUBLISH and MESSAGE_RESPONSE to SUBSCRIBE
+ */
+@Component
+public class SharedPolicyGroupPhaseUpgrader extends MongoUpgrader {
+
+    public static final int SHARED_POLICY_GROUP_PHASE_UPGRADER_ORDER = ApiKeyFederatedUpgrader.API_KEY_FEDERATED_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var projection = Projections.fields(Projections.include("_id", "phase"));
+        var bulkActions = new ArrayList<UpdateManyModel<Document>>();
+        this.getCollection("sharedpolicygroups")
+            .find()
+            .projection(projection)
+            .forEach(spg -> {
+                if (spg.getString("phase").equals("MESSAGE_REQUEST")) {
+                    bulkActions.add(new UpdateManyModel<>(Filters.eq("_id", spg.getString("_id")), Updates.set("phase", "PUBLISH")));
+                }
+                if (spg.getString("phase").equals("MESSAGE_RESPONSE")) {
+                    bulkActions.add(new UpdateManyModel<>(Filters.eq("_id", spg.getString("_id")), Updates.set("phase", "SUBSCRIBE")));
+                }
+            });
+        if (!bulkActions.isEmpty()) {
+            this.getCollection("sharedpolicygroups").bulkWrite(bulkActions).wasAcknowledged();
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return SHARED_POLICY_GROUP_PHASE_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SharedPolicyGroupRepositoryTest.java
@@ -114,7 +114,7 @@ public class SharedPolicyGroupRepositoryTest extends AbstractManagementRepositor
             .prerequisiteMessage("new prerequisiteMessage")
             .crossId("new crossId")
             .apiType(ApiType.MESSAGE)
-            .phase(SharedPolicyGroup.FlowPhase.MESSAGE_REQUEST)
+            .phase(SharedPolicyGroup.FlowPhase.PUBLISH)
             .definition("new definition")
             .lifecycleState(SharedPolicyGroupLifecycleState.DEPLOYED)
             .environmentId("new environmentId")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -605,8 +605,6 @@ components:
             enum:
                 - REQUEST
                 - RESPONSE
-                - MESSAGE_REQUEST
-                - MESSAGE_RESPONSE
                 - INTERACT
                 - CONNECT
                 - PUBLISH

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
@@ -25,10 +25,10 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.license.License;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
-import io.gravitee.rest.api.management.v2.rest.model.FlowPhase;
 import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.FlowPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
@@ -253,7 +253,7 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         policyPlugin.setProxy(
             Set.of(io.gravitee.rest.api.model.v4.policy.FlowPhase.REQUEST, io.gravitee.rest.api.model.v4.policy.FlowPhase.RESPONSE)
         );
-        policyPlugin.setMessage(Set.of(io.gravitee.rest.api.model.v4.policy.FlowPhase.MESSAGE_REQUEST));
+        policyPlugin.setMessage(Set.of(FlowPhase.PUBLISH));
         return policyPlugin;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/FlowPhase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/FlowPhase.java
@@ -26,17 +26,7 @@ public enum FlowPhase {
     PUBLISH(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
     SUBSCRIBE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
     REQUEST(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE),
-    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE),
-    /**
-     * @deprecated use {@link FlowPhase#PUBLISH} instead
-     */
-    @Deprecated
-    MESSAGE_REQUEST,
-    /**
-     * @deprecated use {@link FlowPhase#SUBSCRIBE} instead
-     */
-    @Deprecated
-    MESSAGE_RESPONSE;
+    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE);
 
     private final List<ApiProtocolType> apiProtocolType;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/FlowPhase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/FlowPhase.java
@@ -26,17 +26,7 @@ public enum FlowPhase {
     PUBLISH(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
     SUBSCRIBE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_MESSAGE),
     REQUEST(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE),
-    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE),
-    /**
-     * @deprecated use {@link FlowPhase#PUBLISH} instead
-     */
-    @Deprecated
-    MESSAGE_REQUEST,
-    /**
-     * @deprecated use {@link FlowPhase#SUBSCRIBE} instead
-     */
-    @Deprecated
-    MESSAGE_RESPONSE;
+    RESPONSE(ApiProtocolType.NATIVE_KAFKA, ApiProtocolType.HTTP_PROXY, ApiProtocolType.HTTP_MESSAGE);
 
     private final List<ApiProtocolType> apiProtocolType;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -217,8 +217,8 @@ public class SharedPolicyGroup {
             return (
                 this.phase == FlowPhase.REQUEST ||
                 this.phase == FlowPhase.RESPONSE ||
-                this.phase == FlowPhase.MESSAGE_REQUEST ||
-                this.phase == FlowPhase.MESSAGE_RESPONSE
+                this.phase == FlowPhase.PUBLISH ||
+                this.phase == FlowPhase.SUBSCRIBE
             );
         }
         return false;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SharedPolicyGroupFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SharedPolicyGroupFixtures.java
@@ -77,7 +77,7 @@ public class SharedPolicyGroupFixtures {
             .name("name")
             .description("description")
             .apiType(ApiType.MESSAGE)
-            .phase(FlowPhase.MESSAGE_RESPONSE)
+            .phase(FlowPhase.SUBSCRIBE)
             .policyId("shared-policy-group-policy")
             .build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/CreateSharedPolicyGroupUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/CreateSharedPolicyGroupUseCaseTest.java
@@ -296,7 +296,7 @@ public class CreateSharedPolicyGroupUseCaseTest {
         // Given
         var toCreate = SharedPolicyGroupFixtures.aCreateSharedPolicyGroup();
         toCreate.setApiType(ApiType.PROXY);
-        toCreate.setPhase(FlowPhase.MESSAGE_RESPONSE);
+        toCreate.setPhase(FlowPhase.SUBSCRIBE);
 
         // When
         var throwable = Assertions.catchThrowable(() ->
@@ -307,6 +307,6 @@ public class CreateSharedPolicyGroupUseCaseTest {
         Assertions
             .assertThat(throwable)
             .isInstanceOf(SharedPolicyGroupInvalidPhaseException.class)
-            .hasMessage("Invalid phase MESSAGE_RESPONSE for API type PROXY");
+            .hasMessage("Invalid phase SUBSCRIBE for API type PROXY");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceTest.java
@@ -67,7 +67,7 @@ class PolicyValidationDomainServiceTest {
                             .name("Policy 1")
                             .proxy(Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE))
                             .build(),
-                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.MESSAGE_REQUEST)).build()
+                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.PUBLISH)).build()
                     )
                 );
 
@@ -97,9 +97,9 @@ class PolicyValidationDomainServiceTest {
                             .builder()
                             .id("policy-1")
                             .name("Policy 1")
-                            .message(Set.of(FlowPhase.MESSAGE_REQUEST, FlowPhase.MESSAGE_RESPONSE))
+                            .message(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE))
                             .build(),
-                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.MESSAGE_REQUEST)).build(),
+                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.PUBLISH)).build(),
                         PolicyPluginEntity.builder().id("policy-3").name("Policy 3").build()
                     )
                 );
@@ -109,7 +109,7 @@ class PolicyValidationDomainServiceTest {
                 service.validatePoliciesFlowPhase(
                     List.of("policy-1", "policy-2", "policy-3"),
                     ApiType.MESSAGE,
-                    io.gravitee.apim.core.plugin.model.FlowPhase.MESSAGE_RESPONSE
+                    io.gravitee.apim.core.plugin.model.FlowPhase.SUBSCRIBE
                 )
             );
 
@@ -117,7 +117,7 @@ class PolicyValidationDomainServiceTest {
             Assertions
                 .assertThat(throwable)
                 .isInstanceOf(UnexpectedPoliciesException.class)
-                .hasMessage("Unexpected policies [Policy 2, Policy 3] for API type MESSAGE and phase MESSAGE_RESPONSE");
+                .hasMessage("Unexpected policies [Policy 2, Policy 3] for API type MESSAGE and phase SUBSCRIBE");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -128,11 +128,11 @@ public class PolicyPluginServiceImplTest {
     }
 
     @Test
-    public void shouldFindAll() {
+    public void should_find_all() {
         when(mockPlugin.id()).thenReturn(PLUGIN_ID);
         when(mockPlugin.manifest()).thenReturn(mockPluginManifest);
         when(pluginManager.findAll(true)).thenReturn(List.of(mockPlugin));
-        when(mockPluginManifest.properties()).thenReturn(Map.of("proxy", "REQUEST", "message", "MESSAGE_REQUEST"));
+        when(mockPluginManifest.properties()).thenReturn(Map.of("proxy", "REQUEST", "message", "PUBLISH"));
         Set<PolicyPluginEntity> result = cut.findAll();
 
         assertNotNull(result);
@@ -140,7 +140,22 @@ public class PolicyPluginServiceImplTest {
         PolicyPluginEntity policyPlugin = result.iterator().next();
         assertEquals(PLUGIN_ID, policyPlugin.getId());
         assertEquals(Set.of(FlowPhase.REQUEST), policyPlugin.getProxy());
-        assertEquals(Set.of(FlowPhase.MESSAGE_REQUEST), policyPlugin.getMessage());
+        assertEquals(Set.of(FlowPhase.PUBLISH), policyPlugin.getMessage());
+    }
+
+    @Test
+    public void should_find_all_with_legacy_phase() {
+        when(mockPlugin.id()).thenReturn(PLUGIN_ID);
+        when(mockPlugin.manifest()).thenReturn(mockPluginManifest);
+        when(pluginManager.findAll(true)).thenReturn(List.of(mockPlugin));
+        when(mockPluginManifest.properties()).thenReturn(Map.of("message", "MESSAGE_REQUEST, MESSAGE_RESPONSE"));
+        Set<PolicyPluginEntity> result = cut.findAll();
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        PolicyPluginEntity policyPlugin = result.iterator().next();
+        assertEquals(PLUGIN_ID, policyPlugin.getId());
+        assertEquals(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE), policyPlugin.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7242

## Description

- Create upgraders for SPG

- Keep inside PolicyPluginServiceImpl the legacy MESSAGE_REQUEST, MESSAGE_RESPONSE still used in Policies and map to PUBLISH, SUBSCRIBE

Now only Policies continue to use MESSAGE_REQUEST, MESSAGE_RESPONSE in there plugin.properties 

🤞 no bugs. I've tested with all SQL db and mongo db locally. I'll re-test on master next. normally it's completely transparent. 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dyfajzdfat.chromatic.com)
<!-- Storybook placeholder end -->
