### PR TITLE
fix(console): use narrower margin container for entrypoints + more ux…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/component/gio-form-listeners/gio-form-listeners-kafka/gio-form-listeners-kafka-host.component.scss
@@ -13,9 +13,12 @@
     display: flex;
     gap: 8px;
     align-items: center;
+    flex: 1;
+    justify-content: space-between;
 
     gio-clipboard-copy-icon {
       padding-right: 6px;
+      margin-top: 6px;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.scss
@@ -4,7 +4,7 @@
 @use '@gravitee/ui-particles-angular' as gio;
 
 :host {
-  @include gio-layout.gio-responsive-content-container;
+  @include gio-layout.gio-responsive-margin-container;
   overflow: visible;
 }
 


### PR DESCRIPTION
…-friendly kafka host prefix layout

## Issue

https://gravitee.atlassian.net/browse/APIM-7783


Native API:
<img width="1122" alt="Screenshot 2024-12-19 at 11 00 04" src="https://github.com/user-attachments/assets/3ed1e318-26c5-428d-bb14-5eb68ad71317" />

Non-Native:
<img width="1350" alt="Screenshot 2024-12-19 at 11 10 56" src="https://github.com/user-attachments/assets/71b8c8c6-09c4-42d4-aa3b-6d6965c83a95" />


## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zqpitzotzj.chromatic.com)
<!-- Storybook placeholder end -->
