### PR TITLE
APIM-6981: fix code block in documentation pre wrap

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -49,6 +49,9 @@
   max-width: 100%;
   display: inline;
   overflow: auto;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 app-gv-markdown-toc {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-6981

## Description

Added word-break, pre wrap for code blocks inside documentation as they are wrapped within pre tag.

## Additional context

Before:
<img width="1503" alt="Before" src="https://github.com/user-attachments/assets/20896e32-7593-4217-8204-adf01498d1a9">


After:
<img width="1502" alt="After" src="https://github.com/user-attachments/assets/b8991448-7351-463f-9da8-2da292843376">

