### PR TITLE
chore: bump all cache resource dependencies

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/DummyCacheResource.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/DummyCacheResource.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.integration.tests.fake;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.policy.cache.CacheResponse;
 import io.gravitee.policy.cache.configuration.SerializationMode;
 import io.gravitee.policy.cache.mapper.CacheResponseMapper;
@@ -88,6 +89,11 @@ public class DummyCacheResource extends CacheResource {
 
     public String getResourceName() {
         return name();
+    }
+
+    @Override
+    public Cache getCache(BaseExecutionContext ctx) {
+        return null;
     }
 
     static class DummyCache implements Cache {

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <gravitee-reporter-api.version>1.31.2</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
-        <gravitee-resource-cache-provider-api.version>1.4.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.4.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
@@ -227,7 +227,7 @@
         <gravitee-policy-xslt.version>3.0.1</gravitee-policy-xslt.version>
         <gravitee-policy-wssecurity-authentication.version>2.0.2</gravitee-policy-wssecurity-authentication.version>
 
-        <gravitee-resource-cache.version>2.1.0</gravitee-resource-cache.version>
+        <gravitee-resource-cache.version>3.0.0-alpha.1</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>2.1.0</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>2.1.0</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
@@ -263,7 +263,7 @@
         <gravitee-resource-auth-provider-http.version>1.4.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>1.4.0</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>2.0.0</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>3.0.0-alpha.1</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-secretprovider-kubernetes.version>1.0.1</gravitee-secretprovider-kubernetes.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7417

## Description

resource-cache-provider-api -> 2.0.0
resource-cache -> 3.0.0-alpha.1
resource-cache-redis -> 3.0.0-alpha.1
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bzxodilrgt.chromatic.com)
<!-- Storybook placeholder end -->
