### PR TITLE
feat(console): add CTA for native apis in creation workflow + entrypoints + endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.html
@@ -78,7 +78,7 @@
             <gio-license-banner
               [license]="license$ | async"
               [isOEM]="isOEM$ | async"
-              (onRequestUpgrade)="onRequestUpgrade()"
+              (onRequestUpgrade)="onRequestMessageUpgrade()"
             ></gio-license-banner>
           </div>
         </mat-radio-button>
@@ -102,7 +102,7 @@
             <gio-license-banner
               [license]="license$ | async"
               [isOEM]="isOEM$ | async"
-              (onRequestUpgrade)="onRequestUpgrade()"
+              (onRequestUpgrade)="onRequestNativeKafkaUpgrade()"
             ></gio-license-banner>
           </div>
         </mat-radio-button>

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.ts
@@ -204,7 +204,11 @@ export class Step2Entrypoints0ArchitectureComponent implements OnInit, OnDestroy
       .subscribe();
   }
 
-  public onRequestUpgrade() {
+  public onRequestMessageUpgrade() {
     this.licenseService.openDialog(this.messageLicenseOptions);
+  }
+
+  public onRequestNativeKafkaUpgrade() {
+    this.licenseService.openDialog(this.nativeKafkaLicenseOptions);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -101,7 +101,7 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
       this.formGroup.addControl(`${id}-qos`, this.formBuilder.control(selectedQos ?? 'AUTO'));
     });
 
-    if (this.apiType === 'MESSAGE') {
+    if (this.apiType === 'MESSAGE' || this.apiType === 'NATIVE') {
       this.shouldUpgrade = currentStepPayload.selectedEntrypoints.some(({ deployed }) => !deployed);
       this.license$ = this.licenseService.getLicense$();
       this.isOEM$ = this.licenseService.isOEM$();

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.html
@@ -118,9 +118,6 @@
                   <span class="mat-body-strong">{{ plan.name }}</span
                   ><span class="gio-badge-neutral">{{ plan.security?.type || plan.mode }}</span>
                 </div>
-                <div class="step-5-summary__step__info__security__content__card__content">
-                  <span>Entrypoints type: http</span>
-                </div>
               </div>
             </div>
             <ng-template #elseBlock> No plans are selected. </ng-template>

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-5-summary/step-5-summary.component.ts
@@ -78,6 +78,10 @@ export class Step5SummaryComponent implements OnInit {
   }
 
   public onRequestUpgrade() {
-    this.licenseService.openDialog({ feature: ApimFeature.APIM_EN_MESSAGE_REACTOR, context: UTMTags.API_CREATION_MESSAGE_SUMMARY });
+    if (this.currentStepPayload.type === 'NATIVE') {
+      this.licenseService.openDialog({ feature: ApimFeature.APIM_NATIVE_KAFKA_REACTOR, context: UTMTags.API_CREATION_MESSAGE_SUMMARY });
+    } else {
+      this.licenseService.openDialog({ feature: ApimFeature.APIM_EN_MESSAGE_REACTOR, context: UTMTags.API_CREATION_MESSAGE_SUMMARY });
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/api-endpoint-groups.component.ts
@@ -48,8 +48,13 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   public isReadOnly = true;
   public api: ApiV4;
 
-  private licenseOptions = {
+  private messageLicenseOptions = {
     feature: ApimFeature.APIM_EN_MESSAGE_REACTOR,
+    context: UTMTags.GENERAL_ENDPOINT_CONFIG,
+  };
+
+  private nativeLicenseOptions = {
+    feature: ApimFeature.APIM_NATIVE_KAFKA_REACTOR,
     context: UTMTags.GENERAL_ENDPOINT_CONFIG,
   };
 
@@ -200,6 +205,6 @@ export class ApiEndpointGroupsComponent implements OnInit, OnDestroy {
   }
 
   public onRequestUpgrade() {
-    this.licenseService.openDialog(this.licenseOptions);
+    this.licenseService.openDialog(this.api.type === 'NATIVE' ? this.nativeLicenseOptions : this.messageLicenseOptions);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.html
@@ -75,34 +75,39 @@
         </div>
       </mat-card-content>
     </mat-card>
-    <mat-card *ngIf="api.type === 'NATIVE'">
-      <mat-card-content>
-        <div class="entrypoints__host">
-          <div class="entrypoints__host__title">
-            <span class="mat-body-strong">Entrypoint host</span>
+    @if (api.type === 'NATIVE') {
+      <mat-card>
+        <mat-card-content>
+          <div class="entrypoints__host">
+            <div class="entrypoints__host__title">
+              <span class="mat-body-strong">Entrypoint host</span>
+            </div>
+            @if (portalSettings$ | async; as portalSettings) {
+              <gio-form-listeners-kafka-host
+                [formControl]="hostFormControl"
+                [apiId]="apiId"
+                [kafkaPort]="portalSettings.kafkaPort"
+                [kafkaDomain]="portalSettings.kafkaDomain"
+              />
+            }
           </div>
-          @if (portalSettings$ | async; as portalSettings) {
-            <gio-form-listeners-kafka-host
-              [formControl]="hostFormControl"
-              [apiId]="apiId"
-              [kafkaPort]="portalSettings.kafkaPort"
-              [kafkaDomain]="portalSettings.kafkaDomain"
-            />
-          }
-        </div>
-        <div class="entrypoints__footer" *ngIf="!isReadOnly">
-          <button
-            mat-flat-button
-            color="primary"
-            type="submit"
-            [disabled]="formGroup.pristine || formGroup.invalid || dataSource.length === 0"
-          >
-            Save changes
-          </button>
-          <button mat-stroked-button type="button" (click)="onReset()" [disabled]="!formGroup.dirty">Reset</button>
-        </div>
-      </mat-card-content>
-    </mat-card>
+          <div class="entrypoints__footer" *ngIf="!isReadOnly">
+            <button
+              mat-flat-button
+              color="primary"
+              type="submit"
+              [disabled]="formGroup.pristine || formGroup.invalid || dataSource.length === 0"
+            >
+              Save changes
+            </button>
+            <button mat-stroked-button type="button" (click)="onReset()" [disabled]="!formGroup.dirty">Reset</button>
+          </div>
+        </mat-card-content>
+      </mat-card>
+      @if (shouldUpgrade) {
+        <gio-license-banner [license]="license$ | async" [isOEM]="isOEM$ | async" (onRequestUpgrade)="onRequestUpgrade()" />
+      }
+    }
   </form>
   <mat-card *ngIf="api?.type === 'MESSAGE'">
     <mat-card-content>

--- a/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/entrypoints-v4/api-entrypoints-v4-general.component.spec.ts
@@ -49,6 +49,7 @@ const ENTRYPOINTS: Partial<ConnectorPlugin>[] = [
   { id: 'http-post', supportedApiType: 'MESSAGE', supportedListenerType: 'HTTP', name: 'HTTP POST', deployed: true },
   { id: 'sse', supportedApiType: 'MESSAGE', supportedListenerType: 'HTTP', name: 'Server-Sent Events', deployed: false },
   { id: 'webhook', supportedApiType: 'MESSAGE', supportedListenerType: 'SUBSCRIPTION', name: 'Webhook', deployed: false },
+  { id: 'native-kafka', supportedApiType: 'NATIVE', supportedListenerType: 'KAFKA', name: 'Client', deployed: false },
 ];
 
 describe('ApiProxyV4EntrypointsComponent', () => {
@@ -77,7 +78,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
       expectGetPortalSettings();
     }
 
-    if (api.type === 'MESSAGE' && checkLicense) {
+    if ((api.type === 'MESSAGE' || api.type === 'NATIVE') && checkLicense) {
       expectLicenseGetRequest({ tier: 'universe', features: [], packs: [], scope: 'PLATFORM' });
     }
   };
@@ -191,7 +192,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
     });
 
     beforeEach(async () => {
-      await createComponent(RESTRICTED_DOMAINS, API, true);
+      await createComponent(RESTRICTED_DOMAINS, API, true, undefined, true);
     });
 
     afterEach(() => {
@@ -875,6 +876,7 @@ describe('ApiProxyV4EntrypointsComponent', () => {
   describe('When API has entrypoints not available in license feature', () => {
     const RESTRICTED_DOMAINS = [];
     const API = fakeApiV4({
+      type: 'MESSAGE',
       listeners: [{ type: 'HTTP', paths: [{ path: '/context-path' }], entrypoints: [{ type: 'sse' }] }],
     });
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8022

## Description

Kafka CTA for Endpoints page:

![Screenshot 2024-12-23 at 16 34 33](https://github.com/user-attachments/assets/340d498e-f4a0-4afd-9a2a-2e08ae133db3)

Kafka CTA for Entrypoints page:

![Screenshot 2024-12-23 at 16 31 20](https://github.com/user-attachments/assets/5f3e7f58-b902-45d6-a548-8571c1c0d024)


**Creation Workflow**

Architecture choice:

![Screenshot 2024-12-23 at 16 20 06](https://github.com/user-attachments/assets/66d5ab53-058a-4fb1-bdea-1d75ea84c2c5)

Entrypoint configuration:

![Screenshot 2024-12-23 at 16 14 16](https://github.com/user-attachments/assets/088f0c2f-78e0-44be-840f-50e698129c4d)

Endpoint configuration:

![Screenshot 2024-12-23 at 16 14 33](https://github.com/user-attachments/assets/6d6ca7f5-bf08-4f9a-afb8-a1229bfe26db)

Summary: 

![Screenshot 2024-12-23 at 16 20 32](https://github.com/user-attachments/assets/ab756706-eceb-43b4-9674-458832b365a0)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jiokoxbvfk.chromatic.com)
<!-- Storybook placeholder end -->
