### PR TITLE
fix(papi): handle null origin on subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapper.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.portal.rest.model.Subscription;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 
+@Slf4j
 @Component
 public class SubscriptionMapper {
 
@@ -48,7 +50,7 @@ public class SubscriptionMapper {
         subscriptionItem.setReason(subscriptionEntity.getReason());
         subscriptionItem.setStatus(Subscription.StatusEnum.fromValue(subscriptionEntity.getStatus().name()));
         subscriptionItem.setSubscribedBy(subscriptionEntity.getSubscribedBy());
-        subscriptionItem.setOrigin(Subscription.OriginEnum.valueOf(subscriptionEntity.getOrigin()));
+        subscriptionItem.setOrigin(convert(subscriptionEntity.getOrigin()));
         return subscriptionItem;
     }
 
@@ -57,5 +59,14 @@ public class SubscriptionMapper {
             return date.toInstant().atOffset(ZoneOffset.UTC);
         }
         return null;
+    }
+
+    private static Subscription.OriginEnum convert(String origin) {
+        try {
+            return Subscription.OriginEnum.valueOf(origin);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.error("Unable to serialize Subscription Origin: [{}]", origin);
+            return null;
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/SubscriptionMapperTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
@@ -76,6 +77,7 @@ public class SubscriptionMapperTest {
         subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
         subscriptionEntity.setSubscribedBy(SUBSCRIPTION_SUBSCRIBED_BY);
         subscriptionEntity.setUpdatedAt(nowDate);
+        subscriptionEntity.setOrigin("KUBERNETES");
 
         //Test
         Subscription subscription = subscriptionMapper.convert(subscriptionEntity);
@@ -91,5 +93,44 @@ public class SubscriptionMapperTest {
         assertEquals(SUBSCRIPTION_REQUEST, subscription.getRequest());
         assertEquals(now.toEpochMilli(), subscription.getStartAt().toInstant().toEpochMilli());
         assertEquals(StatusEnum.ACCEPTED, subscription.getStatus());
+        assertEquals(Subscription.OriginEnum.KUBERNETES, subscription.getOrigin());
+    }
+
+    @Test
+    public void should_handle_null_origin() {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+
+        //init
+        subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setApi(SUBSCRIPTION_API);
+        subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
+        subscriptionEntity.setOrigin(null);
+
+        //Test
+        Subscription subscription = subscriptionMapper.convert(subscriptionEntity);
+        assertNotNull(subscription);
+
+        assertEquals(SUBSCRIPTION_API, subscription.getApi());
+        assertNull(subscription.getOrigin());
+    }
+
+    @Test
+    public void should_handle_origin_not_in_enum() {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+
+        //init
+        subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setApi(SUBSCRIPTION_API);
+        subscriptionEntity.setStatus(SubscriptionStatus.ACCEPTED);
+        subscriptionEntity.setOrigin("unicorn");
+
+        //Test
+        Subscription subscription = subscriptionMapper.convert(subscriptionEntity);
+        assertNotNull(subscription);
+
+        assertEquals(SUBSCRIPTION_API, subscription.getApi());
+        assertNull(subscription.getOrigin());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

NPE being thrown when a subscription has a null origin.
For the moment, only `KUBERNETES` origins are being written in the Database.

The fix allows for the value saved in the DB to be propagated to the Portal API.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tctqkvdxpq.chromatic.com)
<!-- Storybook placeholder end -->
