### PR TITLE
Apim 7536 console plans edit + deploy

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
@@ -114,7 +114,7 @@ export class ApiCreationV4SpecHttpExpects {
     });
   }
 
-  expectCallsForApiAndPlanCreation(apiId: string, planId: string) {
+  expectCallsForApiAndPlanCreation(apiId: string, planId: string, planName: string = 'Default Keyless (UNSECURED)') {
     this.expectCallsForApiCreation(apiId);
 
     const createPlansRequest = this.httpTestingController.expectOne({
@@ -124,26 +124,16 @@ export class ApiCreationV4SpecHttpExpects {
     expect(createPlansRequest.request.body).toEqual(
       expect.objectContaining({
         definitionVersion: 'V4',
-        name: 'Update name',
+        name: planName,
       }),
     );
     createPlansRequest.flush(fakePlanV4({ apiId: apiId, id: planId }));
-  }
 
-  expectCallsForNativeApiAndPlanCreation(apiId: string, planId: string) {
-    this.expectCallsForApiCreation(apiId);
-
-    const createPlansRequest = this.httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans`,
+    const publishPlansRequest = this.httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans/${planId}/_publish`,
       method: 'POST',
     });
-    expect(createPlansRequest.request.body).toEqual(
-      expect.objectContaining({
-        definitionVersion: 'V4',
-        name: 'Default Keyless (UNSECURED)',
-      }),
-    );
-    createPlansRequest.flush(fakePlanV4({ apiId: apiId, id: planId }));
+    publishPlansRequest.flush({});
   }
 
   expectCallsForApiCreation(apiId: string) {
@@ -158,30 +148,14 @@ export class ApiCreationV4SpecHttpExpects {
     createApiRequest.flush(fakeApiV4({ id: apiId }));
   }
 
-  expectCallsForApiDeployment(apiId: string, planId: string) {
-    this.expectCallsForApiAndPlanCreation(apiId, planId);
-
-    const publishPlansRequest = this.httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans/${planId}/_publish`,
-      method: 'POST',
-    });
-    publishPlansRequest.flush({});
+  expectCallsForApiDeployment(apiId: string, planId: string, planName?: string) {
+    this.expectCallsForApiAndPlanCreation(apiId, planId, planName);
 
     const startApiRequest = this.httpTestingController.expectOne({
       url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_start`,
       method: 'POST',
     });
     startApiRequest.flush(fakeApiV4({ id: apiId }));
-  }
-
-  expectCallsForNativeApiDeployment(apiId: string, planId: string) {
-    this.expectCallsForNativeApiAndPlanCreation(apiId, planId);
-
-    const publishPlansRequest = this.httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans/${planId}/_publish`,
-      method: 'POST',
-    });
-    publishPlansRequest.flush({});
   }
 
   expectVerifyHosts(hosts: string[], times = 1) {

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -187,7 +187,20 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
 
       await step5Harness.clickCreateMyApiButton();
-      httpExpects.expectCallsForNativeApiDeployment('api-id', 'plan-id');
+      httpExpects.expectCallsForApiAndPlanCreation('api-id', 'plan-id');
+      flush();
+    }));
+    it('should deploy the API', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
+      await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
+      await stepperHelper.validateStep4_1_SecurityPlansList();
+
+      discardPeriodicTasks();
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      await step5Harness.clickDeployMyApiButton();
+      httpExpects.expectCallsForApiDeployment('api-id', 'plan-id');
       flush();
     }));
   });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
@@ -1391,7 +1391,7 @@ describe('ApiCreationV4Component - Navigation', () => {
       it('should go to confirmation page after clicking Deploy my API', async () => {
         await step5Harness.clickDeployMyApiButton();
 
-        httpExpects.expectCallsForApiDeployment(API_ID, PLAN_ID);
+        httpExpects.expectCallsForApiDeployment(API_ID, PLAN_ID, 'Update name');
 
         expect(routerNavigateSpy).toHaveBeenCalledWith(['.', 'my-api'], expect.anything());
       });
@@ -1415,13 +1415,7 @@ describe('ApiCreationV4Component - Navigation', () => {
       it('should go to confirmation page after clicking Save API & Ask for review', async () => {
         await step5Harness.clickCreateAndAskForReviewMyApiButton();
 
-        httpExpects.expectCallsForApiAndPlanCreation(API_ID, PLAN_ID);
-
-        const publishPlansRequest = httpTestingController.expectOne({
-          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_ID}/_publish`,
-          method: 'POST',
-        });
-        publishPlansRequest.flush({});
+        httpExpects.expectCallsForApiAndPlanCreation(API_ID, PLAN_ID, 'Update name');
 
         const askRequest = httpTestingController.expectOne({
           url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/reviews/_ask`,

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans-add.component.html
@@ -24,6 +24,7 @@
     [isTcpApi]="isTcpApi"
     [apiType]="apiType"
     [planMenuItem]="planMenuItem"
+    [isNative]="apiType === 'NATIVE'"
   ></api-plan-form>
 
   <div class="api-creation-v4__step__footer">

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
@@ -146,7 +146,7 @@
           ></mat-icon>
         </button>
         <button
-          *ngIf="!hasReviewEnabled && apiType !== 'NATIVE'"
+          *ngIf="!hasReviewEnabled"
           data-testid="deploy_api_button"
           color="primary"
           mat-flat-button

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.ts
@@ -43,8 +43,6 @@ export class Step5SummaryComponent implements OnInit {
   public isOEM$: Observable<boolean>;
   public hasReviewEnabled = this.constants.env?.settings?.apiReview?.enabled ?? false;
 
-  public apiType: ApiCreationPayload['type'];
-
   constructor(
     private readonly stepService: ApiCreationStepService,
     public readonly licenseService: GioLicenseService,
@@ -53,7 +51,6 @@ export class Step5SummaryComponent implements OnInit {
 
   ngOnInit(): void {
     this.currentStepPayload = this.stepService.payload;
-    this.apiType = this.currentStepPayload.type;
 
     this.paths = this.currentStepPayload.paths?.map((path) => path.path);
     this.hosts = this.currentStepPayload.hosts?.map((host) => host.host);

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -499,9 +499,9 @@ describe('ApiPlanEditComponent', () => {
         expectPlanGetRequest(API_ID, PLAN);
       });
 
-      it('should access plan in read only', async () => {
-        fixture.detectChanges();
-        expect(await loader.getAllHarnesses(GioSaveBarHarness)).toHaveLength(0);
+      it('should edit plan', async () => {
+        const saveBar = await loader.getHarness(GioSaveBarHarness);
+        expect(await saveBar.isVisible()).toBe(false);
 
         const planForm = await loader.getHarness(ApiPlanFormHarness);
 
@@ -523,7 +523,20 @@ describe('ApiPlanEditComponent', () => {
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
 
         const nameInput = await planForm.getNameInput();
-        expect(await nameInput.isDisabled()).toEqual(true);
+        await nameInput.setValue('My plan edited');
+
+        expect(await saveBar.isVisible()).toBe(true);
+        await saveBar.clickSubmit();
+
+        expectPlanGetRequest(API_ID, PLAN);
+        const req = httpTestingController.expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN.id}`,
+          method: 'PUT',
+        });
+
+        expect(req.request.body).toEqual(expect.objectContaining({ name: 'My plan edited' }));
+        req.flush({});
+        expect(routerNavigationSpy).toHaveBeenCalled();
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -70,12 +70,10 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
           this.api = api;
           this.hasTcpListeners = isApiV4(api) && api.listeners.find((listener) => listener.type === 'TCP') != null;
           this.isNative = (this.api as ApiV4).type === 'NATIVE';
-          const editingANativeApi = this.isNative && this.mode === 'edit';
           this.isReadOnly =
             !this.permissionService.hasAnyMatching(['api-plan-u']) ||
             this.api.definitionContext?.origin === 'KUBERNETES' ||
-            this.api.definitionVersion === 'V1' ||
-            editingANativeApi;
+            this.api.definitionVersion === 'V1';
         }),
         switchMap(() =>
           this.mode === 'edit'


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7536
https://gravitee.atlassian.net/browse/APIM-7155
https://gravitee.atlassian.net/browse/APIM-7156
https://gravitee.atlassian.net/browse/APIM-7157

## Description

- User can edit plans within the creation workflow and the Consumers menu item
- User can deploy Native API at the end of the creation workflow

https://github.com/user-attachments/assets/ef6c85ea-3649-4d14-a5b3-8809fd9f2626

- "Restriction" step not displayed for native plans in the creation workflow

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yjhykbaopm.chromatic.com)
<!-- Storybook placeholder end -->
