### PR TITLE
APIM-6465: fix yaml parser for binary type

### DIFF
--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
@@ -15,7 +15,26 @@
  */
 import * as jsYAML from 'js-yaml';
 
-const schema = jsYAML.JSON_SCHEMA.extend([]);
+import { Buffer } from 'buffer';
+
+const binaryType = new jsYAML.Type('tag:yaml.org,2002:binary', {
+  kind: 'scalar',
+  resolve: (data: any) => {
+    // Validate that the data is valid Base64
+    return typeof data === 'string' && /^[A-Za-z0-9+/=]*$/.test(data);
+  },
+  construct: (data: string) => {
+    // Convert Base64 to a Buffer
+    return Buffer.from(data, 'base64').toString('utf-8'); // Convert to UTF-8 string
+  },
+  instanceOf: String,
+  represent: (value: any) => {
+    // Encode the value as Base64 for YAML representation
+    return Buffer.from(String(value), 'utf-8').toString('base64');
+  },
+});
+
+const schema = jsYAML.JSON_SCHEMA.extend([binaryType]);
 
 export function readYaml(content: string): any {
   return jsYAML.load(content, { schema });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6465

## Description

Added schema to parse binary type in yaml.

## Additional context

Before: 
<img width="1495" alt="Before" src="https://github.com/user-attachments/assets/6bfb4d95-a4fc-4160-8d87-9bddd41d7e24">


After:
<img width="1498" alt="After" src="https://github.com/user-attachments/assets/c9a43d36-95f0-4f00-bc11-37472d20df9f">



