### PR TITLE
fix: do not check domain name on serve to be able to use multitenant locally

### DIFF
--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -149,7 +149,7 @@
     "prettier:list": "prettier --list-different \"**/*.{js,ts,html,css,scss,json}\"",
     "storybook": "ng run apim-console:start-storybook",
     "build-storybook": "ng run apim-console:build-storybook",
-    "serve": "NODE_OPTIONS=--max_old_space_size=7168 ng serve",
+    "serve": "NODE_OPTIONS=--max_old_space_size=7168 ng serve --disable-host-check --host 0.0.0.0",
     "serve:apim-master": "BACKEND_ENV=apim-master-api.team-apim.gravitee.dev npm run serve",
     "test-old": "jest --config old-jest.config.js --detectOpenHandles",
     "test": "jest",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Today we can not use the multi-tenant locally because of angular 👿 Here is a PR to not check domain name on serve to be able to use multi-tenant locally.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wgtcvyqfsc.chromatic.com)
<!-- Storybook placeholder end -->
