### PR TITLE
fix(deps): bump gravitee-reporter-elasticsearch to 5.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>5.3.1</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>5.3.3</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.1</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.1</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
## Description

To update HealthCheck mapping to index success attribute.
This change will be used for [gravitee.atlassian.net/browse/APIM-7355](https://gravitee.atlassian.net/browse/APIM-7355), which will be implemented in 4.6. Updating the mapping sooner allows the creation an Elastic index with correct mapping earlier

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ymhfnbiktd.chromatic.com)
<!-- Storybook placeholder end -->
