### PR TITLE
ci: move helm chart release after docker rpm and nexus steps

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -674,12 +674,6 @@ workflows:
           name: Package bundle
           requires:
             - Commit and prepare next version
-      - job-release-helm:
-          context:
-            - cicd-orchestrator
-          name: Release Helm Chart
-          requires:
-            - Package bundle
       - job-publish-prod-docker-images:
           context:
             - cicd-orchestrator
@@ -704,17 +698,22 @@ workflows:
           name: Nexus staging
           requires:
             - Package bundle
+      - job-release-helm:
+          context:
+            - cicd-orchestrator
+          name: Release Helm Chart
+          requires:
+            - Nexus staging
+            - Create release note pull request
+            - Build and push RPM packages for APIM 4.2.0-alpha.1
+            - Build and push docker images for APIM 4.2.0-alpha.1
       - job-slack-announcement:
           context:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🎆 APIM - 4.2.0-alpha.1 released!
           requires:
-            - Nexus staging
-            - Create release note pull request
             - Release Helm Chart
-            - Build and push RPM packages for APIM 4.2.0-alpha.1
-            - Build and push docker images for APIM 4.2.0-alpha.1
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -664,12 +664,6 @@ workflows:
           name: Package bundle
           requires:
             - Commit and prepare next version
-      - job-release-helm:
-          context:
-            - cicd-orchestrator
-          name: Release Helm Chart
-          requires:
-            - Package bundle
       - job-publish-prod-docker-images:
           context:
             - cicd-orchestrator
@@ -694,17 +688,22 @@ workflows:
           name: Nexus staging
           requires:
             - Package bundle
+      - job-release-helm:
+          context:
+            - cicd-orchestrator
+          name: Release Helm Chart
+          requires:
+            - Nexus staging
+            - Create release note pull request
+            - Build and push RPM packages for APIM 4.2.0 - Dry Run
+            - Build and push docker images for APIM 4.2.0 - Dry Run
       - job-slack-announcement:
           context:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🎆 APIM - 4.2.0 released!
           requires:
-            - Nexus staging
-            - Create release note pull request
             - Release Helm Chart
-            - Build and push RPM packages for APIM 4.2.0 - Dry Run
-            - Build and push docker images for APIM 4.2.0 - Dry Run
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -676,12 +676,6 @@ workflows:
           name: Package bundle
           requires:
             - Commit and prepare next version
-      - job-release-helm:
-          context:
-            - cicd-orchestrator
-          name: Release Helm Chart
-          requires:
-            - Package bundle
       - job-publish-prod-docker-images:
           context:
             - cicd-orchestrator
@@ -706,17 +700,22 @@ workflows:
           name: Nexus staging
           requires:
             - Package bundle
+      - job-release-helm:
+          context:
+            - cicd-orchestrator
+          name: Release Helm Chart
+          requires:
+            - Nexus staging
+            - Create release note pull request
+            - Build and push RPM packages for APIM 4.2.0
+            - Build and push docker images for APIM 4.2.0
       - job-slack-announcement:
           context:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🎆 APIM - 4.2.0 released!
           requires:
-            - Nexus staging
-            - Create release note pull request
             - Release Helm Chart
-            - Build and push RPM packages for APIM 4.2.0
-            - Build and push docker images for APIM 4.2.0
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -676,12 +676,6 @@ workflows:
           name: Package bundle
           requires:
             - Commit and prepare next version
-      - job-release-helm:
-          context:
-            - cicd-orchestrator
-          name: Release Helm Chart
-          requires:
-            - Package bundle
       - job-publish-prod-docker-images:
           context:
             - cicd-orchestrator
@@ -706,17 +700,22 @@ workflows:
           name: Nexus staging
           requires:
             - Package bundle
+      - job-release-helm:
+          context:
+            - cicd-orchestrator
+          name: Release Helm Chart
+          requires:
+            - Nexus staging
+            - Create release note pull request
+            - Build and push RPM packages for APIM 4.2.0
+            - Build and push docker images for APIM 4.2.0
       - job-slack-announcement:
           context:
             - cicd-orchestrator
           name: Announce release is starting
           message: 🎆 APIM - 4.2.0 released!
           requires:
-            - Nexus staging
-            - Create release note pull request
             - Release Helm Chart
-            - Build and push RPM packages for APIM 4.2.0
-            - Build and push docker images for APIM 4.2.0
 orbs:
   keeper: gravitee-io/keeper@0.6.3
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -131,13 +131,6 @@ export class FullReleaseWorkflow {
         requires: ['Commit and prepare next version'],
       }),
 
-      // Release Helm chart
-      new workflow.WorkflowJob(releaseHelmJob, {
-        context: config.jobContext,
-        name: 'Release Helm Chart',
-        requires: ['Package bundle'],
-      }),
-
       // Publish Docker images
       new workflow.WorkflowJob(publishProdDockerImagesJob, {
         context: config.jobContext,
@@ -166,18 +159,24 @@ export class FullReleaseWorkflow {
         requires: ['Package bundle'],
       }),
 
+      // Release Helm chart
+      new workflow.WorkflowJob(releaseHelmJob, {
+        context: config.jobContext,
+        name: 'Release Helm Chart',
+        requires: [
+          'Nexus staging',
+          'Create release note pull request',
+          `Build and push RPM packages for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
+          `Build and push docker images for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
+        ],
+      }),
+
       // Notify APIM team
       new workflow.WorkflowJob(slackAnnouncementJob, {
         context: config.jobContext,
         name: 'Announce release is starting',
         message: `🎆 APIM - ${environment.graviteeioVersion} released!`,
-        requires: [
-          'Nexus staging',
-          'Create release note pull request',
-          'Release Helm Chart',
-          `Build and push RPM packages for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-          `Build and push docker images for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
-        ],
+        requires: ['Release Helm Chart'],
       }),
     ]);
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The goal of this PR is to ensure that we publish the helm charts online if everything is ok. So if docker, rpm, nexus, etc... are ok. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zgnjitgkfx.chromatic.com)
<!-- Storybook placeholder end -->
