### PR TITLE
refactor: use apim dedicated TemplateVariableProvider accepting an ExecutionContext

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
@@ -220,7 +220,13 @@ public abstract class AbstractExecutionContext<RQ extends MutableRequest, RS ext
             templateEngine = TemplateEngine.templateEngine();
             prepareTemplateEngine(templateEngine);
             if (templateVariableProviders != null) {
-                templateVariableProviders.forEach(templateVariableProvider -> templateVariableProvider.provide(this));
+                templateVariableProviders.forEach(templateVariableProvider -> {
+                    if (templateVariableProvider instanceof ExecutionContextTemplateVariableProvider ctxTemplateVariableProvider) {
+                        ctxTemplateVariableProvider.provide(this);
+                    } else {
+                        templateVariableProvider.provide(templateEngine.getTemplateContext());
+                    }
+                });
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContext.java
@@ -19,7 +19,6 @@ import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.core.component.ComponentProvider;
-import io.gravitee.gateway.reactive.api.context.TlsSession;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import java.util.Collection;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/ExecutionContextTemplateVariableProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/ExecutionContextTemplateVariableProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context;
+
+import io.gravitee.el.TemplateContext;
+import io.gravitee.el.TemplateVariableProvider;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+
+public interface ExecutionContextTemplateVariableProvider extends TemplateVariableProvider {
+    @Override
+    default void provide(TemplateContext templateContext) {
+        // rely on provide(ctx)
+        throw new IllegalStateException("Should provide a BaseExecutionContext to an ExecutionContextTemplateVariableProvider");
+    }
+
+    <T extends BaseExecutionContext> void provide(T ctx);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContextTest.java
@@ -364,7 +364,7 @@ class DefaultExecutionContextTest {
 
     @Test
     void should_provide_template_variables_when_providers_are_specified() {
-        final TemplateVariableProvider templateVariableProvider = mock(TemplateVariableProvider.class);
+        final ExecutionContextTemplateVariableProvider templateVariableProvider = mock(ExecutionContextTemplateVariableProvider.class);
         cut.templateVariableProviders(List.of(templateVariableProvider));
 
         cut.getTemplateEngine();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProvider.java
@@ -29,8 +29,10 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.HttpRequest;
 import io.gravitee.gateway.reactive.api.context.HttpResponse;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.el.EvaluableRequest;
 import io.gravitee.gateway.reactive.api.el.EvaluableResponse;
+import io.gravitee.gateway.reactive.core.context.ExecutionContextTemplateVariableProvider;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +44,7 @@ import java.util.Map;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ContentTemplateVariableProvider implements TemplateVariableProvider {
+public class ContentTemplateVariableProvider implements ExecutionContextTemplateVariableProvider {
 
     protected static final String TEMPLATE_ATTRIBUTE_REQUEST_CONTENT = TEMPLATE_ATTRIBUTE_REQUEST + ".content";
     protected static final String TEMPLATE_ATTRIBUTE_REQUEST_CONTENT_JSON = TEMPLATE_ATTRIBUTE_REQUEST + ".jsonContent";
@@ -56,12 +58,8 @@ public class ContentTemplateVariableProvider implements TemplateVariableProvider
     private static final XmlMapper XML_MAPPER = new XmlMapper();
 
     @Override
-    public void provide(TemplateContext templateContext) {
-        // Use provide(HttpExecutionContext) instead.
-    }
-
-    @Override
-    public <T extends HttpExecutionContext> void provide(T ctx) {
+    public <T extends BaseExecutionContext> void provide(T executionContext) {
+        HttpExecutionContext ctx = (HttpExecutionContext) executionContext;
         final TemplateEngine templateEngine = ctx.getTemplateEngine();
         final TemplateContext templateContext = templateEngine.getTemplateContext();
         final EvaluableRequest evaluableRequest = (EvaluableRequest) templateContext.lookupVariable(TEMPLATE_ATTRIBUTE_REQUEST);

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <gravitee-common.version>4.5.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.5</gravitee-connector-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
-        <gravitee-expression-language.version>3.2.1</gravitee-expression-language.version>
+        <gravitee-expression-language.version>4.0.0-alpha.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.9.0-alpha.16</gravitee-gateway-api.version>
         <gravitee-integration-api.version>4.1.0</gravitee-integration-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7417

## Description

Move the specific code to provide variables to a TemplateContext thanks to an ExecutionContext from gravitee-expression-language to APIM

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wgyivjnbpy.chromatic.com)
<!-- Storybook placeholder end -->
