### PR TITLE
Apim 7783 mapi verify tcp and kafka hosts

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.spec.ts
@@ -27,6 +27,7 @@ import { GioFormListenersKafkaHostComponent, KafkaHostData } from './gio-form-li
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
 import { Constants } from '../../../../../entities/Constants';
+import { ListenerType } from '../../../../../entities/management-api-v2';
 
 @Component({
   template: ` <form [formGroup]="form"><gio-form-listeners-kafka-host formControlName="kafka" /></form> `,
@@ -243,7 +244,7 @@ describe('GioFormListenersKafkaHostComponent', () => {
     const requests = httpTestingController.match({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_verify/hosts`, method: 'POST' });
     hosts.forEach((host, index) => {
       const request = requests[index];
-      const expectedResult: { apiId?: string; hosts: [string] } = { hosts: [host] };
+      const expectedResult: { apiId?: string; hosts: [string]; listenerType: ListenerType } = { hosts: [host], listenerType: 'KAFKA' };
       if (withApiId) {
         expectedResult.apiId = 'api-id';
       }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.ts
@@ -112,7 +112,7 @@ export class GioFormListenersKafkaHostComponent implements OnInit, ControlValueA
 
   ngOnInit(): void {
     this.hostFormControl.addValidators(kafkaHostPrefixSyncValidator(this.kafkaDomain));
-    this.hostFormControl.addAsyncValidators(hostAsyncValidator(this.apiV2Service, this.apiId));
+    this.hostFormControl.addAsyncValidators(hostAsyncValidator(this.apiV2Service, this.apiId, 'KAFKA'));
 
     this.entrypointDomainAndHost = `${this.kafkaDomain?.length ? '.' + this.kafkaDomain : ''}:${this.kafkaPort}`;
 

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.component.ts
@@ -150,7 +150,7 @@ export class GioFormListenersTcpHostsComponent implements OnInit, OnDestroy, Con
     return new FormGroup({
       host: new FormControl(listener.host || '', {
         validators: [hostSyncValidator],
-        asyncValidators: [hostAsyncValidator(this.apiV2Service, this.apiId)],
+        asyncValidators: [hostAsyncValidator(this.apiV2Service, this.apiId, 'TCP')],
       }),
     });
   }

--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.module.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-tcp-hosts/gio-form-listeners-tcp-hosts.module.spec.ts
@@ -28,6 +28,7 @@ import { GioFormListenersTcpHostsHarness } from './gio-form-listeners-tcp-hosts.
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
 import { Constants } from '../../../../../entities/Constants';
+import { ListenerType } from '../../../../../entities/management-api-v2';
 
 @Component({
   template: ` <gio-form-listeners-tcp-hosts [formControl]="formControl"></gio-form-listeners-tcp-hosts> `,
@@ -358,7 +359,7 @@ describe('GioFormListenersTcpHostsModule', () => {
     const requests = httpTestingController.match({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_verify/hosts`, method: 'POST' });
     hosts.forEach((host, index) => {
       const request = requests[index];
-      const expectedResult: { apiId?: string; hosts: [string] } = { hosts: [host] };
+      const expectedResult: { apiId?: string; hosts: [string]; listenerType: ListenerType } = { hosts: [host], listenerType: 'TCP' };
       if (withApiId) {
         expectedResult.apiId = 'api-id';
       }

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-duplicate-dialog/api-general-info-duplicate-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-duplicate-dialog/api-general-info-duplicate-dialog.component.ts
@@ -90,7 +90,10 @@ export class ApiGeneralInfoDuplicateDialogComponent implements OnDestroy {
 
     if (dialogData.api.definitionVersion === 'V4') {
       if (dialogData.api.listeners?.find((listener) => listener.type === 'TCP')) {
-        this.duplicateApiForm.addControl('host', new FormControl('', [hostSyncValidator], [hostAsyncValidator(this.apiV2Service)]));
+        this.duplicateApiForm.addControl(
+          'host',
+          new FormControl('', [hostSyncValidator], [hostAsyncValidator(this.apiV2Service, undefined, 'TCP')]),
+        );
       } else {
         this.duplicateApiForm.addControl(
           'contextPath',

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -423,8 +423,9 @@ describe('ApiV2Service', () => {
     it('should call the API', (done) => {
       const apiId = 'apiId';
       const hosts = ['host1', 'host2'];
+      const listenerType = 'TCP';
 
-      apiV2Service.verifyHosts(apiId, hosts).subscribe(() => {
+      apiV2Service.verifyHosts(apiId, listenerType, hosts).subscribe(() => {
         done();
       });
 
@@ -433,7 +434,7 @@ describe('ApiV2Service', () => {
         method: 'POST',
       });
 
-      expect(req.request.body).toEqual({ apiId, hosts });
+      expect(req.request.body).toEqual({ apiId, listenerType, hosts });
       req.flush(null);
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -32,6 +32,7 @@ import {
   UpdateApi,
   ApiTransferOwnership,
   VerifyApiDeployResponse,
+  ListenerType,
 } from '../entities/management-api-v2';
 import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 import { VerifyApiHostsResponse } from '../entities/management-api-v2/api/verifyApiHosts';
@@ -212,8 +213,8 @@ export class ApiV2Service {
     return this.http.post<VerifyApiPathResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/paths`, { apiId, paths });
   }
 
-  verifyHosts(apiId: string, hosts: string[]): Observable<VerifyApiHostsResponse> {
-    return this.http.post<VerifyApiHostsResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/hosts`, { apiId, hosts });
+  verifyHosts(apiId: string, listenerType: ListenerType, hosts: string[]): Observable<VerifyApiHostsResponse> {
+    return this.http.post<VerifyApiHostsResponse>(`${this.constants.env.v2BaseURL}/apis/_verify/hosts`, { apiId, listenerType, hosts });
   }
 
   rollback(apiId: string, eventId: string): Observable<void> {

--- a/gravitee-apim-console-webui/src/shared/validators/host/host-async-validator.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/validators/host/host-async-validator.directive.ts
@@ -18,12 +18,13 @@ import { Observable, of, timer } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
+import { ListenerType } from '../../../entities/management-api-v2';
 
-export function hostAsyncValidator(apiV2Service: ApiV2Service, apiId?: string): AsyncValidatorFn {
+export function hostAsyncValidator(apiV2Service: ApiV2Service, apiId?: string, listenerType?: ListenerType): AsyncValidatorFn {
   return (formControl: FormControl): Observable<ValidationErrors | null> => {
     if (formControl && formControl.dirty) {
       return timer(250).pipe(
-        switchMap(() => apiV2Service.verifyHosts(apiId, [formControl.value])),
+        switchMap(() => apiV2Service.verifyHosts(apiId, listenerType, [formControl.value])),
         map((res) => (res.ok ? null : { listeners: res.reason })),
       );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ListenerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ListenerMapper.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
@@ -47,6 +48,8 @@ public interface ListenerMapper {
     SubscriptionListener map(io.gravitee.rest.api.management.v2.rest.model.SubscriptionListener listener);
     TcpListener map(io.gravitee.rest.api.management.v2.rest.model.TcpListener listener);
     KafkaListener map(io.gravitee.rest.api.management.v2.rest.model.KafkaListener listener);
+
+    ListenerType map(io.gravitee.rest.api.management.v2.rest.model.ListenerType listenerType);
 
     @Named("toPathMappingsPattern")
     default Map<String, Pattern> toPathMappingsPattern(List<String> pathMappings) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -37,6 +37,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.ImportExportApiMapper;
+import io.gravitee.rest.api.management.v2.rest.mapper.ListenerMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiCRDSpec;
 import io.gravitee.rest.api.management.v2.rest.model.ApiSearchQuery;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
@@ -429,7 +430,12 @@ public class ApisResource extends AbstractResource {
         var executionContext = GraviteeContext.getExecutionContext();
         try {
             verifyApiHostsUseCase.execute(
-                new VerifyApiHostsUseCase.Input(executionContext.getEnvironmentId(), verifyPayload.getApiId(), verifyPayload.getHosts())
+                new VerifyApiHostsUseCase.Input(
+                    executionContext.getEnvironmentId(),
+                    verifyPayload.getApiId(),
+                    ListenerMapper.INSTANCE.map(verifyPayload.getListenerType()),
+                    verifyPayload.getHosts()
+                )
             );
             return Response.accepted(VerifyApiHostsResponse.builder().ok(true).build()).build();
         } catch (Exception e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -244,11 +244,11 @@ paths:
                 - $ref: "#/components/parameters/envIdParam"
             tags:
                 - APIs
-            summary: Verify TCP API hosts
+            summary: Verify TCP and Kafka API hosts
             description: |-
-                Verify hosts before creating or updating a TCP API.<br>
+                Verify hosts before creating or updating a TCP or Kafka API.<br>
                 This will check it is not already used by other APIs in the environment.<br>
-                The result will indicate if the hists are OK, and give the reason of the failure if they are not.
+                The result will indicate if the hosts are OK, and give the reason of the failure if they are not.
             operationId: verifyHosts
             requestBody:
                 content:
@@ -5471,6 +5471,8 @@ components:
             properties:
                 apiId:
                     type: string
+                listenerType:
+                  $ref: "#/components/schemas/ListenerType"
                 hosts:
                     type: array
                     example:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainService.java
@@ -43,13 +43,13 @@ public class VerifyApiHostsDomainService {
 
     /**
      * According to <a href="https://www.rfc-editor.org/rfc/rfc1123">RFC-1123</a> and <a href="https://www.rfc-editor.org/rfc/rfc952">RFC-952</a>
-     * - hostname label can contain lowercase, uppercase and digits characters.
+     * - hostname label can contain lowercase and digits characters.
      * - hostname label can contain dash or underscores, but not starts or ends with these characters
      * - each hostname label must have a max length of 63 characters
      */
     @SuppressWarnings("squid:S5998") // A max host size validation is done before the regexp to avoid applying it
     private static final Pattern HOST_PATTERN = Pattern.compile(
-        "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,61}[a-zA-Z0-9]))*$"
+        "^([a-z0-9]|[a-z0-9][a-z0-9\\-_]{0,61}[a-z0-9])(\\.([a-z0-9]|[a-z0-9][a-z0-9\\-_]{0,61}[a-z0-9]))*$"
     );
 
     private final ApiQueryService apiQueryService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/VerifyApiHostsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/VerifyApiHostsUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.api.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -28,13 +28,13 @@ public class VerifyApiHostsUseCase {
     private final VerifyApiHostsDomainService verifyApiHostsDomainService;
 
     public Output execute(Input input) {
-        if (verifyApiHostsDomainService.checkApiHosts(input.environmentId(), input.apiId(), input.hosts())) {
+        if (verifyApiHostsDomainService.checkApiHosts(input.environmentId(), input.apiId(), input.hosts(), input.listenerType())) {
             return new Output(input.hosts());
         }
         return null;
     }
 
-    public record Input(String environmentId, String apiId, List<String> hosts) {}
+    public record Input(String environmentId, String apiId, ListenerType listenerType, List<String> hosts) {}
 
     public record Output(List<String> hosts) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -140,7 +140,8 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
         verifyApiHostsDomainService.checkApiHosts(
             executionContext.getEnvironmentId(),
             apiId,
-            Collections.singletonList(listener.getHost())
+            Collections.singletonList(listener.getHost()),
+            ListenerType.KAFKA
         );
 
         validateEntrypoints(listener.getType(), listener.getEntrypoints(), endpointGroups);
@@ -195,7 +196,7 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
         final TcpListener listener,
         final List<EndpointGroup> endpointGroups
     ) {
-        verifyApiHostsDomainService.checkApiHosts(executionContext.getEnvironmentId(), apiId, listener.getHosts());
+        verifyApiHostsDomainService.checkApiHosts(executionContext.getEnvironmentId(), apiId, listener.getHosts(), ListenerType.TCP);
 
         validateEntrypoints(listener.getType(), listener.getEntrypoints(), endpointGroups);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainServiceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.api.exception.DuplicatedHostException;
 import io.gravitee.apim.core.api.exception.HostAlreadyExistsException;
 import io.gravitee.apim.core.api.exception.InvalidHostException;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +70,7 @@ class VerifyApiHostsDomainServiceTest {
     @ParameterizedTest
     @NullAndEmptySource
     void should_throw_invalid_hosts_exception_when_no_host(List<String> hosts) {
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(InvalidHostException.class)
             .hasMessage("At least one host is required for the TCP listener.");
     }
@@ -77,7 +78,7 @@ class VerifyApiHostsDomainServiceTest {
     @Test
     void should_throw_hosts_already_exist_exception_when_hosts_are_duplicated() {
         var hosts = List.of("foo.example.com", "bar.example.com", "foo.example.com");
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(DuplicatedHostException.class)
             .hasMessage("Duplicated hosts detected: 'foo.example.com'. Please ensure each host is unique.");
     }
@@ -85,7 +86,7 @@ class VerifyApiHostsDomainServiceTest {
     @Test
     void should_throw_hosts_already_exist_exception_when_host_is_used_by_another_api() {
         var hosts = List.of("foo.example.com", "tcp.example.com");
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(HostAlreadyExistsException.class)
             .hasMessage("Hosts [foo.example.com] already exists");
     }
@@ -93,7 +94,7 @@ class VerifyApiHostsDomainServiceTest {
     @Test
     void should_throw_hosts_already_exist_exception_when_host_is_used_by_another_native_api() {
         var hosts = List.of("native.kafka");
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(HostAlreadyExistsException.class)
             .hasMessage("Hosts [native.kafka] already exists");
     }
@@ -101,7 +102,7 @@ class VerifyApiHostsDomainServiceTest {
     @Test
     void should_throw_invalid_hosts_exception_when_host_is_blank() {
         var hosts = List.of("foo.example.com", "");
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(InvalidHostException.class)
             .hasMessage("The hosts should not be null or blank.");
     }
@@ -120,7 +121,7 @@ class VerifyApiHostsDomainServiceTest {
         }
     )
     void should_throw_invalid_exception_when_not_matching_rfc_pattern(String host) {
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, List.of(host)))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, List.of(host), null))
             .isInstanceOf(InvalidHostException.class)
             .hasMessage("The hosts should be valid.");
     }
@@ -130,9 +131,26 @@ class VerifyApiHostsDomainServiceTest {
         var hosts = List.of(
             "a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host.a-valid-sub-host"
         );
-        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts))
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null))
             .isInstanceOf(InvalidHostException.class)
             .hasMessage("The hosts should not be greater than 255 characters.");
+    }
+
+    @Test
+    void should_throw_invalid_hosts_exception_when_first_segment_too_long_for_kafka() {
+        var hosts = List.of("a-valid-sub-host-a-valid-sub-host-a-valid-sub-host.dev");
+        assertThatThrownBy(() -> verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, ListenerType.KAFKA))
+            .isInstanceOf(InvalidHostException.class)
+            .hasMessage("The first segment must be less than 50 characters.");
+    }
+
+    @Test
+    void should_allow_long_first_segment_for_non_kafka_listeners() {
+        var hosts = List.of("a-valid-sub-host-a-valid-sub-host-a-valid-sub-host.dev");
+
+        var result = verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, ListenerType.TCP);
+
+        assertThat(result).isTrue();
     }
 
     @Test
@@ -147,7 +165,7 @@ class VerifyApiHostsDomainServiceTest {
         );
 
         // when
-        var result = verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts);
+        var result = verifyApiHostsDomainService.checkApiHosts(ENVIRONMENT_ID, API_ID, hosts, null);
 
         // then
         assertThat(result).isTrue();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/VerifyApiHostsDomainServiceTest.java
@@ -109,13 +109,14 @@ class VerifyApiHostsDomainServiceTest {
     @ParameterizedTest
     @ValueSource(
         strings = {
-            "ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase",
-            "host.ThisIsALongHostNameWithMoreThan63CharactersWhichIsNotValidInOurCase.gravitee",
+            "thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase",
+            "host.thisisalonghostnamewithmorethan63charactereswhichisnotvalidinourcase.gravitee",
             "-simple-host",
             "simple-host-",
             "simple-host-.host",
             "_simple-host",
             "simple-host_",
+            "MiXed-C4s3.example.c0m",
         }
     )
     void should_throw_invalid_exception_when_not_matching_rfc_pattern(String host) {
@@ -142,7 +143,7 @@ class VerifyApiHostsDomainServiceTest {
             "tcp.2.example.com",
             "tcp-hyphen.example.com",
             "tcp_underscore.example.com",
-            "MiXed-C4s3.example.c0m"
+            "mixed-c4s3.example.c0m"
         );
 
         // when

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -685,7 +685,8 @@ class ListenerValidationServiceImplTest {
 
         @Test
         void should_throw_error_when_tcp_listener_hosts_are_not_valid() {
-            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any())).thenThrow(new InvalidHostException("invalid hosts"));
+            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any(), any()))
+                .thenThrow(new InvalidHostException("invalid hosts"));
 
             assertThatExceptionOfType(InvalidHostException.class)
                 .isThrownBy(() ->
@@ -769,7 +770,8 @@ class ListenerValidationServiceImplTest {
 
         @Test
         void should_throw_error_when_kafka_listener_host_is_not_valid() {
-            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any())).thenThrow(new InvalidHostException("invalid hosts"));
+            when(verifyApiHostsDomainService.checkApiHosts(any(), any(), any(), any()))
+                .thenThrow(new InvalidHostException("invalid hosts"));
 
             assertThatExceptionOfType(InvalidHostException.class)
                 .isThrownBy(() ->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7783

## Description

- Do not allow uppercase letters for TCP hosts.
- Add backend verification for Kafka hosts.
- Update Console to add in `listenerType` as a request param for `/apis/_verify/hosts`.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rnskohqapq.chromatic.com)
<!-- Storybook placeholder end -->
