### PR TITLE
fix: host name validation for mulitenant installation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/cockpit/CockpitAccessServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/cockpit/CockpitAccessServiceImpl.java
@@ -97,7 +97,7 @@ public class CockpitAccessServiceImpl implements CockpitAccessService {
     }
 
     private void validateHost(String value) {
-        String toValidate = value.replaceAll("[{}]", "").replaceAll(":\\d*", "");
+        String toValidate = value.replaceAll("[{}]", "").replaceAll(":\\d*", "").replaceAll("/.*", "");
         if (!isValidDomainName(toValidate)) {
             throw new InvalidAccessPointException("Installation access point '%s' is malformed.".formatted(value));
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7600

## Description

Excluding '{}, :, \' from the hostname to validate for multitenant.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/10074/console](https://pr.team-apim.gravitee.dev/10074/console)
      Portal: [https://pr.team-apim.gravitee.dev/10074/portal](https://pr.team-apim.gravitee.dev/10074/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/10074/api/management](https://pr.team-apim.gravitee.dev/10074/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/10074](https://pr.team-apim.gravitee.dev/10074)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/10074](https://pr.gateway-v3.team-apim.gravitee.dev/10074)

<!-- Environment placeholder end -->
