### PR TITLE
feat(console) resume endpoint for failed customer status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -130,6 +130,10 @@
                 <mat-icon svgIcon="gio:calendar"></mat-icon>
                 Change end date
               </button>
+              <button mat-stroked-button (click)="resumeFailureSubscription()" *ngIf="subscription.consumerStatus === 'FAILURE'">
+                <mat-icon svgIcon="gio:play-circle"></mat-icon>
+                Resume from failure
+              </button>
               <button mat-raised-button color="warn" (click)="closeSubscription()">
                 <mat-icon svgIcon="gio:x-circle"></mat-icon>
                 Close

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.ts
@@ -366,6 +366,36 @@ export class ApiSubscriptionEditComponent implements OnInit {
       );
   }
 
+  resumeFailureSubscription() {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: `Resume your failure subscription`,
+          content: 'The application will be able to consume your API.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeFailureSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((confirm) => {
+          if (confirm) {
+            return this.apiSubscriptionService.resumeFailure(this.subscription.id, this.apiId);
+          }
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`Subscription resumed`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
+  }
+
   changeEndDate() {
     this.matDialog
       .open<

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.harness.ts
@@ -120,8 +120,16 @@ export class ApiSubscriptionEditHarness extends ComponentHarness {
     return this.btnIsVisible('Resume');
   }
 
+  public async resumeFailureBtnIsVisible(): Promise<boolean> {
+    return this.btnIsVisible('Resume from failure');
+  }
+
   public async openResumeDialog(): Promise<void> {
     return this.getBtnByText('Resume').then((btn) => btn.click());
+  }
+
+  public async openResumeFailureDialog(): Promise<void> {
+    return this.getBtnByText('Resume from failure').then((btn) => btn.click());
   }
 
   public async changeEndDateBtnIsVisible(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -104,6 +104,9 @@ export class ApiSubscriptionV2Service {
   resume(subscriptionId: string, apiId: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_resume`, {});
   }
+  resumeFailure(subscriptionId: string, apiId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_resumeFailure`, {});
+  }
 
   create(apiId: string, createSubscription: CreateSubscription): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions`, createSubscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
-import io.gravitee.rest.api.model.ProcessSubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.TransferSubscriptionEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionConfigurationEntity;
@@ -69,6 +68,7 @@ public interface SubscriptionService {
     SubscriptionEntity pause(ExecutionContext executionContext, String subscription);
 
     SubscriptionEntity resumeConsumer(ExecutionContext executionContext, String subscriptionId);
+    SubscriptionEntity resumeFailed(ExecutionContext executionContext, String subscriptionId);
 
     SubscriptionEntity resume(ExecutionContext executionContext, String subscription);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionFailureCustomerStatusRequiredException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionFailureCustomerStatusRequiredException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+public class SubscriptionFailureCustomerStatusRequiredException extends RuntimeException {
+
+    public SubscriptionFailureCustomerStatusRequiredException() {
+        super("Subscription FAILURE customer status required to resume subscription");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -92,14 +92,11 @@ import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.PageService;
-import io.gravitee.rest.api.service.ParameterService;
-import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
@@ -110,6 +107,7 @@ import io.gravitee.rest.api.service.exceptions.PlanNotSubscribableWithSharedApiK
 import io.gravitee.rest.api.service.exceptions.PlanNotYetPublishedException;
 import io.gravitee.rest.api.service.exceptions.PlanRestrictedException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionConsumerStatusNotUpdatableException;
+import io.gravitee.rest.api.service.exceptions.SubscriptionFailureCustomerStatusRequiredException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionFailureException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotPausableException;
@@ -2098,6 +2096,64 @@ public class SubscriptionServiceTest {
                 any(),
                 any()
             );
+    }
+
+    @Test
+    public void shouldResumeFailureByConsumer() throws Exception {
+        Subscription subscription = buildTestSubscription(ACCEPTED);
+        subscription.setConsumerStatus(Subscription.ConsumerStatus.FAILURE);
+        subscription.setApi(API_ID);
+
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        io.gravitee.rest.api.model.v4.api.ApiModel apiModel = mock(io.gravitee.rest.api.model.v4.api.ApiModel.class);
+        when(apiTemplateService.findByIdForTemplates(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiModel);
+        when(apiModel.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+        when(apiModel.getListeners()).thenReturn(List.of(new SubscriptionListener()));
+        when(subscriptionRepository.update(subscription)).thenReturn(subscription);
+        final ApiKeyEntity apiKey = buildTestApiKey(subscription.getId(), false, false);
+        when(apiKeyService.findBySubscription(any(), any())).thenReturn(List.of(apiKey));
+
+        subscriptionService.resumeFailed(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
+
+        assertThat(subscription.getConsumerPausedAt()).isNull();
+        assertThat(subscription.getConsumerStatus()).isEqualTo(Subscription.ConsumerStatus.STARTED);
+        verify(apiKeyService).update(GraviteeContext.getExecutionContext(), apiKey);
+        verify(auditService)
+            .createApiAuditLog(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(API_ID),
+                anyMap(),
+                eq(Subscription.AuditEvent.SUBSCRIPTION_RESUMED_BY_CONSUMER),
+                any(),
+                any(),
+                any()
+            );
+        verify(auditService)
+            .createApplicationAuditLog(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(APPLICATION_ID),
+                anyMap(),
+                eq(Subscription.AuditEvent.SUBSCRIPTION_RESUMED_BY_CONSUMER),
+                any(),
+                any(),
+                any()
+            );
+    }
+
+    @Test(expected = SubscriptionFailureCustomerStatusRequiredException.class)
+    public void shouldNotResumeFailureByConsumerBecauseApiDefinitionNotV4() throws Exception {
+        Subscription subscription = buildTestSubscription(ACCEPTED);
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+
+        subscriptionService.resumeFailed(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
+    }
+
+    @Test(expected = SubscriptionNotFoundException.class)
+    public void shouldNotResumeFailureByConsumerBecauseDoesNoExist() throws Exception {
+        // Stub
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.empty());
+
+        subscriptionService.resumeFailed(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7811

## Description

Adding possibility to resume failed subscription when backend failed

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yopdasbfbe.chromatic.com)
<!-- Storybook placeholder end -->
