### PR TITLE
Apim 7749 console plans list and create

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -46,7 +46,7 @@ export class ApiV4MenuService implements ApiMenuService {
       this.addEntrypointsMenuEntry(hasTcpListeners, api),
       this.addEndpointsMenuEntry(api, hasTcpListeners),
       this.addPoliciesMenuEntry(hasTcpListeners),
-      ...(api.type !== 'NATIVE' ? [this.addConsumersMenuEntry(hasTcpListeners)] : []),
+      this.addConsumersMenuEntry(hasTcpListeners),
       this.addDocumentationMenuEntry(api),
       this.addDeploymentMenuEntry(),
       ...(api.type !== 'NATIVE' ? [this.addApiTrafficMenuEntry(hasTcpListeners)] : []),

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -128,6 +128,9 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
   isFederated = false;
 
   @Input()
+  isNative = false;
+
+  @Input()
   apiType?: ApiType;
 
   @Input()
@@ -196,7 +199,7 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     this.ngControl.control.setValidators(this.validate.bind(this));
     this.ngControl.control.updateValueAndValidity();
 
-    this.displayRestrictionStep = this.mode === 'create' && !this.isTcpApi;
+    this.displayRestrictionStep = this.mode === 'create' && !this.isTcpApi && !this.isNative;
     this.displaySecurityStep =
       !this.isFederated &&
       !['KEY_LESS', 'PUSH'].includes(this.planMenuItem.planFormType) &&
@@ -534,6 +537,10 @@ const internalFormValueToPlanV4 = (
 ): PlanFormValue => {
   // Init flows with restriction step. Only used in create mode
   const initFlowsWithRestriction = (restriction: InternalPlanFormValue['restriction']): FlowV4[] => {
+    if (apiType === 'NATIVE') {
+      return [];
+    }
+
     const restrictionPolicies: StepV4[] = displayRestrictionStep
       ? [
           ...(restriction.rateLimitEnabled

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.html
@@ -30,6 +30,7 @@
       [api]="$any(api)"
       [isTcpApi]="hasTcpListeners"
       [isFederated]="api.definitionVersion === 'FEDERATED'"
+      [isNative]="isNative"
       [planMenuItem]="planMenuItem"
       [planStatus]="currentPlanStatus"
     ></api-plan-form>

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -35,6 +35,7 @@ import { ApiPlanFormHarness } from '../../component/plan/api-plan-form.harness';
 import {
   Api,
   CreatePlanV2,
+  CreatePlanV4,
   fakeApiFederated,
   fakeApiV1,
   fakeApiV2,
@@ -385,6 +386,121 @@ describe('ApiPlanEditComponent', () => {
       });
 
       it('should access plan in read only', async () => {
+        expect(await loader.getAllHarnesses(GioSaveBarHarness)).toHaveLength(0);
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+        planForm
+          .httpRequest(httpTestingController)
+          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
+          fakeGroup({
+            id: 'group-a',
+            name: 'Group A',
+          }),
+        ]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API_ID, [
+          {
+            id: 'doc-1',
+            name: 'Doc 1',
+          },
+        ]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+
+        const nameInput = await planForm.getNameInput();
+        expect(await nameInput.isDisabled()).toEqual(true);
+      });
+    });
+  });
+
+  describe('With a V4 Native API', () => {
+    describe('Create', () => {
+      const TAG_1_ID = 'tag-1';
+
+      beforeEach(() => {
+        configureTestingModule();
+        fixture.detectChanges();
+        expectApiGetRequest(fakeApiV4({ id: API_ID, type: 'NATIVE' }));
+      });
+
+      it('should create new plan', async () => {
+        const saveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await saveBar.isVisible()).toBe(true);
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+        planForm
+          .httpRequest(httpTestingController)
+          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([
+          fakeGroup({
+            id: 'group-a',
+            name: 'Group A',
+          }),
+        ]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API_ID, [
+          {
+            id: 'doc-1',
+            name: 'Doc 1',
+          },
+        ]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('jwt', {});
+
+        await planForm.getNameInput().then((i) => i.setValue('My new plan'));
+
+        // Click on Next buttons to display Save one
+        await loader.getHarness(MatButtonHarness.with({ text: 'Next' })).then((b) => b.click());
+
+        await saveBar.clickSubmit();
+
+        const req = httpTestingController.expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`,
+          method: 'POST',
+        });
+
+        expect(req.request.body).toEqual({
+          definitionVersion: 'V4',
+          name: 'My new plan',
+          description: '',
+          commentMessage: '',
+          commentRequired: false,
+          mode: 'STANDARD',
+          validation: 'MANUAL',
+          generalConditions: '',
+          characteristics: [],
+          excludedGroups: [],
+          tags: [],
+          security: {
+            type: 'JWT',
+            configuration: {},
+          },
+          selectionRule: null,
+          flows: [],
+        } as CreatePlanV4);
+        req.flush({});
+        expect(routerNavigationSpy).toHaveBeenCalledWith(['../'], {
+          queryParams: {
+            status: 'STAGING',
+          },
+          relativeTo: expect.anything(),
+        });
+      });
+    });
+
+    describe('Edit', () => {
+      const TAG_1_ID = 'tag-1';
+      const PLAN = fakePlanV4({ apiId: API_ID, security: { type: 'KEY_LESS' } });
+
+      beforeEach(() => {
+        configureTestingModule(PLAN.id);
+        fixture.detectChanges();
+        expectApiGetRequest(fakeApiV4({ id: API_ID, type: 'NATIVE' }));
+        expectPlanGetRequest(API_ID, PLAN);
+      });
+
+      it('should access plan in read only', async () => {
+        fixture.detectChanges();
         expect(await loader.getAllHarnesses(GioSaveBarHarness)).toHaveLength(0);
 
         const planForm = await loader.getHarness(ApiPlanFormHarness);

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -23,7 +23,7 @@ import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiPlanFormComponent, PlanFormValue } from '../../component/plan/api-plan-form.component';
 import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
-import { Api, CreatePlanV2, CreatePlanV4, Plan, PlanStatus } from '../../../../entities/management-api-v2';
+import { Api, ApiV4, CreatePlanV2, CreatePlanV4, Plan, PlanStatus } from '../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
 import { isApiV4 } from '../../../../util';
@@ -48,6 +48,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
   private apiPlanForm: ApiPlanFormComponent;
   public currentPlanStatus: PlanStatus;
   public hasTcpListeners;
+  public isNative: boolean = false;
 
   constructor(
     private readonly router: Router,
@@ -68,10 +69,13 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
         tap((api) => {
           this.api = api;
           this.hasTcpListeners = isApiV4(api) && api.listeners.find((listener) => listener.type === 'TCP') != null;
+          this.isNative = (this.api as ApiV4).type === 'NATIVE';
+          const editingANativeApi = this.isNative && this.mode === 'edit';
           this.isReadOnly =
             !this.permissionService.hasAnyMatching(['api-plan-u']) ||
             this.api.definitionContext?.origin === 'KUBERNETES' ||
-            this.api.definitionVersion === 'V1';
+            this.api.definitionVersion === 'V1' ||
+            editingANativeApi;
         }),
         switchMap(() =>
           this.mode === 'edit'

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
@@ -195,6 +195,32 @@ describe('ConstantsService', () => {
         ]);
       });
 
+      it('should filter PUSH plan and mTLS menu items when API definition version is V4 and Kafka Listeners selected', () => {
+        const result = constantsService.getPlanMenuItems('V4', ['KAFKA']);
+
+        expect(result).toMatchObject([
+          {
+            planFormType: 'OAUTH2',
+            name: 'OAuth2',
+            policy: 'oauth2',
+          },
+          {
+            planFormType: 'JWT',
+            name: 'JWT',
+            policy: 'jwt',
+          },
+          {
+            planFormType: 'API_KEY',
+            name: 'API Key',
+            policy: 'api-key',
+          },
+          {
+            planFormType: 'KEY_LESS',
+            name: 'Keyless (public)',
+          },
+        ]);
+      });
+
       it('should return all plan menu items when user has HTTP and SUBSCRIPTION listeners types selected', () => {
         const result = constantsService.getPlanMenuItems('V4', ['HTTP', 'SUBSCRIPTION']);
 

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
@@ -93,6 +93,12 @@ export class ConstantsService {
       return availablePlanMenuItems.filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH');
     }
 
+    if (definitionVersion === 'V4' && listenerTypes?.every((listenerType) => listenerType === 'KAFKA')) {
+      return availablePlanMenuItems
+        .filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH')
+        .filter((planMenuItem) => planMenuItem.planFormType !== 'MTLS');
+    }
+
     if (definitionVersion !== 'V4') {
       return availablePlanMenuItems
         .filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH')

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanFederated;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV4;
+import io.gravitee.rest.api.model.v4.nativeapi.NativePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.model.v4.plan.UpdatePlanEntity;
@@ -60,6 +61,10 @@ public interface PlanMapper {
     @Mapping(target = "security.type", qualifiedByName = "mapToPlanSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")
     PlanV4 map(PlanEntity planEntity);
+
+    @Mapping(target = "security.type", qualifiedByName = "mapToPlanSecurityType")
+    @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")
+    PlanV4 map(NativePlanEntity planEntity);
 
     @Mapping(target = "security.type", qualifiedByName = "mapToPlanSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")
@@ -107,6 +112,8 @@ public interface PlanMapper {
                 return new Plan(this.map((PlanEntity) entity));
             }
             return new Plan(this.mapFederated((PlanEntity) entity));
+        } else if (entity instanceof NativePlanEntity nativePlanEntity) {
+            return new Plan(this.map(nativePlanEntity));
         } else {
             return new Plan(this.map((io.gravitee.rest.api.model.PlanEntity) entity));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -21,6 +21,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.definition.model.v4.plan.AbstractPlan;
 import io.gravitee.rest.api.management.v2.rest.model.BasePlan;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePlanV4;
@@ -65,6 +66,15 @@ public interface PlanMapper {
     @Mapping(target = "security.type", qualifiedByName = "mapToPlanSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")
     PlanV4 map(NativePlanEntity planEntity);
+
+    default PlanV4 mapToPlanV4(GenericPlanEntity planEntity) {
+        if (planEntity instanceof NativePlanEntity nativePlanEntity) {
+            return map(nativePlanEntity);
+        } else if (planEntity instanceof PlanEntity httpPlanEntity) {
+            return map(httpPlanEntity);
+        }
+        return null;
+    }
 
     @Mapping(target = "security.type", qualifiedByName = "mapToPlanSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.nativeapi.NativePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanQuery;
@@ -318,8 +319,8 @@ public class ApiPlansResource extends AbstractResource {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
-        if (planEntity instanceof PlanEntity) {
-            return Response.ok(planMapper.map(planServiceV4.publish(executionContext, planId))).build();
+        if (planEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4) {
+            return Response.ok(planMapper.mapToPlanV4(planServiceV4.publish(executionContext, planId))).build();
         }
 
         return Response.ok(planMapper.map(planServiceV2.publish(executionContext, planId))).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -338,8 +338,8 @@ public class ApiPlansResource extends AbstractResource {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
-        if (planEntity instanceof PlanEntity) {
-            return Response.ok(planMapper.map(planServiceV4.deprecate(executionContext, planId))).build();
+        if (planEntity.getDefinitionVersion() == io.gravitee.definition.model.DefinitionVersion.V4) {
+            return Response.ok(planMapper.mapToPlanV4(planServiceV4.deprecate(executionContext, planId))).build();
         }
 
         return Response.ok(planMapper.map(planServiceV2.deprecate(executionContext, planId))).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/PlanFixtures.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericPlanSecurity;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanFederated;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePlanV4;
+import io.gravitee.rest.api.model.v4.nativeapi.NativePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.Date;
 import java.util.List;
@@ -194,6 +195,10 @@ public class PlanFixtures {
 
     public static PlanEntity aPlanEntityV4() {
         return PlanModelFixtures.aPlanEntityV4();
+    }
+
+    public static NativePlanEntity aNativePlanEntityV4() {
+        return PlanModelFixtures.aNativePlanEntityV4();
     }
 
     public static io.gravitee.rest.api.model.PlanEntity aPlanEntityV2() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
@@ -71,6 +71,33 @@ public class PlanMapperTest {
     }
 
     @Test
+    void should_map_NativePlanEntity_to_PlanV4() {
+        final var planEntity = PlanFixtures.aNativePlanEntityV4();
+        final var plan = planMapper.map(planEntity);
+
+        assertEquals(planEntity.getId(), plan.getId());
+        assertEquals(planEntity.getApiId(), plan.getApiId());
+        assertEquals(planEntity.getName(), plan.getName());
+        assertEquals(planEntity.getDescription(), plan.getDescription());
+        assertEquals(planEntity.getOrder(), (int) plan.getOrder());
+        assertEquals(planEntity.getCharacteristics(), plan.getCharacteristics());
+        assertEquals(planEntity.getCreatedAt().getTime(), plan.getCreatedAt().toInstant().toEpochMilli());
+        assertEquals(planEntity.getUpdatedAt().getTime(), plan.getUpdatedAt().toInstant().toEpochMilli());
+        assertEquals(planEntity.getCommentMessage(), plan.getCommentMessage());
+        assertEquals(planEntity.getCrossId(), plan.getCrossId());
+        assertEquals(planEntity.getGeneralConditions(), plan.getGeneralConditions());
+        assertEquals(planEntity.getTags(), new HashSet<>(plan.getTags()));
+        assertEquals(planEntity.getStatus().name(), plan.getStatus().name());
+        assertEquals(planEntity.getType().name(), plan.getType().name());
+        assertEquals(planEntity.getExcludedGroups(), plan.getExcludedGroups());
+        assertEquals(planEntity.getValidation().name(), plan.getValidation().name());
+        assertEquals(planEntity.getSelectionRule(), plan.getSelectionRule());
+
+        assertSecurityV4Equals(planEntity.getSecurity(), plan.getSecurity());
+        assertEquals(planEntity.getFlows().size(), plan.getFlows().size()); // Flow mapping is tested in FlowMapperTest
+    }
+
+    @Test
     void should_map_PlanEntity_to_PlanV2() {
         final var planEntity = PlanFixtures.aPlanEntityV2();
         final var plan = planMapper.map(planEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -1096,6 +1096,21 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_return_plan_when_v4_native_plan_closed() {
+            var planEntity = PlanFixtures.aNativePlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+            when(planServiceV4.close(GraviteeContext.getExecutionContext(), PLAN))
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.CLOSED).build());
+
+            final Response response = target.request().post(Entity.json(null));
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(PlanV4.class)
+                .extracting(PlanV4::getId, PlanV4::getStatus)
+                .containsExactly(PLAN, io.gravitee.rest.api.management.v2.rest.model.PlanStatus.CLOSED);
+        }
+
+        @Test
         public void should_return_plan_when_v2_plan_closed() {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -215,6 +215,40 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_return_list_if_no_params_specified_native_v4() {
+            var plan1 = PlanFixtures.aNativePlanEntityV4().toBuilder().id("plan-1").order(3).build();
+            var plan2 = PlanFixtures.aNativePlanEntityV4().toBuilder().id("plan-3").order(1).build();
+
+            var planQuery = PlanQuery.builder().apiId(API).securityType(new ArrayList<>()).status(List.of(PlanStatus.PUBLISHED)).build();
+            when(planSearchService.search(eq(GraviteeContext.getExecutionContext()), eq(planQuery), eq(USER_NAME), eq(true)))
+                .thenReturn(List.of(plan1, plan2));
+
+            final Response response = target.request().get();
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(PlansResponse.class)
+                .isEqualTo(
+                    PlansResponse
+                        .builder()
+                        .pagination(Pagination.builder().page(1).perPage(10).pageItemsCount(2).totalCount(2L).pageCount(1).build())
+                        .data(
+                            Stream
+                                .of(plan2, plan1)
+                                .map(PlanMapper.INSTANCE::map)
+                                .map(p -> {
+                                    var plan = new Plan();
+                                    plan.setActualInstance(p);
+                                    return plan;
+                                })
+                                .toList()
+                        )
+                        .links(Links.builder().self(target.getUri().toString()).build())
+                        .build()
+                );
+        }
+
+        @Test
         public void should_return_list_with_params_specified_v2() {
             io.gravitee.rest.api.model.PlanEntity plan1 = PlanFixtures
                 .aPlanEntityV2()
@@ -666,6 +700,16 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         @Test
         public void should_return_v4_plan() {
             final PlanEntity planEntity = PlanFixtures.aPlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+        }
+
+        @Test
+        public void should_return_native_v4_plan() {
+            var planEntity = PlanFixtures.aNativePlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
 
             final Response response = target.request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -1293,6 +1293,22 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_return_plan_when_v4_native_plan_published() {
+            var planEntity = PlanFixtures.aNativePlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+            when(planServiceV4.publish(GraviteeContext.getExecutionContext(), PLAN))
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.PUBLISHED).build());
+
+            final Response response = target.request().post(Entity.json(null));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(PlanV4.class)
+                .extracting(PlanV4::getId, PlanV4::getStatus)
+                .containsExactly(PLAN, io.gravitee.rest.api.management.v2.rest.model.PlanStatus.PUBLISHED);
+        }
+
+        @Test
         public void should_return_plan_when_v2_plan_published() {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -1202,6 +1202,22 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_deprecate_v4_native_plan() {
+            var planEntity = PlanFixtures.aNativePlanEntityV4().toBuilder().id(PLAN).apiId(API).build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+            when(planServiceV4.deprecate(GraviteeContext.getExecutionContext(), PLAN))
+                .thenReturn(planEntity.toBuilder().status(PlanStatus.DEPRECATED).build());
+
+            final Response response = target.request().post(Entity.json(null));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(PlanV4.class)
+                .extracting(PlanV4::getId, PlanV4::getStatus)
+                .containsExactly(PLAN, io.gravitee.rest.api.management.v2.rest.model.PlanStatus.DEPRECATED);
+        }
+
+        @Test
         public void should_deprecate_v2_plan() {
             final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build();
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -1000,6 +1000,17 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        public void should_return_no_content_when_native_v4_plan_deleted() {
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN))
+                .thenReturn(PlanFixtures.aNativePlanEntityV4().toBuilder().id(PLAN).apiId(API).build());
+
+            final Response response = target.request().delete();
+
+            assertThat(response).hasStatus(NO_CONTENT_204);
+            verify(planServiceV4, times(1)).delete(GraviteeContext.getExecutionContext(), PLAN);
+        }
+
+        @Test
         public void should_return_no_content_when_v2_plan_deleted() {
             when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN))
                 .thenReturn(PlanFixtures.aPlanEntityV2().toBuilder().id(PLAN).api(API).build());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
@@ -42,9 +42,9 @@ public interface PlanService {
 
     GenericPlanEntity publish(final ExecutionContext executionContext, final String plan);
 
-    PlanEntity deprecate(final ExecutionContext executionContext, final String plan);
+    GenericPlanEntity deprecate(final ExecutionContext executionContext, final String plan);
 
-    PlanEntity deprecate(final ExecutionContext executionContext, final String plan, final boolean allowStaging);
+    GenericPlanEntity deprecate(final ExecutionContext executionContext, final String plan, final boolean allowStaging);
 
     PlansConfigurationEntity getConfiguration();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
@@ -40,7 +40,7 @@ public interface PlanService {
 
     void delete(final ExecutionContext executionContext, final String plan);
 
-    PlanEntity publish(final ExecutionContext executionContext, final String plan);
+    GenericPlanEntity publish(final ExecutionContext executionContext, final String plan);
 
     PlanEntity deprecate(final ExecutionContext executionContext, final String plan);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -616,12 +616,12 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
     }
 
     @Override
-    public PlanEntity deprecate(final ExecutionContext executionContext, String planId) {
+    public GenericPlanEntity deprecate(final ExecutionContext executionContext, String planId) {
         return deprecate(executionContext, planId, false);
     }
 
     @Override
-    public PlanEntity deprecate(final ExecutionContext executionContext, String planId, boolean allowStaging) {
+    public GenericPlanEntity deprecate(final ExecutionContext executionContext, String planId, boolean allowStaging) {
         try {
             logger.debug("Deprecate plan {}", planId);
 
@@ -653,7 +653,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
                 plan
             );
 
-            return mapToEntity(plan);
+            return mapToGenericEntity(plan);
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to deprecate plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to deprecate plan: %s", planId), ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -520,7 +521,11 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             }
 
             // Delete plan and his flows
-            flowCrudService.savePlanFlows(planId, null);
+            if (plan.getApiType() == ApiType.NATIVE) {
+                flowCrudService.saveNativePlanFlows(planId, null);
+            } else {
+                flowCrudService.savePlanFlows(planId, null);
+            }
             planRepository.delete(planId);
 
             // Audit

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PlanServiceImpl.java
@@ -548,7 +548,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
     }
 
     @Override
-    public PlanEntity publish(final ExecutionContext executionContext, String planId) {
+    public GenericPlanEntity publish(final ExecutionContext executionContext, String planId) {
         try {
             logger.debug("Publish plan {}", planId);
 
@@ -608,7 +608,7 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
                 plan
             );
 
-            return mapToEntity(plan);
+            return mapToGenericEntity(plan);
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to publish plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to publish plan: %s", planId), ex);
@@ -722,6 +722,14 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
     private PlanEntity mapToEntity(final Plan plan) {
         List<Flow> flows = flowService.findByReference(FlowReferenceType.PLAN, plan.getId());
         return planMapper.toEntity(plan, flows);
+    }
+
+    private GenericPlanEntity mapToGenericEntity(final Plan plan) {
+        if (plan.getApiType() == ApiType.NATIVE) {
+            var flows = flowCrudService.getNativePlanFlows(plan.getId());
+            return planMapper.toNativeEntity(plan, flows);
+        }
+        return mapToEntity(plan);
     }
 
     private void assertPlanSecurityIsAllowed(final ExecutionContext executionContext, String securityType) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_DeleteTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
@@ -145,5 +146,19 @@ public class PlanService_DeleteTest {
 
         verify(planRepository, times(1)).delete(PLAN_ID);
         verify(flowCrudService, times(1)).savePlanFlows(PLAN_ID, null);
+    }
+
+    @Test
+    public void shouldDeleteNativePlanAndFlows() throws TechnicalException {
+        when(plan.getApiType()).thenReturn(ApiType.NATIVE);
+        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
+        when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(Collections.emptySet());
+        when(plan.getApi()).thenReturn(API_ID);
+        when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
+
+        planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
+
+        verify(planRepository, times(1)).delete(PLAN_ID);
+        verify(flowCrudService, times(1)).saveNativePlanFlows(PLAN_ID, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PlanModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/PlanModelFixtures.java
@@ -15,9 +15,11 @@
  */
 package fixtures;
 
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.nativeapi.NativePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.model.v4.plan.PlanType;
@@ -39,6 +41,7 @@ public class PlanModelFixtures {
     private static final PlanEntity.PlanEntityBuilder<?, ?> BASE_PLAN_ENTITY_V4 = PlanEntity
         .builder()
         .id("my-plan")
+        .definitionVersion(DefinitionVersion.V4)
         .apiId("my-api")
         .name("My plan")
         .description("Description")
@@ -58,6 +61,30 @@ public class PlanModelFixtures {
         .validation(PlanValidationType.AUTO)
         .selectionRule("{#request.attribute['selectionRule'] != null}")
         .flows(List.of(FlowModelFixtures.aModelFlowHttpV4()));
+
+    private static final NativePlanEntity.NativePlanEntityBuilder<?, ?> BASE_NATIVE_PLAN_ENTITY_V4 = NativePlanEntity
+        .builder()
+        .id("my-plan")
+        .definitionVersion(DefinitionVersion.V4)
+        .apiId("my-api")
+        .name("My plan")
+        .description("Description")
+        .order(1)
+        .characteristics(List.of("characteristic1", "characteristic2"))
+        .createdAt(new Date())
+        .updatedAt(new Date())
+        .commentMessage("Comment message")
+        .crossId("my-plan-crossId")
+        .generalConditions("General conditions")
+        .tags(Set.of("tag1", "tag2"))
+        .status(PlanStatus.PUBLISHED)
+        .security(BASE_PLAN_SECURITY_V4.build())
+        .type(PlanType.API)
+        .mode(PlanMode.STANDARD)
+        .excludedGroups(List.of("excludedGroup1", "excludedGroup2"))
+        .validation(PlanValidationType.AUTO)
+        .selectionRule("{#request.attribute['selectionRule'] != null}")
+        .flows(List.of(FlowModelFixtures.aModelFlowNativeV4()));
 
     private static final io.gravitee.rest.api.model.PlanEntity.PlanEntityBuilder<?, ?> BASE_PLAN_ENTITY_V2 =
         io.gravitee.rest.api.model.PlanEntity
@@ -84,6 +111,10 @@ public class PlanModelFixtures {
 
     public static PlanEntity aPlanEntityV4() {
         return BASE_PLAN_ENTITY_V4.build();
+    }
+
+    public static NativePlanEntity aNativePlanEntityV4() {
+        return BASE_NATIVE_PLAN_ENTITY_V4.build();
     }
 
     public static PlanEntity aKeylessPlanV4() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7749

## Description

For a Native API...
- User can get a list of plans
- User can get details of a plan
- User can publish a plan
- User can close a plan
- User can deprecate a plan



https://github.com/user-attachments/assets/8c1a134a-bc36-46b1-8272-f627b7befd10




Next steps:
- User can update a plan --> https://github.com/gravitee-io/gravitee-api-management/pull/10060

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ialpavnhit.chromatic.com)
<!-- Storybook placeholder end -->
