### PR TITLE
fix(console): rename label in api list from native kafka -> kafka

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -439,7 +439,7 @@ describe('ApisListComponent', () => {
 
         const { rowCells } = await computeApisTableCells();
         expect(rowCells).toEqual([
-          ['', '🪐 Planets (1.0)', 'V4 - Native Kafka Gravitee', '', 'kafka-host:1000', '', '', '', 'admin', 'public', 'edit'],
+          ['', '🪐 Planets (1.0)', 'V4 - Kafka Gravitee', '', 'kafka-host:1000', '', '', '', 'admin', 'public', 'edit'],
         ]);
         expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
       }));

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -243,7 +243,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
         return { label: this.titleCasePipe.transform(api.definitionVersion) };
       case 'V4':
         if ((api as ApiV4).type === 'NATIVE') {
-          return { label: `${api.definitionVersion} - ${this.titleCasePipe.transform((api as ApiV4).type)}${this.getLabelType(api)}` };
+          return { label: `${api.definitionVersion} -${this.getLabelType(api)}` };
         }
         return { label: `${api.definitionVersion} -${this.getLabelType(api)} ${this.titleCasePipe.transform((api as ApiV4).type)}` };
       case 'FEDERATED':


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Rename label per what is being used by Documentation and Marketing for Native Kafka APIs

<img width="1459" alt="Screenshot 2024-12-11 at 17 04 46" src="https://github.com/user-attachments/assets/53602c7d-b918-4f7a-a52a-8aca5e26b17b" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zuuuyqbhrk.chromatic.com)
<!-- Storybook placeholder end -->
