### PR TITLE
Apim 8051 hide load balancer info for native kafka apis

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.html
@@ -26,7 +26,7 @@
         <mat-tab label="General" *ngIf="generalForm">
           <!-- General tab content -->
           <div class="tab-body-wrapper">
-            <api-endpoint-group-general [generalForm]="generalForm"></api-endpoint-group-general>
+            <api-endpoint-group-general [generalForm]="generalForm" [isNativeKafka]="isNativeKafkaApi"></api-endpoint-group-general>
           </div>
         </mat-tab>
         <mat-tab label="Configuration" *ngIf="configurationForm && endpointGroup.type != 'mock'">

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.spec.ts
@@ -35,6 +35,7 @@ import { ApiV4, fakeApiV4, fakeProxyApiV4, fakeProxyTcpApiV4 } from '../../../..
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { fakeEndpointGroupV4, fakeHTTPProxyEndpointGroupV4 } from '../../../../entities/management-api-v2/api/v4/endpointGroupV4.fixture';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { fakeKafkaListener } from '../../../../entities/management-api-v2/api/v4/listener.fixture';
 
 /**
  * Expect that a single GET request has been made which matches the specified URL
@@ -195,6 +196,20 @@ describe('ApiEndpointGroupComponent', () => {
       expect(endpointsGroup[0].name).toEqual('default-group');
       expect(endpointsGroup[0].loadBalancer.type).toEqual('RANDOM');
       expect(await componentHarness.configurationTabIsVisible()).toEqual(true);
+    });
+
+    it('should not show native api endpoint group load balancing', async () => {
+      api = fakeApiV4({
+        id: API_ID,
+        type: 'NATIVE',
+        listeners: [fakeKafkaListener()],
+        endpointGroups: [fakeEndpointGroupV4({ type: 'native-kafka' })],
+      });
+      await initComponent(api);
+      await componentHarness.clickGeneralTab();
+      expectApiSchemaGetRequests(api, fixture, httpTestingController);
+
+      expect(await componentHarness.isEndpointGroupLoadBalancerSelectorShown()).toEqual(false);
     });
   });
   describe('endpoint group update - health check', () => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.component.ts
@@ -53,6 +53,7 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
   public healthCheckForm: EndpointGroupHealthCheckFormType;
   public healthCheckSchema: unknown;
   public isHttpProxyApi: boolean;
+  public isNativeKafkaApi: boolean;
 
   public initialGroupFormValue: any;
   public endpointGroup: EndpointGroupV4;
@@ -108,6 +109,7 @@ export class ApiEndpointGroupComponent implements OnInit, OnDestroy {
     this.api = api;
 
     this.isHttpProxyApi = api.type === 'PROXY' && !(api.listeners.find((listener) => listener.type === 'TCP') != null);
+    this.isNativeKafkaApi = api.type === 'NATIVE' && api.listeners.some((listener) => listener.type === 'KAFKA');
 
     this.initialApi = this.api;
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/api-endpoint-group.harness.ts
@@ -49,6 +49,13 @@ export class ApiEndpointGroupHarness extends ComponentHarness {
     return this.getEndpointGroupGeneralHarness().then((harness) => harness.setNameValue(inputValue));
   }
 
+  public async isEndpointGroupLoadBalancerSelectorShown() {
+    return this.getEndpointGroupGeneralHarness()
+      .then((harness) => harness.getLoadBalancerValue())
+      .then((_) => true)
+      .catch((_) => false);
+  }
+
   public async readEndpointGroupLoadBalancerSelector() {
     return this.getEndpointGroupGeneralHarness().then((harness) => harness.getLoadBalancerValue());
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.component.html
@@ -29,17 +29,19 @@
     </mat-form-field>
   </div>
 
-  <!-- Load balancing algorithm -->
-  <div class="card__endpoint-group-lb">
-    <p class="card__endpoint-group-lb__hint">
-      You can configure load balancing by creating a logical group of endpoints and specifying a load balancing algorithm for them.
-    </p>
-    <mat-form-field class="card__endpoint-group-lb__form-field">
-      <mat-label>Load balancing algorithm</mat-label>
-      <mat-select aria-label="Load balancing algorithm" formControlName="loadBalancerType" required>
-        <mat-option *ngFor="let loadBalancerType of loadBalancerTypes" [value]="loadBalancerType">{{ loadBalancerType }}</mat-option>
-      </mat-select>
-      <mat-error *ngIf="generalForm.get('loadBalancerType').hasError('required')"> Load balancing algorithm is required. </mat-error>
-    </mat-form-field>
-  </div>
+  @if (!isNativeKafka) {
+    <!-- Load balancing algorithm -->
+    <div class="card__endpoint-group-lb">
+      <p class="card__endpoint-group-lb__hint">
+        You can configure load balancing by creating a logical group of endpoints and specifying a load balancing algorithm for them.
+      </p>
+      <mat-form-field class="card__endpoint-group-lb__form-field">
+        <mat-label>Load balancing algorithm</mat-label>
+        <mat-select aria-label="Load balancing algorithm" formControlName="loadBalancerType" required>
+          <mat-option *ngFor="let loadBalancerType of loadBalancerTypes" [value]="loadBalancerType">{{ loadBalancerType }}</mat-option>
+        </mat-select>
+        <mat-error *ngIf="generalForm.get('loadBalancerType').hasError('required')"> Load balancing algorithm is required. </mat-error>
+      </mat-form-field>
+    </div>
+  }
 </form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/general/api-endpoint-group-general.component.ts
@@ -25,5 +25,7 @@ import { LOAD_BALANCER_TYPES } from '../../../../../entities/management-api-v2';
 })
 export class ApiEndpointGroupGeneralComponent {
   @Input() generalForm: UntypedFormGroup;
+  @Input() isNativeKafka: boolean;
+
   public loadBalancerTypes = LOAD_BALANCER_TYPES;
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -49,14 +49,16 @@
               <div class="endpoint-card__form__config">
                 <gio-form-json-schema formControlName="configuration" [jsonSchema]="endpointSchema?.config"></gio-form-json-schema>
               </div>
-              <div class="endpoint-card__form__lb">
-                <span class="mat-h3">Configure the load balancer</span>
-                <mat-form-field class="endpoint-card__form__weight">
-                  <mat-label>Weight</mat-label>
-                  <input id="weight" type="number" aria-label="Endpoint weight input" matInput formControlName="weight" required />
-                  <mat-error *ngIf="formGroup.get('weight').hasError('required')"> Weight is required. </mat-error>
-                </mat-form-field>
-              </div>
+              @if (!isNativeKafkaApi) {
+                <div class="endpoint-card__form__lb">
+                  <span class="mat-h3">Configure the load balancer</span>
+                  <mat-form-field class="endpoint-card__form__weight">
+                    <mat-label>Weight</mat-label>
+                    <input id="weight" type="number" aria-label="Endpoint weight input" matInput formControlName="weight" required />
+                    <mat-error *ngIf="formGroup.get('weight').hasError('required')"> Weight is required. </mat-error>
+                  </mat-form-field>
+                </div>
+              }
             </div>
           </mat-tab>
           <mat-tab label="Configuration" *ngIf="endpointSchema.sharedConfig">

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.harness.ts
@@ -67,6 +67,12 @@ export class ApiEndpointHarness extends ComponentHarness {
     return this.getHealthCheckInheritToggle().then((toggle) => toggle.toggle());
   }
 
+  public async isWeightButtonShown(): Promise<boolean> {
+    return this.getWeightButton()
+      .then((_) => true)
+      .catch((_) => false);
+  }
+
   public async fillWeightButton(weight: number) {
     return this.getWeightButton().then((button) => button.setValue(weight.toString()));
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8051

## Description

Do not show endpoint group load balancing configuration for Native Kafka APIs:

![Screenshot 2024-12-23 at 17 40 39](https://github.com/user-attachments/assets/3d2cea50-97f5-4541-8e92-ab866e6e4743)

Do not show endpoint weight configuration for Native Kafka APIs:

![Screenshot 2024-12-23 at 17 40 29](https://github.com/user-attachments/assets/e1cba13a-d070-4e14-9149-cbc1f89b7780)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pphxewamwp.chromatic.com)
<!-- Storybook placeholder end -->
