### PR TITLE
fix(portal-next): update comment in native kafka api access propertie…

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -21,9 +21,7 @@
       <div class="m3-title-medium api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">API access</div>
     </mat-card-header>
     <mat-card-content class="api-access__copy-code-content">
-      @if (planSecurity === 'API_KEY') {
-        <app-copy-code id="api-key" class="test-1" title="API Key" [text]="apiKey ?? ''" />
-      } @else if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
+      @if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
         <app-copy-code id="client-id" title="Client ID" [text]="clientId ?? ''" />
 
         @if (!!clientSecret) {
@@ -39,6 +37,9 @@
           [apiKeyConfigUsername]="apiKeyConfigUsername ?? ''"
           [clientId]="clientId ?? ''" />
       } @else if (planSecurity === 'KEY_LESS' || planSecurity === 'API_KEY') {
+        @if (planSecurity === 'API_KEY') {
+          <app-copy-code id="api-key" class="test-1" title="API Key" [text]="apiKey ?? ''" />
+        }
         <app-copy-code id="base-url" title="Base URL" [text]="entrypointUrl ?? ''" />
         <app-copy-code id="command-line" title="Command Line" [text]="curlCmd" />
       }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -125,9 +125,12 @@ describe('ApiAccessComponent', () => {
           component.apiKeyConfigUsername = 'hash-username';
 
           fixture.detectChanges();
-          expect(await apiKeyShown()).toBeTruthy();
+          expect(await apiKeyShown()).toBeFalsy();
           expect(await baseUrlShown()).toBeFalsy();
           expect(await commandLineShown()).toBeFalsy();
+
+          expect(await apiKeyUsernameShown()).toBeTruthy();
+          expect(await apiKeyPasswordShown()).toBeTruthy();
           expect(await plainConfigurationShown()).toBeTruthy();
           expect(await scram256ConfigurationShown()).toBeFalsy();
           expect(await scram512ConfigurationShown()).toBeFalsy();
@@ -243,6 +246,12 @@ describe('ApiAccessComponent', () => {
 
   async function apiKeyShown() {
     return !!(await getCopyCodeHarnessOrNullByTitle('API Key'));
+  }
+  async function apiKeyUsernameShown() {
+    return !!(await getCopyCodeHarnessOrNullByTitle('Username'));
+  }
+  async function apiKeyPasswordShown() {
+    return !!(await getCopyCodeHarnessOrNullByTitle('Password'));
   }
   async function baseUrlShown() {
     return !!(await getCopyCodeHarnessOrNullByTitle('Base URL'));

--- a/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
@@ -26,6 +26,17 @@
   </div>
 </div>
 
+@if (planSecurity() === 'API_KEY') {
+  <div class="native-kafka-api-access__section">
+    <div class="m3-title-medium" i18n="@@nativeKafkaApiAccessAuthentication">Authentication</div>
+    <div class="m3-body-medium" i18n="@@nativeKafkaApiAccessApiKeyHash">
+      Use the MD5 hash of the API Key as the username and the API Key as the password.
+    </div>
+    <app-copy-code id="native-kafka-api-key-username" title="Username" [text]="apiKeyConfigUsername()" />
+    <app-copy-code id="native-kafka-api-key-password" title="Password" [text]="apiKey()" />
+  </div>
+}
+
 <div class="native-kafka-api-access__section">
   <div class="m3-title-medium" i18n="@@nativeKafkaApiAccessReviewProperties">Review Kafka Properties</div>
   <div class="m3-body-medium" i18n="@@nativeKafkaApiAccessCreatePropertiesFile">

--- a/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.html
@@ -40,7 +40,7 @@
 
     <mat-tab-group aria-label="API Key connect properties">
       <mat-tab label="PLAIN">
-        <div class="native-kafka-api-access__api-key__tab-container">
+        <div class="native-kafka-api-access__tab-container">
           <app-copy-code id="native-kafka-api-key-plain-properties" [text]="plainConfig()" />
         </div>
       </mat-tab>

--- a/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/native-kafka-api-access/native-kafka-api-access.component.ts
@@ -96,7 +96,8 @@ ${this.trustStoreConfig}`,
 
   private trustStoreConfig =
     '\n' +
-    '# Configure your truststore if using self-sign certificates\n' +
+    '# Configure your truststore if you are using a certificate\n' +
+    '# not automatically trusted by your installation\n' +
     '# ssl.truststore.location={{ PATH_TO_TRUSTSTORE_JKS }}\n' +
     '# ssl.truststore.password={{ TRUSTSTORE_PASSWORD }}';
 }


### PR DESCRIPTION
…s section

## Issue

https://gravitee.atlassian.net/browse/APIM-7166

## Description

- Update comment about truststore in the `connect.properties` snippet
- Fix missing class for plain snippet 🙈 
- Add `Authentication` section for API Key plan subscriptions --> explain username and password composition

![Screenshot 2024-12-17 at 18 32 33](https://github.com/user-attachments/assets/6ad7a056-2041-4191-ae18-69ea8d309374)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

