### PR TITLE
feat: improve routingHostMode and add defaultDomain & defaultPort

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -162,10 +162,15 @@ secrets:
 #kafka:
 #  enabled: false
 
-#  # Host Mode
 #  routingMode: host # default is host. Only host is supported for now.
-#  brokerHostPrefix: broker- # default is broker-
+#  # Routing Host Mode
+#  routingHostMode:
+#    brokerPrefix: broker- # default is broker-
+#    # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
+#    defaultDomain: mycompany.org # Should set according to the public wildcard DNS/Certificate. Default is empty
+#    defaultPort: 9092 # Default public port for Kafka APIs. Default is 9092
 
+#  # Kafka Network settings
 #  port: 9092
 #  host: 0.0.0.0
 #  idleTimeout: 0

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -166,8 +166,20 @@ data:
     {{- if hasKey .Values.gateway "kafka" }}
     kafka:
       enabled: {{ .Values.gateway.kafka.enabled }}
-      {{- if hasKey .Values.gateway.kafka "brokerHostPrefix" }}
-      brokerHostPrefix: {{ .Values.gateway.kafka.brokerHostPrefix }}
+      {{- if hasKey .Values.gateway.kafka "routingMode" }}
+      routingMode: {{ .Values.gateway.kafka.routingMode }}
+      {{- end}}
+      {{- if hasKey .Values.gateway.kafka "routingHostMode" }}
+      routingHostMode:
+        {{- if hasKey .Values.gateway.kafka.routingHostMode "brokerPrefix" }}
+        brokerPrefix: {{ .Values.gateway.kafka.routingHostMode.brokerPrefix }}
+        {{- end}}
+        {{- if hasKey .Values.gateway.kafka.routingHostMode "defaultDomain" }}
+        defaultDomain: {{ .Values.gateway.kafka.routingHostMode.defaultDomain }}
+        {{- end}}
+        {{- if hasKey .Values.gateway.kafka.routingHostMode "defaultPort" }}
+        defaultPort: {{ .Values.gateway.kafka.routingHostMode.defaultPort }}
+        {{- end}}
       {{- end}}
       {{- if hasKey .Values.gateway.kafka "port" }}
       port: {{ .Values.gateway.kafka.port }}

--- a/helm/tests/gateway/configmap_kafka_test.yaml
+++ b/helm/tests/gateway/configmap_kafka_test.yaml
@@ -20,7 +20,11 @@ tests:
       gateway:
         kafka:
           enabled: true
-          brokerHostPrefix: fox-
+          routingMode: host
+          routingHostMode:
+            brokerPrefix: fox-
+            defaultDomain: gravitee.io
+            defaultPort: 42
           port: 9042
           host: 42.42.42.42
           idleTimeout: 42
@@ -33,7 +37,11 @@ tests:
           pattern: |
             kafka:
               enabled: true
-              brokerHostPrefix: fox-
+              routingMode: host
+              routingHostMode:
+                brokerPrefix: fox-
+                defaultDomain: gravitee.io
+                defaultPort: 42
               port: 9042
               host: 42.42.42.42
               idleTimeout: 42

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -952,10 +952,16 @@ gateway:
     requestTimeout: 30000
     requestTimeoutGraceDelay: 30
 
-  # Gateway Kafka server
+# # Gateway Kafka server
 #  kafka:
 #    enabled: false
-#    brokerHostPrefix: broker- # default is broker-
+#    routingMode: host # default is host. Only host is supported for now.
+#    # Routing Host Mode
+#    routingHostMode:
+#      brokerPrefix: broker- # default is broker-
+#      # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
+#      defaultDomain: mycompany.org # Should set according to the public wildcard DNS/Certificate. Default is empty
+#      defaultPort: 9092 # Default public port for Kafka APIs. Default is 9092
 #    port: 9092
 #    host: 0.0.0.0
 #    idleTimeout: 0

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
         <gravitee-service-secrets.version>1.0.0-alpha.4</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.2</gravitee-policy-interops.version>
 
-        <gravitee-connectors-native-kafka.version>1.0.0-alpha.9</gravitee-connectors-native-kafka.version>
+        <gravitee-connectors-native-kafka.version>1.0.0-alpha.10</gravitee-connectors-native-kafka.version>
         <gravitee-policy-kafka-quota.version>1.0.0-alpha.2</gravitee-policy-kafka-quota.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>3.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-reactor-message.version>5.0.0-alpha.11</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>1.0.0-alpha.32</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>1.0.0-alpha.33</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>5.1.2</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.0.0-alpha.4</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0-alpha.2</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8004

## Description

A host for kafka is made from a host prefix linked to the api ex: `myapi`.
And a domain linked to a certificate ex: `*.mydomain.com`. + The server gateway listening port

This PR add defaultDomain & defaultPort in order to 
- Configure reactor to suffix all api hosts. Probably with the associated wildcard certificate
- Set default listening port. hard coded actually

Notes: 
These 2 options are linked to routing mode host. In port mode they won't be useful
The defaultDomain option will also be useless if the client uses AcessePoints

I'll make the changes in the reactor if the interface here is validated.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-relwyniert.chromatic.com)
<!-- Storybook placeholder end -->
