### PR TITLE
APIM-7318 fix: hide create bar on success

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.html
@@ -52,6 +52,7 @@
     *ngIf="!isReadOnly"
     class="save-bar"
     [creationMode]="mode === 'new'"
+    [opened]="groupForm.dirty"
     [form]="groupForm"
     [formInitialValues]="initialGroupFormValue"
     (submitted)="onSubmit()"

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
@@ -108,7 +108,11 @@ export class ApiProxyGroupEditComponent implements OnInit, OnDestroy {
           groupIndex !== -1 ? api.proxy.groups.splice(groupIndex, 1, updatedGroup) : api.proxy.groups.push(updatedGroup);
           return this.apiService.update(api.id, api);
         }),
-        tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        tap(() => {
+          this.snackBarService.success('Configuration successfully saved!');
+          this.initialGroupFormValue = this.groupForm.getRawValue();
+          this.groupForm.markAsPristine();
+        }),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7318

## Description

Hide create bar on success by making readOnly True as it is used in ngIf.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

Before:
<img width="1504" alt="Before" src="https://github.com/user-attachments/assets/0a970128-0619-4ecc-9557-e504f05c8f77">

After:

<img width="1503" alt="After" src="https://github.com/user-attachments/assets/96458f7e-56ba-4276-9efe-fc231f84471a">


<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/9824/console](https://pr.team-apim.gravitee.dev/9824/console)
      Portal: [https://pr.team-apim.gravitee.dev/9824/portal](https://pr.team-apim.gravitee.dev/9824/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/9824/api/management](https://pr.team-apim.gravitee.dev/9824/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/9824](https://pr.team-apim.gravitee.dev/9824)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/9824](https://pr.gateway-v3.team-apim.gravitee.dev/9824)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hoftltsggp.chromatic.com)
<!-- Storybook placeholder end -->
