### PR TITLE
fix: create and edit a group

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.html
@@ -49,10 +49,9 @@
   </mat-tab-group>
 
   <gio-save-bar
-    *ngIf="!isReadOnly"
+    *ngIf="!isReadOnly && groupForm.dirty"
     class="save-bar"
     [creationMode]="mode === 'new'"
-    [opened]="groupForm.dirty"
     [form]="groupForm"
     [formInitialValues]="initialGroupFormValue"
     (submitted)="onSubmit()"

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.spec.ts
@@ -477,7 +477,6 @@ describe('ApiProxyGroupEditComponent', () => {
     });
 
     it('should not be able to create new group when name is already used', async () => {
-      const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
       const newGroupName = 'default-group';
       const groupNameInput = await loader.getHarness(MatInputHarness.with({ selector: '[aria-label="Group name input"]' }));
 
@@ -486,6 +485,7 @@ describe('ApiProxyGroupEditComponent', () => {
       const lbSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Load balancing algorithm"]' }));
       await lbSelect.clickOptions({ text: 'RANDOM' });
 
+      const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await gioSaveBar.isSubmitButtonInvalid()).toBeTruthy();
       expect(fixture.componentInstance.generalForm.get('name').hasError('isUnique')).toBeTruthy();
     });

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/edit/api-proxy-group-edit.component.ts
@@ -112,6 +112,7 @@ export class ApiProxyGroupEditComponent implements OnInit, OnDestroy {
           this.snackBarService.success('Configuration successfully saved!');
           this.initialGroupFormValue = this.groupForm.getRawValue();
           this.groupForm.markAsPristine();
+          this.mode = 'edit';
         }),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7318

## Description

In this [PR](https://github.com/gravitee-io/gravitee-api-management/pull/9824) we have fixed the save bar when we create or edit a group but their is still a small bug when we stay in the page after the creation.
The mergify PRs are ok and already contains the good fix

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-abnobyhvzv.chromatic.com)
<!-- Storybook placeholder end -->
