### PR TITLE
fix: use good path for mapi V2 api analytics response status endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1939,7 +1939,7 @@ paths:
                     $ref: "#/components/responses/ApiAnalyticsAverageConnectionDurationResponse"
                 default:
                     $ref: "#/components/responses/Error"
-    /environments/{envId}/apis/{apiId}/analytics/response-statuses:
+    /environments/{envId}/apis/{apiId}/analytics/response-status-ranges:
       parameters:
         - $ref: "#/components/parameters/envIdParam"
         - $ref: "#/components/parameters/apiIdParam"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7581

## Description

I may be wrong but in this PR ( links : https://github.com/gravitee-io/gravitee-api-management/pull/7655/files#diff-84b68aece67601a2395554f4554929b5e988faa887a2e7435ce72947de34e5e9R1938 & https://github.com/gravitee-io/gravitee-api-management/pull/7655/files#diff-95c2f765bb5a338237dabf672d1e794409e6797486c1a3dcae94802cb8493e15R100) we have set the wrong path in the openapi.yml file

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

