### PR TITLE
style: :art: import order constitent with prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ ij_smart_tabs = false
 
 [*.java]
 ij_java_class_count_to_use_import_on_demand = 99
-ij_java_imports_layout = $*,|,*,javax.**,java.**,|
+ij_java_imports_layout = $*,|,*,|
 ij_java_layout_static_imports_separately = true
 ij_java_names_count_to_use_import_on_demand = 99
 ij_java_packages_to_use_import_on_demand = java.awt.*,javax.swing.*


### PR DESCRIPTION
## Issue

No related issue

## Description

Made the `.editorconfig` consistent with the java-prettier import order

## Additional context

For example:
* Open the file `AbstractBestMatchFlowSelectorTest.java` in IntelliJ
* Use Refactor > Optimize Imports
* In command-line: `mvn prettier:check`

It will raise a formatting issue on the import order

