### PR TITLE
chore: update alpine to version 3.20

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17-alpine-3.18 AS base
+FROM graviteeio/java:17-alpine-3.20 AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-gateway
 
 RUN apk update  \

--- a/gravitee-apim-gateway/docker/Dockerfile-from-download
+++ b/gravitee-apim-gateway/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17-alpine-3.18
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # First stage to share environment variable
-FROM graviteeio/java:17-alpine-3.18 AS base
+FROM graviteeio/java:17-alpine-3.20 AS base
 ENV GRAVITEEIO_HOME=/opt/graviteeio-management-api
 
 RUN addgroup -g 1000 graviteeio \

--- a/gravitee-apim-rest-api/docker/Dockerfile-from-download
+++ b/gravitee-apim-rest-api/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/java:17-alpine-3.18
+FROM graviteeio/java:17-alpine-3.20
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
## Issue

No issue

## Description

Uses the newer Alpine 3.20/Java 17 image [already built by graviteeio](https://hub.docker.com/layers/graviteeio/java/17-alpine-3.20/images/sha256-563b68dbeb74467b611b191b647491a5fd65b918aea7ff711055cc24af57e5d2?context=explore). Updated for security.

## Additional context


