### PR TITLE
APIM-7405: fix display grammar and assignment issues

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-proxy-settings/api-runtime-logs-proxy-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-settings/runtime-logs-proxy-settings/api-runtime-logs-proxy-settings.component.html
@@ -85,7 +85,7 @@
         <mat-form-field>
           <mat-label>Request phase condition</mat-label>
           <input matInput formControlName="condition" />
-          <mat-hint> Support EL (e.g: &#123; #request.headers['Content-Type'][0] === 'application/json' &#125;)</mat-hint>
+          <mat-hint> Support EL (e.g: &#123; #request.headers['Content-Type'][0] == 'application/json' &#125;)</mat-hint>
         </mat-form-field>
       </div>
     </mat-card-content>

--- a/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.html
+++ b/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.html
@@ -21,8 +21,8 @@
     <mat-card-header>
       <mat-card-title>API Resources</mat-card-title>
       <mat-card-subtitle
-        >Resources are link to the API lifecycle. They are initialized when the API is starting and released when API is stopped. Resources
-        are used via the API policies to enhance API behavior.</mat-card-subtitle
+        >Resources are linked to the API lifecycle. They are initialized when the API is starting and released when API is stopped.
+        Resources are used via the API policies to enhance API behavior.</mat-card-subtitle
       >
       <div class="headerRightBtn" *gioPermission="{ anyOf: ['api-definition-c'] }">
         <button *ngIf="!apiResourceDS.isReadOnly" mat-raised-button color="primary" (click)="addResource()">

--- a/gravitee-apim-console-webui/src/management/settings/client-registration-providers/client-registration-provider/client-registration-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/client-registration-providers/client-registration-provider/client-registration-provider.component.ts
@@ -43,7 +43,7 @@ export class ClientRegistrationProviderComponent implements OnInit, OnDestroy {
     },
   ];
   public renewClientSecretMethods = ['POST', 'PATCH', 'PUT'];
-  public renewClientSecretEndpointUrlExample: 'https://authorization_server/oidc/dcr/{#client_id}/renew_secret';
+  public renewClientSecretEndpointUrlExample: string = 'https://authorization_server/oidc/dcr/{#client_id}/renew_secret';
 
   public formInitialValues: unknown;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7405

## Description

Fix minor display, grammar, and assignment issues in HTML and TypeScript files

1. Settings > Portal > Client Registration > Configuration - URL example is missing (At the bottom)

Before:
<img width="1502" alt="Screenshot 2024-11-05 at 1 20 14 PM" src="https://github.com/user-attachments/assets/e2d7df13-76ce-42cd-abc7-7c4b565d29a3">


After:
<img width="1502" alt="Screenshot 2024-11-05 at 1 19 45 PM" src="https://github.com/user-attachments/assets/9fdf52e7-c88e-494b-801e-7ecfef832740">

2.  Grammar on API Resources UI page: "Resources are link to the API lifecycle." needs to be changed to "Resources are linked to the API lifecycle."

Before:
<img width="1502" alt="Screenshot 2024-11-05 at 1 19 04 PM" src="https://github.com/user-attachments/assets/1b7c9dc5-c8d0-4ce0-8a7b-fc3089e3df5a">


After:
<img width="1502" alt="Screenshot 2024-11-05 at 1 19 11 PM" src="https://github.com/user-attachments/assets/cf964739-be89-4b4b-b459-ba4e22938529">

3. API Traffic > Settings UI.  EL example is malformed (at the bottom): Remove one equal to sign

Before:
<img width="1502" alt="Screenshot 2024-11-05 at 1 18 39 PM" src="https://github.com/user-attachments/assets/96c5d55c-fb2a-4d81-bf53-722a0e6d2e74">


After:
<img width="1502" alt="Screenshot 2024-11-05 at 1 18 09 PM" src="https://github.com/user-attachments/assets/fd3411c8-2b4d-493d-a62e-aa829fcb9326">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-akncuzkgdw.chromatic.com)
<!-- Storybook placeholder end -->
