### PR TITLE
fix: improve API update performances using import with swagger

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FlowRepository.java
@@ -52,4 +52,8 @@ public interface FlowRepository extends CrudRepository<Flow, String> {
      * @throws TechnicalException
      */
     List<String> deleteByReferenceIdAndReferenceType(String referenceId, FlowReferenceType referenceType) throws TechnicalException;
+
+    List<Flow> createAll(List<Flow> flows) throws TechnicalException;
+
+    List<Flow> updateAll(List<Flow> flows) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
@@ -65,4 +65,6 @@ public interface PlanRepository extends CrudRepository<Plan, String> {
      * @throws TechnicalException
      */
     List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException;
+
+    boolean exists(String id) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Page.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Page.java
@@ -27,7 +27,7 @@ import lombok.*;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Page {
 
     public enum AuditEvent implements Audit.ApiAuditEvent {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/Flow.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/Flow.java
@@ -34,7 +34,7 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode
 @ToString
-@Builder
+@Builder(toBuilder = true)
 public class Flow {
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -464,6 +464,24 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
     }
 
     @Override
+    public List<Flow> createAll(List<Flow> flows) throws TechnicalException {
+        var createdFlows = new ArrayList<Flow>();
+        for (Flow flow : flows) {
+            createdFlows.add(create(flow));
+        }
+        return createdFlows;
+    }
+
+    @Override
+    public List<Flow> updateAll(List<Flow> flows) throws TechnicalException {
+        var updatedFlows = new ArrayList<Flow>();
+        for (Flow flow : flows) {
+            updatedFlows.add(update(flow));
+        }
+        return updatedFlows;
+    }
+
+    @Override
     public void deleteAllById(Collection<String> ids) throws TechnicalException {
         LOGGER.debug("JdbcFlowRepository.deleteByIds({})", ids);
         try {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -380,4 +380,15 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
             throw new TechnicalException(message, ex);
         }
     }
+
+    @Override
+    public boolean exists(String id) throws TechnicalException {
+        LOGGER.debug("JdbcPlanRepository.exists({})", id);
+        try {
+            return jdbcTemplate.queryForObject("select count(id) from " + tableName + " where id = ?", Integer.class, id) > 0;
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to check if plan exists", ex);
+            throw new TechnicalException("Failed to check if plan exists", ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
@@ -122,6 +122,18 @@ public class MongoFlowRepository implements FlowRepository {
         return internalRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 
+    @Override
+    public List<Flow> createAll(List<Flow> flows) {
+        final List<FlowMongo> savedFlows = internalRepository.insert(flows.stream().map(this::map).collect(Collectors.toList()));
+        return savedFlows.stream().map(this::map).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Flow> updateAll(List<Flow> flows) {
+        final List<FlowMongo> savedFlows = internalRepository.saveAll(flows.stream().map(this::map).collect(Collectors.toList()));
+        return savedFlows.stream().map(this::map).collect(Collectors.toList());
+    }
+
     private FlowMongo map(Flow flow) {
         return mapper.map(flow);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
@@ -89,7 +89,7 @@ public class MongoFlowRepository implements FlowRepository {
 
     @Override
     public List<Flow> findByReference(FlowReferenceType referenceType, String referenceId) {
-        final List<FlowMongo> flows = internalRepository.findAll(referenceType.name(), referenceId);
+        final List<FlowMongo> flows = internalRepository.findByReference(referenceType.name(), referenceId);
         return flows.stream().map(this::map).collect(Collectors.toList());
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
@@ -127,4 +127,16 @@ public class MongoPlanRepository implements PlanRepository {
             throw new TechnicalException("Failed to delete plan by environment", e);
         }
     }
+
+    @Override
+    public boolean exists(String id) throws TechnicalException {
+        LOGGER.debug("Checking if plan exists by id [{}]", id);
+
+        try {
+            return internalPlanRepository.existsById(id);
+        } catch (Exception e) {
+            LOGGER.error("Failed to check if plan exists by id [{}]", id, e);
+            throw new TechnicalException("Failed to determine if plan exists by id", e);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/flow/FlowMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/flow/FlowMongoRepository.java
@@ -35,4 +35,7 @@ public interface FlowMongoRepository extends MongoRepository<FlowMongo, String> 
 
     @Query(value = "{ 'referenceId': ?0, 'referenceType': ?1}", fields = "{ _id : 1 }", delete = true)
     List<FlowMongo> deleteByReferenceIdAndReferenceType(String referenceId, String referenceTYpe);
+
+    @Query(value = "{ 'referenceType': ?0, 'referenceId': ?1 }", sort = "{referenceId: -1, order: -1}")
+    List<FlowMongo> findByReference(String referenceType, String referenceId);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/flows/ReferenceIdReferenceTypeOrderIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/flows/ReferenceIdReferenceTypeOrderIndexUpgrader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.flows;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("FlowsReferenceIdReferenceTypeOrderIndexUpgrader")
+public class ReferenceIdReferenceTypeOrderIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index
+            .builder()
+            .collection("flows")
+            .name("ri1rt1o1")
+            .key("referenceId", ascending())
+            .key("referenceType", ascending())
+            .key("order", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpPlanRepository.java
@@ -47,4 +47,9 @@ public class NoOpPlanRepository extends AbstractNoOpManagementRepository<Plan, S
     public List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException {
         return List.of();
     }
+
+    @Override
+    public boolean exists(String id) throws TechnicalException {
+        return false;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PlanRepositoryTest.java
@@ -431,4 +431,14 @@ public class PlanRepositoryTest extends AbstractManagementRepositoryTest {
         assertThat(deleted).containsOnly("plan-deleted-1", "plan-deleted-2");
         assertEquals(0, planRepository.findAll().stream().filter(plan -> "ToBeDeleted".equals(plan.getEnvironmentId())).count());
     }
+
+    @Test
+    public void plan_should_exist() throws Exception {
+        assertTrue(planRepository.exists("my-plan"));
+    }
+
+    @Test
+    public void plan_should_not_exist() throws Exception {
+        assertFalse(planRepository.exists("unknown"));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -116,6 +116,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     @Value("${documentation.markdown.sanitize:true}")
     private boolean markdownSanitize;
 
+    @Value("${documentation.swagger.validate-safe-content:true}")
+    private boolean swaggerValidateSafeContent;
+
     @Value("${documentation.audit.max-content-size:-1}")
     private int maxContentSize;
 
@@ -2512,7 +2515,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 if (!sanitizeInfos.isSafe()) {
                     throw new PageContentUnsafeException(sanitizeInfos.getRejectedMessage());
                 }
-            } else if (PageType.SWAGGER.name().equals(pageEntity.getType()) && pageEntity.getContent() != null) {
+            } else if (
+                swaggerValidateSafeContent && PageType.SWAGGER.name().equals(pageEntity.getType()) && pageEntity.getContent() != null
+            ) {
                 OAIDescriptor openApiDescriptor = new OAIParser().parse(pageEntity.getContent());
                 if (openApiDescriptor != null && openApiDescriptor.getMessages() != null) {
                     return openApiDescriptor.getMessages();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -116,6 +116,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     @Value("${documentation.markdown.sanitize:true}")
     private boolean markdownSanitize;
 
+    @Value("${documentation.audit.max-content-size:-1}")
+    private int maxContentSize;
+
     @Lazy
     @Autowired
     private PageRepository pageRepository;
@@ -906,13 +909,23 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
             //only one homepage is allowed
             onlyOneHomepage(page);
+
+            String content = createdPage.getContent();
+            if (content != null && !content.isEmpty()) {
+                if (maxContentSize > 0 && content.length() > maxContentSize) {
+                    content = content.substring(0, maxContentSize) + "...";
+                } else if (maxContentSize == 0) {
+                    content = null;
+                }
+            }
+
             createAuditLog(
                 executionContext,
                 PageReferenceType.API.equals(page.getReferenceType()) ? page.getReferenceId() : null,
                 PAGE_CREATED,
                 page.getCreatedAt(),
                 null,
-                page
+                createdPage.toBuilder().content(content).build()
             );
             PageEntity pageEntity = convert(createdPage);
             if (messages != null && messages.size() > 0) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -211,15 +211,10 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
     @Override
     public PlanEntity createOrUpdatePlan(final ExecutionContext executionContext, PlanEntity planEntity) {
         PlanEntity resultPlanEntity;
-        try {
-            if (planEntity.getId() == null) {
-                resultPlanEntity = create(executionContext, planConverter.toNewPlanEntity(planEntity));
-            } else {
-                planSearchService.findById(executionContext, planEntity.getId());
-                resultPlanEntity = update(executionContext, planConverter.toUpdatePlanEntity(planEntity));
-            }
-        } catch (PlanNotFoundException npe) {
+        if (planEntity.getId() == null || !planSearchService.exists(planEntity.getId())) {
             resultPlanEntity = create(executionContext, planConverter.toNewPlanEntity(planEntity));
+        } else {
+            resultPlanEntity = update(executionContext, planConverter.toUpdatePlanEntity(planEntity));
         }
         return resultPlanEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
@@ -115,6 +115,12 @@ public class SearchEngineServiceImpl implements SearchEngineService {
 
     @Async("indexerThreadPoolTaskExecutor")
     @Override
+    public void index(ExecutionContext executionContext, Indexable source, boolean locally) {
+        index(executionContext, source, locally, true);
+    }
+
+    @Async("indexerThreadPoolTaskExecutor")
+    @Override
     public void index(ExecutionContext executionContext, Indexable source, boolean locally, boolean commit) {
         indexLocally(source, commit);
 
@@ -126,6 +132,12 @@ public class SearchEngineServiceImpl implements SearchEngineService {
 
             sendCommands(executionContext, content);
         }
+    }
+
+    @Async("indexerThreadPoolTaskExecutor")
+    @Override
+    public void delete(ExecutionContext executionContext, Indexable source) {
+        delete(executionContext, source, false);
     }
 
     @Async("indexerThreadPoolTaskExecutor")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
@@ -26,15 +26,11 @@ import io.gravitee.rest.api.service.search.query.Query;
  * @author GraviteeSource Team
  */
 public interface SearchEngineService {
-    default void index(ExecutionContext executionContext, Indexable source, boolean locally) {
-        index(executionContext, source, locally, true);
-    }
+    void index(ExecutionContext executionContext, Indexable source, boolean locally);
 
     void index(ExecutionContext executionContext, Indexable source, boolean locally, boolean commit);
 
-    default void delete(ExecutionContext executionContext, Indexable source) {
-        delete(executionContext, source, false);
-    }
+    void delete(ExecutionContext executionContext, Indexable source);
 
     void delete(ExecutionContext executionContext, Indexable source, boolean locally);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanSearchService.java
@@ -39,4 +39,6 @@ public interface PlanSearchService {
     boolean anyPlanMismatchWithApi(List<String> planIds, String apiId);
 
     Map<String, Object> findByIdAsMap(String id) throws TechnicalException;
+
+    boolean exists(String planId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiNotificationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiNotificationServiceImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiNotificationService;
 import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 /**
@@ -50,32 +51,38 @@ public class ApiNotificationServiceImpl extends AbstractService implements ApiNo
     }
 
     @Override
+    @Async
     public void triggerUpdateNotification(final ExecutionContext executionContext, final Api api) {
         GenericApiEntity indexableApi = indexableApiMapper.toGenericApi(api, null);
         triggerUpdateNotification(executionContext, indexableApi);
     }
 
     @Override
+    @Async
     public void triggerUpdateNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_UPDATED, indexableApi);
     }
 
     @Override
+    @Async
     public void triggerDeprecatedNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_DEPRECATED, indexableApi);
     }
 
     @Override
+    @Async
     public void triggerDeployNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_DEPLOYED, indexableApi);
     }
 
     @Override
+    @Async
     public void triggerStartNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_STARTED, indexableApi);
     }
 
     @Override
+    @Async
     public void triggerStopNotification(final ExecutionContext executionContext, final GenericApiEntity indexableApi) {
         triggerNotification(executionContext, ApiHook.API_STOPPED, indexableApi);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanSearchServiceImpl.java
@@ -166,6 +166,15 @@ public class PlanSearchServiceImpl extends TransactionalService implements PlanS
         return objectMapper.convertValue(plan, Map.class);
     }
 
+    @Override
+    public boolean exists(String planId) {
+        try {
+            return planRepository.exists(planId);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to check if a plan exists", e);
+        }
+    }
+
     private GenericPlanEntity mapToGeneric(final Plan plan) {
         try {
             Optional<Api> apiOptional = apiRepository.findById(plan.getApi());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FlowServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FlowServiceTest.java
@@ -176,11 +176,11 @@ public class FlowServiceTest {
         when(flowRepository.findByReference(FlowReferenceType.API, "api-id")).thenReturn(flows);
 
         io.gravitee.repository.management.model.flow.Flow updatedFlow = createRepoFlow(1);
-        when(flowRepository.update(any())).thenReturn(updatedFlow);
+        when(flowRepository.updateAll(any())).thenReturn(List.of(updatedFlow));
 
         io.gravitee.repository.management.model.flow.Flow createdFlow4 = createRepoFlow(4);
         io.gravitee.repository.management.model.flow.Flow createdFlow5 = createRepoFlow(5);
-        when(flowRepository.create(any())).thenReturn(createdFlow4, createdFlow5);
+        when(flowRepository.createAll(any())).thenReturn(List.of(createdFlow4, createdFlow5));
 
         List<Flow> savedFlows = new ArrayList<>();
         savedFlows.add(createFlow("flow-1"));
@@ -191,8 +191,8 @@ public class FlowServiceTest {
 
         verify(flowRepository, times(1)).delete("flow-0");
         verify(flowRepository, times(1)).delete("flow-2");
-        verify(flowRepository, times(1)).update(any());
-        verify(flowRepository, times(2)).create(any());
+        verify(flowRepository, times(1)).updateAll(any());
+        verify(flowRepository, times(1)).createAll(any());
         assertNotNull(byReference);
         assertEquals(3, byReference.size());
     }
@@ -203,7 +203,7 @@ public class FlowServiceTest {
 
         io.gravitee.repository.management.model.flow.Flow createdFlow1 = createRepoFlow(1);
         io.gravitee.repository.management.model.flow.Flow createdFlow2 = createRepoFlow(2);
-        when(flowRepository.create(any())).thenReturn(createdFlow1, createdFlow2);
+        when(flowRepository.createAll(any())).thenReturn(List.of(createdFlow1, createdFlow2));
 
         List<Flow> savedFlows = new ArrayList<>();
         savedFlows.add(createFlow("flow-1"));
@@ -212,8 +212,8 @@ public class FlowServiceTest {
         List<Flow> byReference = flowService.save(FlowReferenceType.API, "api-id", savedFlows);
 
         verify(flowRepository, never()).delete(any());
-        verify(flowRepository, never()).update(any());
-        verify(flowRepository, times(2)).create(any());
+        verify(flowRepository, never()).updateAll(any());
+        verify(flowRepository, times(1)).createAll(any());
         assertNotNull(byReference);
         assertEquals(2, byReference.size());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
@@ -15,19 +15,68 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.repository.management.api.PageRepository;
+import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.Page;
+import io.gravitee.repository.management.model.PageReferenceType;
+import io.gravitee.rest.api.model.NewPageEntity;
+import io.gravitee.rest.api.model.PageSourceEntity;
+import io.gravitee.rest.api.model.PageType;
+import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.PageRevisionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.swagger.OAIDescriptor;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class PageServiceImplTests {
 
-    private PageServiceImpl pageService = new PageServiceImpl();
+    public static final String ORGANIZATION_ID = "my-org";
+    public static final String ENVIRONMENT_ID = "my-env";
+    public static final String API_ID = "my-api";
+    public static final ExecutionContext executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+    @InjectMocks
+    private PageServiceImpl pageService;
+
+    @Mock
+    AuditService auditService;
+
+    @Mock
+    PageRepository pageRepository;
+
+    @Mock
+    PageRevisionService pageRevisionService;
+
+    @Captor
+    private ArgumentCaptor<Page> pageCaptor;
 
     @Test
     public void getParentPathFromFilePath_should_return_correct_path() {
@@ -45,5 +94,112 @@ public class PageServiceImplTests {
     public void getParentPathFromFilePath_with_empty_path_should_return_slash() {
         String parentPath = pageService.getParentPathFromFilePath("");
         assertEquals("/", parentPath);
+    }
+
+    @Test
+    @SneakyThrows
+    public void create_page_should_not_save_content_in_audit() {
+        ReflectionTestUtils.setField(pageService, "maxContentSize", -1);
+        var aNewPageEntity = aNewPageEntity();
+        var createdPage = aPage(aNewPageEntity);
+        when(pageRepository.create(any())).thenReturn(createdPage);
+
+        pageService.createPage(executionContext, API_ID, aNewPageEntity);
+
+        verify(auditService)
+            .createApiAuditLog(
+                any(ExecutionContext.class),
+                eq(API_ID),
+                any(),
+                any(Audit.AuditEvent.class),
+                any(),
+                isNull(),
+                pageCaptor.capture()
+            );
+        var auditPage = pageCaptor.getValue();
+        assertThat(auditPage).isNotNull();
+        assertThat(auditPage.getContent()).isNotNull();
+        assertThat(auditPage.getContent().length()).isEqualTo(aNewPageEntity.getContent().length());
+    }
+
+    @Test
+    @SneakyThrows
+    public void create_page_should_limit_content_in_audit() {
+        ReflectionTestUtils.setField(pageService, "maxContentSize", 10);
+        var aNewPageEntity = aNewPageEntity();
+        var createdPage = aPage(aNewPageEntity);
+        when(pageRepository.create(any())).thenReturn(createdPage);
+
+        pageService.createPage(executionContext, API_ID, aNewPageEntity);
+
+        verify(auditService)
+            .createApiAuditLog(
+                any(ExecutionContext.class),
+                eq(API_ID),
+                any(),
+                any(Audit.AuditEvent.class),
+                any(),
+                isNull(),
+                pageCaptor.capture()
+            );
+        var auditPage = pageCaptor.getValue();
+        assertThat(auditPage).isNotNull();
+        assertThat(auditPage.getContent()).isEqualTo("""
+{
+  "opena...""");
+    }
+
+    @Test
+    @SneakyThrows
+    public void create_page_should_force_null_content_in_audit() {
+        ReflectionTestUtils.setField(pageService, "maxContentSize", 0);
+        var aNewPageEntity = aNewPageEntity();
+        var createdPage = aPage(aNewPageEntity);
+        when(pageRepository.create(any())).thenReturn(createdPage);
+
+        pageService.createPage(executionContext, API_ID, aNewPageEntity);
+
+        verify(auditService)
+            .createApiAuditLog(
+                any(ExecutionContext.class),
+                eq(API_ID),
+                any(),
+                any(Audit.AuditEvent.class),
+                any(),
+                isNull(),
+                pageCaptor.capture()
+            );
+        var auditPage = pageCaptor.getValue();
+        assertThat(auditPage).isNotNull();
+        assertThat(auditPage.getContent()).isNull();
+    }
+
+    private NewPageEntity aNewPageEntity() throws JsonProcessingException {
+        var page = new NewPageEntity();
+        page.setType(PageType.SWAGGER);
+        page.setVisibility(Visibility.PUBLIC);
+        page.setName("my awesome page");
+
+        var source = new PageSourceEntity();
+        page.setSource(source);
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.setInfo(new Info().title("My API").version("1.0.0").description("A description"));
+        openAPI.setServers(List.of());
+        var descriptor = new OAIDescriptor(openAPI);
+        page.setContent(descriptor.toJson());
+
+        return page;
+    }
+
+    private Page aPage(NewPageEntity newPageEntity) {
+        return Page
+            .builder()
+            .type(newPageEntity.getType().name())
+            .visibility(newPageEntity.getVisibility().name())
+            .name(newPageEntity.getName())
+            .content(newPageEntity.getContent())
+            .referenceType(PageReferenceType.API)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
@@ -129,6 +129,7 @@ public class PageService_CreateTest {
         when(page1.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
         when(page1.getReferenceId()).thenReturn("envId");
         when(page1.getVisibility()).thenReturn("PUBLIC");
+        when(page1.toBuilder()).thenReturn(new Page().toBuilder());
 
         when(pageRepository.create(any())).thenReturn(page1);
 
@@ -568,6 +569,7 @@ public class PageService_CreateTest {
         when(page1.getLastContributor()).thenReturn(contrib);
         when(page1.getOrder()).thenReturn(1);
         when(page1.getContent()).thenReturn(content);
+        when(page1.toBuilder()).thenReturn(new Page().toBuilder());
 
         when(pageRepository.create(any())).thenReturn(page1);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDescriptorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDescriptorTest.java
@@ -124,6 +124,7 @@ public class PageService_ImportDescriptorTest {
         when(newPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
         when(newPage.getReferenceId()).thenReturn("envId");
         when(newPage.getVisibility()).thenReturn("PUBLIC");
+        when(newPage.toBuilder()).thenReturn(new Page().toBuilder());
         when(pageRepository.create(any())).thenReturn(newPage);
         when(graviteeDescriptorService.descriptorName()).thenReturn(".gravitee.json");
         when(graviteeDescriptorService.read(anyString())).thenCallRealMethod();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDirectoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDirectoryTest.java
@@ -120,6 +120,7 @@ public class PageService_ImportDirectoryTest {
         when(newPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
         when(newPage.getReferenceId()).thenReturn("envId");
         when(newPage.getVisibility()).thenReturn("PUBLIC");
+        when(newPage.toBuilder()).thenReturn(new Page().toBuilder());
         when(pageRepository.create(any())).thenReturn(newPage);
         when(graviteeDescriptorService.descriptorName()).thenReturn(".gravitee.json");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CreateOrUpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CreateOrUpdateTest.java
@@ -85,13 +85,13 @@ public class PlanService_CreateOrUpdateTest {
 
         when(this.planEntity.getId()).thenReturn(PLAN_ID);
         when(planConverter.toUpdatePlanEntity(planEntity)).thenCallRealMethod();
-        doReturn(new PlanEntity()).when(planSearchService).findById(GraviteeContext.getExecutionContext(), PLAN_ID);
+        doReturn(true).when(planSearchService).exists(PLAN_ID);
         doReturn(expected).when(planService).update(eq(GraviteeContext.getExecutionContext()), any(UpdatePlanEntity.class));
 
         final PlanEntity actual = planService.createOrUpdatePlan(GraviteeContext.getExecutionContext(), this.planEntity);
 
         assertThat(actual.getId()).isEqualTo(expected.getId());
-        verify(planSearchService, times(1)).findById(GraviteeContext.getExecutionContext(), PLAN_ID);
+        verify(planSearchService).exists(PLAN_ID);
         verify(planService, times(1)).update(eq(GraviteeContext.getExecutionContext()), any(UpdatePlanEntity.class));
     }
 
@@ -101,14 +101,14 @@ public class PlanService_CreateOrUpdateTest {
         expected.setId("created");
 
         when(planEntity.getId()).thenReturn(PLAN_ID);
-        doThrow(PlanNotFoundException.class).when(planSearchService).findById(GraviteeContext.getExecutionContext(), PLAN_ID);
+        doReturn(false).when(planSearchService).exists(PLAN_ID);
         doReturn(expected).when(planService).create(eq(GraviteeContext.getExecutionContext()), any());
 
         final PlanEntity actual = planService.createOrUpdatePlan(GraviteeContext.getExecutionContext(), planEntity);
 
         assertThat(actual.getId()).isEqualTo(expected.getId());
-        verify(planSearchService, times(1)).findById(GraviteeContext.getExecutionContext(), PLAN_ID);
-        verify(planService, times(1)).create(eq(GraviteeContext.getExecutionContext()), any());
+        verify(planSearchService).exists(PLAN_ID);
+        verify(planService).create(eq(GraviteeContext.getExecutionContext()), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -505,6 +505,8 @@ user:
 documentation:
   markdown:
     sanitize: true
+  swagger:
+    validate-safe-content: true # Validate safe content in Swagger descriptor. Default is true.
   audit:
     max-content-size: -1 # Max size of content in bytes to be stored in audit logs when importing an API. Default is -1 meaning their is no limit.
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -505,6 +505,8 @@ user:
 documentation:
   markdown:
     sanitize: true
+  audit:
+    max-content-size: -1 # Max size of content in bytes to be stored in audit logs when importing an API. Default is -1 meaning their is no limit.
 
 #imports:
   # Enable / disable import from private hosts. Enabled by default. (See https://en.wikipedia.org/wiki/Private_network)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,3 +29,8 @@ annotations:
       links:
         - name: Github Issue
           url: https://github.com/gravitee-io/issues/issues/10100
+    - kind: fixed
+      description: 'allow users to limit documentation content size in audit page when importing an API'
+      links:
+        - name: Github Issue
+          url: https://github.com/gravitee-io/issues/issues/10117

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -474,9 +474,15 @@ data:
 
     {{- if .Values.api.documentation }}
     documentation:
+      {{- if .Values.api.documentation.swagger }}
+      swagger:
+        {{- if hasKey .Values.api.documentation.swagger "validateSafeContent" }}
+        validate-safe-content: {{ .Values.api.documentation.swagger.validateSafeContent }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.api.documentation.audit }}
       audit:
-        {{- if .Values.api.documentation.audit.maxContentSize }}
+        {{- if hasKey .Values.api.documentation.audit "maxContentSize" }}
         max-content-size: {{ .Values.api.documentation.audit.maxContentSize }}
         {{- end }}
       {{- end }}

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -471,6 +471,17 @@ data:
         #expire-after: 86400
         anonymize-on-delete:
           enabled: {{ .Values.api.user.anynomizeOnDelete }}
+
+    {{- if .Values.api.documentation }}
+    documentation:
+      {{- if .Values.api.documentation.audit }}
+      audit:
+        {{- if .Values.api.documentation.audit.maxContentSize }}
+        max-content-size: {{ .Values.api.documentation.audit.maxContentSize }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
     # The portal URL used in emails
     {{- if .Values.api.portalURL }}
     portalURL: {{ .Values.api.portalURL }}

--- a/helm/tests/api/configmap_test_documentation.yaml
+++ b/helm/tests/api/configmap_test_documentation.yaml
@@ -8,9 +8,8 @@ tests:
       - notMatchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            documentation:
-              audit:
-                max-content-size:
+            audit:
+              max-content-size:
 
   - it: should set documentation.audit.maxContentSize with size defined
     template: api/api-configmap.yaml
@@ -26,3 +25,46 @@ tests:
             documentation:
               audit:
                 max-content-size: 100
+
+  - it: should not set documentation.swagger.validateSafeContent with no value defined
+    template: api/api-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            swagger:
+              validate-safe-content:
+
+  - it: should set documentation.swagger.validateSafeContent with false value
+    template: api/api-configmap.yaml
+    set:
+      api:
+        documentation:
+          swagger:
+            validateSafeContent: false
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            documentation:
+              swagger:
+                validate-safe-content: false
+
+  - it: should set documentation.swagger.validateSafeContent and documentation.audit.maxContentSize
+    template: api/api-configmap.yaml
+    set:
+      api:
+        documentation:
+          swagger:
+            validateSafeContent: true
+          audit:
+            maxContentSize: 0
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            documentation:
+              swagger:
+                validate-safe-content: true
+              audit:
+                max-content-size: 0

--- a/helm/tests/api/configmap_test_documentation.yaml
+++ b/helm/tests/api/configmap_test_documentation.yaml
@@ -1,0 +1,28 @@
+suite: Test Management API default configmap - Installation
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: should not set documentation.audit.maxContentSize with no size defined
+    template: api/api-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            documentation:
+              audit:
+                max-content-size:
+
+  - it: should set documentation.audit.maxContentSize with size defined
+    template: api/api-configmap.yaml
+    set:
+      api:
+        documentation:
+          audit:
+            maxContentSize: 100
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            documentation:
+              audit:
+                max-content-size: 100


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7282

## Description

The goal of this PR is to do some performance improvements on the update of an API using the import with a swagger file.

To note:
-  We pass from **15/17s** to **2.15/2.40s** with a **2/3Mo** file.
- There was an issue with OAS containing a lot of path which result to the creation of a lot of flows. The fix done has been done only for MongoDB. On JDBC it will be part of another improvement as the implementations are really different and it's not so easy to apply the same fix.
- We will now allow user to not analyse their specification when they import an OAS
- We will allow user to filter the amount of data added to the audits when we create a page.
- We will now ensure that Lucene indexation is really asynchronous
- We will now ensure that notifying the users is an asynchronous process too.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/10005/console](https://pr.team-apim.gravitee.dev/10005/console)
      Portal: [https://pr.team-apim.gravitee.dev/10005/portal](https://pr.team-apim.gravitee.dev/10005/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/10005/api/management](https://pr.team-apim.gravitee.dev/10005/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/10005](https://pr.team-apim.gravitee.dev/10005)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/10005](https://pr.gateway-v3.team-apim.gravitee.dev/10005)

<!-- Environment placeholder end -->
