### PR TITLE
fix: sync process should not fail if api

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -63,7 +63,15 @@ public class SubscriptionAppender {
             Map<String, List<Subscription>> subscriptionsByApi = loadSubscriptions(initialSync, allPlans);
             subscriptionsByApi.forEach((api, subscriptions) -> {
                 ApiReactorDeployable deployable = deployableByApi.get(api);
-                deployable.subscriptions(subscriptions);
+                if (deployable == null) {
+                    log.warn(
+                        "Cannot find api {} for subscriptions [{}]",
+                        api,
+                        subscriptions.stream().map(Subscription::getId).collect(Collectors.joining(","))
+                    );
+                } else {
+                    deployable.subscriptions(subscriptions);
+                }
             });
         }
         return deployables;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/appender/MemoryAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/appender/MemoryAppender.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appender;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.Collections;
+import java.util.List;
+
+public class MemoryAppender extends ListAppender<ILoggingEvent> {
+
+    public void reset() {
+        this.list.clear();
+    }
+
+    public List<ILoggingEvent> getLoggedEvents() {
+        return Collections.unmodifiableList(this.list);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -20,6 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import appender.MemoryAppender;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.repository.mapper.SubscriptionMapper;
@@ -27,6 +31,8 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -34,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -45,6 +52,8 @@ class SubscriptionAppenderTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    private final MemoryAppender memoryAppender = new MemoryAppender();
+
     @Mock
     private SubscriptionRepository subscriptionRepository;
 
@@ -54,6 +63,7 @@ class SubscriptionAppenderTest {
     public void beforeEach() {
         SubscriptionMapper subscriptionMapper = new SubscriptionMapper(objectMapper);
         cut = new SubscriptionAppender(subscriptionRepository, subscriptionMapper);
+        memoryAppender.reset();
     }
 
     @Test
@@ -101,5 +111,51 @@ class SubscriptionAppenderTest {
         assertThat(deployables).hasSize(2);
         assertThat(deployables.get(0).subscriptions()).hasSize(2);
         assertThat(deployables.get(1).subscriptions()).isEmpty();
+    }
+
+    @Test
+    void should_ignore_and_log_subscriptions_with_missing_deployable() throws TechnicalException {
+        configureMemoryAppender();
+        ApiReactorDeployable apiReactorDeployable1 = ApiReactorDeployable
+            .builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(Set.of("plan1"))
+            .build();
+        io.gravitee.repository.management.model.Subscription subscription1 = new io.gravitee.repository.management.model.Subscription();
+        subscription1.setId("sub1");
+        subscription1.setApi("api1");
+        io.gravitee.repository.management.model.Subscription subscription2 = new io.gravitee.repository.management.model.Subscription();
+        subscription2.setId("sub2");
+        subscription2.setApi("api3");
+        io.gravitee.repository.management.model.Subscription subscription3 = new io.gravitee.repository.management.model.Subscription();
+        subscription3.setId("sub3");
+        subscription3.setApi("api3");
+        when(subscriptionRepository.search(any(), any())).thenReturn(List.of(subscription1, subscription2, subscription3));
+        ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable
+            .builder()
+            .apiId("api2")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(Set.of("nosubscriptionplan"))
+            .build();
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(apiReactorDeployable1, apiReactorDeployable2));
+        assertThat(deployables).hasSize(2);
+        assertThat(deployables.get(0).subscriptions()).hasSize(1);
+        assertThat(deployables.get(1).subscriptions()).isEmpty();
+
+        Assertions.assertThat(memoryAppender.getLoggedEvents()).hasSize(1);
+        SoftAssertions.assertSoftly(soft -> {
+            var event = memoryAppender.getLoggedEvents().get(0);
+            soft.assertThat(event.getMessage()).contains("Cannot find api {} for subscriptions [{}]");
+            soft.assertThat(event.getArgumentArray()).contains("api3", "sub2,sub3");
+        });
+    }
+
+    private void configureMemoryAppender() {
+        Logger logger = (Logger) LoggerFactory.getLogger(SubscriptionAppender.class);
+        memoryAppender.setContext((LoggerContext) LoggerFactory.getILoggerFactory());
+        logger.setLevel(Level.WARN);
+        logger.addAppender(memoryAppender);
+        memoryAppender.start();
     }
 }


### PR DESCRIPTION
not found while processing subscription appender

## Issue

https://gravitee.atlassian.net/browse/APIM-7365

## Description

This PR aims to strengthen the sync process by managing a use case seen while upgrading from a 3.20 version to a 4.x version. While trying to sync APIs, an appender is executed to link subscriptions to api and it appears that some subscriptions were linked to APIs that do not exist anymore which make the sync process fail. A log has been added to warn when this problem happens.

