### PR TITLE
fix: delete page revisions when api is deleted

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
@@ -46,4 +46,6 @@ public interface PageRevisionRepository extends FindAllRepository<PageRevision> 
      * @return
      */
     Optional<PageRevision> findLastByPageId(String pageId) throws TechnicalException;
+
+    void deleteAllByPageId(String pageId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRevisionRepository.java
@@ -134,4 +134,21 @@ public class JdbcPageRevisionRepository extends JdbcAbstractFindAllRepository<Pa
             throw new TechnicalException("Failed to find last revision by page id", ex);
         }
     }
+
+    @Override
+    public void deleteAllByPageId(String pageId) throws TechnicalException {
+        LOGGER.debug("JdbcPageRevisionRepository.deleteAllByPageId({})", pageId);
+        try {
+            String sql = "DELETE FROM " + this.tableName + " WHERE page_id = ?";
+            int rowsAffected = jdbcTemplate.update(sql, pageId);
+            LOGGER.debug("JdbcPageRevisionRepository.deleteAllByPageId({}) = {} rows deleted", pageId, rowsAffected);
+
+            if (rowsAffected == 0) {
+                LOGGER.warn("No revisions found for page id: {}", pageId);
+            }
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to delete revisions by page id: {}", pageId, ex);
+            throw new TechnicalException("Failed to delete revisions by page id", ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
@@ -108,6 +108,16 @@ public class MongoPageRevisionRepository implements PageRevisionRepository {
     }
 
     @Override
+    public void deleteAllByPageId(String pageId) throws TechnicalException {
+        try {
+            internalPageRevisionRepo.deleteAllByPageId(pageId);
+        } catch (Exception e) {
+            logger.error("An error occurred when deleting revision for page [{}]", pageId, e);
+            throw new TechnicalException("An error occurred when deleting the page revisions");
+        }
+    }
+
+    @Override
     public Set<PageRevision> findAll() throws TechnicalException {
         return internalPageRevisionRepo
             .findAll()

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/revision/PageRevisionMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/revision/PageRevisionMongoRepository.java
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Repository;
 public interface PageRevisionMongoRepository
     extends MongoRepository<PageRevisionMongo, PageRevisionPkMongo>, PageRevisionMongoRepositoryCustom {
     @Query(value = "{ '_id.pageId' : ?0 }", delete = true)
-    void deleteByPageId(String pageId);
+    void deleteAllByPageId(String pageId);
 
     @Query(value = "{ '_id.pageId' : ?0 }")
     List<PageRevisionMongo> findAllByPageId(String pageId);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRevisionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRevisionRepositoryTest.java
@@ -147,4 +147,26 @@ public class PageRevisionRepositoryTest extends AbstractManagementRepositoryTest
         assertNotNull(pageShouldExists);
         assertFalse(pageShouldExists.isPresent());
     }
+
+    @Test
+    public void shouldDeleteAllByPageId() throws TechnicalException {
+        List<PageRevision> revisionsBefore = pageRevisionRepository.findAllByPageId("findByPageId");
+        assertNotNull(revisionsBefore);
+        assertEquals(3, revisionsBefore.size());
+
+        pageRevisionRepository.deleteAllByPageId("findByPageId");
+
+        List<PageRevision> revisionsAfter = pageRevisionRepository.findAllByPageId("findByPageId");
+        assertNotNull(revisionsAfter);
+        assertEquals(0, revisionsAfter.size());
+    }
+
+    @Test
+    public void shouldDoNothingWhenNoRevisionsFoundWhileDeleting() throws TechnicalException {
+        pageRevisionRepository.deleteAllByPageId("nonExistingPageId");
+
+        List<PageRevision> revisionsAfter = pageRevisionRepository.findAllByPageId("nonExistingPageId");
+        assertNotNull(revisionsAfter);
+        assertEquals(0, revisionsAfter.size());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageRevisionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageRevisionService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service;
 
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.rest.api.model.PageRevisionEntity;
@@ -35,4 +36,6 @@ public interface PageRevisionService {
     List<PageRevisionEntity> findAllByPageId(String pageId);
 
     PageRevisionEntity create(Page page);
+
+    void deleteAllByPageId(String pageId) throws TechnicalException;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageRevisionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageRevisionServiceImpl.java
@@ -126,6 +126,11 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
         }
     }
 
+    @Override
+    public void deleteAllByPageId(String pageId) throws TechnicalException {
+        pageRevisionRepository.deleteAllByPageId(pageId);
+    }
+
     private PageRevisionEntity convert(PageRevision revision) {
         PageRevisionEntity entity = new PageRevisionEntity();
         entity.setPageId(revision.getPageId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2148,6 +2148,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
             pageRepository.delete(pageId);
 
+            // delete page revisions
+            pageRevisionService.deleteAllByPageId(pageId);
+
             // delete links and translations related to the page
             if (!PageType.LINK.name().equalsIgnoreCase(page.getType()) && !PageType.TRANSLATION.name().equalsIgnoreCase(page.getType())) {
                 this.deleteRelatedPages(page.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageRevisionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageRevisionServiceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.PageRevision;
 import io.gravitee.rest.api.model.PageRevisionEntity;
 import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.PageRevisionServiceImpl;
 import java.util.Date;
@@ -148,5 +149,17 @@ public class PageRevisionServiceTest {
         when(page.getId()).thenReturn(PAGE_ID);
         when(page.getType()).thenReturn(PageType.FOLDER.name());
         pageRevisionService.create(page);
+    }
+
+    @Test
+    public void shouldDeletePageRevision() throws TechnicalException {
+        pageRevisionService.deleteAllByPageId(PAGE_ID);
+        verify(pageRevisionRepository).deleteAllByPageId(PAGE_ID);
+    }
+
+    @Test(expected = TechnicalException.class)
+    public void shouldNotDeletePageRevisionBecauseTechnicalException() throws TechnicalException {
+        doThrow(TechnicalException.class).when(pageRevisionRepository).deleteAllByPageId(PAGE_ID);
+        pageRevisionService.deleteAllByPageId(PAGE_ID);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6959

## Description

Reopen this PR: https://github.com/gravitee-io/gravitee-api-management/pull/9657
Because we had to revert the previous commit before the maintenance release.