### PR TITLE
APIM-7554 fix: enable user search with case-insensitive email address

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
@@ -123,7 +123,9 @@ public class UserDocumentTransformer implements DocumentTransformer<UserEntity> 
                 logger.warn("Email of the user {} is not valid", user.getId());
             } else {
                 // For security reasons, we remove the domain part of the email
-                doc.add(new StringField(FIELD_EMAIL, user.getEmail().substring(0, user.getEmail().indexOf('@')), Field.Store.NO));
+                doc.add(
+                    new StringField(FIELD_EMAIL, user.getEmail().substring(0, user.getEmail().indexOf('@')).toLowerCase(), Field.Store.NO)
+                );
             }
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7554

## Description

The search should be case-insensitive and return results regardless of whether the email contains uppercase or lowercase letters.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

