### PR TITLE
feat: dashboard analytics UI improvements

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-v4-api-request-stats/dashboard-v4-api-request-stats.scss
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-v4-api-request-stats/dashboard-v4-api-request-stats.scss
@@ -47,7 +47,7 @@ $typography: map.get(gio.$mat-theme, typography);
     flex-direction: column;
 
     &__title {
-      @include mat.m2-typography-level($typography, subtitle-1);
+      @include mat.m2-typography-level($typography, subtitle-2);
       border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
       height: 52px;
       padding-right: 8px;

--- a/gravitee-apim-console-webui/src/management/home/components/gio-request-stats/gio-request-stats.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-request-stats/gio-request-stats.component.scss
@@ -21,7 +21,7 @@ $typography: map.get(gio.$mat-theme, typography);
     flex-direction: column;
 
     &__title {
-      @include mat.m2-typography-level($typography, subtitle-1);
+      @include mat.m2-typography-level($typography, subtitle-2);
       border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
       height: 52px;
       padding-right: 8px;

--- a/gravitee-apim-console-webui/src/management/home/components/gio-top-apis-table/gio-top-apis-table.component.html
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-top-apis-table/gio-top-apis-table.component.html
@@ -36,7 +36,7 @@
 
     <ng-container matColumnDef="value">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Hits</th>
-      <td mat-cell *matCellDef="let element">{{ element.value }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.value | number }}</td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/gravitee-apim-console-webui/src/management/home/components/gio-top-apis-table/gio-top-apis-table.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/gio-top-apis-table/gio-top-apis-table.component.spec.ts
@@ -115,7 +115,7 @@ describe('GioStatsTableComponent', () => {
     expect(link2.length).toEqual(1);
 
     const nbHits = await rows[0].getCellTextByIndex({ columnName: 'value' });
-    expect(nbHits).toEqual(['2764281']);
+    expect(nbHits).toEqual(['2,764,281']);
 
     const paginotorHarness = await loader.getHarness(MatPaginatorHarness);
     expect(paginotorHarness).toBeDefined();

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -20,32 +20,32 @@
     <gio-quick-time-range [formControl]="timeRangeControl" (onRefreshClicked)="fetchAnalyticsRequest()"></gio-quick-time-range>
   </div>
   <div class="home-overview__row-cards">
-    <mat-card class="home-overview__card flex">
-      <mat-card-content>
-        <div class="mat-body-1">Summary</div>
-        <div *ngIf="apiNb !== undefined && applicationNb !== undefined; else loader" class="home-overview__card__list">
-          <div class="home-overview__card__list__row">
-            <span class="home-overview__card__list__row__value">{{ apiNb }}</span>
-            <span class="home-overview__card__list__row__label">Total APIs</span>
+    <mat-card class="card flex">
+      <div class="card__header">Summary</div>
+      <mat-card-content class="card__content">
+        <div *ngIf="apiNb !== undefined && applicationNb !== undefined; else loader" class="card__list">
+          <div class="card__list__row">
+            <span class="card__list__row__value">{{ apiNb }}</span>
+            <span class="card__list__row__label">Total APIs</span>
           </div>
-          <div class="home-overview__card__list__row">
-            <span class="home-overview__card__list__row__value">{{ applicationNb }}</span>
-            <span class="home-overview__card__list__row__label">Total Applications</span>
+          <div class="card__list__row">
+            <span class="card__list__row__value">{{ applicationNb }}</span>
+            <span class="card__list__row__label">Total Applications</span>
           </div>
         </div>
       </mat-card-content>
     </mat-card>
-    <mat-card class="home-overview__card">
-      <mat-card-content>
-        <div class="mat-body-1">API Lifecycle State</div>
+    <mat-card class="card">
+      <div class="card__header">API Lifecycle State</div>
+      <mat-card-content class="card__content">
         <ng-container *ngIf="apiLifecycleState; else loader">
           <gio-api-lifecycle-state [data]="apiLifecycleState"></gio-api-lifecycle-state>
         </ng-container>
       </mat-card-content>
     </mat-card>
-    <mat-card class="home-overview__card">
-      <mat-card-content>
-        <div class="mat-body-1">API State</div>
+    <mat-card class="card">
+      <div class="card__header">API State</div>
+      <mat-card-content class="card__content">
         <ng-container *ngIf="apiState; else loader">
           <gio-api-state [data]="apiState"></gio-api-state>
         </ng-container>
@@ -55,28 +55,26 @@
 
   <h2 class="home-overview__row-title">V2 APIs</h2>
   <div class="home-overview__row-cards">
-    <mat-card class="home-overview__card">
-      <mat-card-content>
-        <div class="mat-body-1">API Response Status</div>
-
+    <mat-card class="card">
+      <div class="card__header">API Response Status</div>
+      <mat-card-content class="card__content">
         <ng-container *ngIf="apiResponseStatus; else loader">
           <gio-api-response-status [data]="apiResponseStatus"></gio-api-response-status>
         </ng-container>
       </mat-card-content>
     </mat-card>
-    <mat-card class="home-overview__card">
-      <mat-card-content>
-        <div class="mat-body-1">
-          Top APIs
-          <span class="mat-caption">(Ordered by API calls)</span>
-        </div>
-      </mat-card-content>
+    <mat-card class="card">
+      <div class="card__header">
+        Top APIs
+        <mat-icon class="card__header__tooltip" svgIcon="gio:info" matTooltip="Ordered by API calls"></mat-icon>
+      </div>
       <ng-container *ngIf="topApis; else loader">
         <gio-top-apis-table [data]="topApis"></gio-top-apis-table>
       </ng-container>
     </mat-card>
-    <mat-card class="home-overview__card flex">
-      <mat-card-content>
+    <mat-card class="card">
+      <div class="card__header">API Request Stats</div>
+      <mat-card-content class="card__content">
         <ng-container *ngIf="requestStats; else loader">
           <gio-request-stats [data]="requestStats"></gio-request-stats>
         </ng-container>

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.scss
@@ -27,42 +27,61 @@ $typography: map.get(gio.$mat-theme, typography);
     grid-auto-flow: column;
     gap: 14px;
   }
+}
 
-  &__card {
-    width: 100%;
-    flex: 1 1 100%;
-    min-height: 250px;
+.card {
+  width: 100%;
+  flex: 1 1 100%;
+  min-height: 250px;
 
-    &.flex {
-      display: flex;
-      flex-direction: column;
+  &__header {
+    @include mat.m2-typography-level($typography, 'body-1');
+    border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+    padding: 16px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+
+    &__tooltip {
+      height: 16px;
+      width: 16px;
     }
+  }
 
-    &__list {
+  &__content {
+    padding: 16px;
+  }
+
+  &.flex {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+
+    flex: 1 1 auto;
+
+    &__row {
+      gap: 4px;
+      padding-bottom: 8px;
       display: flex;
       flex-direction: column;
+      justify-content: center;
+      border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
+      flex: 1 1 100%;
 
-      flex: 1 1 auto;
+      &:last-child {
+        border-bottom: none;
+      }
 
-      &__row {
-        gap: 4px;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        border-bottom: 1px mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker10') solid;
-        flex: 1 1 100%;
+      &__label {
+        @include mat.m2-typography-level($typography, 'caption');
+      }
 
-        &:last-child {
-          border-bottom: none;
-        }
-
-        &__label {
-          @include mat.m2-typography-level($typography, 'caption');
-        }
-
-        &__value {
-          @include mat.m2-typography-level($typography, 'headline-6');
-        }
+      &__value {
+        @include mat.m2-typography-level($typography, 'headline-6');
       }
     }
   }

--- a/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.html
@@ -44,7 +44,7 @@
 
         <ng-container matColumnDef="count">
           <th mat-header-cell *matHeaderCellDef mat-sort-header>Hits</th>
-          <td mat-cell *matCellDef="let element">{{ element.count }}</td>
+          <td mat-cell *matCellDef="let element">{{ element.count | number }}</td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7495

## Description

Post demo dashboard analytics improvements to make all widgets look aligned with the V4 analytics widgets

## Additional context

- Add comma separators for thousands, millions, consistently in all widgets
- Align the design of the v2 and v4 response times widgets (new header with the info bubble)
- response time widgets title sizes are weird

**Before**: 
<img width="867" alt="before" src="https://github.com/user-attachments/assets/7956532b-48e2-4683-9b0d-b1ccb583c1bf">

**After**:
<img width="873" alt="after" src="https://github.com/user-attachments/assets/5a762a19-f0e6-406b-81d8-f210e796fcdd">
 

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dwmiexxboc.chromatic.com)
<!-- Storybook placeholder end -->
