### PR TITLE
Apim 8042 creation workflow conflicting plan authentication

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
@@ -168,7 +168,7 @@ export class ApiCreationV4SpecStepperHelper {
     await endpointsConfig.clickValidate();
   }
 
-  async fillAndValidateStep4_1_SecurityPlansList() {
+  async editAndValidateStep4_1_SecurityPlansList() {
     const plansList = await this.harnessLoader.getHarness(Step4Security1PlansHarness);
 
     await plansList.editDefaultKeylessPlanNameAndAddRateLimit('Update name', this.httpTestingController);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component, HostBinding, Injector, OnDestroy, OnInit } from '@angular/core';
-import { catchError, concatMap, map, switchMap, takeUntil, toArray } from 'rxjs/operators';
+import { catchError, concatMap, filter, map, switchMap, takeUntil, toArray } from 'rxjs/operators';
 import { from, Observable, of, Subject, throwError } from 'rxjs';
 import { isEmpty, isString } from 'lodash';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -29,6 +29,7 @@ import { Step1MenuItemComponent } from './steps/step-1-menu-item/step-1-menu-ite
 import { StepEntrypointMenuItemComponent } from './steps/step-connector-menu-item/step-entrypoint-menu-item.component';
 import { StepEndpointMenuItemComponent } from './steps/step-connector-menu-item/step-endpoint-menu-item.component';
 import { Step4MenuItemComponent } from './steps/step-4-menu-item/step-4-menu-item.component';
+import { ApiCreationCommonService } from './services/api-creation-common.service';
 
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -237,12 +238,14 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
     }
 
     const api = previousResult.result.api;
+    const canPublishPlans = ApiCreationCommonService.canPublishPlans(previousResult.apiCreationPayload);
 
     // For each plan
     return from(previousResult.apiCreationPayload.plans).pipe(
       concatMap((plan) =>
         // Create it
         this.apiPlanV2Service.create(api.id, { ...plan, definitionVersion: 'V4' }).pipe(
+          filter((_) => canPublishPlans),
           concatMap((plan) =>
             // If create success, publish it
             this.apiPlanV2Service.publish(api.id, plan.id).pipe(

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
@@ -363,7 +363,7 @@ describe('ApiCreationV4Component - Message', () => {
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig();
       await stepperHelper.fillAndValidateStep3_1_EndpointsList();
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
-      await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+      await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
 
       const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       const step1Summary = await step5Harness.getStepSummaryTextContent(1);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -30,6 +30,7 @@ import { Step2Entrypoints2ConfigHarness } from './steps/step-2-entrypoints/step-
 import { Step5SummaryHarness } from './steps/step-5-summary/step-5-summary.harness';
 import { ApiCreationV4SpecStepperHelper } from './api-creation-v4-spec-stepper-helper';
 import { ApiCreationV4SpecHttpExpects } from './api-creation-v4-spec-http-expects';
+import { Step4Security1PlansHarness } from './steps/step-4-security/step-4-security-1-plans.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ConnectorPlugin } from '../../../entities/management-api-v2';
@@ -194,6 +195,40 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       httpExpects.expectCallsForApiAndPlanCreation('api-id', 'plan-id');
       flush();
     }));
+    it('should create the API with conflicting plans', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
+      await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
+
+      const plansList = await harnessLoader.getHarness(Step4Security1PlansHarness);
+      await plansList.addApiKeyPlan('my-api-key-plan', httpTestingController, true, true);
+      await plansList.clickValidate();
+
+      discardPeriodicTasks();
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      const step1Summary = await step5Harness.getStepSummaryTextContent(1);
+      expect(step1Summary).toContain('API name:' + 'API');
+      expect(step1Summary).toContain('Version:' + '1.0');
+      expect(step1Summary).toContain('Description:' + ' Description');
+
+      const step2Summary = await step5Harness.getStepSummaryTextContent(2);
+      expect(step2Summary).toContain('Host:' + 'kafka-host');
+      expect(step2Summary).toContain('Type:' + 'KAFKA');
+      expect(step2Summary).toContain('Entrypoints:' + ' Native Kafka Entrypoint');
+
+      const step3Summary = await step5Harness.getStepSummaryTextContent(3);
+      expect(step3Summary).toContain('Endpoints' + 'Endpoints: ' + 'Native Kafka Endpoint');
+
+      const step4Summary = await step5Harness.getStepSummaryTextContent(4);
+      expect(step4Summary).toContain('Conflicting Authentication');
+      expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
+      expect(step4Summary).toContain('my-api-key-plan' + 'API_KEY');
+
+      await step5Harness.clickCreateMyApiButton();
+      httpExpects.expectCallsForApiAndPlanCreation('api-id', 'plan-id', ['Default Keyless (UNSECURED)', 'my-api-key-plan'], false);
+      flush();
+    }));
     it('should deploy the API', fakeAsync(async () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
@@ -206,6 +241,21 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await step5Harness.clickDeployMyApiButton();
       httpExpects.expectCallsForApiDeployment('api-id', 'plan-id');
       flush();
+    }));
+
+    it('should not deploy the API with conflicting plans', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
+      await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
+
+      const plansList = await harnessLoader.getHarness(Step4Security1PlansHarness);
+      await plansList.addApiKeyPlan('my-api-key-plan', httpTestingController, true, true);
+      await plansList.clickValidate();
+
+      discardPeriodicTasks();
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      expect(await step5Harness.getDeployMyApiButton().then((btn) => btn.isDisabled())).toEqual(true);
     }));
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.navigation.component.spec.ts
@@ -1258,7 +1258,7 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig();
         await stepperHelper.fillAndValidateStep3_1_EndpointsList();
         await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
-        await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+        await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
         step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       }));
 
@@ -1315,7 +1315,7 @@ describe('ApiCreationV4Component - Navigation', () => {
 
         await stepperHelper.fillAndValidateStep3_1_EndpointsList();
         await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
-        await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+        await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
 
         // Reinitialize step5Harness after last step validation
         step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
@@ -1342,7 +1342,7 @@ describe('ApiCreationV4Component - Navigation', () => {
         await dialogHarness.confirm();
         await stepperHelper.fillAndValidateStep3_2_EndpointsConfig([{ id: 'mock', supportedApiType: 'MESSAGE', name: 'Mock' }]);
 
-        await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+        await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
 
         // Reinitialize step5Harness after step2 validation
         step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
@@ -1384,14 +1384,14 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig();
         await stepperHelper.fillAndValidateStep3_1_EndpointsList();
         await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
-        await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+        await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
         step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       }));
 
       it('should go to confirmation page after clicking Deploy my API', async () => {
         await step5Harness.clickDeployMyApiButton();
 
-        httpExpects.expectCallsForApiDeployment(API_ID, PLAN_ID, 'Update name');
+        httpExpects.expectCallsForApiDeployment(API_ID, PLAN_ID, ['Update name']);
 
         expect(routerNavigateSpy).toHaveBeenCalledWith(['.', 'my-api'], expect.anything());
       });
@@ -1408,14 +1408,14 @@ describe('ApiCreationV4Component - Navigation', () => {
         await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig();
         await stepperHelper.fillAndValidateStep3_1_EndpointsList();
         await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
-        await stepperHelper.fillAndValidateStep4_1_SecurityPlansList();
+        await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
         step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
       }));
 
       it('should go to confirmation page after clicking Save API & Ask for review', async () => {
         await step5Harness.clickCreateAndAskForReviewMyApiButton();
 
-        httpExpects.expectCallsForApiAndPlanCreation(API_ID, PLAN_ID, 'Update name');
+        httpExpects.expectCallsForApiAndPlanCreation(API_ID, PLAN_ID, ['Update name']);
 
         const askRequest = httpTestingController.expectOne({
           url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/reviews/_ask`,

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/services/api-creation-common.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/services/api-creation-common.service.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiCreationPayload } from '../models/ApiCreationPayload';
+
+export class ApiCreationCommonService {
+  static canPublishPlans(apiCreationPayload: ApiCreationPayload): boolean {
+    if (apiCreationPayload.type !== 'NATIVE') {
+      return true;
+    }
+    const plans = apiCreationPayload.plans;
+
+    const keylessPlanPresent = !!plans.find((p) => p.security.type === 'KEY_LESS');
+    const authPlanPresent = !!plans.find((p) => p.security.type !== 'KEY_LESS');
+
+    return !(keylessPlanPresent && authPlanPresent);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.html
@@ -24,6 +24,12 @@
     </div>
 
     <ng-container *ngIf="view === 'list'">
+      @if (isNativeKafkaApi) {
+        <gio-banner type="info"
+          >Kafka APIs cannot have published plans with conflicting authentication. In order to automatically deploy your API, add either a
+          Keyless plan or one or more plans with authentication.</gio-banner
+        >
+      }
       <step-4-security-1-plans-list
         [plans]="plans"
         (addPlanClicked)="onAddPlanClicked($event)"

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.scss
@@ -6,5 +6,6 @@
   @include gio-layout.gio-responsive-content-container;
 }
 
-.step-4-security-2-plans-add {
+gio-banner {
+  padding-bottom: 18px;
 }

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -36,6 +36,7 @@ export class Step4Security1PlansComponent implements OnInit {
   selectedPlanMenuItem: PlanMenuItemVM;
   public apiType: ApiType;
   public isTcpApi: boolean;
+  public isNativeKafkaApi: boolean;
 
   constructor(
     private readonly stepService: ApiCreationStepService,
@@ -54,6 +55,8 @@ export class Step4Security1PlansComponent implements OnInit {
 
     this.apiType = currentStepPayload.type;
     this.isTcpApi = currentStepPayload.hosts?.length > 0;
+    this.isNativeKafkaApi =
+      currentStepPayload.type === 'NATIVE' && currentStepPayload.selectedEntrypoints.some((e) => e.supportedListenerType === 'KAFKA');
   }
 
   private computeDefaultApiPlans(currentStepPayload: ApiCreationPayload) {
@@ -116,6 +119,4 @@ export class Step4Security1PlansComponent implements OnInit {
   onRemovePlanClicked(plan: CreatePlanV4) {
     this.plans = this.plans.filter((listedPlan) => listedPlan !== plan);
   }
-
-  protected readonly undefined = undefined;
 }

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -68,7 +68,12 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     return this.clickValidate();
   }
 
-  async addApiKeyPlan(planName: string, httpTestingController: HttpTestingController): Promise<void> {
+  async addApiKeyPlan(
+    planName: string,
+    httpTestingController: HttpTestingController,
+    isNativeKafka: boolean = false,
+    isFakeAsync: boolean = false,
+  ): Promise<void> {
     await this.getButtonBySelector('[aria-label="Add new plan"]').then((b) => b.click());
     const planSecurityDropdown = await this.locatorFor(MatMenuHarness)();
     expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(4);
@@ -80,10 +85,23 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     apiPlanFormHarness.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(planName));
 
+    const nextButton = await this.getButtonByText('Next');
+    expect(await nextButton.isDisabled()).toEqual(false);
+    await nextButton.click();
+
+    if (isFakeAsync) {
+      tick(100);
+    }
+
     apiPlanFormHarness.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {});
 
-    await (await this.getButtonByText('Next')).click();
-    await (await this.getButtonByText('Next')).click();
+    if (!isNativeKafka) {
+      await (await this.getButtonByText('Next')).click();
+      if (isFakeAsync) {
+        tick(100);
+      }
+    }
+
     await (await this.getButtonByText('Add plan')).click();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
@@ -112,6 +112,9 @@
         <div class="mat-h3">Security</div>
         <div class="step-5-summary__step__body">
           <div class="step-5-summary__step__info">
+            <div>
+              <span class="gio-badge-warning api-creation-v4__badge" *ngIf="hasInvalidNativeKafkaPlans">Conflicting Authentication</span>
+            </div>
             <div class="step-5-summary__step__info__security__content" *ngIf="currentStepPayload.plans?.length > 0; else elseBlock">
               <div class="step-5-summary__step__info__security__content__card" *ngFor="let plan of currentStepPayload.plans">
                 <div class="step-5-summary__step__info__security__content__card__title">
@@ -145,25 +148,20 @@
             matTooltip="Your API definition will be saved, but not deployed to the gateway."
           ></mat-icon>
         </button>
-        <button
-          *ngIf="!hasReviewEnabled"
-          data-testid="deploy_api_button"
-          color="primary"
-          mat-flat-button
-          type="button"
-          [disabled]="shouldUpgrade"
-          (click)="createApi({ deploy: true, askForReview: false })"
-        >
-          Save & Deploy API<mat-icon
-            svgIcon="gio:info"
-            class="step-5-summary__footer__button-icon"
-            [matTooltip]="
-              deployable
-                ? 'Your API will be deployed to the gateway.'
-                : 'You cannot deploy an API with endpoints or entrypoints not deployed.'
-            "
-          ></mat-icon>
-        </button>
+        <div [matTooltip]="deployTooltipMessage">
+          <button
+            *ngIf="!hasReviewEnabled"
+            data-testid="deploy_api_button"
+            color="primary"
+            mat-flat-button
+            type="button"
+            [disabled]="shouldUpgrade || hasInvalidNativeKafkaPlans"
+            (click)="createApi({ deploy: true, askForReview: false })"
+          >
+            Save & Deploy API<mat-icon svgIcon="gio:info" class="step-5-summary__footer__button-icon"></mat-icon>
+          </button>
+        </div>
+
         <button
           *ngIf="hasReviewEnabled"
           data-testid="create_and_ask_review_api_button"

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.harness.ts
@@ -41,6 +41,10 @@ export class Step5SummaryHarness extends ComponentHarness {
     await button.click();
   }
 
+  async getDeployMyApiButton(): Promise<MatButtonHarness> {
+    return await this.getButtonDeployMyApi();
+  }
+
   async clickDeployMyApiButton(): Promise<void> {
     const button: MatButtonHarness = await this.getButtonDeployMyApi();
     await button.click();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8042

## Description

Display message when creating plans for Native Kafka API:
![Screenshot 2024-12-23 at 10 23 00](https://github.com/user-attachments/assets/270c8cee-a404-45fe-8734-265586b6e8e8)

In the summary screen, add badge `Conflicting Authentication` to security step and disable deploy w/tool-tip:

![Screenshot 2024-12-23 at 11 53 05](https://github.com/user-attachments/assets/a91a2c5d-987b-4571-99c9-bc5f87f4a320)
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cczdiobhyw.chromatic.com)
<!-- Storybook placeholder end -->
