### PR TITLE
feat: Dashboard top apis navigation to v4 API-level analytics

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-filters-bar/api-analytics-filters-bar.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-filters-bar/api-analytics-filters-bar.component.harness.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class ApiAnalyticsFiltersBarHarness extends ComponentHarness {
   static hostSelector = 'api-analytics-filters-bar';
@@ -24,4 +25,6 @@ export class ApiAnalyticsFiltersBarHarness extends ComponentHarness {
   async refresh(): Promise<void> {
     return (await this.getRefreshButton()).click();
   }
+
+  getMatSelect = this.locatorFor(MatSelectHarness);
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-filters-bar/api-analytics-filters-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/components/api-analytics-filters-bar/api-analytics-filters-bar.component.ts
@@ -23,11 +23,12 @@ import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatOption } from '@angular/material/autocomplete';
 import { MatSelect } from '@angular/material/select';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { FiltersApplied } from './api-analytics-filters-bar.configuration';
 
 import { timeFrames, TimeRangeParams } from '../../../../../../shared/utils/timeFrameRanges';
-import { ApiAnalyticsV2Service } from '../../../../../../services-ngx/api-analytics-v2.service';
+import { ApiAnalyticsV2Service, DefaultFilters } from '../../../../../../services-ngx/api-analytics-v2.service';
 
 @Component({
   selector: 'api-analytics-filters-bar',
@@ -47,7 +48,7 @@ import { ApiAnalyticsV2Service } from '../../../../../../services-ngx/api-analyt
   styleUrl: './api-analytics-filters-bar.component.scss',
 })
 export class ApiAnalyticsFiltersBarComponent implements OnInit {
-  private readonly defaultFilters = this.apiAnalyticsV2Service.defaultFilters;
+  private readonly defaultFilters = this.getDefaultFilters();
   protected readonly timeFrames = timeFrames;
   public formGroup: FormGroup;
   public activeFilters: FiltersApplied = this.defaultFilters;
@@ -56,6 +57,8 @@ export class ApiAnalyticsFiltersBarComponent implements OnInit {
     private readonly formBuilder: FormBuilder,
     private readonly destroyRef: DestroyRef,
     private readonly apiAnalyticsV2Service: ApiAnalyticsV2Service,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly router: Router,
   ) {}
 
   ngOnInit() {
@@ -76,5 +79,19 @@ export class ApiAnalyticsFiltersBarComponent implements OnInit {
 
   private getPeriodTimeRangeParams(): TimeRangeParams {
     return timeFrames.find((timeFrame) => timeFrame.id === this.activeFilters.period)?.timeFrameRangesParams();
+  }
+
+  private getDefaultFilters(): DefaultFilters {
+    const periodFromQueryParam = this.activatedRoute.snapshot.queryParams.period;
+    const validPeriod = timeFrames.find((timeFrame) => timeFrame.id === periodFromQueryParam);
+
+    if (periodFromQueryParam && validPeriod) {
+      return { period: periodFromQueryParam };
+    }
+
+    this.router.navigate(['../analytics'], {
+      relativeTo: this.activatedRoute,
+    });
+    return { period: '1d' };
   }
 }

--- a/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-overview/home-overview.component.html
@@ -90,7 +90,7 @@
       [responseStatusRanges]="v4ApiAnalyticsResponseStatusRanges"
     ></api-analytics-response-status-ranges>
 
-    <app-top-apis-widget [data]="topApisV4"></app-top-apis-widget>
+    <app-top-apis-widget [data]="topApisV4" [period]="this.timeRangeParams.id"></app-top-apis-widget>
     <dashboard-v4-api-request-stats [data]="requestStatsV4"></dashboard-v4-api-request-stats>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/top-apis-widget/top-apis-widget.component.ts
@@ -53,6 +53,7 @@ export interface TopApisV4 {
 })
 export class TopApisWidgetComponent implements OnChanges {
   @Input() data: TopApisV4[];
+  @Input() period: string;
 
   displayedColumns = ['name', 'count'];
   filteredTableData: TopApisV4[];
@@ -74,6 +75,7 @@ export class TopApisWidgetComponent implements OnChanges {
   navigateToApi(apiKey: string): void {
     this.router.navigate(['../../', 'apis', apiKey, 'v4', 'analytics'], {
       relativeTo: this.activatedRoute,
+      queryParams: { period: this.period },
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7418

## Description

When you come from the env-level Dashboard, and you’ve picked a time period e.g. “Last week”, then you open an API directly e.g. from the “Top 5 APIs” widget, then you should see the API-level analytics open with the same time period pre-selected.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ppuulbncsx.chromatic.com)
<!-- Storybook placeholder end -->
