### PR TITLE
fix: fix for blank pie chart in case of 0 hits for each response range status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-message/api-analytics-message.component.spec.ts
@@ -253,11 +253,19 @@ describe('ApiAnalyticsMessageComponent', () => {
       expectApiAnalyticsResponseStatusRangesGetRequest(
         fakeAnalyticsResponseStatusRanges({
           ranges: {
-            '200': 0,
+            '300.0-400.0': 0,
+            '100.0-200.0': 1,
+            '200.0-300.0': 60,
+            '400.0-500.0': 0,
+            '500.0-600.0': 1,
           },
           rangesByEntrypoint: {
             'http-get': {
-              '200': 0,
+              '300.0-400.0': 0,
+              '100.0-200.0': 1,
+              '200.0-300.0': 60,
+              '400.0-500.0': 0,
+              '500.0-600.0': 1,
             },
           },
         }),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-proxy/api-analytics-proxy.component.spec.ts
@@ -154,7 +154,20 @@ describe('ApiAnalyticsProxyComponent', () => {
       expectApiAnalyticsResponseStatusRangesGetRequest(
         fakeAnalyticsResponseStatusRanges({
           ranges: {
-            '200': 0,
+            '300.0-400.0': 0,
+            '100.0-200.0': 1,
+            '200.0-300.0': 60,
+            '400.0-500.0': 0,
+            '500.0-600.0': 1,
+          },
+          rangesByEntrypoint: {
+            'http-proxy': {
+              '300.0-400.0': 0,
+              '100.0-200.0': 1,
+              '200.0-300.0': 60,
+              '400.0-500.0': 0,
+              '500.0-600.0': 1,
+            },
           },
         }),
       );

--- a/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/api-analytics-response-status-ranges/api-analytics-response-status-ranges.component.ts
@@ -45,11 +45,13 @@ export class ApiAnalyticsResponseStatusRangesComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.responseStatusRanges && !this.responseStatusRanges?.isLoading) {
-      this.input = this.responseStatusRanges?.data.map((data) => ({
-        label: getLabel(data.label),
-        value: data.value,
-        color: getColor(data.label),
-      }));
+      this.input = this.responseStatusRanges?.data
+        .filter((data) => data.value > 0)
+        .map((data) => ({
+          label: getLabel(data.label),
+          value: data.value,
+          color: getColor(data.label),
+        }));
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7358

## Description

When backend returned 0 for all v4 APIs response ranges the generated Pie chart looked like empty circle. 
Right now the API Response status should return _"No content to display"_ 

## Additional context

The situation like this may happen for example when we have one ongoing websocket request. 
There is no response status for that request available but the request already exist in elastisearch so we can return it to display in TOP API calls.  

Before: 
![image](https://github.com/user-attachments/assets/cebf99f0-bbaf-4d7e-a6eb-71362414e5a2)

After: 
![image](https://github.com/user-attachments/assets/1a8cea94-2519-4158-a2bf-c8befd364a27)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-whqvfzsdrq.chromatic.com)
<!-- Storybook placeholder end -->
