### PR TITLE
fix(categories): avoid NPE when counting API by category

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -89,11 +89,11 @@ public class ApisResource extends AbstractResource<Api, String> {
             convert(apisParam.getExcludedFilter())
         );
 
-        Map<String, Long> countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
+        var countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
 
         List<Category> categoryList = categories
             .stream()
-            .peek(categoryEntity -> categoryEntity.setTotalApis(countByCategory.get(categoryEntity.getId())))
+            .peek(categoryEntity -> categoryEntity.setTotalApis(countByCategory.applyAsLong(categoryEntity.getId())))
             .map(categoryEntity -> categoryMapper.convert(categoryEntity, uriInfo.getBaseUriBuilder()))
             .collect(Collectors.toList());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
@@ -34,6 +34,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.LongFunction;
+import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -59,14 +61,14 @@ public class CategoriesResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @RequirePortalAuth
     public Response getCategories(@BeanParam PaginationParam paginationParam) {
-        Map<String, Long> countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
+        var countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
 
         List<Category> categoriesList = categoryService
             .findAll(GraviteeContext.getCurrentEnvironment())
             .stream()
             .filter(c -> !c.isHidden())
             .sorted(Comparator.comparingInt(CategoryEntity::getOrder))
-            .peek(c -> c.setTotalApis(countByCategory.getOrDefault(c.getId(), 0L)))
+            .peek(c -> c.setTotalApis(countByCategory.applyAsLong(c.getId())))
             .filter(c -> c.getTotalApis() > 0)
             .map(c -> categoryMapper.convert(c, uriInfo.getBaseUriBuilder()))
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoryResource.java
@@ -31,7 +31,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
-import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -55,8 +54,8 @@ public class CategoryResource extends AbstractResource {
     public Response get(@PathParam("categoryId") String categoryId) {
         CategoryEntity category = categoryService.findNotHiddenById(categoryId, GraviteeContext.getCurrentEnvironment());
 
-        Map<String, Long> countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
-        category.setTotalApis(countByCategory.getOrDefault(category.getId(), 0L));
+        var countByCategory = apiCategoryService.countApisPublishedGroupedByCategoriesForUser(getAuthenticatedUserOrNull());
+        category.setTotalApis(countByCategory.applyAsLong(category.getId()));
 
         return Response.ok(categoryMapper.convert(category, uriInfo.getBaseUriBuilder())).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
@@ -17,14 +17,10 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.CategoryEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.CategoriesResponse;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
@@ -69,13 +65,12 @@ public class CategoriesResourceNotAuthenticatedTest extends AbstractResourceTest
         category3.setOrder(1);
 
         List<CategoryEntity> mockCategories = Arrays.asList(category1, category2, category3);
-        doReturn(mockCategories).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
+        when(categoryService.findAll(GraviteeContext.getCurrentEnvironment())).thenReturn(mockCategories);
 
-        doReturn(Map.of(category1.getId(), 1L, category2.getId(), 1L, category3.getId(), 1L))
-            .when(apiCategoryService)
-            .countApisPublishedGroupedByCategoriesForUser(any());
+        Map<String, Long> countByCat = Map.of(category1.getId(), 1L, category2.getId(), 1L, category3.getId(), 1L);
+        when(apiCategoryService.countApisPublishedGroupedByCategoriesForUser(any())).thenReturn(cat -> countByCat.getOrDefault(cat, 0L));
 
-        doReturn(false).when(ratingService).isEnabled(GraviteeContext.getExecutionContext());
+        when(ratingService.isEnabled(GraviteeContext.getExecutionContext())).thenReturn(false);
 
         Mockito.when(categoryMapper.convert(any(), any())).thenCallRealMethod();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceTest.java
@@ -17,13 +17,9 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.portal.rest.model.CategoriesResponse;
 import io.gravitee.rest.api.portal.rest.model.Error;
@@ -67,15 +63,15 @@ public class CategoriesResourceTest extends AbstractResourceTest {
         category3.setHidden(true);
         category3.setOrder(1);
 
-        doReturn(Map.of(category1.getId(), 1L, category2.getId(), 0L, category3.getId(), 2L))
-            .when(apiCategoryService)
-            .countApisPublishedGroupedByCategoriesForUser(any());
+        Map<String, Long> countByCategory = Map.of(category1.getId(), 1L, category2.getId(), 0L, category3.getId(), 2L);
+        when(apiCategoryService.countApisPublishedGroupedByCategoriesForUser(any()))
+            .thenReturn(cat -> countByCategory.getOrDefault(cat, 0L));
 
-        existingCategories = Arrays.asList(category1, category2, category3);
+        existingCategories = List.of(category1, category2, category3);
 
-        doReturn(existingCategories).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
+        when(categoryService.findAll(GraviteeContext.getCurrentEnvironment())).thenReturn(existingCategories);
 
-        Mockito.when(categoryMapper.convert(any(), any())).thenCallRealMethod();
+        when(categoryMapper.convert(any(), any())).thenCallRealMethod();
     }
 
     @Test
@@ -105,7 +101,7 @@ public class CategoriesResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoPublishedApiAndNoLink() {
-        doReturn(new ArrayList<>()).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
+        when(categoryService.findAll(GraviteeContext.getCurrentEnvironment())).thenReturn(new ArrayList<>());
 
         //Test with default limit
         final Response response = target().request().get();
@@ -131,7 +127,7 @@ public class CategoriesResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetNothingIfAllCategoriesEmpty() {
         // 0 APIs returned for user in any categories
-        doReturn(Map.of()).when(apiCategoryService).countApisPublishedGroupedByCategoriesForUser(any());
+        when(apiCategoryService.countApisPublishedGroupedByCategoriesForUser(any())).thenReturn(cat -> 0);
 
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceNotAuthenticatedTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
@@ -61,11 +62,13 @@ public class CategoryResourceNotAuthenticatedTest extends AbstractResourceTest {
         CategoryEntity categoryEntity = new CategoryEntity();
         categoryEntity.setId(CATEGORY_ID);
         categoryEntity.setHidden(false);
-        doReturn(categoryEntity).when(categoryService).findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment());
+        when(categoryService.findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment())).thenReturn(categoryEntity);
 
-        doReturn(Map.of(CATEGORY_ID, 5L)).when(apiCategoryService).countApisPublishedGroupedByCategoriesForUser(null);
+        Map<String, Long> countByCategory = Map.of(CATEGORY_ID, 5L);
+        when(apiCategoryService.countApisPublishedGroupedByCategoriesForUser(null))
+            .thenReturn(cat -> countByCategory.getOrDefault(cat, 0L));
 
-        Mockito.when(categoryMapper.convert(any(), any())).thenCallRealMethod();
+        when(categoryMapper.convert(any(), any())).thenCallRealMethod();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiCategoryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiCategoryService.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.ToLongFunction;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -30,7 +31,7 @@ public interface ApiCategoryService {
 
     void deleteCategoryFromAPIs(ExecutionContext executionContext, String categoryId);
 
-    Map<String, Long> countApisPublishedGroupedByCategoriesForUser(String userId);
+    ToLongFunction<String> countApisPublishedGroupedByCategoriesForUser(String userId);
 
     void addApiToCategories(String apiId, Set<String> categoryId);
     void changeApiOrderInCategory(String apiId, String categoryId, int nextOrder);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiCategoryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiCategoryServiceImplTest.java
@@ -249,9 +249,10 @@ public class ApiCategoryServiceImplTest {
                 .thenReturn(Stream.of(api1, api2, api3, api4));
 
             Map<String, Long> expectedCounts = Map.of(category1.getId(), 3L, category2.getId(), 2L, category3.getId(), 1L);
-            Map<String, Long> counts = apiCategoryService.countApisPublishedGroupedByCategoriesForUser("user-1");
+            var counts = apiCategoryService.countApisPublishedGroupedByCategoriesForUser("user-1");
 
-            assertThat(counts).isEqualTo(expectedCounts);
+            expectedCounts.forEach((catId, expectedCount) -> assertThat(counts.applyAsLong(catId)).isEqualTo(expectedCount));
+            assertThat(counts.applyAsLong("unexistingCategory")).isZero();
         }
     }
 


### PR DESCRIPTION
**Issue** [APIM-7299](https://gravitee.atlassian.net/browse/APIM-7299)

## Description

Avoid an error prone managment: instead of return a `Map<String, Long>` return a `FunctionToLong<String>`.

Users of the function don't need manage null value anymore, the function return always a value: the number of APIs or 0.


[APIM-7299]: https://gravitee.atlassian.net/browse/APIM-7299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ