### PR TITLE
chore(deps): bump gravitee-endpoint-rabbitmq to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <gravitee-entrypoint-websocket.version>1.0.4</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>2.10.2</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>2.2.0</gravitee-endpoint-mqtt5.version>
-        <gravitee-endpoint-rabbitmq.version>1.3.1</gravitee-endpoint-rabbitmq.version>
+        <gravitee-endpoint-rabbitmq.version>1.3.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>1.2.0</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>0.1.0</gravitee-endpoint-azure-service-bus.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-446

## Description

Bump endpoint rabbitmq version to include a memory leak fix (see https://github.com/gravitee-io/gravitee-endpoint-rabbitmq/pull/73)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-glmopnupzb.chromatic.com)
<!-- Storybook placeholder end -->
