### PR TITLE
feat: add frontend support for custom ruleset formats

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/ruleset.ts
@@ -21,6 +21,7 @@ export interface ScoringRuleset {
   id: string;
   name: string;
   description: string;
+  format?: RulesetFormat;
   payload: string;
   createdAt: string;
   referenceId: string;
@@ -31,11 +32,29 @@ export interface CreateRulesetRequestData {
   name: string;
   description: string;
   payload: string;
+  format?: RulesetFormat;
 }
 
 export interface EditRulesetRequestData {
   name: string;
   description: string;
+}
+
+export enum RulesetFormat {
+  GRAVITEE_FEDERATION = 'GRAVITEE_FEDERATION',
+  GRAVITEE_MESSAGE = 'GRAVITEE_MESSAGE',
+  GRAVITEE_PROXY = 'GRAVITEE_PROXY',
+}
+
+export function mapToRulesetFormat(formValue: string) {
+  switch (formValue) {
+    case 'Gravitee Proxy API':
+      return RulesetFormat.GRAVITEE_PROXY;
+    case 'Gravitee Message API':
+      return RulesetFormat.GRAVITEE_MESSAGE;
+    default:
+      return null;
+  }
 }
 
 export interface ScoringFunctionsResponse {

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.html
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.component.html
@@ -40,6 +40,7 @@
             <mat-expansion-panel-header>
               <mat-panel-title class="panel-title">
                 {{ ruleset.name }}
+                <span class="gio-badge-neutral">{{ ruleset.format | rulesetFormatPipe }}</span>
               </mat-panel-title>
               <mat-panel-description>
                 <span class="mat-body subtitle">{{ ruleset.description }}</span>

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.module.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/api-score-rulesets.module.ts
@@ -39,6 +39,7 @@ import { ApiScoreRulesetsComponent } from './api-score-rulesets.component';
 import { ImportApiScoreRulesetComponent } from './import/import-api-score-ruleset.component';
 import { EditApiScoreRulesetComponent } from './edit/edit-api-score-ruleset.component';
 import { ImportScoringFunctionComponent } from './import-function/import-scoring-function.component';
+import { RulesetFormatPipe } from './ruleset-format-mapper.pipe';
 
 import { ApiImportFilePickerComponent } from '../../api/component/api-import-file-picker/api-import-file-picker.component';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
@@ -69,6 +70,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioLoaderModule,
     GioPermissionModule,
     MatTooltip,
+    RulesetFormatPipe,
   ],
   exports: [ApiScoreRulesetsComponent, ImportApiScoreRulesetComponent, EditApiScoreRulesetComponent, ImportScoringFunctionComponent],
 })

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.component.html
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.component.html
@@ -56,7 +56,7 @@
           @if (definitionFormatValue.value === 'GraviteeAPI') {
             <div class="form-section">
               <h3>Gravitee API Format</h3>
-              <gio-form-selection-inline formControlName="graviteeApiFormat">
+              <gio-form-selection-inline data-testid="gravitee-api-format-selection" formControlName="graviteeApiFormat">
                 <gio-form-selection-inline-card value="Gravitee Proxy API">
                   <gio-form-selection-inline-card-content icon="gio:laptop">
                     <gio-card-content-title>Gravitee Proxy API</gio-card-content-title>

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.component.ts
@@ -21,7 +21,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { RulesetV2Service } from '../../../../services-ngx/ruleset-v2.service';
-import { CreateRulesetRequestData } from '../../../../entities/management-api-v2/api/v4/ruleset';
+import { CreateRulesetRequestData, mapToRulesetFormat } from '../../../../entities/management-api-v2/api/v4/ruleset';
 
 @Component({
   selector: 'import-api-score-ruleset',
@@ -55,6 +55,10 @@ export class ImportApiScoreRulesetComponent implements OnInit {
     return this.form.get('definitionFormat') as FormControl;
   }
 
+  get graviteeApiFormat() {
+    return this.form.get('graviteeApiFormat') as FormControl;
+  }
+
   public handleDefinitionFormatChange() {
     this.definitionFormatValue.valueChanges.subscribe((definitionFormat) => {
       if (definitionFormat === 'GraviteeAPI') {
@@ -74,11 +78,16 @@ export class ImportApiScoreRulesetComponent implements OnInit {
   public importRuleset() {
     this.isLoading = true;
 
-    const data: CreateRulesetRequestData = {
+    let data: CreateRulesetRequestData = {
       name: this.form.value.name,
       description: this.form.value.description,
       payload: this.importFileContent,
     };
+
+    if (this.graviteeApiFormat?.value) {
+      data = { ...data, format: mapToRulesetFormat(this.graviteeApiFormat.value) };
+    }
+
     this.rulesetV2Service
       .createRuleset(data)
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/import/import-api-score-ruleset.harness.ts
@@ -25,6 +25,9 @@ export class ImportApiScoreRulesetHarness extends ComponentHarness {
   locatorForDefinitionFormatRadioGroup = this.locatorFor(
     GioFormSelectionInlineHarness.with({ selector: '[data-testid=definition-format-selection]' }),
   );
+  locatorForGraviteeApiDefinitionFormatRadioGroup = this.locatorFor(
+    GioFormSelectionInlineHarness.with({ selector: '[data-testid=gravitee-api-format-selection]' }),
+  );
 
   private nameInputLocator: AsyncFactoryFn<MatInputHarness> = this.locatorForOptional(
     MatInputHarness.with({ selector: '[data-testid=name-input]' }),

--- a/gravitee-apim-console-webui/src/management/api-score/rulesets/ruleset-format-mapper.pipe.ts
+++ b/gravitee-apim-console-webui/src/management/api-score/rulesets/ruleset-format-mapper.pipe.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { RulesetFormat } from '../../../entities/management-api-v2/api/v4/ruleset';
+
+@Pipe({
+  name: 'rulesetFormatPipe',
+  standalone: true,
+  pure: true,
+})
+export class RulesetFormatPipe implements PipeTransform {
+  transform(value: RulesetFormat): string {
+    switch (value) {
+      case RulesetFormat.GRAVITEE_FEDERATION:
+        return 'Gravitee Federation API';
+      case RulesetFormat.GRAVITEE_MESSAGE:
+        return 'Gravitee Message API';
+      case RulesetFormat.GRAVITEE_PROXY:
+        return 'Gravitee Proxy API';
+      default:
+        return 'OpenAPI - AsyncAPI';
+    }
+  }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
@@ -27,12 +27,19 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}scoring_rulesets")
 public class ScoringRulesetMongo extends Auditable {
 
+    public enum Format {
+        GRAVITEE_FEDERATION,
+        GRAVITEE_MESSAGE,
+        GRAVITEE_PROXY,
+    }
+
     @Id
     private String id;
 
     private String name;
     private String description;
     private String payload;
+    private Format format;
     private String referenceId;
     private String referenceType;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7701

## Description

Add frontend support for custom ruleset format 

## Additional context

![image](https://github.com/user-attachments/assets/97488c55-461e-4e59-81ba-b9560805e24f)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vaqdszgtst.chromatic.com)
<!-- Storybook placeholder end -->
