### PR TITLE
fix(helm): add missing haproxy mapping attribute

### DIFF
--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -103,6 +103,9 @@ data:
         {{- if $server.websocket }}
         websocket: {{ toYaml $server.websocket | nindent 10 }}
         {{- end }}
+        {{- if $server.haproxy }}
+        haproxy: {{ toYaml $server.haproxy | nindent 10 }}
+        {{- end }}
     {{- end }}
     {{- else }}
     http:
@@ -156,6 +159,9 @@ data:
       {{- end }}
       websocket:
         enabled: {{ .Values.gateway.websocket }}
+      {{- if .Values.gateway.haproxy }}
+      haproxy: {{ toYaml .Values.gateway.haproxy | nindent 8 }}
+      {{- end }}
     {{- end }}
     management:
     {{- if .Values.gateway.dbLess }}

--- a/helm/tests/gateway/configmap_haproxy_test.yaml
+++ b/helm/tests/gateway/configmap_haproxy_test.yaml
@@ -1,0 +1,46 @@
+suite: Test Gateway configmap - haproxy
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Default configmap doesn't have any haproxy config
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s haproxy:\s*
+
+  - it: Sets configmap haproxy config globally
+    set:
+      gateway:
+        haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+          proxyProtocol: false
+          proxyProtocolTimeout: 10000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s haproxy:\s*
+            \s   proxyProtocol: false
+            \s   proxyProtocolTimeout: 10000
+          multiline: true
+
+  - it: Sets configmap haproxy config in servers
+    set:
+      gateway:
+        servers:
+          - type: http
+            port: 8082
+            haproxy:
+              proxyProtocol: false
+              proxyProtocolTimeout: 10000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            servers:
+              - type: http
+                port: 8082
+                host: 0.0.0.0
+                haproxy:\s*
+                  proxyProtocol: false
+                  proxyProtocolTimeout: 10000

--- a/helm/tests/gateway/service_test.yaml
+++ b/helm/tests/gateway/service_test.yaml
@@ -182,3 +182,15 @@ tests:
           of: Service
       - isAPIVersion:
           of: v1
+
+  - it: Check service annotations
+    template: gateway/gateway-service.yaml
+    set:
+      gateway:
+        service:
+          annotations:
+            loadbalancer.openstack.org/proxy-protocol: true
+    asserts:
+      - equal:
+          path: metadata.annotations["loadbalancer.openstack.org/proxy-protocol"]
+          value: "true"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1073,6 +1073,9 @@ gateway:
   # sharding_tags:
   # tenant:
   websocket: false
+#  haproxy: # Support for https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+#    proxyProtocol: false
+#    proxyProtocolTimeout: 10000
   ratelimit:
     # redis:
     #   host: redis
@@ -1356,6 +1359,8 @@ gateway:
     # nodePort: 30082
     internalPort: 8082
     internalPortName: http
+#    annotations:
+#      loadbalancer.openstack.org/proxy-protocol: true
 #    appProtocol: http
   # annotations:
   autoscaling:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6916

## Description

The haproxy can be configure to setup the proxyProtocol on gravitee.yml.
But this setting was not able from helm values.yaml

This fix that issue.

