### PR TITLE
feat: integrate api score ruleset list display with backend

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.fixture.ts
@@ -13,18 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ScoringRulesetsResponse } from './ruleset';
 
-import { NgModule } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { AsyncPipe } from '@angular/common';
+export function fakeRulesetsList(attribute?: Partial<ScoringRulesetsResponse>) {
+  const base: ScoringRulesetsResponse = {
+    data: [
+      {
+        name: 'Test ruleset name',
+        description: 'Test ruleset description',
+        payload: 'Ruleset payload',
+        id: 'ruleset-id',
+        createdAt: '2024-11-19T12:41:18.85Z',
+        referenceId: 'DEFAULT',
+        referenceType: 'ENVIRONMENT',
+      },
+    ],
+  };
 
-import { ApiScoreRulesetsComponent } from './api-score-rulesets.component';
-
-@NgModule({
-  declarations: [ApiScoreRulesetsComponent],
-  imports: [MatCardModule, MatButtonModule, MatExpansionModule, AsyncPipe],
-  exports: [ApiScoreRulesetsComponent],
-})
-export class ApiScoreRulesetsModule {}
+  return {
+    ...base,
+    ...attribute,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.ts
@@ -13,18 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export interface ScoringRulesetsResponse {
+  data: ScoringRuleset[];
+}
 
-import { NgModule } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { AsyncPipe } from '@angular/common';
-
-import { ApiScoreRulesetsComponent } from './api-score-rulesets.component';
-
-@NgModule({
-  declarations: [ApiScoreRulesetsComponent],
-  imports: [MatCardModule, MatButtonModule, MatExpansionModule, AsyncPipe],
-  exports: [ApiScoreRulesetsComponent],
-})
-export class ApiScoreRulesetsModule {}
+export interface ScoringRuleset {
+  id: string;
+  name: string;
+  description: string;
+  payload: string;
+  createdAt: string;
+  referenceId: string;
+  referenceType: string;
+}

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.html
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.html
@@ -28,21 +28,25 @@
 
   <div class="separator-hr"></div>
 
-  <mat-card-content>
-    <mat-expansion-panel>
-      <mat-expansion-panel-header>
-        <mat-panel-title>
-          Default Ruleset provided by Gravitee
-          <span class="gio-badge-neutral">5 rules</span>
-          <span class="gio-badge-accent">Gravitee</span>
-        </mat-panel-title>
-        <span class="body-2 subtitle">This is the Gravitee’s default ruleset governing API.</span>
-      </mat-expansion-panel-header>
-
-      <div class="separator-hr"></div>
-
-      <h4>Raw file preview</h4>
-      <pre class="file-preview">{{ yamlFileExample }}</pre>
-    </mat-expansion-panel>
-  </mat-card-content>
+  @if (rulesets$ | async; as rulesets) {
+    <mat-card-content class="rulesets">
+      @for (ruleset of rulesets.data; track ruleset.id) {
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              {{ ruleset.name }}
+            </mat-panel-title>
+            <mat-panel-description>
+              <span class="body-2 subtitle">{{ ruleset.description }}</span>
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+          <div class="separator-hr"></div>
+          <h4>Raw file preview</h4>
+          <pre class="file-preview">{{ ruleset.payload }}</pre>
+        </mat-expansion-panel>
+      } @empty {
+        No rulesets
+      }
+    </mat-card-content>
+  }
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.scss
@@ -81,3 +81,9 @@ $typography: map.get(gio.$mat-theme, typography);
 .file-preview {
   margin: 0;
 }
+
+.rulesets {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.spec.ts
@@ -16,15 +16,21 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 
 import { ApiScoreRulesetsComponent } from './api-score-rulesets.component';
+import { ApiScoreRulesetsHarness } from './api-score-rulesets.harness';
 
-import { GioTestingModule } from '../../../shared/testing';
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ApiScoreModule } from '../api-score.module';
+import { fakeRulesetsList } from '../../../entities/management-api-v2/api/v4/ruleset.fixture';
 
 describe('ApiScoreRulesetsComponent', () => {
   let component: ApiScoreRulesetsComponent;
   let fixture: ComponentFixture<ApiScoreRulesetsComponent>;
+  let httpTestingController: HttpTestingController;
+  let componentHarness: ApiScoreRulesetsHarness;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -33,10 +39,39 @@ describe('ApiScoreRulesetsComponent', () => {
 
     fixture = TestBed.createComponent(ApiScoreRulesetsComponent);
     component = fixture.componentInstance;
+    httpTestingController = TestBed.inject(HttpTestingController);
+    componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiScoreRulesetsHarness);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should display rulesets', async () => {
+    expectListRulesets();
     expect(component).toBeTruthy();
+
+    const matExpansionPanel = await componentHarness.getMatExpansionPanelHarness();
+    const title = await matExpansionPanel.getTitle();
+    const description = await matExpansionPanel.getDescription();
+
+    expect(title).toEqual('Test ruleset name');
+    expect(description).toEqual('Test ruleset description');
   });
+
+  it('should display no ruleset info if backend returns empty list of rulesets', async () => {
+    const emptyRulesetList = { data: [] };
+    expectListRulesets(emptyRulesetList);
+
+    const matCardHarness = await componentHarness.getMatCardHarness();
+
+    const content = await matCardHarness.getText();
+
+    expect(content).toContain('No rulesets');
+  });
+
+  function expectListRulesets(res = fakeRulesetsList()) {
+    const url = `${CONSTANTS_TESTING.env.v2BaseURL}/scoring/rulesets`;
+    const req = httpTestingController.expectOne((req) => {
+      return req.method === 'GET' && req.url.startsWith(url);
+    });
+    req.flush(res);
+  }
 });

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.ts
@@ -14,36 +14,33 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { EMPTY, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
-const yamlFileExample = `
-ratelimit-headers:
-    description: Response must include ratelimit-x headers
-    message: '{{description}}; missing {{property}}'
-    severity: error
-    given: $..responses.*
-    then:
-      - field: headers.ratelimit-limit
-        function: truthy
-      - field: headers.ratelimit-remaining
-        function: truthy
-      - field: headers.ratelimit-reset
-        function: truthy
-
-  properties-must-include-examples:
-    description: Object properties must include examples
-    given: $..properties..properties.*
-    severity: error
-    message: '{{description}}; {{property}}'
-    then:
-      function: ensurePropertiesExample
-`;
+import { RulesetV2Service } from '../../../services-ngx/ruleset-v2.service';
+import { ScoringRulesetsResponse } from '../../../entities/management-api-v2/api/v4/ruleset';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 @Component({
   selector: 'app-api-score-rulesets',
   templateUrl: './api-score-rulesets.component.html',
   styleUrl: './api-score-rulesets.component.scss',
 })
-export class ApiScoreRulesetsComponent {
-  public readonly yamlFileExample = yamlFileExample;
+export class ApiScoreRulesetsComponent implements OnInit {
+  rulesets$: Observable<ScoringRulesetsResponse>;
+
+  constructor(
+    private readonly rulesetV2Service: RulesetV2Service,
+    private readonly snackBarService: SnackBarService,
+  ) {}
+
+  ngOnInit(): void {
+    this.rulesets$ = this.rulesetV2Service.listRulesets().pipe(
+      catchError(({ error }) => {
+        this.snackBarService.error(error.message);
+        return EMPTY;
+      }),
+    );
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.harness.ts
@@ -13,18 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatExpansionPanelHarness } from '@angular/material/expansion/testing';
+import { MatCardHarness } from '@angular/material/card/testing';
 
-import { NgModule } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { AsyncPipe } from '@angular/common';
+export class ApiScoreRulesetsHarness extends ComponentHarness {
+  static hostSelector = 'app-api-score-rulesets';
 
-import { ApiScoreRulesetsComponent } from './api-score-rulesets.component';
+  getMatExpansionPanelHarness = this.locatorForOptional(MatExpansionPanelHarness);
 
-@NgModule({
-  declarations: [ApiScoreRulesetsComponent],
-  imports: [MatCardModule, MatButtonModule, MatExpansionModule, AsyncPipe],
-  exports: [ApiScoreRulesetsComponent],
-})
-export class ApiScoreRulesetsModule {}
+  getMatCardHarness = this.locatorForOptional(MatCardHarness);
+}

--- a/gravitee-apim-console-webui/src/services-ngx/ruleset-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/ruleset-v2.service.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+
+import { Constants } from '../entities/Constants';
+import { ScoringRulesetsResponse } from '../entities/management-api-v2/api/v4/ruleset';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RulesetV2Service {
+  constructor(
+    @Inject(Constants) private readonly constants: Constants,
+    private httpClient: HttpClient,
+  ) {}
+
+  public listRulesets(): Observable<ScoringRulesetsResponse> {
+    const url = `${this.constants.env.v2BaseURL}/scoring/rulesets`;
+    return this.httpClient.get<ScoringRulesetsResponse>(url);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7598

## Description

Integrate the frontend part of displaying rulesets lists with the backend 

## Additional context
![image](https://github.com/user-attachments/assets/e9544047-546e-4e21-afc9-756f5cdf95cf)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-krmwdwjltm.chromatic.com)
<!-- Storybook placeholder end -->
