### PR TITLE
[4.5.x] fix: allow users to configure ISM with Opensearch

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -419,12 +419,13 @@ reporters:
     endpoints:
       - http://${ds.elastic.host}:${ds.elastic.port}
 #    lifecycle:
-#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+#      policy_property_name: index.lifecycle.name   #for Opensearch, use 'index.plugins.index_state_management.policy_id' instead of 'index.lifecycle.name'
+#      rollover_alias_property_name: index.lifecycle.rollover_alias   #for Opensearch, use 'index.plugins.index_state_management.rollover_alias' instead of 'index.lifecycle.rollover_alias'
 #      policies:
-#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
-#        request: my_policy ## ILM policy for the gravitee-request-* indexes
-#        health: my_policy ## ILM policy for the gravitee-health-* indexes
-#        log: my_policy ## ILM policy for the gravitee-log-* indexes
+#        monitor: my_policy # ILM policy for the gravitee-monitor-* indexes
+#        request: my_policy # ILM policy for the gravitee-request-* indexes
+#        health: my_policy # ILM policy for the gravitee-health-* indexes
+#        log: my_policy # ILM policy for the gravitee-log-* indexes
 #    index: gravitee
 #    index_per_type: true
 #    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,4 +23,9 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: 'allow users to overwrite the Elasticsearch or Opensearch rollover alias property name'
+      links:
+        - name: Github Issue
+          url: https://github.com/gravitee-io/issues/issues/10100

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -406,6 +406,7 @@ data:
         {{- if (eq .Values.es.lifecycle.enabled true) }}
         lifecycle:
           policy_property_name: {{ .Values.es.lifecycle.policyPropertyName }}
+          rollover_alias_property_name: {{ .Values.es.lifecycle.rolloverAliasPropertyName }}
           policies:
             monitor: {{ .Values.es.lifecycle.policies.monitor }}
             request: {{ .Values.es.lifecycle.policies.request }}

--- a/helm/tests/gateway/configmap_es_reporter_test.yaml
+++ b/helm/tests/gateway/configmap_es_reporter_test.yaml
@@ -125,3 +125,49 @@ tests:
               # Elasticsearch reporter
               elasticsearch:
                 enabled: false
+
+  - it: Check override es lifecycle settings
+    template: gateway/gateway-configmap.yaml
+    set:
+      es:
+        index_mode: ilm
+        lifecycle:
+          enabled: true
+          policyPropertyName: index.plugins.index_state_management.policy_id
+          rolloverAliasPropertyName: index.plugins.index_state_management.rollover_alias
+          policies:
+            monitor: monitor
+            request: request
+            health: health
+            log: log
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            reporters:
+              # Elasticsearch reporter
+              elasticsearch:
+                endpoints:
+                  - http://graviteeio-apim-elasticsearch-ingest-hl:9200
+                index_mode: ilm
+                pipeline:
+                  plugins:
+                    ingest: geoip, user_agent
+                lifecycle:
+                  policy_property_name: index.plugins.index_state_management.policy_id
+                  rollover_alias_property_name: index.plugins.index_state_management.rollover_alias
+                  policies:
+                    monitor: monitor
+                    request: request
+                    health: health
+                    log: log
+                index: gravitee
+                settings:
+                  number_of_replicas: 1
+                  number_of_shards: 1
+                  refresh_interval: 5s
+                bulk:
+                  actions: 1000           # Number of requests action before flush
+                  flush_interval: 5       # Flush interval in seconds

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -321,7 +321,8 @@ es:
     password: example
   lifecycle:
     enabled: false
-    policyPropertyName: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+    policyPropertyName: index.lifecycle.name   #for Opensearch, use 'index.plugins.index_state_management.policy_id' instead of 'index.lifecycle.name'
+    rolloverAliasPropertyName: index.lifecycle.rollover_alias   #for Opensearch, use 'index.plugins.index_state_management.rollover_alias' instead of 'index.lifecycle.name'
     policies:
       monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
       request: my_policy ## ILM policy for the gravitee-request-* indexes

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.3</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>5.5.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>5.5.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>3.2.2</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>2.3.2</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>1.1.0</gravitee-reporter-cloud.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7236

## Description

Following this [PR](https://github.com/gravitee-io/gravitee-api-management/pull/9866) here is a simple cherry pick of the commit for 4.5.x and master

Linked PR: https://github.com/gravitee-io/gravitee-reporter-elasticsearch/pull/95

👉🏼 👀  NB: I'll merge the PRs on 4.2, 4.3, 4.4, gravitee-reporter-elasticsearch. After I'll update the pom.xml to not use the snapshot and after I'll open this PR

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xbnvvloral.chromatic.com)
<!-- Storybook placeholder end -->
