### PR TITLE
feat(console): Publisher can add a plan during API Creation Workflow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
@@ -130,6 +130,22 @@ export class ApiCreationV4SpecHttpExpects {
     createPlansRequest.flush(fakePlanV4({ apiId: apiId, id: planId }));
   }
 
+  expectCallsForNativeApiAndPlanCreation(apiId: string, planId: string) {
+    this.expectCallsForApiCreation(apiId);
+
+    const createPlansRequest = this.httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans`,
+      method: 'POST',
+    });
+    expect(createPlansRequest.request.body).toEqual(
+      expect.objectContaining({
+        definitionVersion: 'V4',
+        name: 'Default Keyless (UNSECURED)',
+      }),
+    );
+    createPlansRequest.flush(fakePlanV4({ apiId: apiId, id: planId }));
+  }
+
   expectCallsForApiCreation(apiId: string) {
     const createApiRequest = this.httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis`, method: 'POST' });
 
@@ -156,6 +172,16 @@ export class ApiCreationV4SpecHttpExpects {
       method: 'POST',
     });
     startApiRequest.flush(fakeApiV4({ id: apiId }));
+  }
+
+  expectCallsForNativeApiDeployment(apiId: string, planId: string) {
+    this.expectCallsForNativeApiAndPlanCreation(apiId, planId);
+
+    const publishPlansRequest = this.httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans/${planId}/_publish`,
+      method: 'POST',
+    });
+    publishPlansRequest.flush({});
   }
 
   expectVerifyHosts(hosts: string[], times = 1) {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -159,15 +159,16 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       }),
     );
   });
+
   describe('API Creation', () => {
     it('should create the API', fakeAsync(async () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
+      await stepperHelper.validateStep4_1_SecurityPlansList();
 
       discardPeriodicTasks();
-
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       const step1Summary = await step5Harness.getStepSummaryTextContent(1);
       expect(step1Summary).toContain('API name:' + 'API');
@@ -183,11 +184,10 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       expect(step3Summary).toContain('Endpoints' + 'Endpoints: ' + 'Native Kafka Endpoint');
 
       const step4Summary = await step5Harness.getStepSummaryTextContent(4);
-      expect(step4Summary).toContain('No plans are selected.');
+      expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
 
       await step5Harness.clickCreateMyApiButton();
-      httpExpects.expectCallsForApiCreation('api-id');
-
+      httpExpects.expectCallsForNativeApiDeployment('api-id', 'plan-id');
       flush();
     }));
   });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-2-config.component.ts
@@ -23,10 +23,8 @@ import { mapValues, omitBy } from 'lodash';
 
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
-import { Step4Security1PlansComponent } from '../step-4-security/step-4-security-1-plans.component';
-import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 import { ApimFeature, UTMTags } from '../../../../../shared/components/gio-license/gio-license-data';
-import { Step5SummaryComponent } from '../step-5-summary/step-5-summary.component';
+import { Step4Security1PlansComponent } from '../step-4-security/step-4-security-1-plans.component';
 
 @Component({
   selector: 'step-3-endpoints-2-config',
@@ -44,8 +42,6 @@ export class Step3Endpoints2ConfigComponent implements OnInit, OnDestroy {
   public license$: Observable<License>;
   public isOEM$: Observable<boolean>;
 
-  private apiType: ApiCreationPayload['type'];
-
   constructor(
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
     private readonly stepService: ApiCreationStepService,
@@ -54,7 +50,6 @@ export class Step3Endpoints2ConfigComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     const currentStepPayload = this.stepService.payload;
-    this.apiType = currentStepPayload.type;
 
     forkJoin(
       currentStepPayload.selectedEndpoints.reduce((map: Record<string, Observable<[GioJsonSchema, GioJsonSchema]>>, { id }) => {
@@ -114,15 +109,7 @@ export class Step3Endpoints2ConfigComponent implements OnInit, OnDestroy {
       })),
     }));
 
-    switch (this.apiType) {
-      case 'NATIVE':
-        this.stepService.goToNextStep({ groupNumber: 5, component: Step5SummaryComponent });
-        break;
-      case 'PROXY':
-      case 'MESSAGE':
-        this.stepService.goToNextStep({ groupNumber: 4, component: Step4Security1PlansComponent });
-        break;
-    }
+    this.stepService.goToNextStep({ groupNumber: 4, component: Step4Security1PlansComponent });
   }
 
   goBack(): void {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
@@ -125,9 +125,7 @@
             </div>
             <ng-template #elseBlock> No plans are selected. </ng-template>
           </div>
-          <div *ngIf="apiType !== 'NATIVE'">
-            <button mat-stroked-button (click)="onChangeStepInfo('Security')">Change</button>
-          </div>
+          <button mat-stroked-button (click)="onChangeStepInfo('Security')">Change</button>
         </div>
       </div>
       <div *ngIf="shouldUpgrade">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7747

## Description

A user should be able to add a plan during the creation workflow. The plan types can be: 
- Keyless
- API Key
- JWT
- OAuth

The editing of a plan that has been added will be in a separate ticket.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

https://github.com/user-attachments/assets/68e9d67b-6f15-466d-85d5-8b19181ef160


<img width="1590" alt="Screenshot 2024-12-05 at 17 48 15" src="https://github.com/user-attachments/assets/9d23526a-2302-4fa1-98b3-860ca7df5efc">
<img width="1372" alt="Screenshot 2024-12-05 at 17 48 10" src="https://github.com/user-attachments/assets/f71102d6-d78d-45a3-afc2-0ddbec0c8534">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-czgfpdrmcs.chromatic.com)
<!-- Storybook placeholder end -->
