### PR TITLE
feat: endpoint to get request response time analytics for all v4 APIs for environment 

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -20,6 +20,8 @@ import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
@@ -48,4 +50,6 @@ public interface AnalyticsRepository {
     Maybe<AverageAggregate> searchResponseTimeOverTime(QueryContext queryContext, ResponseTimeRangeQuery query);
 
     ResponseStatusOverTimeAggregate searchResponseStatusOvertime(QueryContext queryContext, ResponseStatusOverTimeQuery query);
+
+    RequestResponseTimeAggregate searchRequestResponseTimes(QueryContext queryContext, RequestResponseTimeQueryCriteria query);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/RequestResponseTimeAggregate.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/RequestResponseTimeAggregate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class RequestResponseTimeAggregate {
+
+    double requestsPerSecond;
+    long requestsTotal;
+    double responseMinTime;
+    double responseMaxTime;
+    double responseAvgTime;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/RequestResponseTimeQueryCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/RequestResponseTimeQueryCriteria.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor
+public class RequestResponseTimeQueryCriteria {
+
+    List<String> apiIds;
+    long from;
+    long to;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageCo
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageConnectionDurationResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageMessagesPerRequestQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchAverageMessagesPerRequestResponseAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchRequestResponseTimeAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchRequestsCountQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchRequestsCountResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchResponseStatusOverTimeAdapter;
@@ -36,6 +37,8 @@ import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
@@ -134,5 +137,19 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
 
         log.debug("Search response top hit query: {}", esQuery);
         return this.client.search(index, null, esQuery).map(SearchTopHitsAdapter::adaptResponse).blockingGet();
+    }
+
+    @Override
+    public RequestResponseTimeAggregate searchRequestResponseTimes(
+        QueryContext queryContext,
+        RequestResponseTimeQueryCriteria queryCriteria
+    ) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+        var esQuery = SearchRequestResponseTimeAdapter.adaptQuery(queryCriteria);
+
+        log.debug("Search request response time query: {}", esQuery);
+        return this.client.search(index, null, esQuery)
+            .map(response -> SearchRequestResponseTimeAdapter.adaptResponse(response, queryCriteria))
+            .blockingGet();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchRequestResponseTimeAdapter {
+
+    private static final List<String> FILTERED_ENTRYPOINT_TYPES = List.of("http-post", "http-get", "http-proxy");
+    private static final String GATEWAY_RESPONSE_TIME_MS_FIELD = "gateway-response-time-ms";
+    private static final String MAX_RESPONSE_TIME_AGG = "max_response_time";
+    private static final String MIN_RESPONSE_TIME_AGG = "min_response_time";
+    private static final String AVG_RESPONSE_TIME_AGG = "avg_response_time";
+
+    public static String adaptQuery(RequestResponseTimeQueryCriteria queryCriteria) {
+        var jsonContent = new HashMap<String, Object>();
+
+        jsonContent.put("size", 0);
+        jsonContent.put("query", buildQuery(queryCriteria));
+        jsonContent.put("aggs", buildAggregation());
+        return new JsonObject(jsonContent).encode();
+    }
+
+    private static JsonObject buildQuery(RequestResponseTimeQueryCriteria queryCriteria) {
+        var filterQuery = new ArrayList<JsonObject>();
+
+        if (queryCriteria == null || queryCriteria.getApiIds() == null) {
+            log.warn("Null query params or queried API IDs. Empty ranges will be returned");
+            filterQuery.add(apiIdsFilterForQuery(List.of()));
+        } else {
+            filterQuery.add(apiIdsFilterForQuery(queryCriteria.getApiIds()));
+        }
+
+        if (queryCriteria != null) {
+            filterQuery.add(dateRangeFilterForQuery(queryCriteria.getFrom(), queryCriteria.getTo()));
+        }
+
+        filterQuery.add(entrypointFilterForQuery());
+
+        return JsonObject.of("bool", JsonObject.of("filter", filterQuery));
+    }
+
+    private static JsonObject apiIdsFilterForQuery(List<String> apiIds) {
+        return JsonObject.of("terms", JsonObject.of("api-id", apiIds));
+    }
+
+    private static JsonObject dateRangeFilterForQuery(Long from, Long to) {
+        log.info("Top Hits Query: filtering date range from {} to {}", from, to);
+        return JsonObject.of("range", JsonObject.of("@timestamp", JsonObject.of("gte", from, "lte", to)));
+    }
+
+    private static JsonObject entrypointFilterForQuery() {
+        return JsonObject.of("terms", JsonObject.of("entrypoint-id", FILTERED_ENTRYPOINT_TYPES));
+    }
+
+    private static JsonObject buildAggregation() {
+        return JsonObject.of(
+            MAX_RESPONSE_TIME_AGG,
+            JsonObject.of("max", JsonObject.of("field", GATEWAY_RESPONSE_TIME_MS_FIELD)),
+            MIN_RESPONSE_TIME_AGG,
+            JsonObject.of("min", JsonObject.of("field", GATEWAY_RESPONSE_TIME_MS_FIELD)),
+            AVG_RESPONSE_TIME_AGG,
+            JsonObject.of("avg", JsonObject.of("field", GATEWAY_RESPONSE_TIME_MS_FIELD))
+        );
+    }
+
+    public static RequestResponseTimeAggregate adaptResponse(SearchResponse response, RequestResponseTimeQueryCriteria queryCriteria) {
+        final Map<String, Aggregation> aggregations = response.getAggregations();
+        var requestResponseTimeAggregateBuilder = RequestResponseTimeAggregate.builder();
+
+        if (aggregations == null || aggregations.isEmpty() || queryCriteria == null) {
+            return requestResponseTimeAggregateBuilder.build();
+        }
+
+        requestResponseTimeAggregateBuilder.responseMinTime(getAggregationResponseValue(aggregations, MIN_RESPONSE_TIME_AGG));
+        requestResponseTimeAggregateBuilder.responseMaxTime(getAggregationResponseValue(aggregations, MAX_RESPONSE_TIME_AGG));
+        requestResponseTimeAggregateBuilder.responseAvgTime(getAggregationResponseValue(aggregations, AVG_RESPONSE_TIME_AGG));
+
+        if (response.getSearchHits() != null && response.getSearchHits().getTotal() != null) {
+            var totalRequestValue = response.getSearchHits().getTotal().getValue();
+            requestResponseTimeAggregateBuilder.requestsTotal(totalRequestValue);
+
+            var timeDiffInSeconds = ((queryCriteria.getTo() - queryCriteria.getFrom()) / 1000);
+            double requestsPerSecond = (double) totalRequestValue / timeDiffInSeconds;
+            requestResponseTimeAggregateBuilder.requestsPerSecond(requestsPerSecond);
+        }
+
+        return requestResponseTimeAggregateBuilder.build();
+    }
+
+    private static Double getAggregationResponseValue(Map<String, Aggregation> aggregations, String aggregationName) {
+        var aggregation = aggregations.get(aggregationName);
+        if (aggregation == null || aggregation.getValue() == null) {
+            log.error("Aggregation with name {} not found", aggregationName);
+            return 0.0;
+        }
+        return aggregation.getValue().doubleValue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/SearchRequestResponseTimeAdapterTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.adapter;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchHits;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.elasticsearch.model.TotalHits;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SearchRequestResponseTimeAdapterTest {
+
+    private static final long FROM = 1728992401566L;
+    private static final long TO = 1729078801566L;
+    private static final List<String> API_IDS = List.of("api-id-1", "api-id-2");
+
+    @Nested
+    class Query {
+
+        @Test
+        void should_build_request_response_time_query_searching_for_ids_and_time_ranges() {
+            var queryParams = new RequestResponseTimeQueryCriteria(API_IDS, FROM, TO);
+
+            var result = SearchRequestResponseTimeAdapter.adaptQuery(queryParams);
+
+            assertThatJson(result).isEqualTo(REQUEST_RESPONSE_TIME_QUERY_WITH_API_IDS_AND_TIME_RANGES);
+        }
+
+        @Test
+        void should_build_top_hits_query_with_empty_id_filter_array_for_null_query_params() {
+            RequestResponseTimeQueryCriteria queryParams = null;
+
+            var result = SearchRequestResponseTimeAdapter.adaptQuery(queryParams);
+
+            assertThatJson(result).isEqualTo(REQUEST_RESPONSE_TIME_QUERY_WITH_NULL_QUERY_PARAMS);
+        }
+
+        @Test
+        void should_build_top_hits_query_with_empty_id_filter_array_for_empty_api_ids_query_params() {
+            var queryParams = new RequestResponseTimeQueryCriteria(List.of(), FROM, TO);
+            var result = SearchRequestResponseTimeAdapter.adaptQuery(queryParams);
+
+            assertThatJson(result).isEqualTo(REQUEST_RESPONSE_TIME_QUERY_WITH_EMPTY_ID_LIST);
+        }
+
+        private static final String REQUEST_RESPONSE_TIME_QUERY_WITH_API_IDS_AND_TIME_RANGES =
+            """
+                {
+                    "size": 0,
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "api-id": [
+                                            "api-id-1",
+                                            "api-id-2"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "range": {
+                                        "@timestamp": {
+                                            "gte": 1728992401566,
+                                            "lte": 1729078801566
+                                        }
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "entrypoint-id": [
+                                            "http-post",
+                                            "http-get",
+                                            "http-proxy"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggs": {
+                        "max_response_time": {
+                            "max": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "min_response_time": {
+                            "min": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "avg_response_time": {
+                            "avg": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        }
+                    }
+                }
+                """;
+
+        private static final String REQUEST_RESPONSE_TIME_QUERY_WITH_NULL_QUERY_PARAMS =
+            """
+                {
+                    "size": 0,
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "api-id": []
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "entrypoint-id": [
+                                            "http-post",
+                                            "http-get",
+                                            "http-proxy"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggs": {
+                        "max_response_time": {
+                            "max": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "min_response_time": {
+                            "min": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "avg_response_time": {
+                            "avg": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        }
+                    }
+                }
+                """;
+
+        private static final String REQUEST_RESPONSE_TIME_QUERY_WITH_EMPTY_ID_LIST =
+            """
+                {
+                    "size": 0,
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "terms": {
+                                        "api-id": []
+                                    }
+                                },
+                                {
+                                    "range": {
+                                        "@timestamp": {
+                                            "gte": 1728992401566,
+                                            "lte": 1729078801566
+                                        }
+                                    }
+                                },
+                                {
+                                    "terms": {
+                                        "entrypoint-id": [
+                                            "http-post",
+                                            "http-get",
+                                            "http-proxy"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "aggs": {
+                        "max_response_time": {
+                            "max": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "min_response_time": {
+                            "min": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        },
+                        "avg_response_time": {
+                            "avg": {
+                                "field": "gateway-response-time-ms"
+                            }
+                        }
+                    }
+                }
+                """;
+    }
+
+    @Nested
+    class Response {
+
+        private final SearchResponse searchResponse = new SearchResponse();
+        private final RequestResponseTimeQueryCriteria queryParams = new RequestResponseTimeQueryCriteria(API_IDS, FROM, TO);
+
+        @Test
+        void should_return_empty_result_if_aggregations_is_null() {
+            assertThat(SearchRequestResponseTimeAdapter.adaptResponse(searchResponse, queryParams))
+                .isEqualTo(RequestResponseTimeAggregate.builder().build());
+        }
+
+        @Test
+        void should_return_just_zeros_result_if_no_aggregation_exist() {
+            searchResponse.setAggregations(Map.of());
+
+            assertThat(SearchRequestResponseTimeAdapter.adaptResponse(searchResponse, queryParams))
+                .isEqualTo(RequestResponseTimeAggregate.builder().build());
+        }
+
+        @Test
+        void should_return_just_zeros_result_if_no_top_hits_count_aggregation_exist() {
+            searchResponse.setAggregations(Map.of("fake_aggregation", new Aggregation()));
+
+            assertThat(SearchRequestResponseTimeAdapter.adaptResponse(searchResponse, queryParams))
+                .isEqualTo(RequestResponseTimeAggregate.builder().build());
+        }
+
+        @Test
+        void should_return_just_zeros_result_if_query_criteria_is_null() {
+            assertThat(SearchRequestResponseTimeAdapter.adaptResponse(searchResponse, null))
+                .isEqualTo(RequestResponseTimeAggregate.builder().build());
+        }
+
+        @Test
+        void should_return_request_response_time_aggregate() {
+            final Aggregation minResponseTimeAggregation = new Aggregation();
+            minResponseTimeAggregation.setValue(20.0f);
+            final Aggregation maxResponseTimeAggregation = new Aggregation();
+            maxResponseTimeAggregation.setValue(1200.0f);
+            final Aggregation avgResponseTimeAggregation = new Aggregation();
+            avgResponseTimeAggregation.setValue(335.23f);
+
+            searchResponse.setAggregations(
+                Map.of(
+                    "max_response_time",
+                    maxResponseTimeAggregation,
+                    "min_response_time",
+                    minResponseTimeAggregation,
+                    "avg_response_time",
+                    avgResponseTimeAggregation
+                )
+            );
+
+            final SearchHits searchHits = new SearchHits();
+            searchHits.setTotal(new TotalHits(4L));
+            searchResponse.setSearchHits(searchHits);
+
+            var result = SearchRequestResponseTimeAdapter.adaptResponse(searchResponse, queryParams);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getRequestsPerSecond()).isEqualTo(4.6296296296296294E-5);
+                soft.assertThat(result.getRequestsTotal()).isEqualTo(4);
+                soft.assertThat(result.getResponseMinTime()).isEqualTo(20.0);
+                soft.assertThat(result.getResponseMaxTime()).isEqualTo(1200.0);
+                soft.assertThat(result.getResponseAvgTime()).isEqualTo(335.2300109863281);
+            });
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EnvironmentAnalyticsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/EnvironmentAnalyticsMapper.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsRequestResponseTimeResponse;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsResponseStatusRangesResponse;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsTopHitsApisResponse;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
 import io.gravitee.rest.api.model.v4.analytics.ResponseStatusRanges;
 import io.gravitee.rest.api.model.v4.analytics.TopHitsApis;
 import org.mapstruct.Mapper;
@@ -29,4 +31,6 @@ public interface EnvironmentAnalyticsMapper {
     EnvironmentAnalyticsResponseStatusRangesResponse map(ResponseStatusRanges responseStatusRanges);
 
     EnvironmentAnalyticsTopHitsApisResponse map(TopHitsApis topHitsApis);
+
+    EnvironmentAnalyticsRequestResponseTimeResponse map(RequestResponseTime requestResponseTime);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
@@ -16,9 +16,11 @@
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
 import io.gravitee.apim.core.analytics.model.EnvironmentAnalyticsQueryParameters;
+import io.gravitee.apim.core.analytics.use_case.SearchEnvironmentRequestResponseTimeUseCase;
 import io.gravitee.apim.core.analytics.use_case.SearchEnvironmentResponseStatusRangesUseCase;
 import io.gravitee.apim.core.analytics.use_case.SearchEnvironmentTopHitsApisCountUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.EnvironmentAnalyticsMapper;
+import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsRequestResponseTimeResponse;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsResponseStatusRangesResponse;
 import io.gravitee.rest.api.management.v2.rest.model.EnvironmentAnalyticsTopHitsApisResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.environment.param.TimeRangeParam;
@@ -40,6 +42,9 @@ public class EnvironmentAnalyticsResource {
 
     @Inject
     SearchEnvironmentTopHitsApisCountUseCase searchEnvironmentTopHitsApisCountUseCase;
+
+    @Inject
+    SearchEnvironmentRequestResponseTimeUseCase searchEnvironmentRequestResponseTimeUseCase;
 
     @Path("/response-status-ranges")
     @GET
@@ -67,5 +72,19 @@ public class EnvironmentAnalyticsResource {
             .topHitsApis()
             .map(EnvironmentAnalyticsMapper.INSTANCE::map)
             .orElse(EnvironmentAnalyticsTopHitsApisResponse.builder().data(List.of()).build());
+    }
+
+    @Path("/request-response-time")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public EnvironmentAnalyticsRequestResponseTimeResponse getRequestResponseTime(@BeanParam @Valid TimeRangeParam timeRangeParam) {
+        var params = EnvironmentAnalyticsQueryParameters.builder().from(timeRangeParam.getFrom()).to(timeRangeParam.getTo()).build();
+        var input = new SearchEnvironmentRequestResponseTimeUseCase.Input(GraviteeContext.getExecutionContext(), params);
+
+        return searchEnvironmentRequestResponseTimeUseCase
+            .execute(input)
+            .requestResponseTime()
+            .map(EnvironmentAnalyticsMapper.INSTANCE::map)
+            .orElse(EnvironmentAnalyticsRequestResponseTimeResponse.builder().build());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2064,23 +2064,23 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/analytics/response-time-over-time:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - API Analytics
-        summary: Get API Analytics average response time over 24h by interval of 30 minutes
-        description: |-
-          Get API Analytics average response time over 24h by interval of 30 minutes
-          
-          User must have the API_ANALYTICS[READ] permission.
-        operationId: getAverageConnectionDuration
-        responses:
-          "200":
-            $ref: "#/components/responses/ApiAnalyticsAverageConnectionDurationResponse"
-          default:
-            $ref: "#/components/responses/Error"
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - API Analytics
+            summary: Get API Analytics average response time over 24h by interval of 30 minutes
+            description: |-
+                Get API Analytics average response time over 24h by interval of 30 minutes
+
+                User must have the API_ANALYTICS[READ] permission.
+            operationId: getAverageConnectionDuration
+            responses:
+                "200":
+                    $ref: "#/components/responses/ApiAnalyticsAverageConnectionDurationResponse"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/analytics/response-statuses-over-time:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -2445,50 +2445,50 @@ paths:
 
     # API SpecGen
     /environments/{envId}/apis/{apiId}/spec-gen/_state:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - API SpecGen
-        summary: Evaluate the state of the API SpecGen
-        description: |-
-          Evaluate the state of the API SpecGen
-          
-          User must have the API_DOCUMENTATION[READ] permission.
-        operationId: getSpecGenState
-        responses:
-          "200":
-            description: API Scoring trigger response
-            content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/ApiSpecGenRequestState"
-          default:
-            $ref: "#/components/responses/Error"
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - API SpecGen
+            summary: Evaluate the state of the API SpecGen
+            description: |-
+                Evaluate the state of the API SpecGen
+
+                User must have the API_DOCUMENTATION[READ] permission.
+            operationId: getSpecGenState
+            responses:
+                "200":
+                    description: API Scoring trigger response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiSpecGenRequestState"
+                default:
+                    $ref: "#/components/responses/Error"
 
     /environments/{envId}/apis/{apiId}/spec-gen/_start:
-      parameters:
-        - $ref: "#/components/parameters/envIdParam"
-        - $ref: "#/components/parameters/apiIdParam"
-      get:
-        tags:
-          - API SpecGen
-        summary: Starts the API SpecGen
-        description: |-
-          Starts the API SpecGen
-          
-          User must have the API_DOCUMENTATION[CREATE] permission.
-        operationId: post
-        responses:
-          "200":
-            description: API Scoring trigger response
-            content:
-              application/json:
-                schema:
-                  $ref: "#/components/schemas/ApiSpecGenRequestState"
-          default:
-            $ref: "#/components/responses/Error"
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        get:
+            tags:
+                - API SpecGen
+            summary: Starts the API SpecGen
+            description: |-
+                Starts the API SpecGen
+
+                User must have the API_DOCUMENTATION[CREATE] permission.
+            operationId: post
+            responses:
+                "200":
+                    description: API Scoring trigger response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiSpecGenRequestState"
+                default:
+                    $ref: "#/components/responses/Error"
     # API Scoring
     /environments/{envId}/apis/{apiId}/scoring/_evaluate:
         parameters:
@@ -2646,6 +2646,26 @@ paths:
             responses:
                 "200":
                     $ref: "#/components/responses/EnvironmentAnalyticsTopHitsApisResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/analytics/request-response-time:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            parameters:
+                - $ref: "#/components/parameters/from"
+                - $ref: "#/components/parameters/to"
+            tags:
+                - Environment Analytics
+            summary: V4 APIs request and response times analytics
+            description: |-
+                Get analytics for v4 APIs regarding number of requests, requests per second and response max, min and average times for 
+                specified time range. Analytics contains data only for HTTP GET, HTTP POST and HTTP PROXY entrypoints.
+
+            operationId: getDashboardRequestResponseTime
+            responses:
+                "200":
+                    $ref: "#/components/responses/EnvironmentAnalyticsRequestResponseTimeResponse"
                 default:
                     $ref: "#/components/responses/Error"
 
@@ -4742,7 +4762,7 @@ components:
                     items:
                         type: string
                     description: The list of ids of APIs to ingest. If null or empty, ingest all.
-            required: ['apiIds']
+            required: ["apiIds"]
 
         CreateSubscription:
             type: object
@@ -7004,23 +7024,23 @@ components:
                         type: string
             required:
                 - name
-      # API SpecGen
+        # API SpecGen
         ApiSpecGenRequestState:
             type: object
             description: API SpecGen state.
             properties:
-              state:
-                $ref: "#/components/schemas/SpecGenState"
+                state:
+                    $ref: "#/components/schemas/SpecGenState"
         SpecGenState:
             type: string
             description: API SpecGen state value
             example: AVAILABLE
             enum:
-              - AVAILABLE
-              - UNAVAILABLE
-              - STARTED
-              - GENERATING
-      # API Scoring
+                - AVAILABLE
+                - UNAVAILABLE
+                - STARTED
+                - GENERATING
+        # API Scoring
         ApiScoringTriggerResponse:
             type: object
             properties:
@@ -7786,40 +7806,40 @@ components:
                                     description: A map of rounded average connection duration by entrypoint
                                     type: number
         ApiAnalyticsOverPeriodResponse:
-          description: Analytics for number over period
-          content:
-            application/json:
-              schema:
-                title: "ApiAnalyticsOverPeriodResponse"
-                description: API Analytics integer data point on a period.
-                properties:
-                  timeRange:
-                    type: object
-                    description: Time range of the analytics
-                    properties:
-                      from:
-                        type: integer
-                        format: int64
-                        description: The timestamp starting the time range
-                        example: 1621339200000
-                      to:
-                        type: integer
-                        format: int64
-                        description: The timestamp ending the time range
-                        example: 1621425600000
-                      interval:
-                        type: integer
-                        format: int64
-                        description: The interval in milliseconds splitting the data
-                        example: 120000
-                  data:
-                    type: array
-                    description: Response time average (in milliseconds) over time
-                    items:
-                      type: integer
-                      format: int64
-                      minimum: 0
-                      exclusiveMinimum: true
+            description: Analytics for number over period
+            content:
+                application/json:
+                    schema:
+                        title: "ApiAnalyticsOverPeriodResponse"
+                        description: API Analytics integer data point on a period.
+                        properties:
+                            timeRange:
+                                type: object
+                                description: Time range of the analytics
+                                properties:
+                                    from:
+                                        type: integer
+                                        format: int64
+                                        description: The timestamp starting the time range
+                                        example: 1621339200000
+                                    to:
+                                        type: integer
+                                        format: int64
+                                        description: The timestamp ending the time range
+                                        example: 1621425600000
+                                    interval:
+                                        type: integer
+                                        format: int64
+                                        description: The interval in milliseconds splitting the data
+                                        example: 120000
+                            data:
+                                type: array
+                                description: Response time average (in milliseconds) over time
+                                items:
+                                    type: integer
+                                    format: int64
+                                    minimum: 0
+                                    exclusiveMinimum: true
         ApiAnalyticsResponseStatusRangesResponse:
             description: Analytics for status codes by entrypoint
             content:
@@ -7868,41 +7888,41 @@ components:
                                             500.0-600.0:
                                                 value: 0
         ApiAnalyticsResponseStatusOvertimeResponse:
-          description: Analytics for status codes over time
-          content:
-            application/json:
-              schema:
-                title: "ApiAnalyticsResponseStatusOvertimeResponse"
-                description: API Analytics for status codes over time.
-                properties:
-                  timeRange:
-                    type: object
-                    description: Time range of the analytics
-                    properties:
-                      from:
-                        type: integer
-                        format: int64
-                        description: The timestamp starting the time range
-                        example: 1621339200000
-                      to:
-                        type: integer
-                        format: int64
-                        description: The timestamp ending the time range
-                        example: 1621425600000
-                      interval:
-                        type: integer
-                        format: int64
-                        description: The interval in milliseconds splitting the data
-                        example: 120000
-                  data:
-                    type: object
-                    description: Status count overt time
-                    additionalProperties:
-                      description: A map of response status and counts
-                      type: array
-                      items:
-                        type: integer
-                        format: int64
+            description: Analytics for status codes over time
+            content:
+                application/json:
+                    schema:
+                        title: "ApiAnalyticsResponseStatusOvertimeResponse"
+                        description: API Analytics for status codes over time.
+                        properties:
+                            timeRange:
+                                type: object
+                                description: Time range of the analytics
+                                properties:
+                                    from:
+                                        type: integer
+                                        format: int64
+                                        description: The timestamp starting the time range
+                                        example: 1621339200000
+                                    to:
+                                        type: integer
+                                        format: int64
+                                        description: The timestamp ending the time range
+                                        example: 1621425600000
+                                    interval:
+                                        type: integer
+                                        format: int64
+                                        description: The interval in milliseconds splitting the data
+                                        example: 120000
+                            data:
+                                type: object
+                                description: Status count overt time
+                                additionalProperties:
+                                    description: A map of response status and counts
+                                    type: array
+                                    items:
+                                        type: integer
+                                        format: int64
         EnvironmentAnalyticsResponseStatusRangesResponse:
             description: Analytics for status codes by entrypoint at environment level
             content:
@@ -7941,6 +7961,40 @@ components:
                                 description: List of top hit results
                                 items:
                                     $ref: "#/components/schemas/TopHitApi"
+        EnvironmentAnalyticsRequestResponseTimeResponse:
+            description: Analytics for request response times at environment level
+            content:
+                application/json:
+                    schema:
+                        title: "EnvironmentAnalyticsRequestResponseTimeResponse"
+                        description: Analytics for top hits APIs at environment level
+                        properties:
+                            requestsPerSecond:
+                                type: number
+                                format: double
+                                description: Number of requests per second
+                                example: 0.7
+                            requestsTotal:
+                                type: number
+                                format: int64
+                                description: Total number of requests
+                                example: 3567
+                            responseMinTime:
+                                type: number
+                                format: double
+                                description: Response minimum time in ms
+                                example: 32.23
+                            responseMaxTime:
+                                type: number
+                                format: double
+                                description: Response maximum time in ms
+                                example: 7240.11
+                            responseAvgTime:
+                                type: number
+                                format: double
+                                description: Response average time in ms
+                                example: 89.2
+
         # Analytics - Logs
         ApiLogsResponse:
             description: Page of API Logs

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/analytics/RequestResponseTime.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/analytics/RequestResponseTime.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.analytics;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RequestResponseTime {
+
+    private Double requestsPerSecond;
+    private Long requestsTotal;
+    private Double responseMinTime;
+    private Double responseMaxTime;
+    private Double responseAvgTime;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/query_service/AnalyticsQueryService.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.analytics.model.EnvironmentAnalyticsQueryParameters
 import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
 import io.gravitee.rest.api.model.v4.analytics.ResponseStatusRanges;
 import io.gravitee.rest.api.model.v4.analytics.TopHitsApis;
@@ -52,6 +53,8 @@ public interface AnalyticsQueryService {
     );
 
     ResponseStatusOvertime searchResponseStatusOvertime(ExecutionContext executionContext, ResponseStatusOverTimeQuery query);
+
+    RequestResponseTime searchRequestResponseTime(ExecutionContext executionContext, EnvironmentAnalyticsQueryParameters parameters);
 
     record ResponseStatusOverTimeQuery(String apiId, Instant from, Instant to, Duration interval) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentRequestResponseTimeUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentRequestResponseTimeUseCase.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics.model.EnvironmentAnalyticsQueryParameters;
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@AllArgsConstructor
+public class SearchEnvironmentRequestResponseTimeUseCase {
+
+    private final ApiQueryService apiQueryService;
+    private final AnalyticsQueryService analyticsQueryService;
+
+    public Output execute(Input input) {
+        var envId = input.executionContext().getEnvironmentId();
+        var v4Apis = getAllV4ApisIdsForEnv(envId);
+
+        log.info("Searching Request Response Time, found: {} v4 APIs for env: {}", v4Apis.size(), envId);
+
+        var requestResponseTime = analyticsQueryService.searchRequestResponseTime(
+            input.executionContext(),
+            input.parameters().withApiIds(v4Apis)
+        );
+
+        return new Output(requestResponseTime);
+    }
+
+    private List<String> getAllV4ApisIdsForEnv(String envId) {
+        return apiQueryService
+            .search(
+                ApiSearchCriteria.builder().environmentId(envId).definitionVersion(List.of(DefinitionVersion.V4)).build(),
+                null,
+                ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build()
+            )
+            .map(Api::getId)
+            .toList();
+    }
+
+    @Builder
+    public record Input(ExecutionContext executionContext, EnvironmentAnalyticsQueryParameters parameters) {}
+
+    public record Output(Optional<RequestResponseTime> requestResponseTime) {
+        Output(RequestResponseTime requestResponseTime) {
+            this(Optional.of(requestResponseTime));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImpl.java
@@ -23,12 +23,14 @@ import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.log.v4.model.analytics.AverageAggregate;
 import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQuery;
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeQueryCriteria;
 import io.gravitee.repository.log.v4.model.analytics.RequestsCountQuery;
 import io.gravitee.repository.log.v4.model.analytics.ResponseTimeRangeQuery;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsAggregate;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsQueryCriteria;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
 import io.gravitee.rest.api.model.v4.analytics.ResponseStatusRanges;
 import io.gravitee.rest.api.model.v4.analytics.TopHitsApis;
@@ -163,6 +165,26 @@ public class AnalyticsQueryServiceImpl implements AnalyticsQueryService {
             .builder()
             .data(result.getStatusCount())
             .timeRange(new ResponseStatusOvertime.TimeRange(query.from(), query.to(), query.interval()))
+            .build();
+    }
+
+    @Override
+    public RequestResponseTime searchRequestResponseTime(
+        ExecutionContext executionContext,
+        EnvironmentAnalyticsQueryParameters parameters
+    ) {
+        var result = analyticsRepository.searchRequestResponseTimes(
+            executionContext.getQueryContext(),
+            new RequestResponseTimeQueryCriteria(parameters.getApiIds(), parameters.getFrom(), parameters.getTo())
+        );
+
+        return RequestResponseTime
+            .builder()
+            .requestsPerSecond(result.getRequestsPerSecond())
+            .requestsTotal(result.getRequestsTotal())
+            .responseMinTime(result.getResponseMinTime())
+            .responseMaxTime(result.getResponseMaxTime())
+            .responseAvgTime(result.getResponseAvgTime())
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakeAnalyticsQueryService.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.analytics.model.ResponseStatusOvertime;
 import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.rest.api.model.v4.analytics.AverageConnectionDuration;
 import io.gravitee.rest.api.model.v4.analytics.AverageMessagesPerRequest;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
 import io.gravitee.rest.api.model.v4.analytics.RequestsCount;
 import io.gravitee.rest.api.model.v4.analytics.ResponseStatusRanges;
 import io.gravitee.rest.api.model.v4.analytics.TopHitsApis;
@@ -42,6 +43,7 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     public AverageConnectionDuration averageConnectionDuration;
     public ResponseStatusRanges responseStatusRanges;
     public TopHitsApis topHitsApis;
+    public RequestResponseTime requestResponseTime;
     public LinkedHashMap<String, Double> averageAggregate = new LinkedHashMap<>();
     public ResponseStatusOvertime responseStatusOvertime;
 
@@ -67,6 +69,7 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
         averageAggregate = new LinkedHashMap<>();
         responseStatusRanges = null;
         responseStatusOvertime = null;
+        requestResponseTime = null;
     }
 
     @Override
@@ -96,5 +99,13 @@ public class FakeAnalyticsQueryService implements AnalyticsQueryService {
     @Override
     public ResponseStatusOvertime searchResponseStatusOvertime(ExecutionContext executionContext, ResponseStatusOverTimeQuery query) {
         return responseStatusOvertime;
+    }
+
+    @Override
+    public RequestResponseTime searchRequestResponseTime(
+        ExecutionContext executionContext,
+        EnvironmentAnalyticsQueryParameters parameters
+    ) {
+        return requestResponseTime;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentRequestResponseTimeUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentRequestResponseTimeUseCaseTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics.use_case;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fakes.FakeAnalyticsQueryService;
+import fixtures.core.model.ApiFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import io.gravitee.apim.core.analytics.model.EnvironmentAnalyticsQueryParameters;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SearchEnvironmentRequestResponseTimeUseCaseTest {
+
+    public static final String ENV_ID = "environment-id";
+    public static final String ORG_ID = "org-id";
+    private static final long FROM = 1728981738L;
+    private static final long TO = 1729068138L;
+    private final ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+
+    private FakeAnalyticsQueryService analyticsQueryService;
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    private SearchEnvironmentRequestResponseTimeUseCase cut;
+
+    private ArgumentCaptor<EnvironmentAnalyticsQueryParameters> argumentCaptor;
+
+    @BeforeEach
+    void setUp() {
+        analyticsQueryService = mock(FakeAnalyticsQueryService.class);
+        cut = new SearchEnvironmentRequestResponseTimeUseCase(apiQueryService, analyticsQueryService);
+
+        argumentCaptor = ArgumentCaptor.forClass(EnvironmentAnalyticsQueryParameters.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        analyticsQueryService.reset();
+        apiQueryService.reset();
+    }
+
+    @Test
+    public void should_get_request_response_time_only_for_v4_api() {
+        apiQueryService.initWith(
+            List.of(
+                ApiFixtures.aMessageApiV4().toBuilder().id("message-api-v4-id").build(),
+                ApiFixtures.aProxyApiV4().toBuilder().id("proxy-api-v4-id").build(),
+                ApiFixtures.aProxyApiV2().toBuilder().id("proxy-api-v2-id").build()
+            )
+        );
+        var input = SearchEnvironmentRequestResponseTimeUseCase.Input
+            .builder()
+            .executionContext(executionContext)
+            .parameters(EnvironmentAnalyticsQueryParameters.builder().from(FROM).to(TO).build())
+            .build();
+
+        when(analyticsQueryService.searchRequestResponseTime(any(), any()))
+            .thenReturn(
+                RequestResponseTime
+                    .builder()
+                    .requestsPerSecond(3.7d)
+                    .requestsTotal(25600L)
+                    .responseMinTime(32.5d)
+                    .responseMaxTime(1220.87d)
+                    .responseAvgTime(159.2d)
+                    .build()
+            );
+
+        var result = cut.execute(input).requestResponseTime();
+
+        verify(analyticsQueryService).searchRequestResponseTime(any(), argumentCaptor.capture());
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions
+                .assertThat(argumentCaptor.getValue())
+                .isEqualTo(
+                    EnvironmentAnalyticsQueryParameters
+                        .builder()
+                        .from(FROM)
+                        .to(TO)
+                        .apiIds(List.of("message-api-v4-id", "proxy-api-v4-id"))
+                        .build()
+                );
+            softAssertions
+                .assertThat(result)
+                .isNotNull()
+                .get()
+                .isEqualTo(
+                    RequestResponseTime
+                        .builder()
+                        .requestsPerSecond(3.7d)
+                        .requestsTotal(25600L)
+                        .responseMinTime(32.5d)
+                        .responseMaxTime(1220.87d)
+                        .responseAvgTime(159.2d)
+                        .build()
+                );
+        });
+    }
+
+    @Test
+    public void should_get_request_response_time_only_for_specified_env() {
+        apiQueryService.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV4().toBuilder().id("proper-env-proxy-api-v4-id").build(),
+                ApiFixtures.aProxyApiV4().toBuilder().id("other-env-proxy-api-v4-id").environmentId("other-env").build()
+            )
+        );
+        var input = SearchEnvironmentRequestResponseTimeUseCase.Input
+            .builder()
+            .executionContext(executionContext)
+            .parameters(EnvironmentAnalyticsQueryParameters.builder().from(FROM).to(TO).build())
+            .build();
+
+        when(analyticsQueryService.searchRequestResponseTime(any(), any()))
+            .thenReturn(
+                RequestResponseTime
+                    .builder()
+                    .requestsPerSecond(3.7d)
+                    .requestsTotal(25600L)
+                    .responseMinTime(32.5d)
+                    .responseMaxTime(1220.87d)
+                    .responseAvgTime(159.2d)
+                    .build()
+            );
+
+        var result = cut.execute(input).requestResponseTime();
+
+        verify(analyticsQueryService).searchRequestResponseTime(any(), argumentCaptor.capture());
+
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions
+                .assertThat(argumentCaptor.getValue())
+                .isEqualTo(
+                    EnvironmentAnalyticsQueryParameters.builder().from(FROM).to(TO).apiIds(List.of("proper-env-proxy-api-v4-id")).build()
+                );
+            softAssertions
+                .assertThat(result)
+                .isPresent()
+                .isNotNull()
+                .get()
+                .isEqualTo(
+                    RequestResponseTime
+                        .builder()
+                        .requestsPerSecond(3.7d)
+                        .requestsTotal(25600L)
+                        .responseMinTime(32.5d)
+                        .responseMaxTime(1220.87d)
+                        .responseAvgTime(159.2d)
+                        .build()
+                );
+        });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics/AnalyticsQueryServiceImplTest.java
@@ -26,10 +26,12 @@ import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.repository.common.query.QueryContext;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
+import io.gravitee.repository.log.v4.model.analytics.RequestResponseTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeAggregate;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusOverTimeQuery;
 import io.gravitee.repository.log.v4.model.analytics.ResponseStatusRangesAggregate;
 import io.gravitee.repository.log.v4.model.analytics.TopHitsAggregate;
+import io.gravitee.rest.api.model.v4.analytics.RequestResponseTime;
 import io.gravitee.rest.api.model.v4.analytics.TopHitsApis;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.Duration;
@@ -155,6 +157,37 @@ class AnalyticsQueryServiceImplTest {
                             TopHitsApis.TopHitApi.builder().id("api-id-2").count(2L).build(),
                             TopHitsApis.TopHitApi.builder().id("api-id-3").count(17L).build()
                         )
+                );
+        }
+
+        @Test
+        void should_return_request_response_time() {
+            var queryParameters = EnvironmentAnalyticsQueryParameters.builder().apiIds(List.of("api#1")).build();
+            when(analyticsRepository.searchRequestResponseTimes(any(QueryContext.class), any()))
+                .thenReturn(
+                    RequestResponseTimeAggregate
+                        .builder()
+                        .requestsPerSecond(3.7d)
+                        .requestsTotal(25600L)
+                        .responseMinTime(32.5d)
+                        .responseMaxTime(1220.87d)
+                        .responseAvgTime(159.2d)
+                        .build()
+                );
+
+            var result = cut.searchRequestResponseTime(GraviteeContext.getExecutionContext(), queryParameters);
+
+            assertThat(result)
+                .isNotNull()
+                .isEqualTo(
+                    RequestResponseTime
+                        .builder()
+                        .requestsPerSecond(3.7d)
+                        .requestsTotal(25600L)
+                        .responseMinTime(32.5d)
+                        .responseMaxTime(1220.87d)
+                        .responseAvgTime(159.2d)
+                        .build()
                 );
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7241

## Description

PR that exposes an endpoint to get new analytics for v4 APIs containing info such as: 
- number of requests per s for a given period 
- number of requests for a given period 
- minimum response time for all v4 APIs (excluding SSE / WS / Webhooks entrypoints ) for a given period 
- maximum response time for all v4 APIs (excluding SSE / WS / Webhook sentrypoints)  for a given period 
- average response time for all v4 APIs (excluding SSE / WS / Webhooks entrypoints)  for a given period 


![image](https://github.com/user-attachments/assets/976b397d-4029-4e6b-8686-7f1e22778901)



