### PR TITLE
feat: Allow IPv4 or IPv6 configuration

### DIFF
--- a/gravitee-apim-console-webui/docker/config/default.conf
+++ b/gravitee-apim-console-webui/docker/config/default.conf
@@ -1,6 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
+    listen [::]:$HTTP_PORT;
+    listen [::]:$HTTPS_PORT;
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -21,11 +21,6 @@ case "`uname`" in
         ;;
 esac
 
-# Force IPv4 on Linux systems since IPv6 doesn't work correctly with jdk5 and lower
-if [ "$linux" = "true" ]; then
-   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-fi
-
 # Searching for configuration 
 GRAVITEE_OPTS=""
 if [ -f "/etc/gravitee-gateway/gravitee.yml" ]

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -9,9 +9,6 @@ for %%B in (%~dp0\.) do set GRAVITEE_HOME=%%~dpB
 
 IF "%JAVA_HOME%"=="" GOTO nojavahome
 
-set JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-
-
 set JAVA="%JAVA_HOME%/bin/java"
 
 rem Setup the classpath
@@ -35,7 +32,7 @@ REM set to headless, just in case
 set JAVA_OPTS=%JAVA_OPTS% -Djava.awt.headless=true
 
 REM Force the JVM to use IPv4 stack
-if NOT "%ES_USE_IPV4%" == "" (
+if NOT "%GIO_USE_IPV4%" == "" (
 set JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true
 )
 

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -1,6 +1,8 @@
 server {
     listen $HTTP_PORT;
     listen $HTTPS_PORT;
+    listen [::]:$HTTP_PORT;
+    listen [::]:$HTTPS_PORT;
     server_name $SERVER_NAME;
 
     add_header Content-Security-Policy "frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS;" always;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -21,11 +21,6 @@ case "`uname`" in
         ;;
 esac
 
-# Force IPv4 on Linux systems since IPv6 doesn't work correctly with jdk5 and lower
-if [ "$linux" = "true" ]; then
-   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-fi
-
 # Searching for configuration 
 GRAVITEE_OPTS=""
 if [ -f "/etc/gravitee-management/gravitee.yml" ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee.bat
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee.bat
@@ -8,9 +8,6 @@ for %%B in (%~dp0\.) do set GRAVITEE_HOME=%%~dpB
 
 IF "%JAVA_HOME%"=="" GOTO nojavahome
 
-set JAVA_OPTS="-Djava.net.preferIPv4Stack=true"
-
-
 set JAVA="%JAVA_HOME%/bin/java"
 
 rem Setup the classpath
@@ -38,7 +35,7 @@ set JAVA_OPTS=%JAVA_OPTS% -Djersey.config.allowSystemPropertiesProvider=true
 set JAVA_OPTS=%JAVA_OPTS% -Djersey.config.server.wadl.disableWadl=true
 
 REM Force the JVM to use IPv4 stack
-if NOT "%ES_USE_IPV4%" == "" (
+if NOT "%GIO_USE_IPV4%" == "" (
 set JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true
 )
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/10247

## Description

The option -Djava.net.preferIPv4Stack=true , block a deployment on an IPv6 cluster.
We can always add this option in the configuration  JAVA_OPTS


