### PR TITLE
fix: correctly retrieved environment role during cloud target token creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandler.java
@@ -154,8 +154,13 @@ public class TargetTokenCommandHandler implements CommandHandler<TargetTokenComm
             ? ROLE_ENVIRONMENT_FEDERATION_AGENT
             : ROLE_ENVIRONMENT_API_PUBLISHER;
 
-        if (roleService.findByScopeAndName(RoleScope.ENVIRONMENT, newRole.getName(), payload.environmentId()).isEmpty()) {
-            log.error("Couldn't find environment {} for organization with id [{}]", newRole.getName(), payload.organizationId());
+        if (roleService.findByScopeAndName(RoleScope.ENVIRONMENT, newRole.getName(), payload.organizationId()).isEmpty()) {
+            log.error(
+                "Couldn't find role {} with scope {} for organization with id [{}]",
+                newRole.getName(),
+                RoleScope.ENVIRONMENT,
+                payload.organizationId()
+            );
             return false;
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/TargetTokenCommandHandlerTest.java
@@ -87,7 +87,7 @@ class TargetTokenCommandHandlerTest {
         when(userService.create(any(), any(), eq(false))).thenReturn(user);
         when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
             .thenReturn(Optional.of(new RoleEntity()));
-        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ORGANISATION_ID)))
             .thenReturn(Optional.of(new RoleEntity()));
 
         TokenEntity tokenEntity = new TokenEntity();
@@ -112,7 +112,9 @@ class TargetTokenCommandHandlerTest {
         when(userService.create(any(), any(), eq(false))).thenReturn(user);
         when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(DEFAULT_ROLE_ORGANIZATION_USER.getName()), eq(ORGANISATION_ID)))
             .thenReturn(Optional.of(new RoleEntity()));
-        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_FEDERATION_AGENT.getName()), eq(ENVIRONMENT_ID)))
+        when(
+            roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_FEDERATION_AGENT.getName()), eq(ORGANISATION_ID))
+        )
             .thenReturn(Optional.of(new RoleEntity()));
 
         TokenEntity tokenEntity = new TokenEntity();
@@ -180,7 +182,7 @@ class TargetTokenCommandHandlerTest {
         when(userService.create(any(), any(), eq(false))).thenReturn(user);
         when(roleService.findByScopeAndName(eq(RoleScope.ORGANIZATION), eq(SystemRole.ADMIN.name()), eq(ORGANISATION_ID)))
             .thenReturn(Optional.of(new RoleEntity()));
-        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ENVIRONMENT_ID)))
+        when(roleService.findByScopeAndName(eq(RoleScope.ENVIRONMENT), eq(ROLE_ENVIRONMENT_API_PUBLISHER.getName()), eq(ORGANISATION_ID)))
             .thenReturn(Optional.empty());
 
         targetTokenCommandHandler


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-2616

## Description

Retrieved the environment role based on organization ID 

