### PR TITLE
chore: bump testcontainer version

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -204,6 +204,14 @@
             </dependency>
 
             <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin</artifactId>
                 <version>${gravitee-plugin.version}</version>
@@ -612,14 +620,6 @@
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>${javassist.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <swagger-core.version>2.2.22</swagger-core.version>
         <swagger-jaxrs2.version>2.2.22</swagger-jaxrs2.version>
         <swagger-parser.version>2.1.22</swagger-parser.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <wiremock.version>3.8.0</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
         <xmlbeans.version>5.2.1</xmlbeans.version>


### PR DESCRIPTION
## Issue

N/A

## Description

Update testcontainer lib to have access to the latest kafkacontainer classes.

https://java.testcontainers.org/modules/kafka/
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ixswrckirv.chromatic.com)
<!-- Storybook placeholder end -->
