### PR TITLE
fix: TOP APIs widget displays properly instead of endlessly spinning loader for empty list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResource.java
@@ -67,11 +67,13 @@ public class EnvironmentAnalyticsResource {
         var params = AnalyticsQueryParameters.builder().from(timeRangeParam.getFrom()).to(timeRangeParam.getTo()).build();
         var input = new SearchEnvironmentTopHitsApisCountUseCase.Input(GraviteeContext.getExecutionContext(), params);
 
-        return searchEnvironmentTopHitsApisCountUseCase
-            .execute(input)
-            .topHitsApis()
-            .map(EnvironmentAnalyticsMapper.INSTANCE::map)
-            .orElse(EnvironmentAnalyticsTopHitsApisResponse.builder().data(List.of()).build());
+        var topHitsApis = searchEnvironmentTopHitsApisCountUseCase.execute(input).topHitsApis();
+
+        if (topHitsApis == null) {
+            return EnvironmentAnalyticsTopHitsApisResponse.builder().build();
+        }
+
+        return EnvironmentAnalyticsMapper.INSTANCE.map(topHitsApis);
     }
 
     @Path("/request-response-time")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
@@ -166,6 +166,21 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                         .build()
                 );
         }
+
+        @Test
+        void should_return_200_with_empty_list_if_no_apis_found() {
+            apiQueryService.initWith(List.of());
+            analyticsQueryService.topHitsApis = TopHitsApis.builder().data(List.of()).build();
+
+            //When
+
+            Response response = statusRangeTarget.queryParam("from", FROM).queryParam("to", TO).request().get();
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(EnvironmentAnalyticsTopHitsApisResponse.class)
+                .isEqualTo(EnvironmentAnalyticsTopHitsApisResponse.builder().data(List.of()).build());
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentTopHitsApisCountUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentTopHitsApisCountUseCase.java
@@ -53,7 +53,7 @@ public class SearchEnvironmentTopHitsApisCountUseCase {
             .searchTopHitsApis(input.executionContext(), input.parameters().withApiIds(v4ApiIds))
             .map(topHitsApis -> sortByCountAndUpdateTopHitsWithApiNames(v4Apis, topHitsApis))
             .map(Output::new)
-            .orElse(new Output());
+            .orElse(new Output(TopHitsApis.builder().data(List.of()).build()));
     }
 
     private Map<String, Api> getAllV4ApisForEnv(String envId) {
@@ -81,13 +81,5 @@ public class SearchEnvironmentTopHitsApisCountUseCase {
     @Builder
     public record Input(ExecutionContext executionContext, AnalyticsQueryParameters parameters) {}
 
-    public record Output(Optional<TopHitsApis> topHitsApis) {
-        Output(TopHitsApis topHitsApis) {
-            this(Optional.of(topHitsApis));
-        }
-
-        Output() {
-            this(TopHitsApis.builder().build());
-        }
-    }
+    public record Output(TopHitsApis topHitsApis) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentTopHitsApisCountUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics/use_case/SearchEnvironmentTopHitsApisCountUseCaseTest.java
@@ -89,14 +89,12 @@ class SearchEnvironmentTopHitsApisCountUseCaseTest {
         var result = cut.execute(input).topHitsApis();
 
         assertThat(result)
-            .isNotNull()
-            .isPresent()
-            .hasValueSatisfying(topHitsApis ->
-                assertThat(topHitsApis.getData())
-                    .containsExactly(
-                        TopHitsApis.TopHitApi.builder().id("message-api-v4-id").name("Message Api v4").count(17L).build(),
-                        TopHitsApis.TopHitApi.builder().id("proxy-api-v4-id").name("Proxy Api v4").count(3L).build()
-                    )
+            .extracting(TopHitsApis::getData)
+            .isEqualTo(
+                List.of(
+                    TopHitsApis.TopHitApi.builder().id("message-api-v4-id").name("Message Api v4").count(17L).build(),
+                    TopHitsApis.TopHitApi.builder().id("proxy-api-v4-id").name("Proxy Api v4").count(3L).build()
+                )
             );
     }
 
@@ -125,12 +123,8 @@ class SearchEnvironmentTopHitsApisCountUseCaseTest {
         var result = cut.execute(input).topHitsApis();
 
         assertThat(result)
-            .isNotNull()
-            .isPresent()
-            .hasValueSatisfying(topHitsApis ->
-                assertThat(topHitsApis.getData())
-                    .containsExactly(TopHitsApis.TopHitApi.builder().id("message-api-v4-id").name("Message Api v4").count(17L).build())
-            );
+            .extracting(TopHitsApis::getData)
+            .isEqualTo(List.of(TopHitsApis.TopHitApi.builder().id("message-api-v4-id").name("Message Api v4").count(17L).build()));
     }
 
     @Test
@@ -168,11 +162,21 @@ class SearchEnvironmentTopHitsApisCountUseCaseTest {
 
         var result = cut.execute(input).topHitsApis();
 
-        assertThat(result)
-            .isNotNull()
-            .isPresent()
-            .hasValueSatisfying(topHitsApis ->
-                assertThat(topHitsApis.getData()).extracting(TopHitsApis.TopHitApi::count).containsExactly(17L, 5L, 3L, 2L)
-            );
+        assertThat(result.getData()).extracting(TopHitsApis.TopHitApi::count).containsExactly(17L, 5L, 3L, 2L);
+    }
+
+    @Test
+    void should_get_empty_top_hits_list_if_case_of_no_records_found() {
+        var input = SearchEnvironmentTopHitsApisCountUseCase.Input
+            .builder()
+            .executionContext(executionContext)
+            .parameters(AnalyticsQueryParameters.builder().from(FROM).to(TO).build())
+            .build();
+
+        when(analyticsQueryService.searchTopHitsApis(any(), any())).thenReturn(Optional.empty());
+
+        var result = cut.execute(input).topHitsApis();
+
+        assertThat(result).extracting(TopHitsApis::getData).isEqualTo(List.of());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7993

## Description

Fix for displaying the top APIS widget for v4 dashboard analytics. It ran a spinning loader endlessly instead of "no content to display info" prompt. 

## Additional context

Before fix: 
<img width="1194" alt="Zrzut ekranu 2024-12-16 o 13 14 46" src="https://github.com/user-attachments/assets/971e362f-b738-469e-92b3-ca5f9913c41d" />
After fix:
<img width="1125" alt="Zrzut ekranu 2024-12-16 o 14 42 37" src="https://github.com/user-attachments/assets/cd10dea8-c455-46cc-9b00-05c535d4e208" />

