### PR TITLE
fix(portal-next): apply theme colors to table header, select list + calendar

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component.scss
@@ -25,11 +25,8 @@
 
 .api-tab-subscriptions__table {
   overflow: hidden;
-  border: 1px solid color-mix(in srgb, theme.$secondary-main-color 35%, transparent);
-  border-radius: 16px;
 
   &-row {
-    background: var(--mdc-outlined-card-container-color);
     cursor: pointer;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/applications/application/application-tab-logs/application-log-table/application-log-table.component.scss
@@ -32,11 +32,8 @@ $form-field-hint-height: 16px;
 .application-logs {
   &__table {
     overflow: hidden;
-    border: 1px solid color-mix(in srgb, theme.$secondary-main-color 35%, transparent);
-    border-radius: 16px;
 
     &-row {
-      background: var(--mdc-outlined-card-container-color);
       cursor: pointer;
     }
 

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -41,3 +41,23 @@ mat-form-field {
 mat-expansion-panel {
   --mat-expansion-container-background-color: #{theme.$card-background-color};
 }
+
+table.mat-mdc-table {
+  --mat-table-row-item-outline-color: #{theme.$table-border-color};
+  --mat-table-background-color: #{theme.$table-header-background-color};
+
+  border: 1px solid theme.$table-border-color;
+  border-radius: 16px;
+
+  tbody {
+    background: theme.$card-background-color;
+  }
+}
+
+.mat-mdc-select-panel {
+  --mat-select-panel-background-color: #{theme.$select-panel-background-color};
+}
+
+mat-datepicker-content.mat-datepicker-content.mat-primary {
+  --mat-datepicker-calendar-container-background-color: #{theme.$calendar-background-color};
+}

--- a/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/theme/variables.scss
@@ -36,3 +36,7 @@ Component variables
 $banner-background-color: var(--mdc-list-list-item-leading-avatar-color);
 $banner-text-color: var(--mdc-outlined-text-field-focus-label-text-color);
 $chip-background: color-mix(in srgb, $primary-main-color 20%, transparent);
+$table-border-color: color-mix(in srgb, $secondary-main-color 35%, transparent);
+$table-header-background-color: color-mix(in srgb, $banner-background-color 8%, transparent);
+$select-panel-background-color: color-mix(in srgb, $banner-background-color 12%, $card-background-color);
+$calendar-background-color: color-mix(in srgb, $banner-background-color 50%, $card-background-color);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Theme color was not being applied to the calendar background, select list, and table header row.

With fixes:

![Screenshot 2024-10-22 at 10 13 27](https://github.com/user-attachments/assets/4775b347-41ad-4ac5-9f9b-2a2212739ef7)

![Screenshot 2024-10-22 at 10 08 55](https://github.com/user-attachments/assets/50b8ab62-ef57-426c-90a9-50e5b881053d)

![Screenshot 2024-10-22 at 10 19 52](https://github.com/user-attachments/assets/9c5e918b-7230-4343-a2df-b018ca0da032)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

