### PR TITLE
chore: reorder dependencies

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -43,22 +43,6 @@
             </dependency>
 
             <dependency>
-                <groupId>io.gravitee.plugin</groupId>
-                <artifactId>gravitee-plugin</artifactId>
-                <version>${gravitee-plugin.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node</artifactId>
-                <version>${gravitee-node.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-
-            <dependency>
                 <groupId>io.gravitee.alert</groupId>
                 <artifactId>gravitee-alert-api</artifactId>
                 <version>${gravitee-alert-api.version}</version>
@@ -217,6 +201,22 @@
                 <groupId>com.graviteesource.cloud</groupId>
                 <artifactId>gravitee-cloud-initializer</artifactId>
                 <version>${gravitee-cloud-initializer.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.plugin</groupId>
+                <artifactId>gravitee-plugin</artifactId>
+                <version>${gravitee-plugin.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <!-- Other dependencies -->
             <dependency>


### PR DESCRIPTION
## Issue

N/A

## Description

As gravitee-plugin and gravitee-node are imported as pom, they have to be imported in last position to avoid using their version of other dependencies (like gravitee-gateway-api or gravitee-common for instance).

For this same reason, we import first gravitee-plugin to use the version declared in APIM, because gravitee-node depends on another version of gravitee-plugin.
