### PR TITLE
Apim 8042 native api publish auth and non auth plans

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.html
@@ -49,8 +49,8 @@
 <mat-button-toggle-group class="plans__filters" aria-label="Plan status filters" [value]="status">
   <mat-button-toggle
     *ngFor="let planStatus of apiPlanStatus"
-    [attr.aria-label]="'Filter on' + planStatus.name + 'plans'"
-    [matTooltip]="'Filter on' + planStatus.name + 'plans'"
+    [attr.aria-label]="'Filter on ' + planStatus.name + ' plans'"
+    [matTooltip]="'Filter on ' + planStatus.name + ' plans'"
     [value]="planStatus.name"
     (click)="searchPlansByStatus(planStatus.name)"
   >

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NativePlanAuthenticationConflictException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NativePlanAuthenticationConflictException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class NativePlanAuthenticationConflictException extends AbstractManagementException {
+
+    private final boolean planToPublishIsKeyless;
+
+    public NativePlanAuthenticationConflictException(boolean planToPublishIsKeyless) {
+        this.planToPublishIsKeyless = planToPublishIsKeyless;
+    }
+
+    @Override
+    public String getMessage() {
+        return planToPublishIsKeyless
+            ? "A plan with authentication is already published for the Native API."
+            : "A Keyless plan for the Native API is already published.";
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "plan.native.authentication.conflict";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("planToPublishIsKeyless", Boolean.valueOf(planToPublishIsKeyless).toString());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8042

## Description

- Backend: Throw error when publishing plan with conflicting authentication for a Native API
- Console: When publishing conflicting plan for a Native Kafka API, the published plans are closed automatically

https://github.com/user-attachments/assets/8073e98b-343d-483f-9c92-9cc0a56eac8b


Last changes : 

![image](https://github.com/user-attachments/assets/13778598-82cd-4bbf-978b-08a7a5e7ef2d)




Next Steps:
- Handle Creation workflow for Native APIs

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rlnxiyoieg.chromatic.com)
<!-- Storybook placeholder end -->
