### PR TITLE
fix: add owner in webhook notifications when accept or reject subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
@@ -633,5 +634,10 @@ public class ResourceContextConfiguration {
     @Bean
     public PageSourceDomainServiceInMemory pageSourceDomainService() {
         return new PageSourceDomainServiceInMemory();
+    }
+
+    @Bean
+    public ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService() {
+        return mock(ApplicationPrimaryOwnerDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
@@ -21,4 +21,5 @@ public enum HookContextEntry {
     PLAN_ID,
     SUBSCRIPTION_ID,
     API_KEY,
+    OWNER,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApiHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApiHookContext.java
@@ -23,12 +23,20 @@ public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
     private final String applicationId;
     private final String planId;
     private final String subscriptionId;
+    private final String applicationPrimaryOwner;
 
-    public SubscriptionAcceptedApiHookContext(String apiId, String applicationId, String planId, String subscriptionId) {
+    public SubscriptionAcceptedApiHookContext(
+        String apiId,
+        String applicationId,
+        String planId,
+        String subscriptionId,
+        String applicationPrimaryOwner
+    ) {
         super(ApiHook.SUBSCRIPTION_ACCEPTED, apiId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;
+        this.applicationPrimaryOwner = applicationPrimaryOwner;
     }
 
     @Override
@@ -39,7 +47,9 @@ public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
             HookContextEntry.PLAN_ID,
             planId,
             HookContextEntry.SUBSCRIPTION_ID,
-            subscriptionId
+            subscriptionId,
+            HookContextEntry.OWNER,
+            applicationPrimaryOwner
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApplicationHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApplicationHookContext.java
@@ -23,16 +23,33 @@ public class SubscriptionAcceptedApplicationHookContext extends ApplicationHookC
     private final String apiId;
     private final String planId;
     private final String subscriptionId;
+    private final String applicationPrimaryOwner;
 
-    public SubscriptionAcceptedApplicationHookContext(String applicationId, String apiId, String planId, String subscriptionId) {
+    public SubscriptionAcceptedApplicationHookContext(
+        String applicationId,
+        String apiId,
+        String planId,
+        String subscriptionId,
+        String applicationPrimaryOwner
+    ) {
         super(ApplicationHook.SUBSCRIPTION_ACCEPTED, applicationId);
         this.apiId = apiId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;
+        this.applicationPrimaryOwner = applicationPrimaryOwner;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(HookContextEntry.API_ID, apiId, HookContextEntry.PLAN_ID, planId, HookContextEntry.SUBSCRIPTION_ID, subscriptionId);
+        return Map.of(
+            HookContextEntry.API_ID,
+            apiId,
+            HookContextEntry.PLAN_ID,
+            planId,
+            HookContextEntry.SUBSCRIPTION_ID,
+            subscriptionId,
+            HookContextEntry.OWNER,
+            applicationPrimaryOwner
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiHookContext.java
@@ -23,12 +23,20 @@ public class SubscriptionRejectedApiHookContext extends ApiHookContext {
     private final String applicationId;
     private final String planId;
     private final String subscriptionId;
+    private final String applicationPrimaryOwner;
 
-    public SubscriptionRejectedApiHookContext(String apiId, String applicationId, String planId, String subscriptionId) {
+    public SubscriptionRejectedApiHookContext(
+        String apiId,
+        String applicationId,
+        String planId,
+        String subscriptionId,
+        String applicationPrimaryOwner
+    ) {
         super(ApiHook.SUBSCRIPTION_REJECTED, apiId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;
+        this.applicationPrimaryOwner = applicationPrimaryOwner;
     }
 
     @Override
@@ -39,7 +47,9 @@ public class SubscriptionRejectedApiHookContext extends ApiHookContext {
             HookContextEntry.PLAN_ID,
             planId,
             HookContextEntry.SUBSCRIPTION_ID,
-            subscriptionId
+            subscriptionId,
+            HookContextEntry.OWNER,
+            applicationPrimaryOwner
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApplicationHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApplicationHookContext.java
@@ -23,16 +23,33 @@ public class SubscriptionRejectedApplicationHookContext extends ApplicationHookC
     private final String apiId;
     private final String planId;
     private final String subscriptionId;
+    private final String applicationPrimaryOwner;
 
-    public SubscriptionRejectedApplicationHookContext(String applicationId, String apiId, String planId, String subscriptionId) {
+    public SubscriptionRejectedApplicationHookContext(
+        String applicationId,
+        String apiId,
+        String planId,
+        String subscriptionId,
+        String applicationPrimaryOwner
+    ) {
         super(ApplicationHook.SUBSCRIPTION_REJECTED, applicationId);
         this.apiId = apiId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;
+        this.applicationPrimaryOwner = applicationPrimaryOwner;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(HookContextEntry.API_ID, apiId, HookContextEntry.PLAN_ID, planId, HookContextEntry.SUBSCRIPTION_ID, subscriptionId);
+        return Map.of(
+            HookContextEntry.API_ID,
+            apiId,
+            HookContextEntry.PLAN_ID,
+            planId,
+            HookContextEntry.SUBSCRIPTION_ID,
+            subscriptionId,
+            HookContextEntry.OWNER,
+            applicationPrimaryOwner
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseExpiredSubscriptionsUseCaseTest.java
@@ -27,9 +27,13 @@ import inmemory.ApiQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.IntegrationAgentInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
@@ -41,6 +45,8 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditEntity.AuditReferenceType;
 import io.gravitee.apim.core.environment.model.Environment;
+import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
@@ -70,6 +76,10 @@ class CloseExpiredSubscriptionsUseCaseTest {
     private final AuditCrudServiceInMemory auditCrudServiceInMemory = new AuditCrudServiceInMemory();
     private final ApplicationCrudServiceInMemory applicationCrudService = new ApplicationCrudServiceInMemory();
     private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+    private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    private final MembershipQueryService membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+    private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
 
     private CloseExpiredSubscriptionsUseCase usecase;
 
@@ -81,12 +91,20 @@ class CloseExpiredSubscriptionsUseCaseTest {
         var userCrudService = new UserCrudServiceInMemory();
         var auditDomainService = new AuditDomainService(auditCrudServiceInMemory, userCrudService, new JacksonJsonDiffProcessor());
 
+        var applicationPrimaryOwnerDomainService = new ApplicationPrimaryOwnerDomainService(
+            groupQueryService,
+            membershipQueryService,
+            roleQueryService,
+            userCrudService
+        );
+
         var rejectSubscriptionDomainService = new RejectSubscriptionDomainService(
             subscriptionCrudService,
             planCrudService,
             auditDomainService,
             triggerNotificationService,
-            userCrudService
+            userCrudService,
+            applicationPrimaryOwnerDomainService
         );
 
         var apiKeyCrudService = new ApiKeyCrudServiceInMemory();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7613

## Description

We have lost the "owner" in subscription notifications.
Here is a PR to add the owner in webhook notifications when accept or reject a subscription.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/9960/console](https://pr.team-apim.gravitee.dev/9960/console)
      Portal: [https://pr.team-apim.gravitee.dev/9960/portal](https://pr.team-apim.gravitee.dev/9960/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/9960/api/management](https://pr.team-apim.gravitee.dev/9960/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/9960](https://pr.team-apim.gravitee.dev/9960)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/9960](https://pr.gateway-v3.team-apim.gravitee.dev/9960)

<!-- Environment placeholder end -->
