### PR TITLE
Apim 7783 adjust host prefix for kafka api

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.html
@@ -21,34 +21,44 @@
     <tr>
       <th class="gio-form-listeners__table__row__th">
         <div class="gio-form-listeners__table__title">
-          Host
-          <mat-icon class="gio-form-listeners__table__title__icon" matTooltip="The host to run the server on." svgIcon="gio:info" />
+          Host Prefix
+          <mat-icon class="gio-form-listeners__table__title__icon" matTooltip="The host prefix to identify your API." svgIcon="gio:info" />
         </div>
         <div class="gio-form-listeners__table__subtitle">
-          Can contain an uppercase letter, number, dot, dash or underscore. Total maximum length is 63 chars.
+          Can contain a lowercase letter, number, dot, dash or underscore. Each host label segment must be less than 64 characters, except
+          the first label segment which must be less than 50 characters.
         </div>
       </th>
     </tr>
   </thead>
   <tbody>
-    <tr class="gio-form-listeners__table__row kafka-configuration">
-      <div class="gio-form-listeners__table__row__td kafka-configuration__host">
-        <mat-form-field class="gio-form-listeners__table__field">
-          <mat-label>Host</mat-label>
-          <input type="text" matInput formControlName="host" placeholder="Host" />
-          @if (hostFormControl.hasError('required')) {
-            <mat-error> Host is required </mat-error>
-          }
-          @if (hostFormControl.hasError('listeners')) {
-            <mat-error> {{ hostFormControl.getError('listeners') }}</mat-error>
-          }
-          @if (hostFormControl.hasError('max')) {
-            <mat-error> {{ hostFormControl.getError('max') }}</mat-error>
-          }
-          @if (hostFormControl.hasError('format')) {
-            <mat-error> {{ hostFormControl.getError('format') }}</mat-error>
-          }
-        </mat-form-field>
+    <tr class="gio-form-listeners__table__row">
+      <div class="kafka-configuration">
+        <div class="kafka-configuration__host">
+          <mat-form-field class="gio-form-listeners__table__field">
+            <mat-label>Host prefix</mat-label>
+            <input type="text" matInput formControlName="host" placeholder="Host" />
+            @if (hostFormControl.hasError('required')) {
+              <mat-error> Host is required </mat-error>
+            }
+            @if (hostFormControl.hasError('listeners')) {
+              <mat-error> {{ hostFormControl.getError('listeners') }}</mat-error>
+            }
+            @if (hostFormControl.hasError('max')) {
+              <mat-error> {{ hostFormControl.getError('max') }}</mat-error>
+            }
+            @if (hostFormControl.hasError('format')) {
+              <mat-error> {{ hostFormControl.getError('format') }}</mat-error>
+            }
+            @if (hostFormControl.hasError('firstSegment')) {
+              <mat-error> {{ hostFormControl.getError('firstSegment') }}</mat-error>
+            }
+          </mat-form-field>
+        </div>
+        <div class="kafka-configuration__domain">
+          <div class="mat-subtitle-2">{{ entrypointDomainAndHost }}</div>
+          <gio-clipboard-copy-icon matSuffix [contentToCopy]="entrypointCopyValue$()" />
+        </div>
       </div>
     </tr>
   </tbody>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.scss
@@ -1,8 +1,21 @@
 .kafka-configuration {
   display: flex;
   width: 100%;
+  align-items: center;
+  gap: 16px;
+  padding: 0 8px 8px 8px;
 
   &__host {
-    flex: 1 1 100%;
+    flex: 1;
+  }
+
+  &__domain {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    gio-clipboard-copy-icon {
+      padding-right: 6px;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.spec.ts
@@ -107,7 +107,7 @@ describe('GioFormListenersKafkaHostComponent', () => {
         ${'Can contain dash'}                                                | ${true}  | ${'simple-host'}
         ${'Can contain underscore'}                                          | ${true}  | ${'simple_host'}
         ${'Can contain dash and underscore'}                                 | ${true}  | ${'simple-host_underscored'}
-        ${'Can contain uppercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-Host_underscored33'}
+        ${'Can contain lowercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-host_underscored33'}
       `('should validate `$reason`: is valid=$isValid', async ({ isValid, host }) => {
         const formHarness = await loader.getHarness(GioFormListenersKafkaHostHarness);
         const hostInput = await formHarness.getHostInput();
@@ -195,7 +195,7 @@ describe('GioFormListenersKafkaHostComponent', () => {
         ${'Can contain dash'}                                                | ${true}  | ${'simple-host'}
         ${'Can contain underscore'}                                          | ${true}  | ${'simple_host'}
         ${'Can contain dash and underscore'}                                 | ${true}  | ${'simple-host_underscored'}
-        ${'Can contain uppercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-Host_underscored33'}
+        ${'Can contain lowercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-host_underscored33'}
       `('should validate `$reason`: is valid=$isValid', async ({ isValid, host }) => {
         const formHarness = await loader.getHarness(GioFormListenersKafkaHostHarness);
         const hostInput = await formHarness.getHostInput();

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.component.html
@@ -29,7 +29,7 @@
           ></mat-icon>
         </div>
         <div class="gio-form-listeners__table__subtitle">
-          Can contain an uppercase letter, number, dot, dash or underscore. Total maximum length is 255 chars and each hostname label has a
+          Can contain a lowercase letter, number, dot, dash or underscore. Total maximum length is 255 chars and each hostname label has a
           max length of 63 chars.
         </div>
       </th>

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.module.spec.ts
@@ -138,20 +138,21 @@ describe('GioFormListenersTcpHostsModule', () => {
         ${'Host cannot be empty'}                                            | ${false} | ${''}
         ${'Host with only whitespace are considered empty'}                  | ${false} | ${'    '}
         ${'Total length should not be greater than 255 chars'}               | ${false} | ${'a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host'}
-        ${'Simple host label should be lower than 63 chars'}                 | ${false} | ${'ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase'}
-        ${'A label within a hostname should not be more than 63 chars long'} | ${false} | ${'host.ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase.gravitee'}
+        ${'Simple host label should be lower than 63 chars'}                 | ${false} | ${'thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase'}
+        ${'A label within a hostname should not be more than 63 chars long'} | ${false} | ${'host.thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase.gravitee'}
         ${'Can not start with dash'}                                         | ${false} | ${'-simple-host'}
         ${'Can not end with dash'}                                           | ${false} | ${'simple-host-'}
         ${'Host label can not end with dash'}                                | ${false} | ${'simple-host-.host'}
         ${'Can not start with underscore'}                                   | ${false} | ${'_simple-host'}
         ${'Can not end with underscore'}                                     | ${false} | ${'simple-host_'}
         ${'Host label can not end with underscore'}                          | ${false} | ${'simple-host_.host'}
+        ${'Cannot contain uppercase'}                                        | ${false} | ${'simple-Host'}
         ${'IPv4 should be a valid host'}                                     | ${true}  | ${'127.0.0.1'}
         ${'Can contain multiple host label'}                                 | ${true}  | ${'dev.simple-host.gravitee.io'}
         ${'Can contain dash'}                                                | ${true}  | ${'simple-host'}
         ${'Can contain underscore'}                                          | ${true}  | ${'simple_host'}
         ${'Can contain dash and underscore'}                                 | ${true}  | ${'simple-host_underscored'}
-        ${'Can contain uppercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-Host_underscored33'}
+        ${'Can contain lowercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-host_underscored33'}
       `('should validate `$reason`: is valid=$isValid', async ({ isValid, host }) => {
         const formHosts = await loader.getHarness(GioFormListenersTcpHostsHarness);
 
@@ -289,20 +290,21 @@ describe('GioFormListenersTcpHostsModule', () => {
         ${'Host cannot be empty'}                                            | ${false} | ${''}
         ${'Host with only whitespace are considered empty'}                  | ${false} | ${'    '}
         ${'Total length should not be greater than 255 chars'}               | ${false} | ${'a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host'}
-        ${'Simple host label should be lower than 63 chars'}                 | ${false} | ${'ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase'}
-        ${'A label within a hostname should not be more than 63 chars long'} | ${false} | ${'host.ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase.gravitee'}
+        ${'Simple host label should be lower than 63 chars'}                 | ${false} | ${'thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase'}
+        ${'A label within a hostname should not be more than 63 chars long'} | ${false} | ${'host.thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase.gravitee'}
         ${'Can not start with dash'}                                         | ${false} | ${'-simple-host'}
         ${'Can not end with dash'}                                           | ${false} | ${'simple-host-'}
         ${'Host label can not end with dash'}                                | ${false} | ${'simple-host-.host'}
         ${'Can not start with underscore'}                                   | ${false} | ${'_simple-host'}
         ${'Can not end with underscore'}                                     | ${false} | ${'simple-host_'}
         ${'Host label can not end with underscore'}                          | ${false} | ${'simple-host_.host'}
+        ${'Cannot contain uppercase'}                                        | ${false} | ${'simple-Host'}
         ${'IPv4 should be a valid host'}                                     | ${true}  | ${'127.0.0.1'}
         ${'Can contain multiple host label'}                                 | ${true}  | ${'dev.simple-host.gravitee.io'}
         ${'Can contain dash'}                                                | ${true}  | ${'simple-host'}
         ${'Can contain underscore'}                                          | ${true}  | ${'simple_host'}
         ${'Can contain dash and underscore'}                                 | ${true}  | ${'simple-host_underscored'}
-        ${'Can contain uppercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-Host_underscored33'}
+        ${'Can contain lowercase, numbers, dash and underscore'}             | ${true}  | ${'simple1-host_underscored33'}
       `('should validate `$reason`: is valid=$isValid', async ({ isValid, host }) => {
         const formHosts = await loader.getHarness(GioFormListenersTcpHostsHarness);
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-http-expects.ts
@@ -37,6 +37,8 @@ export class ApiCreationV4SpecHttpExpects {
     const settings: PortalSettings = {
       portal: {
         entrypoint: 'entrypoint',
+        kafkaDomain: 'kafka.domain',
+        kafkaPort: 9092,
       },
     };
     this.httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
@@ -134,6 +134,7 @@ export class ApiCreationV4SpecStepperHelper {
       await entrypointsConfig.fillPaths(...paths);
       this.httpExpects.expectVerifyContextPath();
     } else if (entrypoints.some((entrypoint) => entrypoint.supportedListenerType === 'KAFKA')) {
+      this.httpExpects.expectApiGetPortalSettings();
       await entrypointsConfig.fillHost(host);
       this.httpExpects.expectVerifyHosts([host]);
     }

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -22,6 +22,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { set } from 'lodash';
+import { ActivatedRoute } from '@angular/router';
 
 import { ApiCreationV4Component } from './api-creation-v4.component';
 import { ApiCreationV4Module } from './api-creation-v4.module';
@@ -94,6 +95,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
           provide: 'LicenseConfiguration',
           useValue: LICENSE_CONFIGURATION_TESTING,
         },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { envHrid: 'DEFAULT' } } } },
       ],
       imports: [NoopAnimationsModule, ApiCreationV4Module, GioTestingModule, MatIconTestingModule],
     })
@@ -128,6 +130,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
       httpExpects.expectRestrictedDomainsGetRequest([]);
       httpExpects.expectSchemaGetRequest(nativeKafkaEntrypoint);
+      httpExpects.expectApiGetPortalSettings();
 
       const entrypointsConfig = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
       expect(await entrypointsConfig.hasKafkaListenersForm()).toEqual(true);
@@ -150,6 +153,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
 
         httpExpects.expectRestrictedDomainsGetRequest([]);
         httpExpects.expectSchemaGetRequest(nativeKafkaEntrypoint);
+        httpExpects.expectApiGetPortalSettings();
 
         await entrypointsConfig.fillHost(contextPath);
         httpExpects.expectVerifyContextPath();

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
@@ -55,7 +55,13 @@
       <div id="kafka-listeners" class="api-creation-v4__form-container" *ngIf="hasKafkaListeners">
         <h3>Configure common entrypoints fields</h3>
 
-        <gio-form-listeners-kafka-host formControlName="kafka" />
+        @if (portalSettings$ | async; as portalSettings) {
+          <gio-form-listeners-kafka-host
+            formControlName="kafka"
+            [kafkaPort]="portalSettings.kafkaPort"
+            [kafkaDomain]="portalSettings.kafkaDomain"
+          />
+        }
       </div>
 
       <ng-container *ngFor="let entrypoint of selectedEntrypoints">

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -18,8 +18,9 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnIni
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { forkJoin, Observable, Subject } from 'rxjs';
 import { GioFormJsonSchemaComponent, GioJsonSchema, GioLicenseService, License } from '@gravitee/ui-particles-angular';
-import { debounceTime, takeUntil, tap } from 'rxjs/operators';
+import { debounceTime, map, takeUntil, tap } from 'rxjs/operators';
 import { omitBy } from 'lodash';
+import { ActivatedRoute } from '@angular/router';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { Step3Endpoints1ListComponent } from '../step-3-endpoints/step-3-endpoints-1-list.component';
@@ -31,6 +32,8 @@ import { ApimFeature, UTMTags } from '../../../../../shared/components/gio-licen
 import { RestrictedDomainService } from '../../../../../services-ngx/restricted-domain.service';
 import { TcpHost } from '../../../../../entities/management-api-v2/api/v4/tcpHost';
 import { KafkaHostData } from '../../../component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component';
+import { PortalSettingsService } from '../../../../../services-ngx/portal-settings.service';
+import { PortalSettingsPortal } from '../../../../../entities/portal/portalSettings';
 
 @Component({
   selector: 'step-2-entrypoints-2-config',
@@ -52,8 +55,10 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
   public shouldUpgrade = false;
   public license$: Observable<License>;
   public isOEM$: Observable<boolean>;
+  public portalSettings$: Observable<PortalSettingsPortal>;
 
   private apiType: ApiCreationPayload['type'];
+  private envId: string;
 
   constructor(
     private readonly formBuilder: UntypedFormBuilder,
@@ -62,11 +67,16 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
     private readonly restrictedDomainService: RestrictedDomainService,
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly licenseService: GioLicenseService,
-  ) {}
+    private readonly portalSettingsService: PortalSettingsService,
+    private readonly activatedRoute: ActivatedRoute,
+  ) {
+    this.envId = this.activatedRoute.snapshot.params.envHrid;
+  }
 
   ngOnInit(): void {
     const currentStepPayload = this.stepService.payload;
     this.apiType = currentStepPayload.type;
+    this.portalSettings$ = this.portalSettingsService.getByEnvironmentId(this.envId).pipe(map(({ portal }) => portal));
 
     const paths = currentStepPayload.paths ?? [];
     const tcpHosts = currentStepPayload.hosts ?? [];

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -88,7 +88,14 @@
           <div class="entrypoints__host__title">
             <span class="mat-body-strong">Entrypoint host</span>
           </div>
-          <gio-form-listeners-kafka-host [formControl]="hostFormControl" [apiId]="apiId" />
+          @if (portalSettings$ | async; as portalSettings) {
+            <gio-form-listeners-kafka-host
+              [formControl]="hostFormControl"
+              [apiId]="apiId"
+              [kafkaPort]="portalSettings.kafkaPort"
+              [kafkaDomain]="portalSettings.kafkaDomain"
+            />
+          }
         </div>
         <div class="entrypoints__footer" *ngIf="canUpdate">
           <button

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -52,6 +52,7 @@ const ENTRYPOINTS: Partial<ConnectorPlugin>[] = [
 ];
 
 describe('ApiProxyV4EntrypointsComponent', () => {
+  const ENV_ID = 'DEFAULT';
   const API_ID = 'apiId';
   let fixture: ComponentFixture<ApiEntrypointsV4GeneralComponent>;
   let loader: HarnessLoader;
@@ -85,7 +86,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiEntrypointsV4Module, MatIconTestingModule, MatAutocompleteModule],
       providers: [
-        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID, envHrid: ENV_ID } } } },
         { provide: GioTestingPermissionProvider, useValue: permissions },
         {
           provide: 'LicenseConfiguration',
@@ -190,7 +191,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     });
 
     beforeEach(async () => {
-      await createComponent(RESTRICTED_DOMAINS, API, false);
+      await createComponent(RESTRICTED_DOMAINS, API, true);
     });
 
     afterEach(() => {
@@ -890,7 +891,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
   }
 
   function expectGetPortalSettings(): void {
-    const settings: PortalSettings = { portal: { entrypoint: 'localhost' } };
+    const settings: PortalSettings = { portal: { entrypoint: 'localhost', kafkaDomain: 'kafka.domain', kafkaPort: 9092 } };
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
   }
 

--- a/gravitee-apim-console-webui/src/shared/utils/hostPattern.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/hostPattern.util.ts
@@ -20,5 +20,5 @@
  * - each hostname label must have a max length of 63 characters
  */
 export const HOST_PATTERN_REGEX = new RegExp(
-  /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9]))*$/,
+  /^([a-z0-9]|[a-z0-9][a-z0-9\-_]{0,61}[a-z0-9])(\.([a-z0-9]|[a-z0-9][a-z0-9\-_]{0,61}[a-z0-9]))*$/,
 );

--- a/gravitee-apim-console-webui/src/shared/validators/host/host-sync-validator.directive.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/validators/host/host-sync-validator.directive.spec.ts
@@ -21,6 +21,7 @@ describe('HostSyncValidator', () => {
   it.each`
     key           | message                           | host
     ${'format'}   | ${`Host is not valid`}            | ${'ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase'}
+    ${'format'}   | ${`Host is not valid`}            | ${'ThisIsHasUppercaseLetters'}
     ${'max'}      | ${`Max length is 255 characters`} | ${'a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host'}
     ${'required'} | ${`Host is required.`}            | ${''}
     ${'required'} | ${`Host is required.`}            | ${null}

--- a/gravitee-apim-console-webui/src/shared/validators/host/kafka-host-prefix-sync-validator.directive.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/validators/host/kafka-host-prefix-sync-validator.directive.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControl } from '@angular/forms';
+
+import { kafkaHostPrefixSyncValidator } from './kafka-host-prefix-sync-validator.directive';
+
+describe('KafkaHostPrefixSyncValidator', () => {
+  it.each`
+    key               | message                                            | domain       | host
+    ${'format'}       | ${`Host is not valid`}                             | ${undefined} | ${'ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase'}
+    ${'format'}       | ${`Host is not valid`}                             | ${undefined} | ${'ThisIsAHostNameWithUppercase'}
+    ${'max'}          | ${`Max length is 241 characters`}                  | ${undefined} | ${'a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host'}
+    ${'max'}          | ${`Max length is 239 characters`}                  | ${'a'}       | ${'a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host'}
+    ${'required'}     | ${`Host is required.`}                             | ${undefined} | ${''}
+    ${'required'}     | ${`Host is required.`}                             | ${undefined} | ${null}
+    ${'firstSegment'} | ${`First segment must be less than 50 characters`} | ${undefined} | ${'01234567890123456789012345678901234567890123456789.0'}
+    ${'firstSegment'} | ${`First segment must be less than 50 characters`} | ${undefined} | ${'012345678901234567890123456789012345678901234567890'}
+  `('should be invalid host: $host because $message', ({ key, message, domain, host }) => {
+    const validatorFn = kafkaHostPrefixSyncValidator(domain);
+    expect(validatorFn(new FormControl(host))).toEqual({ [key]: message });
+  });
+
+  it('should be valid host without domain', () => {
+    const validatorFn = kafkaHostPrefixSyncValidator(undefined);
+    expect(validatorFn(new FormControl('host'))).toBeNull();
+  });
+
+  it('should be valid host with domain', () => {
+    const validatorFn = kafkaHostPrefixSyncValidator('kafka.value.dev');
+    expect(validatorFn(new FormControl('host'))).toBeNull();
+  });
+
+  it('should be valid host with multiple segments', () => {
+    const validatorFn = kafkaHostPrefixSyncValidator('kafka.value.dev');
+    expect(validatorFn(new FormControl('host.dev-segment'))).toBeNull();
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/validators/host/kafka-host-prefix-sync-validator.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/validators/host/kafka-host-prefix-sync-validator.directive.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControl, ValidatorFn } from '@angular/forms';
+import { isEmpty } from 'lodash';
+
+import { HOST_PATTERN_REGEX } from '../../utils';
+
+const MAX_BROKER_PREFIX_LENGTH: number = 'broker-main99-'.length; // Example of broker prefix added by Kafka Gateway to first segment in host prefix
+const SEPARATOR_LENGTH: number = '.'.length; // Used between host prefix and domain
+
+const FIRST_HOST_SEGMENT_REGEX_TOO_LONG = new RegExp(/^[^.]{50,}/); // The host is longer than 49 characters and contains no periods
+
+export function kafkaHostPrefixSyncValidator(kafkaDomain?: string): ValidatorFn {
+  return (formControl: FormControl) => {
+    const host = formControl.value || '';
+    if (isEmpty(host.trim())) {
+      return { required: 'Host is required.' };
+    }
+    const maxHostPrefixLength = getMaxHostPrefixLength(kafkaDomain);
+    if (host.length > maxHostPrefixLength) {
+      return { max: `Max length is ${maxHostPrefixLength} characters` };
+    }
+
+    if (!HOST_PATTERN_REGEX.test(host)) {
+      return { format: 'Host is not valid' };
+    }
+
+    if (FIRST_HOST_SEGMENT_REGEX_TOO_LONG.test(host)) {
+      return { firstSegment: 'First segment must be less than 50 characters' };
+    }
+
+    return null;
+  };
+}
+
+function getMaxHostPrefixLength(kafkaDomain?: string): number {
+  if (kafkaDomain?.length) {
+    return 255 - kafkaDomain.length - SEPARATOR_LENGTH - MAX_BROKER_PREFIX_LENGTH;
+  }
+  return 255 - MAX_BROKER_PREFIX_LENGTH;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7783

## Description

- TCP hosts cannot contain uppercase letters

Kafka Host Prefix must be validated with the rules:
- max length of host prefix = 255 - domain.length - `.` - `broker-main99-`
- max length of first segment in host prefix = 63 - `broker-main99-`
- max length of subsequent segments in host prefix = 63

- Add clipboard to screen for UX fun

Entrypoints menu item:

https://github.com/user-attachments/assets/1fd62c1e-a522-4e14-be2c-1ca8ec3d0bd2


If no domain specified:

![Screenshot 2024-12-18 at 16 18 58](https://github.com/user-attachments/assets/391280a1-a61f-41ea-af9a-52d4f684ac98)


Creation workflow:

![Screenshot 2024-12-18 at 16 07 22](https://github.com/user-attachments/assets/76201d68-b509-43ec-8885-b0fb7dce6c0e)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

