### PR TITLE
Rest-api: Add new flowPhaseCompatibility to replace old proxy & message for PolicyPlugin

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/apiProtocolType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/apiProtocolType.ts
@@ -13,21 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PlatformPlugin } from './platformPlugin';
-import { FlowPhase } from './flowPhase';
-import { ApiProtocolType } from './apiProtocolType';
-
-export interface PolicyPlugin extends PlatformPlugin {
-  /**
-   * Plugin's uuid.
-   */
-  id: string;
-  /**
-   * Plugin's name.
-   */
-  name: string;
-  /**
-   * Plugin's flow phases compatibility.
-   */
-  flowPhaseCompatibility?: Partial<Record<ApiProtocolType, FlowPhase[]>>;
-}
+export type ApiProtocolType = 'HTTP_PROXY' | 'HTTP_MESSAGE' | 'NATIVE_KAFKA';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/flowPhase.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/flowPhase.ts
@@ -13,28 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FlowPhase as PolicyStudioFlowPhase } from '@gravitee/ui-policy-studio-angular';
 
-export type FlowPhase = 'REQUEST' | 'RESPONSE' | 'MESSAGE_REQUEST' | 'MESSAGE_RESPONSE' | 'INTERACT' | 'CONNECT' | 'PUBLISH' | 'SUBSCRIBE';
-
-export const toPolicyStudioFlowPhase = (flowPhase: FlowPhase): PolicyStudioFlowPhase => {
-  switch (flowPhase) {
-    case 'REQUEST':
-      return 'REQUEST';
-    case 'RESPONSE':
-      return 'RESPONSE';
-    case 'PUBLISH':
-    case 'MESSAGE_REQUEST':
-      return 'PUBLISH';
-    case 'SUBSCRIBE':
-    case 'MESSAGE_RESPONSE':
-      return 'SUBSCRIBE';
-    case 'INTERACT':
-      return 'INTERACT';
-    case 'CONNECT':
-      return 'CONNECT';
-  }
-};
+export type FlowPhase = 'REQUEST' | 'RESPONSE' | 'INTERACT' | 'CONNECT' | 'PUBLISH' | 'SUBSCRIBE';
 
 export const toReadableFlowPhase = (flowPhase: FlowPhase): string => {
   switch (flowPhase) {
@@ -43,10 +23,8 @@ export const toReadableFlowPhase = (flowPhase: FlowPhase): string => {
     case 'RESPONSE':
       return 'Response';
     case 'PUBLISH':
-    case 'MESSAGE_REQUEST':
       return 'Publish';
     case 'SUBSCRIBE':
-    case 'MESSAGE_RESPONSE':
       return 'Subscribe';
   }
 };

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/policyPlugin.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/policyPlugin.fixture.ts
@@ -21,8 +21,10 @@ export function fakePolicyPlugin(modifier?: Partial<PolicyPlugin>): PolicyPlugin
     name: 'Test policy',
     description: 'Test policy description',
     category: 'test',
-    message: ['REQUEST', 'RESPONSE', 'MESSAGE_REQUEST', 'MESSAGE_RESPONSE'],
-    proxy: ['REQUEST', 'RESPONSE'],
+    flowPhaseCompatibility: {
+      HTTP_PROXY: ['REQUEST', 'RESPONSE'],
+      HTTP_MESSAGE: ['REQUEST', 'RESPONSE', 'PUBLISH', 'SUBSCRIBE'],
+    },
   };
 
   return {
@@ -40,8 +42,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '2.0.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'traffic-shadowing',
@@ -50,8 +51,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'rate-limit',
@@ -60,8 +60,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'xml-validation',
@@ -70,8 +69,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'rbac',
@@ -80,8 +78,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-data-logging-masking',
@@ -90,8 +87,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.3',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'aws-lambda',
@@ -100,8 +96,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'ip-filtering',
@@ -110,8 +105,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.9.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-assign-content',
@@ -120,8 +114,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.7.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'xml-json',
@@ -130,8 +123,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.8.3',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-override-request-method',
@@ -140,8 +132,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '2.0.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'key-less',
@@ -150,8 +141,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '2.2.0',
-      proxy: ['REQUEST'],
-      message: ['REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST'],
+        HTTP_MESSAGE: ['REQUEST'],
+      },
     },
     {
       id: 'policy-geoip-filtering',
@@ -159,8 +152,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Description of the GeoIP Filtering Gravitee Policy',
       category: 'security',
       version: '1.1.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'http-signature',
@@ -169,8 +161,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.5.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-assign-attributes',
@@ -179,8 +170,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.5.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'latency',
@@ -189,8 +179,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.4.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'json-threat-protection',
@@ -199,8 +188,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.3.3',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'javascript',
@@ -209,8 +197,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.2.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'xml-threat-protection',
@@ -219,8 +206,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.3.2',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'message-filtering',
@@ -228,8 +214,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Message Filtering Gravitee Policy',
       category: 'others',
       version: '1.1.1',
-      proxy: [],
-      message: ['MESSAGE_RESPONSE', 'MESSAGE_REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: [],
+        HTTP_MESSAGE: ['PUBLISH', 'SUBSCRIBE'],
+      },
     },
     {
       id: 'policy-basic-authentication',
@@ -237,8 +225,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Description of the Basic Authentication Gravitee Policy',
       category: 'security',
       version: '1.4.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-generate-jwt',
@@ -247,8 +234,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.5.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'spike-arrest',
@@ -257,8 +243,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'avro-json',
@@ -267,8 +252,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.2.0-alpha.2',
-      proxy: ['RESPONSE', 'REQUEST'],
-      message: ['MESSAGE_RESPONSE', 'MESSAGE_REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST', 'RESPONSE'],
+        HTTP_MESSAGE: ['PUBLISH', 'SUBSCRIBE'],
+      },
     },
     {
       id: 'cache',
@@ -277,8 +264,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'performance',
       version: '1.16.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'rest-to-soap',
@@ -287,8 +273,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.13.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'dynamic-routing',
@@ -297,8 +282,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.11.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'request-content-limit',
@@ -307,8 +291,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.8.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-http-callout',
@@ -317,8 +300,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-circuit-breaker',
@@ -326,8 +308,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Description of the Circuit Breaker Gravitee Policy',
       category: 'others',
       version: '1.1.4',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'oauth2',
@@ -336,8 +317,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '2.2.0',
-      proxy: ['REQUEST'],
-      message: ['REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST'],
+        HTTP_MESSAGE: ['REQUEST'],
+      },
     },
     {
       id: 'html-json',
@@ -346,8 +329,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.6.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'json-validation',
@@ -356,8 +338,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.6.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-assign-metrics',
@@ -366,8 +347,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '2.0.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'json-xml',
@@ -376,8 +356,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '2.1.4',
-      proxy: ['RESPONSE', 'REQUEST'],
-      message: ['MESSAGE_RESPONSE', 'MESSAGE_REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST', 'RESPONSE'],
+        HTTP_MESSAGE: ['PUBLISH', 'SUBSCRIBE'],
+      },
     },
     {
       id: 'resource-filtering',
@@ -386,8 +368,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.8.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'generate-http-signature',
@@ -396,16 +377,14 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-wssecurity-authentication',
       name: 'WS-Security Authentication',
       description: 'Description of the WS-Security Authentication Gravitee Policy',
       version: '1.0.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'mock',
@@ -414,8 +393,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.13.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'metrics-reporter',
@@ -424,8 +402,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'ssl-enforcement',
@@ -434,8 +411,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.2.3',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'jws',
@@ -444,8 +420,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.3.2',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'jwt',
@@ -454,8 +429,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '3.2.0',
-      proxy: ['REQUEST'],
-      message: ['REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST'],
+        HTTP_MESSAGE: ['REQUEST'],
+      },
     },
     {
       id: 'url-rewriting',
@@ -464,8 +441,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.5.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'retry',
@@ -473,8 +449,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Description of the Retry Gravitee Policy',
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       version: '2.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'transform-headers',
@@ -483,8 +458,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.10.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-interrupt',
@@ -492,8 +466,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       description: 'Description of the Interrupt Policy',
       category: 'others',
       version: '1.1.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'regex-threat-protection',
@@ -502,8 +475,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.3.3',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'json-to-json',
@@ -512,8 +484,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '2.1.0',
-      proxy: ['RESPONSE', 'REQUEST'],
-      message: ['MESSAGE_RESPONSE', 'MESSAGE_REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST', 'RESPONSE'],
+        HTTP_MESSAGE: ['PUBLISH', 'SUBSCRIBE'],
+      },
     },
     {
       id: 'groovy',
@@ -522,8 +496,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.3.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'quota',
@@ -532,8 +505,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '2.0.1',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'api-key',
@@ -542,8 +514,10 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '3.2.1',
-      proxy: ['REQUEST'],
-      message: ['REQUEST'],
+      flowPhaseCompatibility: {
+        HTTP_PROXY: ['REQUEST'],
+        HTTP_MESSAGE: ['REQUEST'],
+      },
     },
     {
       id: 'policy-openid-userinfo',
@@ -552,8 +526,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'security',
       version: '1.5.2',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'transform-queryparams',
@@ -562,8 +535,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'transformation',
       version: '1.6.0',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
     {
       id: 'policy-request-validation',
@@ -572,8 +544,7 @@ export function fakePoliciesPlugin(): PolicyPlugin[] {
       icon: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=',
       category: 'others',
       version: '1.13.2',
-      proxy: [],
-      message: [],
+      flowPhaseCompatibility: {},
     },
   ];
 }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -31,15 +31,7 @@ import { GioLicenseService } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
-import {
-  ApiType,
-  ApiV4,
-  FlowExecution,
-  PlanV4,
-  toPolicyStudioFlowPhase,
-  UpdateApiV4,
-  UpdatePlanV4,
-} from '../../../../entities/management-api-v2';
+import { ApiType, ApiV4, FlowExecution, PlanV4, UpdateApiV4, UpdatePlanV4 } from '../../../../entities/management-api-v2';
 import { IconService } from '../../../../services-ngx/icon.service';
 import { ConnectorPluginsV2Service } from '../../../../services-ngx/connector-plugins-v2.service';
 import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
@@ -157,7 +149,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
           description: plugin.description,
           prerequisiteMessage: plugin.prerequisiteMessage,
           policyId: plugin.policyId,
-          phase: toPolicyStudioFlowPhase(plugin.phase),
+          phase: plugin.phase,
           apiType: plugin.apiType,
         }));
 

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/history-studio-dialog/history-studio-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/history-studio-dialog/history-studio-dialog.component.html
@@ -40,7 +40,7 @@
       [policies]="policies"
       [readOnly]="true"
       [apiType]="sharedPolicyGroup.apiType"
-      [flowPhase]="toPolicyStudioFlowPhase(sharedPolicyGroup.phase)"
+      [flowPhase]="sharedPolicyGroup.phase"
       [policyDocumentationFetcher]="policyDocumentationFetcher"
       [policySchemaFetcher]="policySchemaFetcher"
       [policyGroup]="sharedPolicyGroup.steps ?? []"

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/history-studio-dialog/history-studio-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-history/history-studio-dialog/history-studio-dialog.component.ts
@@ -26,7 +26,7 @@ import { MatInput } from '@angular/material/input';
 
 import { IconService } from '../../../../../../services-ngx/icon.service';
 import { PolicyV2Service } from '../../../../../../services-ngx/policy-v2.service';
-import { SharedPolicyGroup, toPolicyStudioFlowPhase } from '../../../../../../entities/management-api-v2';
+import { SharedPolicyGroup } from '../../../../../../entities/management-api-v2';
 
 export interface HistoryStudioDialogData {
   sharedPolicyGroup: SharedPolicyGroup;
@@ -60,7 +60,6 @@ export class HistoryStudioDialogComponent {
   private readonly iconService = inject(IconService);
 
   protected sharedPolicyGroup = this.data.sharedPolicyGroup;
-  protected toPolicyStudioFlowPhase = toPolicyStudioFlowPhase;
 
   protected policySchemaFetcher: PolicySchemaFetcher = (policy) => this.policyV2Service.getSchema(policy.id);
   protected policyDocumentationFetcher: PolicyDocumentationFetcher = (policy) => this.policyV2Service.getDocumentation(policy.id);

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.html
@@ -75,7 +75,7 @@
           [policies]="policies"
           [readOnly]="isReadOnly"
           [apiType]="sharedPolicyGroup.apiType"
-          [flowPhase]="toPolicyStudioFlowPhase(sharedPolicyGroup.phase)"
+          [flowPhase]="sharedPolicyGroup.phase"
           [policyDocumentationFetcher]="policyDocumentationFetcher"
           [policySchemaFetcher]="policySchemaFetcher"
           [policyGroup]="sharedPolicyGroup.steps ?? []"

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.ts
@@ -44,7 +44,7 @@ import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { GioPermissionModule } from '../../../../../shared/components/gio-permission/gio-permission.module';
 import { removeSharedPolicyGroup } from '../../shared-policy-groups.component';
 import { SharedPolicyGroupsStateBadgeComponent } from '../../shared-policy-groups-state-badge/shared-policy-groups-state-badge.component';
-import { toPolicyStudioFlowPhase, toReadableFlowPhase } from '../../../../../entities/management-api-v2';
+import { toReadableFlowPhase } from '../../../../../entities/management-api-v2';
 
 @Component({
   selector: 'shared-policy-group-studio',
@@ -96,7 +96,6 @@ export class SharedPolicyGroupStudioComponent {
     .pipe(map((policies) => policies.map((policy) => ({ ...policy, icon: this.iconService.registerSvg(policy.id, policy.icon) }))));
   protected enableSaveButton = false;
   protected toReadableFlowPhase = toReadableFlowPhase;
-  protected toPolicyStudioFlowPhase = toPolicyStudioFlowPhase;
 
   public onEdit(): void {
     const sharedPolicyGroup = this.sharedPolicyGroup();

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups-add-edit-dialog/shared-policy-groups-add-edit-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-groups-add-edit-dialog/shared-policy-groups-add-edit-dialog.component.ts
@@ -41,7 +41,7 @@ export type SharedPolicyGroupAddEditDialogResult =
 
 const PHASE_BY_API_TYPE: Record<ApiV4['type'], FlowPhase[]> = {
   PROXY: ['REQUEST', 'RESPONSE'],
-  MESSAGE: ['REQUEST', 'RESPONSE', 'MESSAGE_REQUEST', 'MESSAGE_RESPONSE'],
+  MESSAGE: ['REQUEST', 'RESPONSE', 'PUBLISH', 'SUBSCRIBE'],
 };
 
 @Component({

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PolicyPluginMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PolicyPluginMapper.java
@@ -15,10 +15,16 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.rest.api.management.v2.rest.model.FlowPhase;
 import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
+import io.gravitee.rest.api.management.v2.rest.model.PolicyPluginAllOfFlowPhaseCompatibility;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
+import java.util.Map;
 import java.util.Set;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -29,7 +35,32 @@ public interface PolicyPluginMapper {
 
     Set<PolicyPlugin> map(Set<PolicyPluginEntity> policyEntitySet);
 
-    PolicyPlugin mapToCore(io.gravitee.apim.core.plugin.model.PolicyPlugin policyEntity);
+    @Mapping(target = "flowPhaseCompatibility", qualifiedByName = "flowPhaseCompatibility")
+    PolicyPlugin mapFromCore(io.gravitee.apim.core.plugin.model.PolicyPlugin policyEntity);
 
-    Set<PolicyPlugin> mapToCore(Set<io.gravitee.apim.core.plugin.model.PolicyPlugin> policyEntitySet);
+    Set<PolicyPlugin> mapFromCore(Set<io.gravitee.apim.core.plugin.model.PolicyPlugin> policyEntitySet);
+
+    FlowPhase map(io.gravitee.rest.api.model.v4.policy.FlowPhase flowPhase);
+
+    Set<FlowPhase> mapToFlowPhase(Set<io.gravitee.rest.api.model.v4.policy.FlowPhase> flowPhases);
+
+    @Named("flowPhaseCompatibility")
+    default PolicyPluginAllOfFlowPhaseCompatibility mapToFlowPhaseCompatibility(
+        Map<io.gravitee.rest.api.model.v4.policy.ApiProtocolType, Set<io.gravitee.rest.api.model.v4.policy.FlowPhase>> flowPhaseCompatibility
+    ) {
+        if (flowPhaseCompatibility == null) {
+            return null;
+        }
+        var policyPluginAllOfFlowPhaseCompatibility = new PolicyPluginAllOfFlowPhaseCompatibility();
+        if (flowPhaseCompatibility.get(ApiProtocolType.HTTP_PROXY) != null) {
+            policyPluginAllOfFlowPhaseCompatibility.HTTP_PROXY(mapToFlowPhase(flowPhaseCompatibility.get(ApiProtocolType.HTTP_PROXY)));
+        }
+        if (flowPhaseCompatibility.get(ApiProtocolType.HTTP_MESSAGE) != null) {
+            policyPluginAllOfFlowPhaseCompatibility.HTTP_MESSAGE(mapToFlowPhase(flowPhaseCompatibility.get(ApiProtocolType.HTTP_MESSAGE)));
+        }
+        if (flowPhaseCompatibility.get(ApiProtocolType.NATIVE_KAFKA) != null) {
+            policyPluginAllOfFlowPhaseCompatibility.NATIVE_KAFKA(mapToFlowPhase(flowPhaseCompatibility.get(ApiProtocolType.NATIVE_KAFKA)));
+        }
+        return policyPluginAllOfFlowPhaseCompatibility;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
@@ -42,7 +42,7 @@ public class PoliciesResource extends AbstractResource {
         String organizationId = GraviteeContext.getCurrentOrganization() != null
             ? GraviteeContext.getCurrentOrganization()
             : GraviteeContext.getDefaultOrganization();
-        return PolicyPluginMapper.INSTANCE.mapToCore(
+        return PolicyPluginMapper.INSTANCE.mapFromCore(
             getPolicyPluginsUseCase.getPoliciesByOrganization(new GetPolicyPluginsUseCase.Input(organizationId)).plugins()
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins-deprecated.yaml
@@ -319,7 +319,7 @@ paths:
                             schema:
                                 type: array
                                 items:
-                                    $ref: "#/components/schemas/PolicyPlugin"
+                                   $ref: "./openapi-plugins.yaml#/components/schemas/PolicyPlugin"
                 default:
                     $ref: "#/components/responses/Error"
     /plugins/policies/{policyId}:
@@ -341,7 +341,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/PolicyPlugin"
+                               $ref: "./openapi-plugins.yaml#/components/schemas/PolicyPlugin"
                 default:
                     $ref: "#/components/responses/Error"
     /plugins/policies/{policyId}/documentation:
@@ -429,22 +429,6 @@ components:
                       subscriptionSchema:
                           type: string
                           description: The subscription schema of the plugin.
-        PolicyPlugin:
-            type: object
-            allOf:
-                - $ref: "#/components/schemas/PlatformPlugin"
-                - type: object
-                  properties:
-                      proxy:
-                          type: array
-                          uniqueItems: true
-                          items:
-                              $ref: "./openapi-plugins.yaml#/components/schemas/FlowPhase"
-                      message:
-                          type: array
-                          uniqueItems: true
-                          items:
-                              $ref: "./openapi-plugins.yaml#/components/schemas/FlowPhase"
         PlatformPlugin:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -514,16 +514,24 @@ components:
                 - $ref: "#/components/schemas/PlatformPlugin"
                 - type: object
                   properties:
-                      proxy:
+                    flowPhaseCompatibility:
+                      type: object
+                      properties:
+                        HTTP_PROXY:
                           type: array
                           uniqueItems: true
                           items:
                               $ref: "#/components/schemas/FlowPhase"
-                      message:
+                        HTTP_MESSAGE:
                           type: array
                           uniqueItems: true
                           items:
                               $ref: "#/components/schemas/FlowPhase"
+                        NATIVE_KAFKA:
+                          type: array
+                          uniqueItems: true
+                          items:
+                            $ref: "#/components/schemas/FlowPhase"
         ResourcePlugin:
           type: object
           allOf:
@@ -598,6 +606,7 @@ components:
                 - SUBSCRIBE
                 - PUBLISH
                 - REQUEST_RESPONSE
+
         FlowPhase:
             type: string
             description: The execution phase of a policy.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/PolicyPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/policy/PolicyPluginEntity.java
@@ -17,6 +17,8 @@ package io.gravitee.rest.api.model.v4.policy;
 
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -29,7 +31,19 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 public class PolicyPluginEntity extends PlatformPluginEntity {
 
-    private Set<FlowPhase> proxy;
+    public Map<ApiProtocolType, Set<FlowPhase>> flowPhaseCompatibility = new HashMap<>();
 
-    private Set<FlowPhase> message;
+    public Set<FlowPhase> getFlowPhaseCompatibility(ApiProtocolType apiProtocolType) {
+        if (flowPhaseCompatibility == null) {
+            return null;
+        }
+        return flowPhaseCompatibility.get(apiProtocolType);
+    }
+
+    public void putFlowPhaseCompatibility(ApiProtocolType apiProtocolType, Set<FlowPhase> flowPhases) {
+        if (flowPhaseCompatibility == null) {
+            flowPhaseCompatibility = new HashMap<>();
+        }
+        flowPhaseCompatibility.put(apiProtocolType, flowPhases);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PolicyPlugin.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plugin/model/PolicyPlugin.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.plugin.model;
 
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
+import java.util.Map;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,7 +31,5 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public class PolicyPlugin extends PlatformPlugin {
 
-    private Set<FlowPhase> proxy;
-
-    private Set<FlowPhase> message;
+    public Map<ApiProtocolType, Set<io.gravitee.rest.api.model.v4.policy.FlowPhase>> flowPhaseCompatibility;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceLegacyWrapper.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.policy.exception.UnexpectedPoliciesException;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import java.util.ArrayList;
@@ -54,12 +55,21 @@ public class PolicyValidationDomainServiceLegacyWrapper implements PolicyValidat
                 PolicyPluginEntity policy = policiesMap.get(policyId);
 
                 if (apiType.equals(ApiType.PROXY)) {
-                    if (policy.getProxy() == null || policy.getProxy().stream().noneMatch(p -> p.name().equals(phase.name()))) {
+                    if (
+                        policy.getFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY) == null ||
+                        policy.getFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY).stream().noneMatch(p -> p.name().equals(phase.name()))
+                    ) {
                         policyNamesUnexpected.add(policy.getName());
                     }
                 }
                 if (apiType.equals(ApiType.MESSAGE)) {
-                    if (policy.getMessage() == null || policy.getMessage().stream().noneMatch(p -> p.name().equals(phase.name()))) {
+                    if (
+                        policy.getFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE) == null ||
+                        policy
+                            .getFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE)
+                            .stream()
+                            .noneMatch(p -> p.name().equals(phase.name()))
+                    ) {
                         policyNamesUnexpected.add(policy.getName());
                     }
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.FlowPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
@@ -89,8 +90,11 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
         entity.setCategory(plugin.manifest().category());
         entity.setDeployed(plugin.deployed());
 
-        entity.setProxy(getFlowPhase(plugin, "proxy"));
-        entity.setMessage(getFlowPhase(plugin, "message"));
+        var proxyPhase = getFlowPhase(plugin, "proxy");
+        var messagePhase = getFlowPhase(plugin, "message");
+
+        entity.putFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY, proxyPhase);
+        entity.putFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE, messagePhase);
 
         return entity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/policy/PolicyValidationDomainServiceTest.java
@@ -20,10 +20,12 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.policy.exception.UnexpectedPoliciesException;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.FlowPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -43,8 +45,16 @@ class PolicyValidationDomainServiceTest {
             when(policyPluginService.findAll())
                 .thenReturn(
                     Set.of(
-                        PolicyPluginEntity.builder().id("policy-1").proxy(Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE)).build(),
-                        PolicyPluginEntity.builder().id("policy-2").proxy(Set.of(FlowPhase.REQUEST)).build()
+                        PolicyPluginEntity
+                            .builder()
+                            .id("policy-1")
+                            .flowPhaseCompatibility(Map.of(ApiProtocolType.HTTP_PROXY, Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE)))
+                            .build(),
+                        PolicyPluginEntity
+                            .builder()
+                            .id("policy-2")
+                            .flowPhaseCompatibility(Map.of(ApiProtocolType.HTTP_PROXY, Set.of(FlowPhase.REQUEST)))
+                            .build()
                     )
                 );
             // When
@@ -65,9 +75,14 @@ class PolicyValidationDomainServiceTest {
                             .builder()
                             .id("policy-1")
                             .name("Policy 1")
-                            .proxy(Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE))
+                            .flowPhaseCompatibility(Map.of(ApiProtocolType.HTTP_PROXY, Set.of(FlowPhase.RESPONSE)))
                             .build(),
-                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.PUBLISH)).build()
+                        PolicyPluginEntity
+                            .builder()
+                            .id("policy-2")
+                            .name("Policy 2")
+                            .flowPhaseCompatibility(Map.of(ApiProtocolType.HTTP_MESSAGE, Set.of(FlowPhase.PUBLISH)))
+                            .build()
                     )
                 );
 
@@ -97,9 +112,21 @@ class PolicyValidationDomainServiceTest {
                             .builder()
                             .id("policy-1")
                             .name("Policy 1")
-                            .message(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE))
+                            .flowPhaseCompatibility(
+                                Map.of(
+                                    ApiProtocolType.HTTP_PROXY,
+                                    Set.of(FlowPhase.REQUEST, FlowPhase.RESPONSE),
+                                    ApiProtocolType.HTTP_MESSAGE,
+                                    Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE)
+                                )
+                            )
                             .build(),
-                        PolicyPluginEntity.builder().id("policy-2").name("Policy 2").message(Set.of(FlowPhase.PUBLISH)).build(),
+                        PolicyPluginEntity
+                            .builder()
+                            .id("policy-2")
+                            .name("Policy 2")
+                            .flowPhaseCompatibility(Map.of(ApiProtocolType.HTTP_MESSAGE, Set.of(FlowPhase.PUBLISH)))
+                            .build(),
                         PolicyPluginEntity.builder().id("policy-3").name("Policy 3").build()
                     )
                 );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/plugin/PolicyPluginQueryServiceLegacyWrapperTest.java
@@ -48,7 +48,7 @@ class PolicyPluginQueryServiceLegacyWrapperTest {
             );
 
         assertThat(service.findAll())
-            .containsExactly(
+            .containsExactlyInAnyOrder(
                 PolicyPlugin.builder().id("policy-1").name("Policy 1").build(),
                 PolicyPlugin.builder().id("policy-2").name("Policy 2").build()
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -27,6 +27,7 @@ import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.FlowPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
@@ -139,8 +140,8 @@ public class PolicyPluginServiceImplTest {
         assertEquals(1, result.size());
         PolicyPluginEntity policyPlugin = result.iterator().next();
         assertEquals(PLUGIN_ID, policyPlugin.getId());
-        assertEquals(Set.of(FlowPhase.REQUEST), policyPlugin.getProxy());
-        assertEquals(Set.of(FlowPhase.PUBLISH), policyPlugin.getMessage());
+        assertEquals(Set.of(FlowPhase.REQUEST), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_PROXY));
+        assertEquals(Set.of(FlowPhase.PUBLISH), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE));
     }
 
     @Test
@@ -155,7 +156,7 @@ public class PolicyPluginServiceImplTest {
         assertEquals(1, result.size());
         PolicyPluginEntity policyPlugin = result.iterator().next();
         assertEquals(PLUGIN_ID, policyPlugin.getId());
-        assertEquals(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE), policyPlugin.getMessage());
+        assertEquals(Set.of(FlowPhase.PUBLISH, FlowPhase.SUBSCRIBE), policyPlugin.getFlowPhaseCompatibility(ApiProtocolType.HTTP_MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7242

## Description

- remove the use of MESSAGE_REQUEST & MESSAGE_RESPONSE
- expose new `flowPhaseCompatibility` with mapi-v2 and connect it to PolicyStudio


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dsozakurui.chromatic.com)
<!-- Storybook placeholder end -->
