### PR TITLE
feat(scoring): remove SharedConfiguration of definition sent to scoring

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -122,6 +122,10 @@ public class ScoreApiRequestUseCase {
     }
 
     private ScoreRequest.AssetToScore assetToScore(GraviteeDefinition definition) throws JsonProcessingException {
+        if (definition.getApi().getEndpointGroups() != null) {
+            // remove shared configuration because this produce some errors in scoring (invalid reference: APIM-7877)
+            definition.getApi().getEndpointGroups().forEach(endpoint -> endpoint.setSharedConfiguration((String) null));
+        }
         return new ScoreRequest.AssetToScore(
             definition.getApi().getId(),
             new ScoreRequest.AssetType(


### PR DESCRIPTION
**Issue** [APIM-7877](https://gravitee.atlassian.net/browse/APIM-7877)

## Description

SharedConfiguration produce errors in scoring (caused by invalid references) and seems not useful to be scored so we remove it from definitin sent to scoring.



[APIM-7877]: https://gravitee.atlassian.net/browse/APIM-7877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ