### PR TITLE
feat: target token command handler

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static io.gravitee.rest.api.service.cockpit.command.handler.UserCommandHandler.COCKPIT_SOURCE;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ORGANIZATION_USER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenCommand;
+import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenCommandPayload;
+import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenReply;
+import io.gravitee.exchange.api.command.CommandHandler;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.NewExternalUserEntity;
+import io.gravitee.rest.api.model.NewRoleEntity;
+import io.gravitee.rest.api.model.NewTokenEntity;
+import io.gravitee.rest.api.model.TokenEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.reactivex.rxjava3.core.Single;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TargetTokenCommandHandler implements CommandHandler<TargetTokenCommand, TargetTokenReply> {
+
+    public static final String CLOUD_TOKEN_SOURCE = "cloud-token";
+    public static final String TARGET_TOKEN_USER_NAME = "Cloud Token User";
+    public static final String TARGET_TOKEN_NAME = "Cloud Target Token";
+
+    private final UserService userService;
+    private final MembershipService membershipService;
+    private final RoleService roleService;
+    private final TokenService tokenService;
+
+    @Override
+    public String supportType() {
+        return CockpitCommandType.TARGET_TOKEN.name();
+    }
+
+    public Single<TargetTokenReply> handle(TargetTokenCommand command) {
+        TargetTokenCommandPayload payload = command.getPayload();
+        ExecutionContext context = new ExecutionContext(payload.organizationId(), payload.environmentId());
+        UserEntity user = null;
+        TokenEntity tokenEntity = null;
+
+        try {
+            user = createUser(context, command);
+            if (user == null) {
+                return Single.just(new TargetTokenReply(command.getId(), "Failed to create user."));
+            }
+
+            if (!assignOrganizationRole(context, payload, user)) {
+                rollbackUserCreation(context, user);
+                return Single.just(new TargetTokenReply(command.getId(), "Failed to assign organization role."));
+            }
+
+            if (!assignEnvironmentRole(context, payload, user)) {
+                rollbackMemberships(context, user);
+                rollbackUserCreation(context, user);
+                return Single.just(new TargetTokenReply(command.getId(), "Failed to assign environment role."));
+            }
+
+            tokenEntity = createToken(context, user);
+            return Single.just(new TargetTokenReply(command.getId(), CommandStatus.SUCCEEDED, tokenEntity.getToken()));
+        } catch (Exception e) {
+            log.error("Rolling back due to failure in handling target token command.", e);
+            rollbackTokenCreation(context, tokenEntity);
+            rollbackMemberships(context, user);
+            rollbackUserCreation(context, user);
+
+            String errorDetails = String.format(
+                "Error occurred creating cloud target token for organization [%s] and environment [%s].",
+                payload.organizationId(),
+                payload.environmentId()
+            );
+            return Single.just(new TargetTokenReply(command.getId(), errorDetails));
+        }
+    }
+
+    private UserEntity createUser(ExecutionContext context, TargetTokenCommand command) {
+        NewExternalUserEntity newUser = new NewExternalUserEntity();
+        newUser.setSourceId(command.getPayload().id());
+        newUser.setSource(CLOUD_TOKEN_SOURCE);
+        newUser.setLastname(TARGET_TOKEN_USER_NAME);
+
+        try {
+            UserEntity userEntity = userService.create(context, newUser, false);
+            log.info("Cloud target token user created with id [{}].", userEntity.getId());
+            return userEntity;
+        } catch (Exception e) {
+            log.error("Error occurred when creating cloud target token user.", e);
+            return null;
+        }
+    }
+
+    private boolean assignOrganizationRole(ExecutionContext context, TargetTokenCommandPayload payload, UserEntity user) {
+        String roleName = payload.scope() == TargetTokenCommandPayload.Scope.GKO
+            ? SystemRole.ADMIN.name()
+            : DEFAULT_ROLE_ORGANIZATION_USER.getName();
+        if (roleService.findByScopeAndName(RoleScope.ORGANIZATION, roleName, payload.organizationId()).isEmpty()) {
+            log.error("Couldn't find {} role for organization with id [{}]", roleName, payload.organizationId());
+            return false;
+        }
+
+        MembershipService.MembershipMember member = new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER);
+
+        MembershipService.MembershipReference reference = new MembershipService.MembershipReference(
+            MembershipReferenceType.ORGANIZATION,
+            payload.organizationId()
+        );
+        MembershipService.MembershipRole role = new MembershipService.MembershipRole(RoleScope.ORGANIZATION, roleName);
+        membershipService.updateRolesToMemberOnReference(
+            context,
+            reference,
+            member,
+            Collections.singletonList(role),
+            COCKPIT_SOURCE,
+            false
+        );
+
+        return true;
+    }
+
+    private boolean assignEnvironmentRole(ExecutionContext context, TargetTokenCommandPayload payload, UserEntity user) {
+        NewRoleEntity newRole = payload.scope() == TargetTokenCommandPayload.Scope.FEDERATION
+            ? ROLE_ENVIRONMENT_FEDERATION_AGENT
+            : ROLE_ENVIRONMENT_API_PUBLISHER;
+
+        if (roleService.findByScopeAndName(RoleScope.ENVIRONMENT, newRole.getName(), payload.environmentId()).isEmpty()) {
+            log.error("Couldn't find environment {} for organization with id [{}]", newRole.getName(), payload.organizationId());
+            return false;
+        }
+
+        MembershipService.MembershipMember member = new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER);
+        MembershipService.MembershipReference reference = new MembershipService.MembershipReference(
+            MembershipReferenceType.ENVIRONMENT,
+            payload.environmentId()
+        );
+        MembershipService.MembershipRole role = new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, newRole.getName());
+
+        membershipService.updateRolesToMemberOnReference(
+            context,
+            reference,
+            member,
+            Collections.singletonList(role),
+            COCKPIT_SOURCE,
+            false
+        );
+        return true;
+    }
+
+    private TokenEntity createToken(ExecutionContext context, UserEntity user) {
+        NewTokenEntity token = new NewTokenEntity();
+        token.setName(TARGET_TOKEN_NAME);
+        return tokenService.create(context, token, user.getId());
+    }
+
+    private void rollbackUserCreation(ExecutionContext context, UserEntity user) {
+        if (user != null) {
+            userService.delete(context, user.getId());
+            log.info("Rolled back user creation with id [{}].", user.getId());
+        }
+    }
+
+    private void rollbackMemberships(ExecutionContext context, UserEntity user) {
+        if (user != null) {
+            membershipService.removeMemberMemberships(context, MembershipMemberType.USER, user.getId());
+            log.info("Rolled back memberships for user [{}].", user.getId());
+        }
+    }
+
+    private void rollbackTokenCreation(ExecutionContext context, TokenEntity tokenEntity) {
+        if (tokenEntity != null) {
+            tokenService.revoke(context, tokenEntity.getId());
+            log.info("Revoked token with id [{}].", tokenEntity.getId());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.cockpit.command.handler;
+
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.DEFAULT_ROLE_ORGANIZATION_USER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
+import static java.util.Objects.nonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenCommand;
+import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenCommandPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.TokenEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.UserService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TargetTokenCommandHandlerTest {
+
+    private static final String ORGANISATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String COMMAND_ID = "command-id";
+    private static final String USER_CREATION_FAILED_MESSAGE = "Failed to create user.";
+    private static final String ORG_ROLE_ASSIGNMENT_FAILED_MESSAGE = "Failed to assign organization role.";
+    private static final String ENV_ROLE_ASSIGNMENT_FAILED_MESSAGE = "Failed to assign environment role.";
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @InjectMocks
+    private TargetTokenCommandHandler targetTokenCommandHandler;
+
+    private TargetTokenCommand command;
+    private UserEntity user;
+
+    @BeforeEach
+    void setUp() {
+        user = new UserEntity();
+        user.setId(USER_ID);
+    }
+
+    @Test
+    void shouldGenerateTokenSuccessfullyForGKO() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setToken("token gko");
+        when(tokenService.create(any(), any(), eq(USER_ID))).thenReturn(tokenEntity);
+
+        targetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(reply -> nonNull(reply.getCommandId()))
+            .assertValue(reply -> CommandStatus.SUCCEEDED.equals(reply.getCommandStatus()))
+            .assertValue(reply -> "token gko".equals(reply.getTargetToken()));
+    }
+
+    @Test
+    void shouldGenerateTokenSuccessfullyForFederation() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.FEDERATION));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(DEFAULT_ROLE_ORGANIZATION_USER.getName()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_FEDERATION_AGENT.getName()), eq(ENVIRONMENT_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+
+        TokenEntity tokenEntity = new TokenEntity();
+        tokenEntity.setToken("token federation");
+        when(tokenService.create(any(), any(), eq(USER_ID))).thenReturn(tokenEntity);
+
+        targetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(reply -> nonNull(reply.getCommandId()))
+            .assertValue(reply -> CommandStatus.SUCCEEDED.equals(reply.getCommandStatus()))
+            .assertValue(reply -> "token federation".equals(reply.getTargetToken()));
+    }
+
+    @Test
+    void shouldReturnErrorWhenUserCreationFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenThrow(new RuntimeException("User creation failed"));
+
+        targetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()))
+            .assertValue(reply -> reply.getErrorDetails().contains(USER_CREATION_FAILED_MESSAGE));
+    }
+
+    @Test
+    void shouldReturnErrorWhenOrganizationRoleAssignmentFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.empty());
+
+        targetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()))
+            .assertValue(reply -> reply.getErrorDetails().contains(ORG_ROLE_ASSIGNMENT_FAILED_MESSAGE));
+    }
+
+    @Test
+    void shouldRollbackUserCreationWhenOrganizationRoleAssignmentFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.empty());
+
+        targetTokenCommandHandler.handle(command).test().awaitDone(2, SECONDS);
+
+        verify(userService, times(1)).delete(any(), eq(USER_ID));
+    }
+
+    @Test
+    void shouldReturnErrorWhenEnvironmentRoleAssignmentFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+            .thenReturn(Optional.empty());
+
+        targetTokenCommandHandler
+            .handle(command)
+            .test()
+            .awaitDone(2, SECONDS)
+            .assertValue(reply -> CommandStatus.ERROR.equals(reply.getCommandStatus()))
+            .assertValue(reply -> reply.getErrorDetails().contains(ENV_ROLE_ASSIGNMENT_FAILED_MESSAGE));
+    }
+
+    @Test
+    void shouldRollbackUserCreationAndMembershipAssignmentWhenEnvironmentRoleAssignmentFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+            .thenReturn(Optional.empty());
+
+        targetTokenCommandHandler.handle(command).test().awaitDone(2, SECONDS);
+
+        verify(userService, times(1)).delete(any(), eq(USER_ID));
+        verify(membershipService, times(1)).removeMemberMemberships(any(), eq(MembershipMemberType.USER), eq(USER_ID));
+    }
+
+    @Test
+    void shouldRollbackUserCreationAndMembershipAssignmentWhenTokenCreationFails() {
+        command = new TargetTokenCommand(generatePayload(TargetTokenCommandPayload.Scope.GKO));
+
+        when(userService.create(any(), any(), eq(false))).thenReturn(user);
+        when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+            .thenReturn(Optional.of(new RoleEntity()));
+        when(tokenService.create(any(), any(), anyString())).thenThrow(new RuntimeException("Token creation failed"));
+
+        targetTokenCommandHandler.handle(command).test().awaitDone(2, SECONDS);
+
+        verify(userService, times(1)).delete(any(), eq(USER_ID));
+        verify(membershipService, times(1)).removeMemberMemberships(any(), eq(MembershipMemberType.USER), eq(USER_ID));
+    }
+
+    private static TargetTokenCommandPayload generatePayload(TargetTokenCommandPayload.Scope scope) {
+        return TargetTokenCommandPayload
+            .builder()
+            .organizationId(ORGANISATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .id(COMMAND_ID)
+            .scope(scope)
+            .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>8.1.16</gravitee-bom.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>3.4.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>3.6.1</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.0.2</gravitee-cloud-initializer.version>
         <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
         <gravitee-common.version>4.5.1</gravitee-common.version>


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/CJ-1874
https://gravitee.atlassian.net/browse/CJ-2539

## Description

In Gravitee Cloud we are adding an option to generate a cloud token for use with Federation or GKO. This cloud token needs to contain a target token. Cloud gate will use the cloud token to direct the traffic correctly and use the target token for authentication.  

More information available here: https://gravitee.slab.com/posts/prd-cloud-token-generation-for-federation-and-gko-co1v3dkg and https://gravitee.slab.com/posts/cloud-gate-technical-specifications-2j1vesgq 

**Implementation**: 
Target token create command handler:
* Create new user for cloud token
* Give this new user roles depending on if used for GKO or Federation
* Generate token for this user and return the token value in reply to command

Rollback user creation, memberships and token creation if an exception occurs (whatever has been created so far)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tiesctnwwd.chromatic.com)
<!-- Storybook placeholder end -->
