### PR TITLE
Apim 7163 console restrict native api actions

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/listener.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/listener.fixture.ts
@@ -18,6 +18,7 @@ import { isFunction } from 'lodash';
 
 import { HttpListener } from './httpListener';
 import { SubscriptionListener } from './subscriptionListener';
+import { KafkaListener } from './kafkaListener';
 
 export function fakeHttpListener(modifier?: Partial<HttpListener> | ((baseListener: HttpListener) => HttpListener)): HttpListener {
   const base: HttpListener = {
@@ -67,6 +68,28 @@ export function fakeSubscriptionListener(
             maxConcurrentConnections: 5,
           },
         },
+      },
+    ],
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+export function fakeKafkaListener(modifier?: Partial<KafkaListener> | ((baseListener: KafkaListener) => KafkaListener)): KafkaListener {
+  const base: KafkaListener = {
+    type: 'KAFKA',
+    host: 'kafka-host',
+    port: 1000,
+    entrypoints: [
+      {
+        type: 'native-kafka',
+        configuration: {},
       },
     ],
   };

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -42,15 +42,15 @@ export class ApiV4MenuService implements ApiMenuService {
 
     const subMenuItems: MenuItem[] = [
       this.addConfigurationMenuEntry(),
-      ...(this.constants.org.settings?.scoring?.enabled ? [this.addApiScoreMenuEntry()] : []),
-      this.addEntrypointsMenuEntry(hasTcpListeners),
-      this.addEndpointsMenuEntry(api, hasTcpListeners),
-      this.addPoliciesMenuEntry(hasTcpListeners),
-      this.addConsumersMenuEntry(hasTcpListeners),
+      ...(this.constants.org.settings?.scoring?.enabled && api.type !== 'NATIVE' ? [this.addApiScoreMenuEntry()] : []),
+      ...(api.type !== 'NATIVE' ? [this.addEntrypointsMenuEntry(hasTcpListeners)] : []),
+      ...(api.type !== 'NATIVE' ? [this.addEndpointsMenuEntry(api, hasTcpListeners)] : []),
+      ...(api.type !== 'NATIVE' ? [this.addPoliciesMenuEntry(hasTcpListeners)] : []),
+      ...(api.type !== 'NATIVE' ? [this.addConsumersMenuEntry(hasTcpListeners)] : []),
       this.addDocumentationMenuEntry(api),
-      this.addDeploymentMenuEntry(),
-      this.addApiTrafficMenuEntry(hasTcpListeners),
-      this.addApiRuntimeAlertsMenuEntry(),
+      ...(api.type !== 'NATIVE' ? [this.addDeploymentMenuEntry()] : []),
+      ...(api.type !== 'NATIVE' ? [this.addApiTrafficMenuEntry(hasTcpListeners)] : []),
+      ...(api.type !== 'NATIVE' ? [this.addApiRuntimeAlertsMenuEntry()] : []),
       ...this.addHealthCheckMenuEntry(api.type),
     ].filter((entry) => entry != null && !entry.tabs?.every((tab) => tab.routerLink === 'DISABLED'));
 

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -131,6 +131,7 @@
         mat-button
         class="details-card__actions_btn"
         data-testid="api_info_export_menu"
+        [disabled]="apiType === 'NATIVE'"
         (click)="exportApi()"
       >
         <mat-icon svgIcon="gio:upload"></mat-icon> Export
@@ -148,7 +149,7 @@
         *gioPermission="{ anyOf: ['api-definition-c'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="isKubernetesOrigin || api.definitionVersion === 'V1'"
+        [disabled]="isKubernetesOrigin || api.definitionVersion === 'V1' || apiType === 'NATIVE'"
         data-testid="api_info_duplicate_menu"
         (click)="duplicateApi()"
       >
@@ -158,7 +159,7 @@
         *gioPermission="{ anyOf: ['api-definition-u'] }"
         mat-button
         class="details-card__actions_btn"
-        [disabled]="cannotPromote"
+        [disabled]="cannotPromote || apiType === 'NATIVE'"
         data-testid="api_info_promote"
         (click)="promoteApi()"
       >
@@ -173,7 +174,12 @@
     [apiId]="apiId"
   ></api-general-info-quality>
 
-  <api-general-info-danger-zone class="danger-zone" [api]="api" (reloadDetails)="ngOnInit()"></api-general-info-danger-zone>
+  <api-general-info-danger-zone
+    *ngIf="apiType !== 'NATIVE'"
+    class="danger-zone"
+    [api]="api"
+    (reloadDetails)="ngOnInit()"
+  ></api-general-info-danger-zone>
 
   <gio-save-bar
     [form]="parentForm"

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -47,7 +47,7 @@ import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioApiImportDialogComponent, GioApiImportDialogData } from '../component/gio-api-import-dialog/gio-api-import-dialog.component';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { Api, ApiV2, ApiV4, UpdateApi, UpdateApiV2, UpdateApiV4 } from '../../../entities/management-api-v2';
+import { Api, ApiType, ApiV2, ApiV4, UpdateApi, UpdateApiV2, UpdateApiV4 } from '../../../entities/management-api-v2';
 import { Integration } from '../../integrations/integrations.model';
 import { IntegrationsService } from '../../../services-ngx/integrations.service';
 
@@ -61,6 +61,7 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
 
   public apiId: string;
   public api: Api;
+  public apiType: ApiType;
 
   public apiDetailsForm: UntypedFormGroup;
   public apiImagesForm: UntypedFormGroup;
@@ -140,8 +141,16 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
         ),
         tap(([api, categories]) => {
           this.isKubernetesOrigin = api.originContext?.origin === 'KUBERNETES';
+
+          if (api.definitionVersion === 'V4') {
+            this.apiType = (api as ApiV4).type;
+          }
+
           this.isReadOnly =
-            !this.permissionService.hasAnyMatching(['api-definition-u']) || this.isKubernetesOrigin || api.definitionVersion === 'V1';
+            !this.permissionService.hasAnyMatching(['api-definition-u']) ||
+            this.isKubernetesOrigin ||
+            api.definitionVersion === 'V1' ||
+            this.apiType === 'NATIVE';
 
           this.api = api;
 

--- a/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/properties/api-properties.component.ts
@@ -109,7 +109,7 @@ export class ApiPropertiesComponent implements OnInit, OnDestroy {
           }
           this.apiProperties = api.properties?.map((p) => ({ ...p, _id: uniqueId(), dynamic: p.dynamic })) ?? [];
 
-          this.isReadOnly = api.originContext?.origin === 'KUBERNETES';
+          this.isReadOnly = api.originContext?.origin === 'KUBERNETES' || (api as ApiV4).type === 'NATIVE';
 
           // Initialize the properties form group
           this.initPropertiesFormGroup();

--- a/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/resources/api-resources.component.ts
@@ -54,7 +54,7 @@ import { onlyApiV2V4Filter } from '../../../util/apiFilter.operator';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { gioTableFilterCollection } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
-import { Api } from '../../../entities/management-api-v2';
+import { Api, ApiV4 } from '../../../entities/management-api-v2';
 import { ResourceV2Service } from '../../../services-ngx/resource-v2.service';
 
 type TableDataSource = {
@@ -147,7 +147,7 @@ export class ApiResourcesComponent implements OnInit {
         });
 
         const filteredResources = gioTableFilterCollection(apiResourcesDS, tableFilters);
-        this.isReadOnly = api.definitionContext?.origin === 'KUBERNETES';
+        this.isReadOnly = api.definitionContext?.origin === 'KUBERNETES' || (api as ApiV4).type === 'NATIVE';
         return {
           isReadOnly: this.isReadOnly,
           isLoading: false,

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
@@ -33,7 +33,7 @@ import {
 import { SearchableUser } from '../../../../entities/user/searchableUser';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { ApiMemberV2Service } from '../../../../services-ngx/api-member-v2.service';
-import { Api, Group, Member } from '../../../../entities/management-api-v2';
+import { Api, ApiV4, Group, Member } from '../../../../entities/management-api-v2';
 import { GroupV2Service } from '../../../../services-ngx/group-v2.service';
 import { ApiGeneralGroupsComponent, ApiGroupsDialogData, ApiGroupsDialogResult } from '../groups/api-general-groups.component';
 import {
@@ -285,7 +285,11 @@ export class ApiGeneralMembersComponent implements OnInit {
 
   private initForm(api: Api) {
     this.isKubernetesOrigin = api.originContext?.origin === 'KUBERNETES';
-    this.isReadOnly = !this.permissionService.hasAnyMatching(['api-member-u']) || api.definitionVersion === 'V1' || this.isKubernetesOrigin;
+    this.isReadOnly =
+      !this.permissionService.hasAnyMatching(['api-member-u']) ||
+      api.definitionVersion === 'V1' ||
+      this.isKubernetesOrigin ||
+      (api as ApiV4).type === 'NATIVE';
     this.form = new UntypedFormGroup({
       isNotificationsEnabled: new UntypedFormControl({
         value: !api.disableMembershipNotifications,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7163

## Description

- only show tabs that can be controlled for native apis
- set configuration + configuration tabs to read-only for native apis (except for notifications which already works)
- fix label + access for Native Kafka APIs in API list


https://github.com/user-attachments/assets/2fda7885-1634-4c7b-84d5-59de8f77b215


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pudifwjotd.chromatic.com)
<!-- Storybook placeholder end -->
