### PR TITLE
Alert template filtered by environment during API creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -389,7 +389,7 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
         );
     }
 
-    private Set<AlertTriggerEntity> findByEvent(AlertEventType event) {
+    private Set<AlertTriggerEntity> findByEvent(ExecutionContext executionContext, AlertEventType event) {
         try {
             LOGGER.debug("findByEvent: {}", event);
             Set<AlertTriggerEntity> set = alertTriggerRepository
@@ -398,7 +398,9 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
                 .filter(alert ->
                     alert.isTemplate() &&
                     alert.getEventRules() != null &&
-                    alert.getEventRules().stream().map(AlertEventRule::getEvent).collect(Collectors.toList()).contains(event)
+                    alert.getEventRules().stream().map(AlertEventRule::getEvent).toList().contains(event) &&
+                    executionContext.hasEnvironmentId() &&
+                    executionContext.getEnvironmentId().equals(alert.getEnvironmentId())
                 )
                 .map(alertTriggerConverter::toAlertTriggerEntity)
                 .sorted(Comparator.comparing(AlertTriggerEntity::getName))
@@ -414,7 +416,7 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
     @Override
     public void createDefaults(ExecutionContext executionContext, AlertReferenceType referenceType, String referenceId) {
         if (getStatus(executionContext).isEnabled()) {
-            Set<AlertTriggerEntity> defaultAlerts = findByEvent(AlertEventType.API_CREATE);
+            Set<AlertTriggerEntity> defaultAlerts = findByEvent(executionContext, AlertEventType.API_CREATE);
 
             for (AlertTriggerEntity alert : defaultAlerts) {
                 AlertTrigger trigger = alertTriggerConverter.toAlertTrigger(alert);
@@ -459,34 +461,32 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
                     )
                     .getContent();
                 if (apiIds != null) {
-                    apiIds
-                        .stream()
-                        .forEach(apiId -> {
-                            try {
-                                boolean create = alertTriggerRepository
-                                    .findByReferenceAndReferenceId(API.name(), apiId)
-                                    .stream()
-                                    .noneMatch(alertTrigger -> alertId.equals(alertTrigger.getParentId()));
+                    apiIds.forEach(apiId -> {
+                        try {
+                            boolean create = alertTriggerRepository
+                                .findByReferenceAndReferenceId(API.name(), apiId)
+                                .stream()
+                                .noneMatch(alertTrigger -> alertId.equals(alertTrigger.getParentId()));
 
-                                if (create) {
-                                    AlertTrigger trigger = alertTriggerConverter.toAlertTrigger(alert);
-                                    AlertTriggerEntity triggerEntity = alertTriggerConverter.toAlertTriggerEntity(trigger);
-                                    triggerEntity.setId(UUID.toString(UUID.random()));
-                                    triggerEntity.setReferenceType(API);
-                                    triggerEntity.setReferenceId(apiId);
-                                    triggerEntity.setTemplate(false);
-                                    triggerEntity.setEnabled(true);
-                                    triggerEntity.setEventRules(null);
-                                    triggerEntity.setParentId(alertId);
-                                    triggerEntity.setCreatedAt(new Date());
-                                    triggerEntity.setUpdatedAt(trigger.getCreatedAt());
+                            if (create) {
+                                AlertTrigger trigger = alertTriggerConverter.toAlertTrigger(alert);
+                                AlertTriggerEntity triggerEntity = alertTriggerConverter.toAlertTriggerEntity(trigger);
+                                triggerEntity.setId(UUID.toString(UUID.random()));
+                                triggerEntity.setReferenceType(API);
+                                triggerEntity.setReferenceId(apiId);
+                                triggerEntity.setTemplate(false);
+                                triggerEntity.setEnabled(true);
+                                triggerEntity.setEventRules(null);
+                                triggerEntity.setParentId(alertId);
+                                triggerEntity.setCreatedAt(new Date());
+                                triggerEntity.setUpdatedAt(trigger.getCreatedAt());
 
-                                    create(executionContext, alertTriggerConverter.toAlertTrigger(triggerEntity));
-                                }
-                            } catch (TechnicalException te) {
-                                LOGGER.error("Unable to create default alert for API {}", apiId, te);
+                                create(executionContext, alertTriggerConverter.toAlertTrigger(triggerEntity));
                             }
-                        });
+                        } catch (TechnicalException te) {
+                            LOGGER.error("Unable to create default alert for API {}", apiId, te);
+                        }
+                    });
                 }
             }
         } catch (TechnicalException te) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AlertServiceTest.java
@@ -16,9 +16,9 @@
 package io.gravitee.rest.api.service.impl;
 
 import static java.util.stream.Collectors.toList;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -213,6 +213,11 @@ public class AlertServiceTest {
 
     @NotNull
     protected AlertTrigger getAlertTriggerFromNew(NewAlertTriggerEntity alertEntity) throws JsonProcessingException {
+        return getAlertTriggerFromNew(alertEntity, executionContext.getEnvironmentId());
+    }
+
+    @NotNull
+    protected AlertTrigger getAlertTriggerFromNew(NewAlertTriggerEntity alertEntity, String environmentId) throws JsonProcessingException {
         var alert = new AlertTrigger();
         alert.setId(alertEntity.getId());
         alert.setName(alertEntity.getName());
@@ -234,6 +239,7 @@ public class AlertServiceTest {
         }
         alert.setEnabled(false);
         alert.setDefinition(objectMapper.writeValueAsString(alertEntity));
+        alert.setEnvironmentId(environmentId);
         return alert;
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/AE-128

## Description

Currently, it's possible to have an alert created during API creation if a template exists in another environment. To avoid this, templates are filtered by environment.





