### PR TITLE
chore(deps): bump endpoint rabbitmq version to 2.0.0-alpha.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <gravitee-entrypoint-websocket.version>2.0.0-alpha.2</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>3.0.0-alpha.3</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>3.0.0-alpha.3</gravitee-endpoint-mqtt5.version>
-        <gravitee-endpoint-rabbitmq.version>2.0.0-alpha.4</gravitee-endpoint-rabbitmq.version>
+        <gravitee-endpoint-rabbitmq.version>2.0.0-alpha.5</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>2.0.0-alpha.3</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>1.0.0-alpha.3</gravitee-endpoint-azure-service-bus.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.1</gravitee-policy-graphql-rate-limit.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-446

## Description

Bump endpoint rabbitmq version to include a memory leak fix (see https://github.com/gravitee-io/gravitee-endpoint-rabbitmq/pull/74)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wqfwezwhmr.chromatic.com)
<!-- Storybook placeholder end -->
