### PR TITLE
APIM 7767 fix: empty endpoint group check

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
@@ -154,6 +154,10 @@ describe('ApiProxyHealthCheckComponent', () => {
               { name: 'endpoint2-without-healthcheck', type: 'http' },
             ],
           },
+          {
+            name: 'empty-endpoint-group', // should be able to handle empty endpoint group
+            endpoints: [],
+          },
         ],
       },
     });
@@ -203,6 +207,10 @@ describe('ApiProxyHealthCheckComponent', () => {
           { name: 'endpoint2-with-healthcheck-activated', healthCheck: { inherit: true }, type: 'http' },
           { name: 'endpoint2-without-healthcheck', healthCheck: { inherit: true }, type: 'http' },
         ],
+      },
+      {
+        name: 'empty-endpoint-group', // empty endpoint group
+        endpoints: [],
       },
     ]);
   });

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
@@ -102,7 +102,7 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
 
   updateEndpointsHealthCheckConfig(groups: Proxy['groups']) {
     groups.forEach((group) => {
-      group.endpoints.forEach((endpoint) => {
+      group.endpoints?.forEach((endpoint) => {
         // If healthcheck is disabled, set inherit to false
         if (
           (endpoint.healthCheck?.inherit === undefined || endpoint.healthCheck?.inherit === true) &&


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7767

## Description

Added empty endpoint group check and a try-catch while updating endpoint groups.

## Additional context

Before:
While saving healthCheck:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1b0859dc-9fa8-4f13-b455-e78a18969b14">

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f2f0356e-bb5a-42cd-85a1-9b885d5eae79">


After:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5a9fcd5b-6898-4b7b-bb38-1709a8b9fcd6">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yarypafopd.chromatic.com)
<!-- Storybook placeholder end -->
