### PR TITLE
test: try a memory configuration for surefire

### DIFF
--- a/gravitee-apim-integration-tests/pom.xml
+++ b/gravitee-apim-integration-tests/pom.xml
@@ -36,6 +36,8 @@
         <sol-jcsmp.version>10.22.0</sol-jcsmp.version>
         <solace-messaging-client.version>1.4.0</solace-messaging-client.version>
         <reactor-rabbitmq.version>1.5.6</reactor-rabbitmq.version>
+
+        <surefireArgLine>-Xmx1024m -XX:MaxMetaspaceSize=512m</surefireArgLine>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

## Issue

N/A

## Description
Regular crashes of the VM during surefire plugin execution might be due to memory not correctly allocated.
This PR try to force memory configuration in the maven surefire plugin.