### PR TITLE
fix(service): save category ids on update for native api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapper.java
@@ -176,6 +176,9 @@ public class ValidateApiDomainServiceLegacyWrapper implements ValidateApiDomainS
             groupValidationService.validateAndSanitize(toBeUpdatedApi.getGroups(), toBeUpdatedApi.getEnvironmentId(), primaryOwner)
         );
 
+        // Validate categories
+        toBeUpdatedApi.setCategories(categoryDomainService.toCategoryId(toBeUpdatedApi, environmentId));
+
         // Lifecycle state
         toBeUpdatedApi.setApiLifecycleState(
             apiLifecycleStateDomainService.validateAndSanitizeForUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -246,6 +246,8 @@ class ValidateApiDomainServiceLegacyWrapperTest {
 
             doAnswer(invocation -> Set.of("sanitized")).when(groupValidationService).validateAndSanitize(any(), any(), any());
 
+            doAnswer(invocationOnMock -> Set.of("sanitized")).when(categoryDomainService).toCategoryId(any(), any());
+
             doAnswer(invocation ->
                     List.of(KafkaListener.builder().entrypoints(List.of(NativeEntrypoint.builder().type("sanitized").build())).build())
                 )
@@ -285,7 +287,8 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                 .hasType(ApiType.NATIVE)
                 .hasDescription("sanitized")
                 .hasOnlyGroups(Set.of("sanitized"))
-                .hasOnlyTags(Set.of("sanitized"));
+                .hasOnlyTags(Set.of("sanitized"))
+                .hasOnlyCategories(Set.of("sanitized"));
 
             SoftAssertions.assertSoftly(soft -> {
                 soft


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7694
https://gravitee.atlassian.net/browse/APIM-7898

## Description

The Native APIs were not being shown in the list of APIs per a given category because the `categoryId` saved in the database was actually the category **key**.

Fix: Save category ids in the `api_category_orders` table on update for Native APIs. 

<img width="1188" alt="Screenshot 2024-12-10 at 16 21 54" src="https://github.com/user-attachments/assets/19b60661-4b9a-47f1-8f04-cf5260cb6c89">

<img width="1448" alt="Screenshot 2024-12-10 at 16 21 42" src="https://github.com/user-attachments/assets/2b29e34c-37cc-4983-98f4-62b20eb87b8e">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kskihfkvze.chromatic.com)
<!-- Storybook placeholder end -->
