### PR TITLE
Console / Mapi : Add the support of new native_kafka flow phase

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManager.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-reactor/gravitee-apim-plugin-reactor-handler/src/main/java/io/gravitee/apim/plugin/reactor/internal/DefaultReactorPluginManager.java
@@ -103,6 +103,11 @@ public class DefaultReactorPluginManager extends AbstractPluginManager<ReactorPl
     }
 
     @Override
+    public String getDocumentation(String s, String s1, boolean b, boolean b1) throws IOException {
+        return "";
+    }
+
+    @Override
     public String getCategory(String s) throws IOException {
         return "reactor";
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.PolicyPluginMapper;
 import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import jakarta.inject.Inject;
@@ -57,22 +58,26 @@ public class PoliciesResource extends AbstractResource {
     @GET
     @Path("/{policyId}/schema")
     @Produces(MediaType.APPLICATION_JSON)
-    public String getPolicySchema(@PathParam("policyId") String policyId, @QueryParam("display") String display) {
+    public String getPolicySchema(
+        @PathParam("policyId") String policyId,
+        @QueryParam("apiProtocolType") ApiProtocolType apiProtocolType,
+        @QueryParam("display") SchemaDisplayFormat display
+    ) {
         // Check that the endpoint exists
         policyPluginService.findById(policyId);
-        if (display != null) {
-            return policyPluginService.getSchema(policyId, SchemaDisplayFormat.fromLabel(display));
-        }
-        return policyPluginService.getSchema(policyId);
+        return policyPluginService.getSchema(policyId, apiProtocolType, display);
     }
 
     @GET
     @Path("/{policyId}/documentation")
     @Produces(MediaType.TEXT_PLAIN)
-    public String getPolicyDocumentation(@PathParam("policyId") String policyId) {
+    public String getPolicyDocumentation(
+        @PathParam("policyId") String policyId,
+        @QueryParam("apiProtocolType") ApiProtocolType apiProtocolType
+    ) {
         // Check that the endpoint exists
         policyPluginService.findById(policyId);
 
-        return policyPluginService.getDocumentation(policyId);
+        return policyPluginService.getDocumentation(policyId, apiProtocolType);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -385,10 +385,19 @@ paths:
                   required: false
                   schema:
                       type: string
-                      default: gio-form-json-schema
                       enum:
-                          - gv-schema-form
-                          - gio-form-json-schema
+                          - GV_SCHEMA_FORM
+                          - GIO_FORM_JSON_SCHEMA
+                - name: apiProtocolType
+                  in: query
+                  description: The protocol type of the api.
+                  required: false
+                  schema:
+                    type: string
+                    enum:
+                      - HTTP_PROXY
+                      - HTTP_MESSAGE
+                      - NATIVE_KAFKA
             tags:
                 - Plugins - Policies
             summary: Get a policy schema

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
@@ -158,7 +158,7 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         policyPlugin.setCategory("my-category");
         policyPlugin.setDescription("my-description");
         when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
-        when(policyPluginService.getSchema(FAKE_POLICY_ID)).thenReturn("schemaResponse");
+        when(policyPluginService.getSchema(FAKE_POLICY_ID, null, null)).thenReturn("schemaResponse");
 
         final Response response = rootTarget(FAKE_POLICY_ID).path("schema").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -176,9 +176,25 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         policyPlugin.setCategory("my-category");
         policyPlugin.setDescription("my-description");
         when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
-        when(policyPluginService.getSchema(FAKE_POLICY_ID, SchemaDisplayFormat.GV_SCHEMA_FORM)).thenReturn("schemaResponse");
+        when(policyPluginService.getSchema(FAKE_POLICY_ID, null, SchemaDisplayFormat.GV_SCHEMA_FORM)).thenReturn("schemaResponse");
 
-        final Response response = rootTarget(FAKE_POLICY_ID).path("schema").queryParam("display", "gv-schema-form").request().get();
+        final Response response = rootTarget(FAKE_POLICY_ID).path("schema").queryParam("display", "GV_SCHEMA_FORM").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        assertThat(result).isEqualTo("schemaResponse");
+    }
+
+    @Test
+    public void should_get_policy_schema_with_api_protocol_type() {
+        PolicyPluginEntity policyPlugin = getPolicyPluginEntity();
+        when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
+        when(policyPluginService.getSchema(FAKE_POLICY_ID, ApiProtocolType.HTTP_PROXY, null)).thenReturn("schemaResponse");
+
+        final Response response = rootTarget(FAKE_POLICY_ID)
+            .path("schema")
+            .queryParam("apiProtocolType", ApiProtocolType.HTTP_PROXY)
+            .request()
+            .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         assertThat(result).isEqualTo("schemaResponse");
@@ -218,9 +234,25 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         policyPlugin.setCategory("my-category");
         policyPlugin.setDescription("my-description");
         when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
-        when(policyPluginService.getDocumentation(FAKE_POLICY_ID)).thenReturn("documentationResponse");
+        when(policyPluginService.getDocumentation(FAKE_POLICY_ID, null)).thenReturn("documentationResponse");
 
         final Response response = rootTarget(FAKE_POLICY_ID).path("documentation").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        assertThat(result).isEqualTo("documentationResponse");
+    }
+
+    @Test
+    public void should_get_policy_documentation_with_api_protocol_type() {
+        PolicyPluginEntity policyPlugin = getPolicyPluginEntity();
+        when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
+        when(policyPluginService.getDocumentation(FAKE_POLICY_ID, ApiProtocolType.HTTP_PROXY)).thenReturn("documentationResponse");
+
+        final Response response = rootTarget(FAKE_POLICY_ID)
+            .path("documentation")
+            .queryParam("apiProtocolType", ApiProtocolType.HTTP_PROXY)
+            .request()
+            .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         assertThat(result).isEqualTo("documentationResponse");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.v4;
 
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.PluginService;
 import java.util.Set;
@@ -44,4 +45,20 @@ public interface PolicyPluginService extends PluginService<PolicyPluginEntity> {
      * @return the configuration schema form
      */
     String getSchema(final String policyPluginId, SchemaDisplayFormat schemaDisplayFormat);
+
+    /**
+     * Get the schema form for the given policy plugin
+     * @param policyPluginId is the id of the policy
+     * @param apiProtocolType the protocol type to get the schema for
+     * @return the configuration schema form
+     */
+    String getSchema(String policyPluginId, ApiProtocolType apiProtocolType, SchemaDisplayFormat schemaDisplayFormat);
+
+    /**
+     * Get the documentation for the given policy plugin
+     * @param policyPluginId is the id of the policy
+     * @param apiProtocolType the protocol type to get the documentation for
+     * @return the documentation
+     */
+    String getDocumentation(String policyPluginId, ApiProtocolType apiProtocolType);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
@@ -41,15 +41,8 @@ public interface PolicyPluginService extends PluginService<PolicyPluginEntity> {
     /**
      * Get the schema form for the given policy plugin
      * @param policyPluginId is the id of the policy
-     * @param schemaDisplayFormat the format of the schema to return
-     * @return the configuration schema form
-     */
-    String getSchema(final String policyPluginId, SchemaDisplayFormat schemaDisplayFormat);
-
-    /**
-     * Get the schema form for the given policy plugin
-     * @param policyPluginId is the id of the policy
      * @param apiProtocolType the protocol type to get the schema for
+     * @param schemaDisplayFormat the format of the schema to return
      * @return the configuration schema form
      */
     String getSchema(String policyPluginId, ApiProtocolType apiProtocolType, SchemaDisplayFormat schemaDisplayFormat);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
@@ -128,25 +128,6 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
         return validateConfiguration(policyPluginEntity.getId(), configuration);
     }
 
-    @Override
-    public String getSchema(String policyPluginId, SchemaDisplayFormat schemaDisplayFormat) {
-        if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
-            try {
-                logger.debug("Find plugin schema for format {} by ID: {}", schemaDisplayFormat, policyPluginId);
-                String schema = pluginManager.getSchema(policyPluginId, "display-gv-schema-form", true);
-                if (schema != null) {
-                    return schema;
-                }
-                logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
-            } catch (IOException ioex) {
-                logger.debug(
-                    "Error while getting specific specific schema-form for this display format. Fall back on default schema-form."
-                );
-            }
-        }
-        return getSchema(policyPluginId);
-    }
-
     public String getSchema(String policyPluginId, ApiProtocolType apiProtocolType, SchemaDisplayFormat schemaDisplayFormat) {
         List<String> schemaKeys = new ArrayList<>();
         if (apiProtocolType != null && schemaDisplayFormat != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPolicyValidatorDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPolicyValidatorDomainServiceTest.java
@@ -306,11 +306,6 @@ class ApiPolicyValidatorDomainServiceTest {
         }
 
         @Override
-        public String getSchema(String plugin, SchemaDisplayFormat schemaDisplayFormat) {
-            throw new IllegalStateException("should not be called");
-        }
-
-        @Override
         public String getSchema(String policyPluginId, ApiProtocolType apiProtocolType, SchemaDisplayFormat schemaDisplayFormat) {
             throw new IllegalStateException("should not be called");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPolicyValidatorDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPolicyValidatorDomainServiceTest.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.flow.Step;
 import io.gravitee.plugin.core.api.PluginMoreInformation;
 import io.gravitee.rest.api.model.PolicyEntity;
 import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+import io.gravitee.rest.api.model.v4.policy.ApiProtocolType;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.PolicyService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
@@ -306,6 +307,16 @@ class ApiPolicyValidatorDomainServiceTest {
 
         @Override
         public String getSchema(String plugin, SchemaDisplayFormat schemaDisplayFormat) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public String getSchema(String policyPluginId, ApiProtocolType apiProtocolType, SchemaDisplayFormat schemaDisplayFormat) {
+            throw new IllegalStateException("should not be called");
+        }
+
+        @Override
+        public String getDocumentation(String policyPluginId, ApiProtocolType apiProtocolType) {
             throw new IllegalStateException("should not be called");
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -194,8 +194,25 @@ public class PolicyPluginServiceImplTest {
     }
 
     @Test
+    public void should_get_schema_with_ApiProtocolType() throws IOException {
+        when(pluginManager.getSchema("my-policy", "http_proxy.schema", false, true)).thenReturn("http_proxy");
+
+        String schema = cut.getSchema("my-policy", ApiProtocolType.HTTP_PROXY, null);
+        assertEquals("http_proxy", schema);
+    }
+
+    @Test
+    public void should_get_schema_with_fallback() throws IOException {
+        when(pluginManager.getSchema("my-policy", "http_proxy.schema", false, true)).thenReturn(null);
+        when(pluginManager.getSchema("my-policy", "schema", false, true)).thenReturn("schema");
+
+        String schema = cut.getSchema("my-policy", ApiProtocolType.HTTP_PROXY, null);
+        assertEquals("schema", schema);
+    }
+
+    @Test
     public void shouldGetDefaultSchemaFormWhenIOException() throws IOException {
-        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenThrow(new IOException());
+        when(pluginManager.getSchema("my-policy", "http_proxy.schema", false, true)).thenThrow(new IOException());
         when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
 
         String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
@@ -209,5 +226,13 @@ public class PolicyPluginServiceImplTest {
 
         String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
         assertEquals("default-configuration", schema);
+    }
+
+    @Test
+    public void should_get_documentation_with_ApiProtocolType() throws IOException {
+        when(pluginManager.getDocumentation("my-policy", "native_kafka.documentation", true, true)).thenReturn("documentation");
+
+        String documentation = cut.getDocumentation("my-policy", ApiProtocolType.NATIVE_KAFKA);
+        assertEquals("documentation", documentation);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -186,14 +186,6 @@ public class PolicyPluginServiceImplTest {
     }
 
     @Test
-    public void shouldGetGvSchemaForm() throws IOException {
-        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn("gv-schema-form-config");
-
-        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
-        assertEquals("gv-schema-form-config", schema);
-    }
-
-    @Test
     public void should_get_schema_with_ApiProtocolType() throws IOException {
         when(pluginManager.getSchema("my-policy", "http_proxy.schema", false, true)).thenReturn("http_proxy");
 
@@ -211,20 +203,11 @@ public class PolicyPluginServiceImplTest {
     }
 
     @Test
-    public void shouldGetDefaultSchemaFormWhenIOException() throws IOException {
+    public void should_get_default_schema_when_IOException() throws IOException {
         when(pluginManager.getSchema("my-policy", "http_proxy.schema", false, true)).thenThrow(new IOException());
         when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
 
-        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
-        assertEquals("default-configuration", schema);
-    }
-
-    @Test
-    public void shouldGetDefaultSchemaFormWhenNull() throws IOException {
-        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn(null);
-        when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
-
-        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        String schema = cut.getSchema("my-policy", ApiProtocolType.HTTP_PROXY, null);
         assertEquals("default-configuration", schema);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-node.version>6.5.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
-        <gravitee-plugin.version>4.3.0-APIM-7242-SNAPSHOT</gravitee-plugin.version>
+        <gravitee-plugin.version>4.3.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.31.1</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-node.version>6.5.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
-        <gravitee-plugin.version>4.2.1</gravitee-plugin.version>
+        <gravitee-plugin.version>4.3.0-APIM-7242-SNAPSHOT</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.31.1</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7242

## Description

Add the support of new native_kafka flow phase with new way to defined phase in `plugin.properties`
Allow to get schema or documentation according to ApiProtocolType


## Additional context

ex for targeted `plugin.properties` for hybrid plugin 
```
documentation=README.adoc
schema=schema-form.json

# HTTP
http_proxy=REQUEST,RESPONSE
http_message=REQUEST,RESPONSE,PUBLISH,SUBSCRIBE

# Native Kafka
native_kafka=INTERACT,CONNECT,PUBLISH,SUBSCRIBE
native_kafka.documentation=kafka/README_kafka.md
native_kafka.schema=kafka-schema-form.json
```

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bcxndzkton.chromatic.com)
<!-- Storybook placeholder end -->
