### PR TITLE
APIM 7811 fix: reorder buttons to restore correct layout

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/edit/api-subscription-edit.component.html
@@ -139,13 +139,13 @@
                 <mat-icon svgIcon="gio:calendar"></mat-icon>
                 Change end date
               </button>
-              <button mat-raised-button color="warn" (click)="closeSubscription()" [disabled]="subscription.origin === 'KUBERNETES'">
-                <mat-icon svgIcon="gio:x-circle"></mat-icon>
-                Close
-              </button>
               <button mat-stroked-button (click)="resumeFailureSubscription()" *ngIf="subscription.consumerStatus === 'FAILURE'">
                 <mat-icon svgIcon="gio:play-circle"></mat-icon>
                 Resume from failure
+              </button>
+              <button mat-raised-button color="warn" (click)="closeSubscription()" [disabled]="subscription.origin === 'KUBERNETES'">
+                <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                Close
               </button>
             </ng-container>
             <ng-template #pendingSubscription>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7811

## Description

Reorder buttons because using mergify on master ordered the buttons wrongly.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nfwnxspkzz.chromatic.com)
<!-- Storybook placeholder end -->
