### PR TITLE
feat: add secret support for http proxy endpoint

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
@@ -47,6 +47,10 @@
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-vertx</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.secret</groupId>
+            <artifactId>gravitee-secret-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/http/HttpProxyOptions.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/http/HttpProxyOptions.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.definition.model.v4.http;
 
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
@@ -39,9 +41,15 @@ public class HttpProxyOptions implements Serializable {
 
     private boolean enabled;
     private boolean useSystemProxy;
+
     private String host;
+
     private int port;
+
+    @Secret
     private String username;
+
+    @Secret(FieldKind.PASSWORD)
     private String password;
 
     @Builder.Default

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSKeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSKeyStore.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.ssl.jks;
 
 import io.gravitee.definition.model.v4.ssl.KeyStore;
 import io.gravitee.definition.model.v4.ssl.KeyStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,10 +36,19 @@ public class JKSKeyStore extends KeyStore {
     @Serial
     private static final long serialVersionUID = -4687804681763799542L;
 
+    @Secret
     private String path;
+
+    @Secret
     private String content;
+
+    @Secret(FieldKind.PASSWORD)
     private String password;
+
+    @Secret
     private String alias;
+
+    @Secret(FieldKind.PASSWORD)
     private String keyPassword;
 
     public JKSKeyStore() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSTrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/jks/JKSTrustStore.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.ssl.jks;
 
 import io.gravitee.definition.model.v4.ssl.TrustStore;
 import io.gravitee.definition.model.v4.ssl.TrustStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,9 +36,16 @@ public class JKSTrustStore extends TrustStore {
     @Serial
     private static final long serialVersionUID = -6603840868190194763L;
 
+    @Secret
     private String path;
+
+    @Secret
     private String content;
+
+    @Secret(FieldKind.PASSWORD)
     private String password;
+
+    @Secret
     private String alias;
 
     public JKSTrustStore() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMKeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMKeyStore.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.ssl.pem;
 
 import io.gravitee.definition.model.v4.ssl.KeyStore;
 import io.gravitee.definition.model.v4.ssl.KeyStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,9 +36,16 @@ public class PEMKeyStore extends KeyStore {
     @Serial
     private static final long serialVersionUID = 1051430527272519608L;
 
+    @Secret
     private String keyPath;
+
+    @Secret(FieldKind.PRIVATE_KEY)
     private String keyContent;
+
+    @Secret
     private String certPath;
+
+    @Secret(FieldKind.PUBLIC_KEY)
     private String certContent;
 
     public PEMKeyStore() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMTrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pem/PEMTrustStore.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.model.v4.ssl.pem;
 
 import io.gravitee.definition.model.v4.ssl.TrustStore;
 import io.gravitee.definition.model.v4.ssl.TrustStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,7 +35,10 @@ public class PEMTrustStore extends TrustStore {
     @Serial
     private static final long serialVersionUID = 7432939542056493096L;
 
+    @Secret
     private String path;
+
+    @Secret
     private String content;
 
     public PEMTrustStore() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12KeyStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12KeyStore.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.ssl.pkcs12;
 
 import io.gravitee.definition.model.v4.ssl.KeyStore;
 import io.gravitee.definition.model.v4.ssl.KeyStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,9 +36,16 @@ public class PKCS12KeyStore extends KeyStore {
     @Serial
     private static final long serialVersionUID = 1210626721233767960L;
 
+    @Secret
     private String path;
+
+    @Secret
     private String content;
+
+    @Secret(FieldKind.PASSWORD)
     private String password;
+
+    @Secret
     private String alias;
 
     /**

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12TrustStore.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ssl/pkcs12/PKCS12TrustStore.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.ssl.pkcs12;
 
 import io.gravitee.definition.model.v4.ssl.TrustStore;
 import io.gravitee.definition.model.v4.ssl.TrustStoreType;
+import io.gravitee.secrets.api.annotation.Secret;
+import io.gravitee.secrets.api.el.FieldKind;
 import java.io.Serial;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,9 +36,16 @@ public class PKCS12TrustStore extends TrustStore {
     @Serial
     private static final long serialVersionUID = 3915578060196536545L;
 
+    @Secret
     private String path;
+
+    @Secret
     private String content;
+
+    @Secret(FieldKind.PASSWORD)
     private String password;
+
+    @Secret
     private String alias;
 
     public PKCS12TrustStore() {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/secrets/SecretsV4IntegrationTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.apim.integration.tests.http.secrets;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.secretprovider.hcvault.HCVaultSecretProvider;
+import com.graviteesource.secretprovider.hcvault.HCVaultSecretProviderFactory;
+import com.graviteesource.secretprovider.hcvault.config.manager.VaultConfig;
+import com.graviteesource.service.secrets.SecretsService;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.secrets.SecretProviderBuilder;
+import io.gravitee.apim.gateway.tests.sdk.utils.ResourceUtils;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.node.secrets.plugins.SecretProviderPlugin;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.secrets.api.plugin.SecretManagerConfiguration;
+import io.gravitee.secrets.api.plugin.SecretProviderFactory;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.vault.VaultContainer;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Testcontainers
+@GatewayTest
+public class SecretsV4IntegrationTest extends AbstractGatewayTest {
+
+    private static final String VAULT_TOKEN = UUID.randomUUID().toString();
+
+    @org.testcontainers.junit.jupiter.Container
+    protected static final VaultContainer vaultContainer = new VaultContainer<>("hashicorp/vault:1.13.3")
+        .withVaultToken(VAULT_TOKEN)
+        .withInitCommand(
+            "kv put secret/test private-key='-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCMOMvaM1XZzR1H\nPp127syCvuxnljnxsMLCvfM+8QsdyeuYVURei3z502zxWVTwNbxUbTxOkgIuNYRT\nyypEMpYajSEv0sMt4d7KBchE0eeQlcMDQ2J6kzfVjHyxLMMu8JscBQ5KGvF1vW3Q\np16w6C6JebF21Y0LumL9cMEToN6OrDKx9BrUkbTXHfSf+5rvkrnGfIPMulNJS2On\nl4zmT0bHs8a/zSIGmcwNIG243LmXTFu67TKbknJahICrRz0uZ8h1HMFbe7yY12s0\nd0xGJDJcPIBcdWHhB8z6iduTxCYZ2vY3EdFcC2RMO99zJPlWeDGY4lTM8TRFEAvE\nj4a21CltAgMBAAECggEADu4VNnx0zaX7UhSmq30tpVYy0ay7KrLJafbTqYX8ywUu\n4p9hkjeD7Q3H8cKzOoheLxcabrs5JDZqiol9TJmeReF1ASSNx5rfH9+RvVIkN87a\nXsST/b0jGsfElxDPD3Zq7YbUSKupvgGXaboIaQmvus+MR7zhMbh8xcN1q2NbjxE6\nCLXV+uu8kVPLsUbGFGK53vK7+MHnEKJIbjHR+LRNMxZRzoX7h57UO6uoXwWes2Kr\nopMzIJdv2ZRvXS62NNCTK9BoPb4OreXSoEJZkXS26ispOLLnM36D4UpNeDl6hITN\noCSHKiRGFqY5QOir/MP8uqNmGEtprMDmUQt/K5Z8OQKBgQDVvEi7SmHFJLNSsY2l\nvvxlwIa9rr0d/TFtTXcGMUdLYg7rQtaZ3e0geJv4wU58KahmpgYqpX4s0/Gc4L37\nyG1kCtPUjHvxxauLRr0OcXz35pTqlGhVGyls9onCxM/nDpoiYDvueuse69rVVGDE\nTKg2pxqS0Rxh7FARKY1RpJprjwKBgQCn8xsrRSc5QGF/L7b87MK1sf+lQ7Updubt\nv/XRFq5lhHp888MrIsqcqsDqRChoY2Qoi0vuNv52pgpha6lXkxL5Djd1ypX457KR\ntaJmx7qoolYW7INU4mvcryyIiW9ELiFrGb8XrwhXwmUBWOGGEDJkgYOj6W7Co38T\n2RbkBvBNQwKBgGTniv7A0v+bn/0+Tb0eOVJgXjxWrnnl+tu7YqHNyfbQyHJRD7d8\nimJ2DkyWFlOP5yzu3KJtlu/a74o8n/SqXtqIMhF6cVlnFOGf98lF0tXGSi+k+MyV\nEi2bBtaoy+4tep8YB7NC3JWwi5ODTlveRNvocCc4CcpBIlu33jvZFf4JAoGATJ0R\nn8OECRHdZ++UQfyfNdNlEza3xZp/7aTLtf3qwFSWq7lnJp5QXvdl2XgOFtCAOB6T\nHK/plKZZxece8Nweo45grlMj5s+LHf0FgG1MMPEc5IgvwOEo4xrl7cMEBs4kYH72\nNQ+bdq0u9lZdSpLI6iBKtNMfu5pptdwqHQstQ5ECgYBQ+XWJHuKLadcMAoAdG+gW\n5KxlSlin7PqgmzobXggp2aUGVLHs4pvIGA+7Sf/kAPfJ6bimv4dIODqEe8TZnmWp\n4ZG0jYjFXVnbwbh+hU5EF03ntO9WYqL6rYU3zujz/ZuKBEByIFowTX9uaVKEgML6\n5oHAF4Sb7zxa2jSEehGQ5Q==\n-----END PRIVATE KEY-----'"
+        );
+
+    private static String token;
+
+    private final int backendPort = getAvailablePort();
+
+    @Override
+    protected void configureWireMock(WireMockConfiguration configuration) {
+        configuration
+            .httpsPort(backendPort)
+            .needClientAuth(true)
+            .keystorePath(ResourceUtils.toPath("certs/keystore01.jks"))
+            .keystorePassword("password")
+            .trustStorePath(ResourceUtils.toPath("certs/truststore01.jks"))
+            .trustStorePassword("password");
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+        super.configureGateway(configurationBuilder);
+
+        // create a renewable token so the plugin does not start panicking
+        Container.ExecResult execResult = null;
+        try {
+            execResult = vaultContainer.execInContainer("vault", "token", "create", "-period=10m", "-field", "token");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        token = execResult.getStdout();
+
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].plugin", "vault");
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.enabled", true);
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.host", vaultContainer.getHost());
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.port", vaultContainer.getMappedPort(8200));
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.ssl.enabled", "false");
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.auth.method", "token");
+        configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.auth.config.token", token);
+    }
+
+    @Override
+    public void configureSecretProviders(
+        Set<SecretProviderPlugin<? extends SecretProviderFactory<?>, ? extends SecretManagerConfiguration>> secretProviderPlugins
+    ) {
+        secretProviderPlugins.add(
+            SecretProviderBuilder.build(HCVaultSecretProvider.PLUGIN_ID, HCVaultSecretProviderFactory.class, VaultConfig.class)
+        );
+    }
+
+    @Override
+    public void configureServices(Set<Class<? extends AbstractService<?>>> services) {
+        super.configureServices(services);
+        services.add(SecretsService.class);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        vaultContainer.close();
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> reactableApi, Class<?> definitionClass) {
+        if (!isV4Api(definitionClass)) {
+            throw new AssertionError("TCP api should only be v4 api");
+        }
+        final Api apiDefinition = (Api) reactableApi.getDefinition();
+
+        updateEndpointsPort(apiDefinition, backendPort);
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/http/secrets/api-secured-jks-password-secret-static-ref.json" })
+    void should_retrieve_password_from_secret_provider(HttpClient httpClient, Vertx vertx) {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                // just asserting we get a response (hence no SSL errors), no need for an API.
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete();
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-secured-jks-password-secret-static-ref.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/api-secured-jks-password-secret-static-ref.json
@@ -1,0 +1,73 @@
+{
+    "id": "static-secret-api-v4",
+    "name": "my-secret-api-v4",
+    "gravitee": "4.0.0",
+    "type": "proxy",
+    "listeners": [
+        {
+            "type": "http",
+            "paths": [
+                {
+                    "path": "/test"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "default-group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "https://localhost:8080/endpoint"
+                    },
+                    "sharedConfigurationOverride": {
+                        "http": {
+                            "connectTimeout": 3000,
+                            "readTimeout": 60000
+                        },
+                      "ssl": {
+                        "trustAll": false,
+                        "keyStore": {
+                          "type": "PEM",
+                          "certContent": "-----BEGIN CERTIFICATE-----\nMIICxzCCAa+gAwIBAgIEPvlKwjANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwls\nb2NhbGhvc3QwHhcNMTgxMDA5MTU0MTAyWhcNMTkxMDA0MTU0MTAyWjAUMRIwEAYD\nVQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCM\nOMvaM1XZzR1HPp127syCvuxnljnxsMLCvfM+8QsdyeuYVURei3z502zxWVTwNbxU\nbTxOkgIuNYRTyypEMpYajSEv0sMt4d7KBchE0eeQlcMDQ2J6kzfVjHyxLMMu8Jsc\nBQ5KGvF1vW3Qp16w6C6JebF21Y0LumL9cMEToN6OrDKx9BrUkbTXHfSf+5rvkrnG\nfIPMulNJS2Onl4zmT0bHs8a/zSIGmcwNIG243LmXTFu67TKbknJahICrRz0uZ8h1\nHMFbe7yY12s0d0xGJDJcPIBcdWHhB8z6iduTxCYZ2vY3EdFcC2RMO99zJPlWeDGY\n4lTM8TRFEAvEj4a21CltAgMBAAGjITAfMB0GA1UdDgQWBBQmmZF9umT5DGh4RgYX\nBQhzb6EkQTANBgkqhkiG9w0BAQsFAAOCAQEAW1QaHW4iYjUtjQik+nWD3Xktbm50\ns9PeAYSCp9an757dvzfO/vwJZE+1+grmsS0l/jxh8L0qsdjM5Qt4VmjK5CbikE2v\ne4Vt4o40tQOz8A7fNVVp5S33njgNbp1UMhnrFsHVZ6Aa8HHxisjliluVK1/YPl80\nKRs57GL4SyvELzmWhh7egndxdGYR9nbAbg1RQ+kJClqSS0BL5oQ4Xn4AGmU5839/\nZ1+N5qgNq2/BYOi6FsltL91US0FOLNxDBYqjwShGOJ1V6Lvh27YmSHViscph6GeZ\nkZ2xybRANymp0DSVER5J+D2RuJNtzp/zl//BJ3b19tpVpDTQ1ndzcSGPLg==\n-----END CERTIFICATE-----",
+                          "keyContent": "{#secrets.get('/vault/secret/test:private-key')}"
+                        },
+                        "trustStore": {
+                          "type": "PEM",
+                          "content": "-----BEGIN CERTIFICATE-----\nMIICxzCCAa+gAwIBAgIEPvlKwjANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwls\nb2NhbGhvc3QwHhcNMTgxMDA5MTU0MTAyWhcNMTkxMDA0MTU0MTAyWjAUMRIwEAYD\nVQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCM\nOMvaM1XZzR1HPp127syCvuxnljnxsMLCvfM+8QsdyeuYVURei3z502zxWVTwNbxU\nbTxOkgIuNYRTyypEMpYajSEv0sMt4d7KBchE0eeQlcMDQ2J6kzfVjHyxLMMu8Jsc\nBQ5KGvF1vW3Qp16w6C6JebF21Y0LumL9cMEToN6OrDKx9BrUkbTXHfSf+5rvkrnG\nfIPMulNJS2Onl4zmT0bHs8a/zSIGmcwNIG243LmXTFu67TKbknJahICrRz0uZ8h1\nHMFbe7yY12s0d0xGJDJcPIBcdWHhB8z6iduTxCYZ2vY3EdFcC2RMO99zJPlWeDGY\n4lTM8TRFEAvEj4a21CltAgMBAAGjITAfMB0GA1UdDgQWBBQmmZF9umT5DGh4RgYX\nBQhzb6EkQTANBgkqhkiG9w0BAQsFAAOCAQEAW1QaHW4iYjUtjQik+nWD3Xktbm50\ns9PeAYSCp9an757dvzfO/vwJZE+1+grmsS0l/jxh8L0qsdjM5Qt4VmjK5CbikE2v\ne4Vt4o40tQOz8A7fNVVp5S33njgNbp1UMhnrFsHVZ6Aa8HHxisjliluVK1/YPl80\nKRs57GL4SyvELzmWhh7egndxdGYR9nbAbg1RQ+kJClqSS0BL5oQ4Xn4AGmU5839/\nZ1+N5qgNq2/BYOi6FsltL91US0FOLNxDBYqjwShGOJ1V6Lvh27YmSHViscph6GeZ\nkZ2xybRANymp0DSVER5J+D2RuJNtzp/zl//BJ3b19tpVpDTQ1ndzcSGPLg==\n-----END CERTIFICATE-----"
+                        }
+                      }
+                    }
+                }
+            ]
+        }
+    ],
+    "flows": [
+        {
+            "name": "flow-1",
+            "enabled": true,
+            "selectors": [
+                {
+                    "type": "http",
+                    "path": "/",
+                    "pathOperator": "START_WITH",
+                    "methods": ["GET"]
+                }
+            ]
+        }
+    ],
+    "analytics": {
+        "enabled": false
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
@@ -37,12 +37,14 @@ Bellow you will find the common options related to endpoint configuration which 
 
 === Http proxy connector configuration
 
+#Warning: EL and Secret are evaluated at Api deployment (not request time!)#
+
 ==== Endpoint level configuration
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|target | N/A     | Yes | The target url to use to contact the backend (ex: https://api.gravitee.io/echo).
+|target | N/A     | Yes | Yes | Yes | The target url to use to contact the backend (ex: https://api.gravitee.io/echo).
 
 |===
 
@@ -53,12 +55,12 @@ Shared configuration can be done directly from the endpoint group `sharedConfigu
 If `inheritConfiguration` is false, then shared configuration can be overridden directly from endpoint `overriddenSharedConfiguration` field.
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|headers | N/A     | No | An optional list of headers to add before sending the request to the backend. Header's value support EL expression that are evaluated at Api deployment (not request time!) and support a subset of expressions (api properties, dictionary, node). All headers defined here take precedence over headers defined at request time (override).
-|http | N/A     | No | The configuration related to http (pool, timeout, ...). See bellow for details.
-|proxy | N/A     | No | The configuration related to the configuration of proxy (http or tcp proxy). See bellow for details.
-|ssl | N/A     | No | The configuration related to ssl. See bellow for details.
+|headers | N/A     | No | Yes | Yes | An optional list of headers to add before sending the request to the backend. Header's value support EL expression support a subset of expressions (api properties, dictionary, node). All headers defined here take precedence over headers defined at request time (override).
+|http | N/A     | No | N/A | N/A | The configuration related to http (pool, timeout, ...). See bellow for details.
+|proxy | N/A     | No | N/A | N/A | The configuration related to the configuration of proxy (http or tcp proxy). See bellow for details.
+|ssl | N/A     | No | N/A | N/A | The configuration related to ssl. See bellow for details.
 
 |===
 
@@ -67,21 +69,21 @@ If `inheritConfiguration` is false, then shared configuration can be overridden 
 The http proxy connector comes with default values regarding the connection pool and the different timeout. They are all overridable depending on the need. Each configured endpoint will have its own instance of endpoint connector with its dedicated connection pool and properties.
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|keepAlive | true     | Yes | Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.
-|followRedirects | false     | Yes | When the connector receives a status code in the range 3xx from the backend, it follows the redirection provided by the Location response header.
-|readTimeout | 10000     | Yes | Maximum time given to the backend to complete the request (including response) in milliseconds.
-|idleTimeout | 60000     | Yes | Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.
-|keepAliveTimeout | 30000     | Yes | Maximum time a connection will remains unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.
-|connectTimeout | 5000     | Yes | Maximum time to connect to the backend in milliseconds.
-|propagateClientAcceptEncoding | false     | Yes | Propagate client Accept-Encoding header (no decompression if any). The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.
-|useCompression | true     | Yes | Enable compression (gzip, deflate). The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.
-|maxConcurrentConnections | 20     | Yes | Maximum pool size for connections. It basically represents the maximum number of concurrent requests at a time.
-|version | HTTP_1     | Yes | The http version to use.
-|clearTextUpgrade | true     | No | Allows h2c Clear Text Upgrade. If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge).
-|pipelining | false     | No | Enable HTTP pipelining. When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
-|connectTimeout | 3000     | Yes | Maximum time to connect to the backend in milliseconds.
+|keepAlive | true     | Yes | No | No | Use an HTTP persistent connection to send and receive multiple HTTP requests / responses.
+|followRedirects | false     | Yes | No | No | When the connector receives a status code in the range 3xx from the backend, it follows the redirection provided by the Location response header.
+|readTimeout | 10000     | Yes | No | No | Maximum time given to the backend to complete the request (including response) in milliseconds.
+|idleTimeout | 60000     | Yes | No | No | Maximum time a connection will be opened if no data is received nor sent. Once the timeout has elapsed, the unused connection will be closed, allowing to free the associated resources.
+|keepAliveTimeout | 30000     | Yes | No | No | Maximum time a connection will remains unused in the pool in milliseconds. Once the timeout has elapsed, the unused connection will be evicted.
+|connectTimeout | 5000     | Yes | No | No | Maximum time to connect to the backend in milliseconds.
+|propagateClientAcceptEncoding | false     | Yes | No | No | Propagate client Accept-Encoding header (no decompression if any). The gateway will propagate the Accept-Encoding header's value specified by the client's request to the backend (if any). The gateway will <b>NEVER attempt to decompress the content</b> if the backend response is compressed (gzip, deflate). It is then not possible to apply transformation policy if the body is compressed. Also, body will appear compressed if logging is enabled for the API. <b>DO NOT</b> activate this option if you plan to play with body responses.
+|useCompression | true     | Yes | No | No | Enable compression (gzip, deflate). The gateway can let the remote http server know that it supports compression. In case the remote http server returns a compressed response, the gateway will decompress it. Leave that option off if you don't want compression between the gateway and the remote server.
+|maxConcurrentConnections | 20     | Yes | No | No | Maximum pool size for connections. It basically represents the maximum number of concurrent requests at a time.
+|version | HTTP_1     | Yes | No | No | The http version to use.
+|clearTextUpgrade | true     | No | No | No | Allows h2c Clear Text Upgrade. If enabled, an h2c connection is established using an HTTP/1.1 Upgrade request. If disabled, h2c connection is established directly (with prior knowledge).
+|pipelining | false     | No | No | No | Enable HTTP pipelining. When pipe-lining is enabled requests will be written to connections without waiting for previous responses to return.
+|connectTimeout | 3000     | Yes | No | No | Maximum time to connect to the backend in milliseconds.
 
 |===
 
@@ -96,15 +98,15 @@ Here are some considerations regarding connection pool and timeouts:
 The proxy options allows to configure the use of an http or tcp proxy. Large companies often use a global enterprise proxy to control traffic going outside the company's network (eg: internet traffic). Proxy options allows to indicate the connector to configure a proxy server to pass through.
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|enabled | false     | No | Indicates to use the specified http proxy configuration when contacting the backend target.
-|type | HTTP     | No | The type of proxy (could be `HTTP`, `SOCKS4` or `SOCKS5`)
-|useSystemProxy | false     | No | Indicates if the system proxy configured globally must be used or not. If enabled, it avoids specifying proxy configuration by yourself at endpoint level.
-|host | N/A     | No | The proxy host.
-|port | N/A     | No | The proxy port.
-|username | N/A     | No | The optional proxy username to use in case the proxy requires authentication.
-|password | N/A     | No | The optional proxy password to use in case the proxy requires authentication.
+|enabled | false     | No | No | No | Indicates to use the specified http proxy configuration when contacting the backend target.
+|type | HTTP     | No | No | No | The type of proxy (could be `HTTP`, `SOCKS4` or `SOCKS5`)
+|useSystemProxy | false     | No | No | No | Indicates if the system proxy configured globally must be used or not. If enabled, it avoids specifying proxy configuration by yourself at endpoint level.
+|host | N/A     | No | Yes | No | The proxy host.
+|port | N/A     | No | No | No | The proxy port.
+|username | N/A     | No | Yes | Yes | The optional proxy username to use in case the proxy requires authentication.
+|password | N/A     | No | Yes | Yes | The optional proxy password to use in case the proxy requires authentication.
 
 |===
 
@@ -116,37 +118,36 @@ When configuring the endpoint, you may want to contact a secured target (https).
  * keystore: what is required for mtls (eg: client certificate)
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|hostnameVerifier | true    | No | Verify host. When enabled, the certificate of the backend server will be validated against the targeted host to verify they match together.
-|trustAll | false     | No | Trust all. Use this with caution (if over Internet). The gateway must trust any origin certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks.
-|useSystemProxy | false     | No | Indicates if the system proxy configured globally must be used or not. If enabled, it avoid to specified http proxy configuration by yourself.
-|trustStore | N/A     | No | Configuration for the truststore. The truststore is used to validate the server's certificate. See bellow for details.
-|keystore | N/A     | No | Configuration for Mutual TLS. The keystore is used to select the client certificate to send to the backend server when connecting. See bellow for details.
+|hostnameVerifier | true    | No | No | No | Verify host. When enabled, the certificate of the backend server will be validated against the targeted host to verify they match together.
+|trustAll | false     | No | No | No | Trust all. Use this with caution (if over Internet). The gateway must trust any origin certificates. The connection will still be encrypted but this mode is vulnerable to 'man in the middle' attacks.
+|trustStore | N/A     | No | N/A| N/A | Configuration for the truststore. The truststore is used to validate the server's certificate. See bellow for details.
+|keystore | N/A     | No | N/A | N/A | Configuration for Mutual TLS. The keystore is used to select the client certificate to send to the backend server when connecting. See bellow for details.
 
 |===
 
 Here are the attributes for configuring the truststore options (eg: backend certificate validation).
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|type | true    | Yes | The type of the specified truststore. Could be `PKCS12` (recommended as it is an industry standard), `JKS` (not recommended, deprecated) or `PEM`.
-|password | N/A     | No | The password to use when the truststore is protected.
-|path | N/A     | No | The path to the truststore file on the server. Use content to provide the truststore by yourself.
-|content | N/A     | No | Configuration for the truststore. The truststore is used to validate the server's certificate. See bellow for details.
+|type | true    | Yes | No | No | The type of the specified truststore. Could be `PKCS12` (recommended as it is an industry standard), `JKS` (not recommended, deprecated) or `PEM`.
+|password | N/A     | No | Yes | Yes | The password to use when the truststore is protected.
+|path | N/A     | No | Yes | Yes | The path to the truststore file on the server. Use content to provide the truststore by yourself.
+|content | N/A     | No | Yes | Yes | Configuration for the truststore. The truststore is used to validate the server's certificate. See bellow for details.
 
 |===
 
 Here are the attributes for configuring the keystore options (client certificate, Mutual TLS).
 
 |===
-|Attributes | Default | Mandatory | Description
+|Attributes | Default | Mandatory | Support EL | Support secret | Description
 
-|type | true    | Yes | The type of the specified keystore. Could be `PKCS12` (recommended as it is an industry standard), `JKS` (not recommended, deprecated) or `PEM`.
-|password | N/A     | No | The password to use when the keystore is protected.
-|path | N/A     | No | The path to the keystore file on the server. Use content to provide the keystore by yourself.
-|content | N/A     | No | Configuration for the keystore. The truststore is used to validate the server's certificate. See bellow for details.
+|type | true    | Yes | No | No | The type of the specified keystore. Could be `PKCS12` (recommended as it is an industry standard), `JKS` (not recommended, deprecated) or `PEM`.
+|password | N/A     | No | Yes | Yes | The password to use when the keystore is protected.
+|path | N/A     | No | Yes | Yes | The path to the keystore file on the server. Use content to provide the keystore by yourself.
+|content | N/A     | No | Yes | Yes | Configuration for the keystore. The truststore is used to validate the server's certificate. See bellow for details.
 
 |===
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/pom.xml
@@ -60,6 +60,25 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.plugin</groupId>
+            <artifactId>gravitee-plugin-annotation-processors</artifactId>
+            <version>${gravitee-plugin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Tests -->
         <dependency>
@@ -91,6 +110,25 @@
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>generated-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorConfiguration.java
@@ -16,6 +16,8 @@
 package io.gravitee.plugin.endpoint.http.proxy.configuration;
 
 import io.gravitee.gateway.reactive.api.connector.endpoint.EndpointConnectorConfiguration;
+import io.gravitee.plugin.annotation.ConfigurationEvaluator;
+import io.gravitee.secrets.api.annotation.Secret;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -25,7 +27,9 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@ConfigurationEvaluator(attributePrefix = "gravitee.attributes.endpoint.httpProxy")
 public class HttpProxyEndpointConnectorConfiguration implements EndpointConnectorConfiguration {
 
+    @Secret
     private String target;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/configuration/HttpProxyEndpointConnectorSharedConfiguration.java
@@ -21,6 +21,8 @@ import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.HttpProxyOptions;
 import io.gravitee.definition.model.v4.ssl.SslOptions;
 import io.gravitee.gateway.reactive.api.connector.endpoint.EndpointConnectorSharedConfiguration;
+import io.gravitee.plugin.annotation.ConfigurationEvaluator;
+import io.gravitee.secrets.api.annotation.Secret;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -31,6 +33,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@ConfigurationEvaluator(attributePrefix = "gravitee.attributes.endpoint.httpProxy")
 public class HttpProxyEndpointConnectorSharedConfiguration implements EndpointConnectorSharedConfiguration {
 
     @JsonProperty("proxy")
@@ -43,5 +46,6 @@ public class HttpProxyEndpointConnectorSharedConfiguration implements EndpointCo
     private SslOptions sslOptions;
 
     @JsonProperty("headers")
+    @Secret
     private List<HttpHeader> headers;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorFactoryTest.java
@@ -21,11 +21,13 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.http.HttpClientOptions;
+import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
+import io.reactivex.rxjava3.core.Maybe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,12 +49,16 @@ class HttpProxyEndpointConnectorFactoryTest {
     private TemplateEngine templateEngine;
 
     @Mock
+    private TemplateContext templateContext;
+
+    @Mock
     private DeploymentContext deploymentContext;
 
     @BeforeEach
     void beforeEach() {
         lenient().when(deploymentContext.getTemplateEngine()).thenReturn(templateEngine);
-        lenient().when(templateEngine.convert(anyString())).thenAnswer(i -> i.getArgument(0));
+        lenient().when(templateEngine.getTemplateContext()).thenReturn(templateContext);
+        lenient().when(templateEngine.eval(anyString(), any())).thenAnswer(i -> Maybe.just(i.getArgument(0)));
         cut = new HttpProxyEndpointConnectorFactory(new PluginConfigurationHelper(null, new ObjectMapper()));
     }
 
@@ -85,12 +91,12 @@ class HttpProxyEndpointConnectorFactoryTest {
         HttpProxyEndpointConnector connector = cut.createConnector(deploymentContext, CONFIG, SHARED_CONFIG);
         assertThat(connector).isNotNull();
         assertThat(connector.configuration).isNotNull();
-        verify(templateEngine).convert("https://localhost:8082/echo?foo=bar");
-        verify(templateEngine).convert("localhost");
-        verify(templateEngine).convert("user");
-        verify(templateEngine).convert("pwd");
-        verify(templateEngine).convert("Value1");
-        verify(templateEngine).convert("Value2");
+        verify(templateEngine).eval("https://localhost:8082/echo?foo=bar", String.class);
+        verify(templateEngine).eval("localhost", String.class);
+        verify(templateEngine).eval("user", String.class);
+        verify(templateEngine).eval("pwd", String.class);
+        verify(templateEngine).eval("Value1", String.class);
+        verify(templateEngine).eval("Value2", String.class);
     }
 
     @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -29,9 +29,9 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.plugin.endpoint.http.proxy.client.GrpcHttpClientFactory;
@@ -69,13 +69,13 @@ class HttpProxyEndpointConnectorTest {
     private TemplateEngine templateEngine;
 
     @Mock
-    private ExecutionContext ctx;
+    private HttpExecutionContext ctx;
 
     @Mock
-    private Request request;
+    private HttpRequest request;
 
     @Mock
-    private Response response;
+    private HttpResponse response;
 
     @Mock
     private Metrics metrics;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactoryTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
@@ -47,7 +47,7 @@ class HttpClientFactoryTest {
     public static final int TIMEOUT_SECONDS = 60;
 
     @Mock
-    protected ExecutionContext ctx;
+    protected HttpExecutionContext ctx;
 
     protected HttpClientFactory cut;
     protected HttpProxyEndpointConnectorConfiguration configuration;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -46,9 +46,9 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
@@ -96,13 +96,13 @@ class HttpConnectorTest {
     private TemplateEngine templateEngine;
 
     @Mock
-    private ExecutionContext ctx;
+    private HttpExecutionContext ctx;
 
     @Mock
-    private Request request;
+    private HttpRequest request;
 
     @Mock
-    private Response response;
+    private HttpResponse response;
 
     @Mock
     private Metrics metrics;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7500

## Description

Add support of Secret in Http Proxy endpoint by using the ConfigurationEvaluator annotation processor.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mllutqsjqv.chromatic.com)
<!-- Storybook placeholder end -->
