### PR TITLE
fix(service): handle native definition in api services

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.plugin.apiservice.dynamicproperties.http;
 import io.gravitee.apim.plugin.apiservice.dynamicproperties.http.helper.HttpDynamicPropertiesHelper;
 import io.gravitee.apim.rest.api.common.apiservices.DefaultManagementDeploymentContext;
 import io.gravitee.apim.rest.api.common.apiservices.ManagementApiServiceFactory;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class HttpDynamicPropertiesServiceFactory implements ManagementApiService
 
     @Override
     public HttpDynamicPropertiesService createService(DefaultManagementDeploymentContext deploymentContext) {
-        final Api api = deploymentContext.getComponent(Api.class);
+        final AbstractApi api = deploymentContext.getComponent(AbstractApi.class);
 
         if (HttpDynamicPropertiesHelper.canHandle(api)) {
             return new HttpDynamicPropertiesService(deploymentContext);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/helper/HttpDynamicPropertiesHelper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/helper/HttpDynamicPropertiesHelper.java
@@ -17,7 +17,10 @@ package io.gravitee.apim.plugin.apiservice.dynamicproperties.http.helper;
 
 import static io.gravitee.apim.plugin.apiservice.dynamicproperties.http.HttpDynamicPropertiesService.HTTP_DYNAMIC_PROPERTIES_TYPE;
 
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.service.Service;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -29,8 +32,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HttpDynamicPropertiesHelper {
 
-    public static boolean canHandle(Api api) {
-        return api != null && api.getServices() != null && isServiceEnabled(api.getServices().getDynamicProperty());
+    public static boolean canHandle(AbstractApi api) {
+        if (api == null) {
+            return false;
+        }
+
+        if (api instanceof Api asHttpApi) {
+            return asHttpApi.getServices() != null && isServiceEnabled(asHttpApi.getServices().getDynamicProperty());
+        }
+        if (api instanceof NativeApi asNativeApi) {
+            return asNativeApi.getServices() != null && isServiceEnabled(asNativeApi.getServices().getDynamicProperty());
+        }
+        return false;
     }
 
     private static boolean isServiceEnabled(Service httpDynamicPropertiesService) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/io/gravitee/apim/plugin/apiservice/dynamicproperties/http/HttpDynamicPropertiesServiceFactoryTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 
 import io.gravitee.apim.rest.api.common.apiservices.DefaultManagementDeploymentContext;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -44,12 +46,24 @@ class HttpDynamicPropertiesServiceFactoryTest {
     }
 
     @Test
-    void should_return_service_when_service_can_be_handled() {
+    void should_return_service_when_service_can_be_handled_for_http_api() {
         final ApiServices services = new ApiServices();
         services.setDynamicProperty(Service.builder().enabled(true).type(HTTP_DYNAMIC_PROPERTIES_TYPE).build());
         assertThat(
             cut.createService(
                 new DefaultManagementDeploymentContext(Api.builder().services(services).build(), mock(ApplicationContext.class))
+            )
+        )
+            .isInstanceOf(HttpDynamicPropertiesService.class);
+    }
+
+    @Test
+    void should_return_service_when_service_can_be_handled_for_native_api() {
+        final NativeApiServices services = new NativeApiServices();
+        services.setDynamicProperty(Service.builder().enabled(true).type(HTTP_DYNAMIC_PROPERTIES_TYPE).build());
+        assertThat(
+            cut.createService(
+                new DefaultManagementDeploymentContext(NativeApi.builder().services(services).build(), mock(ApplicationContext.class))
             )
         )
             .isInstanceOf(HttpDynamicPropertiesService.class);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/testhelpers/Fixtures.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/test/java/testhelpers/Fixtures.java
@@ -19,7 +19,10 @@ import static io.gravitee.apim.plugin.apiservice.dynamicproperties.http.HttpDyna
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.plugin.apiservice.dynamicproperties.http.HttpDynamicPropertiesServiceConfiguration;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.node.api.configuration.Configuration;
@@ -50,13 +53,30 @@ public class Fixtures {
             .build();
     }
 
+    public static NativeApi nativeApiWithDynamicPropertiesEnabled() {
+        return NativeApi
+            .builder()
+            .id(MY_API)
+            .services(
+                NativeApiServices
+                    .builder()
+                    .dynamicProperty(Service.builder().enabled(true).type(HTTP_DYNAMIC_PROPERTIES_TYPE).build())
+                    .build()
+            )
+            .build();
+    }
+
     @SneakyThrows
     public static void configureDynamicPropertiesForApi(
         HttpDynamicPropertiesServiceConfiguration configuration,
-        Api api,
+        AbstractApi api,
         ObjectMapper objectMapper
     ) {
-        api.getServices().getDynamicProperty().setConfiguration(objectMapper.writeValueAsString(configuration));
+        if (api instanceof Api asHttpApi) {
+            asHttpApi.getServices().getDynamicProperty().setConfiguration(objectMapper.writeValueAsString(configuration));
+        } else if (api instanceof NativeApi asNativeApi) {
+            asNativeApi.getServices().getDynamicProperty().setConfiguration(objectMapper.writeValueAsString(configuration));
+        }
     }
 
     public static Configuration emptyNodeConfiguration() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/main/java/io/gravitee/apim/rest/api/common/apiservices/DefaultManagementDeploymentContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/main/java/io/gravitee/apim/rest/api/common/apiservices/DefaultManagementDeploymentContext.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.apim.rest.api.common.apiservices;
 
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
@@ -33,6 +35,13 @@ public class DefaultManagementDeploymentContext implements ManagementDeploymentC
     public DefaultManagementDeploymentContext(@Nonnull Api apiDefinitionV4, @Nonnull ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
         components.put(Api.class, apiDefinitionV4);
+        components.put(AbstractApi.class, apiDefinitionV4);
+    }
+
+    public DefaultManagementDeploymentContext(@Nonnull NativeApi apiDefinitionV4, @Nonnull ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        components.put(NativeApi.class, apiDefinitionV4);
+        components.put(AbstractApi.class, apiDefinitionV4);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/main/java/io/gravitee/apim/rest/api/common/apiservices/ManagementApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/main/java/io/gravitee/apim/rest/api/common/apiservices/ManagementApiService.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.apim.rest.api.common.apiservices;
 
-import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.gateway.reactive.api.apiservice.ApiService;
 import io.reactivex.rxjava3.core.Completable;
 
@@ -24,5 +24,5 @@ import io.reactivex.rxjava3.core.Completable;
  * @author GraviteeSource Team
  */
 public interface ManagementApiService extends ApiService {
-    Completable update(Api api);
+    Completable update(AbstractApi api);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/test/java/io/gravitee/apim/rest/api/common/apiservices/DefaultManagementDeploymentContextTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/test/java/io/gravitee/apim/rest/api/common/apiservices/DefaultManagementDeploymentContextTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -47,6 +49,16 @@ class DefaultManagementDeploymentContextTest {
         final Api api = new Api();
         final DefaultManagementDeploymentContext cut = new DefaultManagementDeploymentContext(api, applicationContext);
         assertThat(cut.getComponent(Api.class)).isEqualTo(api);
+        assertThat(cut.getComponent(AbstractApi.class)).isEqualTo(api);
+        verify(applicationContext, never()).getBean(any(Class.class));
+    }
+
+    @Test
+    void should_get_native_api() {
+        final NativeApi api = new NativeApi();
+        final DefaultManagementDeploymentContext cut = new DefaultManagementDeploymentContext(api, applicationContext);
+        assertThat(cut.getComponent(NativeApi.class)).isEqualTo(api);
+        assertThat(cut.getComponent(AbstractApi.class)).isEqualTo(api);
         verify(applicationContext, never()).getBean(any(Class.class));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/test/java/io/gravitee/apim/rest/api/common/apiservices/ManagementApiServiceFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-common/src/test/java/io/gravitee/apim/rest/api/common/apiservices/ManagementApiServiceFactoryTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.rest.api.common.apiservices;
 import static io.gravitee.apim.rest.api.common.apiservices.ManagementApiServiceFactory.DEPLOYMENT_CONTEXT_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
@@ -66,7 +67,7 @@ class ManagementApiServiceFactoryTest {
     static class TestingManagementApiService implements ManagementApiService {
 
         @Override
-        public Completable update(Api api) {
+        public Completable update(AbstractApi api) {
             return Completable.complete();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManager.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.rest.api.common.apiservices.ManagementApiService;
 import io.gravitee.apim.rest.api.common.apiservices.ManagementApiServiceFactory;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
@@ -71,8 +72,9 @@ public class ManagementApiServicesManager extends AbstractService {
             .stream()
             .map(managementApiServiceFactory ->
                 managementApiServiceFactory.createService(
-                    // FIXME: Kafka Gateway - Manage properly NativeApi definition
-                    new DefaultManagementDeploymentContext(api.getApiDefinitionHttpV4(), applicationContext)
+                    api.getType() == ApiType.NATIVE
+                        ? new DefaultManagementDeploymentContext(api.getApiDefinitionNativeV4(), applicationContext)
+                        : new DefaultManagementDeploymentContext(api.getApiDefinitionHttpV4(), applicationContext)
                 )
             )
             .filter(Objects::nonNull)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManagerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/plugin/ManagementApiServicesManagerTest.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.rest.api.common.apiservices.DefaultManagementDeploymentC
 import io.gravitee.apim.rest.api.common.apiservices.ManagementApiService;
 import io.gravitee.apim.rest.api.common.apiservices.ManagementApiServiceFactory;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.List;
@@ -299,7 +300,7 @@ class ManagementApiServicesManagerTest {
         }
 
         @Override
-        public Completable update(io.gravitee.definition.model.v4.Api api) {
+        public Completable update(AbstractApi api) {
             hasBeenRestarted = true;
             return Completable.complete();
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

When deploying a Native API, there was a NPE in the dynamic properties service. 
This fix handles the Native API definition for starting and updating api services.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

