### PR TITLE
fix(service): handle native api when verifying api paths

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -205,10 +205,14 @@ public class VerifyApiPathDomainService implements Validator<VerifyApiPathDomain
     }
 
     private static List<Path> extractPaths(Api api) {
-        return api.getDefinitionVersion() == DefinitionVersion.V4 ? getV4Paths(api) : getV2Paths(api);
+        return api.getDefinitionVersion() == DefinitionVersion.V4 ? getHttpV4Paths(api) : getV2Paths(api);
     }
 
-    private static List<Path> getV4Paths(Api api) {
+    private static List<Path> getHttpV4Paths(Api api) {
+        if (api.getApiDefinitionHttpV4() == null) {
+            return new ArrayList<>();
+        }
+
         return api
             .getApiDefinitionHttpV4()
             .getListeners()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7152

## Description

Avoid NPE thrown when Native APIs are returned from query.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

