### PR TITLE
fix: search for TemplateVariableProviderFactory including ancestors

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/AbstractReactorFactory.java
@@ -47,6 +47,7 @@ import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.resource.api.ResourceManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.context.ApplicationContext;
@@ -153,10 +154,9 @@ public abstract class AbstractReactorFactory<T extends ReactableApi<? extends Ab
     protected List<TemplateVariableProvider> commonTemplateVariableProviders(T reactableApi) {
         final List<TemplateVariableProvider> templateVariableProviders = new ArrayList<>();
         templateVariableProviders.add(new ApiTemplateVariableProvider(reactableApi));
-        List<TemplateVariableProvider> list = applicationContext
-            .getBeansOfType(TemplateVariableProviderFactory.class)
-            .values()
-            .stream()
+        List<TemplateVariableProvider> list = Stream
+            .of(BeanFactoryUtils.beanNamesForTypeIncludingAncestors(applicationContext, TemplateVariableProviderFactory.class))
+            .map(name -> (TemplateVariableProviderFactory) applicationContext.getBean(name))
             .filter(factory -> factory.getTemplateVariableScope() == TemplateVariableScope.API)
             .flatMap(factory -> factory.getTemplateVariableProviders().stream())
             .toList();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -317,9 +317,9 @@ class DefaultApiReactorFactoryTest {
             TemplateVariableProviderFactory apiTemplateVariableProviderFactory = mock(ApiTemplateVariableProviderFactory.class);
             when(apiTemplateVariableProviderFactory.getTemplateVariableProviders()).thenReturn(providers);
             when(apiTemplateVariableProviderFactory.getTemplateVariableScope()).thenReturn(TemplateVariableScope.API);
-            lenient()
-                .when(applicationContext.getBeansOfType(TemplateVariableProviderFactory.class))
-                .thenReturn(Map.of("apiTemplateVariableProviderFactory", apiTemplateVariableProviderFactory));
+            String[] providersName = { "apiTemplateVariableProviderFactory" };
+            lenient().when(applicationContext.getBeanNamesForType(TemplateVariableProviderFactory.class)).thenReturn(providersName);
+            lenient().when(applicationContext.getBean("apiTemplateVariableProviderFactory")).thenReturn(apiTemplateVariableProviderFactory);
             return providers;
         }
 


### PR DESCRIPTION
to retrieve SecretTemplateVariableProviderFactory

## Issue

https://gravitee.atlassian.net/browse/APIM-7497

## Description

Fix SecretTemplateVariableProviderFactory not loaded for v4 message APIs.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xlzvqyawaz.chromatic.com)
<!-- Storybook placeholder end -->
