### PR TITLE
fix: get request count widget missing type range filter support

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.spec.ts
@@ -49,12 +49,7 @@ describe('ApiAnalyticsV2Service', () => {
         done();
       });
 
-      httpTestingController
-        .expectOne({
-          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/analytics/requests-count`,
-          method: 'GET',
-        })
-        .flush(fakeAnalyticsRequestsCount());
+      expectGetRequestCount();
     });
   });
 
@@ -92,6 +87,14 @@ describe('ApiAnalyticsV2Service', () => {
       expectApiAnalyticsResponseStatusRangesGetRequest();
     });
   });
+
+  function expectGetRequestCount() {
+    const url = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/analytics/requests-count`;
+    const req = httpTestingController.expectOne((req) => {
+      return req.method === 'GET' && req.url.startsWith(url);
+    });
+    req.flush(fakeAnalyticsRequestsCount());
+  }
 
   function expectApiAnalyticsResponseStatusRangesGetRequest() {
     const url = `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/analytics/response-status-ranges`;

--- a/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-analytics-v2.service.ts
@@ -51,7 +51,12 @@ export class ApiAnalyticsV2Service {
   }
 
   getRequestsCount(apiId: string): Observable<AnalyticsRequestsCount> {
-    return this.http.get<AnalyticsRequestsCount>(`${this.constants.env.v2BaseURL}/apis/${apiId}/analytics/requests-count`);
+    return this.timeRangeFilter().pipe(
+      switchMap(({ from, to }) => {
+        const url = `${this.constants.env.v2BaseURL}/apis/${apiId}/analytics/requests-count?from=${from}&to=${to}`;
+        return this.http.get<AnalyticsRequestsCount>(url);
+      }),
+    );
   }
 
   getAverageConnectionDuration(apiId: string): Observable<AnalyticsAverageConnectionDuration> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7624

## Description

The total request value for the Request Stats widget didn't have proper time range filter support. It always showed last-day data no matter what time range period you chose.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sudqdevkom.chromatic.com)
<!-- Storybook placeholder end -->
