### PR TITLE
fix(console): display error snackbar when score request is no longer pending

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
@@ -115,11 +115,11 @@ export class ApiScoringComponent implements OnInit {
 
           if (!this.pendingScoreRequest) {
             this.stopPolling$.next();
-          }
 
-          const evaluationErrors = this.getEvaluationErrors(apiScoring);
-          if (evaluationErrors.length) {
-            this.snackBarService.error(this.formatEvaluationErrors(evaluationErrors));
+            const evaluationErrors = this.getEvaluationErrors(apiScoring);
+            if (evaluationErrors.length) {
+              this.snackBarService.error(this.formatEvaluationErrors(evaluationErrors));
+            }
           }
         },
         error: (e) => {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7712

## Description

Right now, the error snackbar with the old validation error is displayed every second until new scoring arrives. The fix makes the snackbar appear only when a new scoring evaluation with an error is available.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aqzlddudks.chromatic.com)
<!-- Storybook placeholder end -->
