### PR TITLE
chore: remove native kafka connectors from gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -148,6 +148,7 @@
                 <exclude>io.gravitee.fetcher:*:zip</exclude>
                 <exclude>io.gravitee.notifier:*:zip</exclude>
                 <exclude>io.gravitee.apim.plugin.apiservice.dynamicproperties:gravitee-apim-plugin-apiservice-dynamicproperties-http:zip</exclude>
+                <exclude>com.graviteesource.connector:gravitee-*-native-kafka:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -189,6 +189,8 @@ const gatewayDependenciesExclusion = [
   'gravitee-apim-repository-elasticsearch',
   'gravitee-cockpit-connectors-ws',
   'gravitee-apim-plugin-apiservice-dynamicproperties-http',
+  'gravitee-endpoint-native-kafka',
+  'gravitee-entrypoint-native-kafka',
 ];
 
 console.log(chalk.blue(`Add plugins to Gateway`));


### PR DESCRIPTION
## Issue

N/A

## Description

On gateway side, native kafka connectors will be embedded directly in the kafka native reactor. We don't need to add them into the gateway distribution.
