### PR TITLE
APIM-6981: fix long words break

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -38,6 +38,8 @@
 .markdown-content {
   background-color: var(--gv-page-markdown--bgc, var(--gv-theme-neutral-color-lightest));
   padding: var(--gv-page-markdown--p, 2rem 4rem);
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .markdown.with-toc {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6981

## Description

Breaking long words in document. Used overflow-wrap for modern browsers and word-wrap for older browsers compatibility.

## Additional context

Before: 
<img width="1493" alt="Before" src="https://github.com/user-attachments/assets/dfd0cba4-77e0-4cb9-9b3b-f81dc449124e">

After: 
<img width="1493" alt="After" src="https://github.com/user-attachments/assets/0222912d-a2ed-4f77-a2cf-66b2c418ef1d">





