### PR TITLE
Revert "chore: bump gravitee-entrypoint-webhook [skip ci]"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <gravitee-entrypoint-http-get.version>2.0.0-alpha.2</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.0.0-alpha.2</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.0-alpha.2</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>4.0.0-alpha.3</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>4.0.0-alpha.2</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0-alpha.2</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>3.0.0-alpha.3</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>3.0.0-alpha.3</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
This reverts commit c24a1dd82ce6b82aac4afa8dc9e01f5d91e447f2.

## Issue

n/a

## Description

Revet the commit that breaks the integration tests and skips the CI that should tell it

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uinmrnxlqh.chromatic.com)
<!-- Storybook placeholder end -->
