### PR TITLE
fix(mapi): handle client_certificate not exists on converter

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -1397,7 +1397,11 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             settings.setOauth(clientSettings);
         }
 
-        if (application.getMetadata() != null && application.getMetadata().containsKey(METADATA_CLIENT_CERTIFICATE)) {
+        if (
+            application.getMetadata() != null &&
+            application.getMetadata().containsKey(METADATA_CLIENT_CERTIFICATE) &&
+            StringUtils.isNotBlank(application.getMetadata().get(METADATA_CLIENT_CERTIFICATE))
+        ) {
             final byte[] decodedCertificate = Base64.getDecoder().decode(application.getMetadata().get(METADATA_CLIENT_CERTIFICATE));
             settings.setTls(TlsSettings.builder().clientCertificate(new String(decodedCertificate)).build());
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7320

## Description

client_certificate may be null value. It should be always checked on converter before decoding 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

