### PR TITLE
Improve units tests of gravitee-apim-gateway-core

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/classloader/DefaultClassLoaderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/classloader/DefaultClassLoaderTest.java
@@ -16,7 +16,7 @@
 package io.gravitee.gateway.core.classloader;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
@@ -125,7 +125,7 @@ class DefaultClassLoaderTest {
         final Policy policy = instantiatePolicy();
 
         when(ctx.getComponent(ResourceManager.class)).thenReturn(resourceManager);
-        assertThrows(NoClassDefFoundError.class, () -> policy.onRequest(ctx));
+        assertThatThrownBy(() -> policy.onRequest(ctx)).isInstanceOf(NoClassDefFoundError.class);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/impl/tenant/MultiTenantAwareEndpointLifecycleManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/impl/tenant/MultiTenantAwareEndpointLifecycleManagerTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.gateway.core.endpoint.impl.tenant;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -37,8 +37,8 @@ import io.gravitee.gateway.core.endpoint.lifecycle.impl.tenant.MultiTenantAwareE
 import io.gravitee.gateway.core.endpoint.ref.ReferenceRegister;
 import io.gravitee.node.api.configuration.Configuration;
 import java.util.Collections;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -82,7 +82,7 @@ public class MultiTenantAwareEndpointLifecycleManagerTest {
     @Mock
     private Configuration configuration;
 
-    @Before
+    @BeforeEach
     public void setUp() throws JsonProcessingException {
         MockitoAnnotations.initMocks(this);
 
@@ -120,7 +120,7 @@ public class MultiTenantAwareEndpointLifecycleManagerTest {
         verify(endpointFactory, never())
             .create(any(io.gravitee.definition.model.Endpoint.class), any(io.gravitee.connector.api.Connector.class));
 
-        assertTrue(endpointLifecycleManager.endpoints().isEmpty());
+        assertThat(endpointLifecycleManager.endpoints()).isEmpty();
     }
 
     @Test
@@ -137,7 +137,7 @@ public class MultiTenantAwareEndpointLifecycleManagerTest {
         verify(endpointFactory, atLeastOnce())
             .create(any(io.gravitee.definition.model.Endpoint.class), any(io.gravitee.connector.api.Connector.class));
 
-        assertTrue(endpointLifecycleManager.endpoints().isEmpty());
+        assertThat(endpointLifecycleManager.endpoints()).isEmpty();
     }
 
     @Test
@@ -162,14 +162,14 @@ public class MultiTenantAwareEndpointLifecycleManagerTest {
 
         Endpoint httpClientEndpoint = endpointLifecycleManager.get("endpoint");
 
-        assertNotNull(httpClientEndpoint);
+        assertThat(httpClientEndpoint).isNotNull();
 
         verify(endpointFactory, times(1)).create(eq(endpoint), any(io.gravitee.connector.api.Connector.class));
         verify(httpClientEndpoint.connector(), times(1)).start();
 
-        assertEquals(httpClientEndpoint, endpointLifecycleManager.get("endpoint"));
-        assertNull(endpointLifecycleManager.get("unknown"));
-        assertFalse(endpointLifecycleManager.endpoints().isEmpty());
+        assertThat(endpointLifecycleManager.get("endpoint")).isEqualTo(httpClientEndpoint);
+        assertThat(endpointLifecycleManager.get("unknown")).isNull();
+        assertThat(endpointLifecycleManager.endpoints()).isNotEmpty();
     }
 
     @Test
@@ -193,13 +193,13 @@ public class MultiTenantAwareEndpointLifecycleManagerTest {
 
         Endpoint httpClientEndpoint = endpointLifecycleManager.get("endpoint");
 
-        assertNotNull(httpClientEndpoint);
+        assertThat(httpClientEndpoint).isNotNull();
 
         verify(endpointFactory, times(1)).create(eq(endpoint), any(io.gravitee.connector.api.Connector.class));
         verify(httpClientEndpoint.connector(), times(1)).start();
 
-        assertEquals(httpClientEndpoint, endpointLifecycleManager.get("endpoint"));
-        assertNull(endpointLifecycleManager.get("unknown"));
-        assertFalse(endpointLifecycleManager.endpoints().isEmpty());
+        assertThat(endpointLifecycleManager.get("endpoint")).isEqualTo(httpClientEndpoint);
+        assertThat(endpointLifecycleManager.get("unknown")).isNull();
+        assertThat(endpointLifecycleManager.endpoints()).isNotEmpty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolverTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.core.endpoint.resolver;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.endpoint.Endpoint;
@@ -28,20 +28,21 @@ import io.gravitee.gateway.core.endpoint.ref.EndpointReference;
 import io.gravitee.gateway.core.endpoint.ref.GroupReference;
 import io.gravitee.gateway.core.endpoint.ref.ReferenceRegister;
 import io.gravitee.gateway.core.endpoint.ref.impl.DefaultReferenceRegister;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProxyEndpointResolverTest {
 
     private ProxyEndpointResolver resolver;
@@ -49,16 +50,14 @@ public class ProxyEndpointResolverTest {
     @Spy
     private final ReferenceRegister referenceRegister = new DefaultReferenceRegister();
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private GroupManager groupManager;
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private LoadBalancedEndpointGroup loadBalancedEndpointGroup;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        initMocks(this);
-
         resolver = new ProxyEndpointResolver(referenceRegister, groupManager);
 
         LoadBalancedEndpointGroup group = mock(LoadBalancedEndpointGroup.class);
@@ -67,72 +66,10 @@ public class ProxyEndpointResolverTest {
     }
 
     @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_selectFirstEndpoint() {
-        resolveUserDefinedEndpoint("http://host:8080/test/", "http://host:8080/test/", "endpoint", "http://endpoint:8080/test/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_selectFirstEndpoint() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "http://host:8080/test", "endpoint", "http://endpoint:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withEncodedTargetURI() {
-        resolveUserDefinedEndpoint(
-            "http://host:8080/test toto  tété/titi",
-            "http://host:8080/test toto  tété/titi",
-            "endpoint",
-            "http://host:8080/test"
-        );
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_withEncodedTargetURI() {
-        resolveUserDefinedEndpoint(
-            "http://host:8080/test/ toto  tété/titi",
-            "http://host:8080/test/ toto  tété/titi",
-            "endpoint",
-            "http://host:8080/test"
-        );
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_startingWithSlash() {
-        resolveUserDefinedEndpoint("http://endpoint:8080/test/myendpoint", "/myendpoint", "endpoint", "http://endpoint:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_startingWithSlash() {
-        resolveUserDefinedEndpoint("http://endpoint:8080/test/myendpoint", "/myendpoint", "endpoint", "http://endpoint:8080/test/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withDynamicRouting() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "local:", "local", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_withDynamicRouting() {
-        resolveUserDefinedEndpoint("http://host:8080/test/", "local:", "local", "http://host:8080/test/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withSlashInName() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "lo/cal:", "lo/cal", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withParenthesisInName() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "lo(cal:", "lo(cal", "http://host:8080/test");
-    }
-
-    @Test
     // : is forbidden thanks to https://github.com/gravitee-io/issues/issues/1939
     public void shouldResolveUserDefinedEndpoint_withPointsInName() {
-        String expectedURI = "http://host:8080/test";
         String requestEndpoint = "lo:cal:";
         String endpointName = "lo:cal";
-        String endpointTarget = "http://host:8080/test";
 
         Endpoint endpoint = mock(Endpoint.class);
         when(endpoint.name()).thenReturn(endpointName);
@@ -140,7 +77,7 @@ public class ProxyEndpointResolverTest {
 
         ProxyEndpoint connectorEndpoint = resolver.resolve(requestEndpoint);
 
-        Assert.assertNull(connectorEndpoint);
+        assertThat(connectorEndpoint).isNull();
         verify(endpoint, never()).target();
         verify(endpoint, never()).available();
 
@@ -148,118 +85,34 @@ public class ProxyEndpointResolverTest {
         verify(loadBalancedEndpointGroup, never()).next();
     }
 
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withParenthesisInQuery() {
-        resolveUserDefinedEndpoint("http://host:8080/test(q=1)", "local:(q=1)", "local", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withSlashParenthesisInQuery() {
-        resolveUserDefinedEndpoint("http://host:8080/test/(q=1)", "local:/(q=1)", "local", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withSpacesInName() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "lo cal:", "lo cal", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withDashInName() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "lo-cal:", "lo-cal", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withSlashInTargetAndPath() {
-        resolveUserDefinedEndpoint("http://host:8080/method", "local:/method", "local", "http://host:8080/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_withSlashInTargetAndPath() {
-        resolveUserDefinedEndpoint("http://host:8080/method/", "local:/method/", "local", "http://host:8080/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withPrefixAndEncodedTargetURI() {
-        resolveUserDefinedEndpoint("http://host:8080/test toto  tété/titi", "local:test toto  tété/titi", "local", "http://host:8080/");
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withEndpointDiscoveryName() {
-        resolveUserDefinedEndpoint("http://host:8080/test", "consul#endpoint_id:", "consul#endpoint_id", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldUseTheRawPath_withEncodedTargetURI() {
-        resolveUserDefinedEndpoint("http://host:8080/foo%2f%3fbar", "http://host:8080/foo%2f%3fbar", "endpoint", "http://host:8080/test");
-    }
-
-    @Test
-    public void shouldResolveEndpoint_withColonInPath() {
-        resolveUserDefinedEndpoint("http://host:8080/foo:", "endpoint:/foo:", "endpoint", "http://host:8080/");
-    }
-
-    /*
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withQueryParamsInTarget() {
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("endpointParam", "v");
-        resolveUserDefinedEndpoint(
-                "http://host:8080/test",
-                parameters,
-                "local:",
-                "local",
-                "http://host:8080/test?endpointParam=v"
-        );
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withQueryParamsInDynRout() {
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("dynroutParam", "v");
-        resolveUserDefinedEndpoint(
-                "http://host:8080/test",
-                parameters,
-                "local:?dynroutParam=v",
-                "local",
-                "http://host:8080/test"
-        );
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withQueryParamsEverywhere() {
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("dynroutParam", "v");
-        parameters.add("endpointParam", "v");
-        resolveUserDefinedEndpoint(
-                "http://host:8080/test",
-                parameters,
-                "local:?dynroutParam=v",
-                "local",
-                "http://host:8080/test?endpointParam=v"
-        );
-    }
-
-    @Test
-    public void shouldResolveUserDefinedEndpoint_withQueryParamsEverywhereAnPath() {
-        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
-        parameters.add("dynroutParam", "v");
-        parameters.add("endpointParam", "v");
-        resolveUserDefinedEndpoint(
-                "http://host:8080/test/my/path",
-                parameters,
-                "local:/my/path?dynroutParam=v",
-                "local",
-                "http://host:8080/test?endpointParam=v"
-        );
-    }
-    */
-
-    @Test
-    public void shouldResolveUserDefinedEndpointAndKeepLastSlash_selectFirstEndpoint_wss() {
-        resolveUserDefinedEndpoint("wss://host:8080/test/", "wss://host:8080/test/", "endpoint", "wss://endpoint:8080/test/");
-    }
-
-    private void resolveUserDefinedEndpoint(String expectedURI, String requestEndpoint, String endpointName, String endpointTarget) {
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = "|",
+        textBlock = """
+                    http://endpoint:8080/test/myendpoint|/myendpoint|endpoint|http://endpoint:8080/test
+                    http://endpoint:8080/test/myendpoint|/myendpoint|endpoint|http://endpoint:8080/test/
+                    http://host:8080/test|local:|local|http://host:8080/test
+                    http://host:8080/test/|local:|local|http://host:8080/test/
+                    http://host:8080/test|lo/cal:|lo/cal|http://host:8080/test
+                    http://host:8080/test|lo(cal:|lo(cal|http://host:8080/test
+                    http://host:8080/test/|http://host:8080/test/|endpoint|http://endpoint:8080/test/
+                    http://host:8080/test|http://host:8080/test|endpoint|http://endpoint:8080/test
+                    http://host:8080/test(q=1)|local:(q=1)|local|http://host:8080/test
+                    http://host:8080/test/(q=1)|local:/(q=1)|local|http://host:8080/test
+                    http://host:8080/test|lo cal:|lo cal|http://host:8080/test
+                    http://host:8080/test|lo-cal:|lo-cal|http://host:8080/test
+                    http://host:8080/method|local:/method|local|http://host:8080/
+                    http://host:8080/method/|local:/method/|local|http://host:8080/
+                    http://host:8080/test toto  tété/titi|local:test toto  tété/titi|local|http://host:8080/
+                    http://host:8080/test|consul#endpoint_id:|consul#endpoint_id|http://host:8080/test
+                    http://host:8080/foo%2f%3fbar|http://host:8080/foo%2f%3fbar|endpoint|http://host:8080/test
+                    http://host:8080/foo:|endpoint:/foo:|endpoint|http://host:8080/
+                    wss://host:8080/test/|wss://host:8080/test/|endpoint|wss://endpoint:8080/test/
+                    http://host:8080/test toto  tété/titi|http://host:8080/test toto  tété/titi|endpoint|http://host:8080/test
+                    http://host:8080/test/ toto  tété/titi|http://host:8080/test/ toto  tété/titi|endpoint|http://host:8080/test
+                    """
+    )
+    void resolveUserDefinedEndpoint(String expectedURI, String requestEndpoint, String endpointName, String endpointTarget) {
         Endpoint endpoint = mock(Endpoint.class);
         when(endpoint.name()).thenReturn(endpointName);
         when(endpoint.target()).thenReturn(endpointTarget);
@@ -269,9 +122,9 @@ public class ProxyEndpointResolverTest {
         when(loadBalancedEndpointGroup.next()).thenReturn(endpoint);
 
         ProxyEndpoint proxyEndpoint = resolver.resolve(requestEndpoint);
-        Assert.assertNotNull(proxyEndpoint);
+        assertThat(proxyEndpoint).isNotNull();
 
         ProxyRequest proxyRequest = proxyEndpoint.createProxyRequest(mock((Request.class)));
-        Assert.assertEquals(expectedURI, proxyRequest.uri());
+        assertThat(proxyRequest.uri()).isEqualTo(expectedURI);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/UserDefinedProxyEndpointTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/UserDefinedProxyEndpointTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.core.endpoint.resolver;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,8 +24,7 @@ import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.endpoint.Endpoint;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -34,53 +34,41 @@ public class UserDefinedProxyEndpointTest {
 
     @Test
     public void shouldCreateProxyRequest_withQueryParamsFromTarget() {
-        MultiValueMap<String, String> expectedParameters = new LinkedMultiValueMap<>();
-        expectedParameters.add("endpointParam", "v");
-
-        ProxyRequest proxyRequest = new UserDefinedProxyEndpoint(mock(Endpoint.class), "http://host:8080/test?endpointParam=v")
+        String queryParamKey = "endpointParam";
+        ProxyRequest proxyRequest = new UserDefinedProxyEndpoint(
+            mock(Endpoint.class),
+            "http://host:8080/test?%s=v".formatted(queryParamKey)
+        )
             .createProxyRequest(mock(Request.class));
 
-        Assert.assertNotNull(proxyRequest);
-        Assert.assertNotNull(proxyRequest.parameters());
-
-        expectedParameters.forEach((paramKey, paramValue) -> Assert.assertTrue(proxyRequest.parameters().containsKey(paramKey)));
+        assertThat(proxyRequest.parameters()).containsKeys(queryParamKey);
     }
 
     @Test
     public void shouldCreateProxyRequest_withQueryParamsFromRequest() {
-        MultiValueMap<String, String> expectedParameters = new LinkedMultiValueMap<>();
-        expectedParameters.add("dynroutParam", "v");
-
+        String queryParamKey = "dynroutParam";
         Request request = mock(Request.class);
         MultiValueMap<String, String> requestQueryParameters = new LinkedMultiValueMap<>();
-        requestQueryParameters.add("dynroutParam", "v");
+        requestQueryParameters.add(queryParamKey, "v");
         when(request.parameters()).thenReturn(requestQueryParameters);
 
         ProxyRequest proxyRequest = new UserDefinedProxyEndpoint(mock(Endpoint.class), "http://host:8080/test").createProxyRequest(request);
 
-        Assert.assertNotNull(proxyRequest);
-        Assert.assertNotNull(proxyRequest.parameters());
-
-        expectedParameters.forEach((paramKey, paramValue) -> Assert.assertTrue(proxyRequest.parameters().containsKey(paramKey)));
+        assertThat(proxyRequest.parameters()).containsKeys(queryParamKey);
     }
 
     @Test
     public void shouldCreateProxyRequest_withQueryParamsFromRequestAndTarget() {
-        MultiValueMap<String, String> expectedParameters = new LinkedMultiValueMap<>();
-        expectedParameters.add("dynroutParam", "v");
-        expectedParameters.add("endpointParam", "v");
-
+        String queryParamKey = "dynroutParam";
+        String urlParamKey = "endpointParam";
         Request request = mock(Request.class);
         MultiValueMap<String, String> requestQueryParameters = new LinkedMultiValueMap<>();
-        requestQueryParameters.add("dynroutParam", "v");
+        requestQueryParameters.add(queryParamKey, "v");
         when(request.parameters()).thenReturn(requestQueryParameters);
 
-        ProxyRequest proxyRequest = new UserDefinedProxyEndpoint(mock(Endpoint.class), "http://host:8080/test?endpointParam=v")
+        var proxyRequest = new UserDefinedProxyEndpoint(mock(Endpoint.class), "http://host:8080/test?%s=v".formatted(urlParamKey))
             .createProxyRequest(request);
 
-        Assert.assertNotNull(proxyRequest);
-        Assert.assertNotNull(proxyRequest.parameters());
-
-        expectedParameters.forEach((paramKey, paramValue) -> Assert.assertTrue(proxyRequest.parameters().containsKey(paramKey)));
+        assertThat(proxyRequest.parameters()).containsKeys(queryParamKey, urlParamKey);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/logging/condition/evaluation/el/ExpressionLanguageBasedConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/logging/condition/evaluation/el/ExpressionLanguageBasedConditionFilterTest.java
@@ -15,22 +15,23 @@
  */
 package io.gravitee.gateway.core.logging.condition.evaluation.el;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.core.logging.condition.el.ExpressionLanguageBasedConditionEvaluator;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ExpressionLanguageBasedConditionFilterTest {
 
     @Mock
@@ -38,9 +39,9 @@ public class ExpressionLanguageBasedConditionFilterTest {
 
     private final TemplateEngine templateEngine = TemplateEngine.templateEngine();
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        when(context.getTemplateEngine()).thenReturn(templateEngine);
+        lenient().when(context.getTemplateEngine()).thenReturn(templateEngine);
     }
 
     @Test
@@ -49,7 +50,7 @@ public class ExpressionLanguageBasedConditionFilterTest {
         Request request = mock(Request.class);
         boolean evaluate = evaluator.evaluate(context, request);
 
-        assertTrue(evaluate);
+        assertThat(evaluate).isTrue();
     }
 
     @Test
@@ -58,24 +59,16 @@ public class ExpressionLanguageBasedConditionFilterTest {
         Request request = mock(Request.class);
         boolean evaluate = evaluator.evaluate(context, request);
 
-        assertTrue(evaluate);
+        assertThat(evaluate).isTrue();
     }
 
-    @Test
-    public void shouldEvalFalseWithFalse() {
-        ExpressionLanguageBasedConditionEvaluator evaluator = new ExpressionLanguageBasedConditionEvaluator("false");
+    @ParameterizedTest
+    @ValueSource(strings = { "foo bar", "false" })
+    public void shouldEvalFalse(String input) {
+        ExpressionLanguageBasedConditionEvaluator evaluator = new ExpressionLanguageBasedConditionEvaluator(input);
         Request request = mock(Request.class);
         boolean evaluate = evaluator.evaluate(context, request);
 
-        assertFalse(evaluate);
-    }
-
-    @Test
-    public void shouldEvalFalseWithParseException() {
-        ExpressionLanguageBasedConditionEvaluator evaluator = new ExpressionLanguageBasedConditionEvaluator("foo bar");
-        Request request = mock(Request.class);
-        boolean evaluate = evaluator.evaluate(context, request);
-
-        assertFalse(evaluate);
+        assertThat(evaluate).isFalse();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/condition/CompositeConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/condition/CompositeConditionFilterTest.java
@@ -54,34 +54,26 @@ class CompositeConditionFilterTest {
 
     @Test
     void shouldNotFilterWhenAllEvaluatorsReturnTheValue() {
-        final CompositeConditionFilter<BaseExecutionContext, ConditionSupplier> cut = new CompositeConditionFilter<>(
-            evaluator1,
-            evaluator2,
-            evaluator3
-        );
+        final var cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilter(evaluator3);
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult(conditionSupplier);
     }
 
     @Test
     void shouldFilterWhenOneEvaluatorReturnsEmpty() {
-        final CompositeConditionFilter<BaseExecutionContext, ConditionSupplier> cut = new CompositeConditionFilter<>(
-            evaluator1,
-            evaluator2,
-            evaluator3
-        );
+        final var cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilterEmpty(evaluator3);
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult();
         obs.assertNoValues();
@@ -89,17 +81,13 @@ class CompositeConditionFilterTest {
 
     @Test
     void shouldErrorWhenOneEvaluatorReturnsError() {
-        final CompositeConditionFilter<BaseExecutionContext, ConditionSupplier> cut = new CompositeConditionFilter<>(
-            evaluator1,
-            evaluator2,
-            evaluator3
-        );
+        final var cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilterError(evaluator3);
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertError(RuntimeException.class);
         obs.assertError(t -> MOCK_EXCEPTION.equals(t.getMessage()));
@@ -107,15 +95,11 @@ class CompositeConditionFilterTest {
 
     @Test
     void shouldNotContinueWhenReturnsEmpty() {
-        final CompositeConditionFilter<BaseExecutionContext, ConditionSupplier> cut = new CompositeConditionFilter<>(
-            evaluator1,
-            evaluator2,
-            evaluator3
-        );
+        final var cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilterEmpty(evaluator1);
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult();
         obs.assertNoValues();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/condition/ExpressionLanguageConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/condition/ExpressionLanguageConditionFilterTest.java
@@ -23,7 +23,6 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.reactivex.rxjava3.core.Maybe;
-import io.reactivex.rxjava3.observers.TestObserver;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -51,7 +50,7 @@ class ExpressionLanguageConditionFilterTest {
         when(ctx.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.just(true));
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult(conditionSupplier);
     }
@@ -60,7 +59,7 @@ class ExpressionLanguageConditionFilterTest {
     void shouldNotFilterWhenEmptyCondition() {
         final ConditionSupplier conditionSupplier = () -> "";
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult(conditionSupplier);
     }
@@ -68,7 +67,7 @@ class ExpressionLanguageConditionFilterTest {
     @Test
     void shouldNotFilterWhenNullCondition() {
         final ConditionSupplier conditionSupplier = () -> null;
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult(conditionSupplier);
     }
@@ -79,7 +78,7 @@ class ExpressionLanguageConditionFilterTest {
         when(ctx.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.just(false));
 
-        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
+        final var obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult();
         obs.assertNoValues();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultDeploymentContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/DefaultDeploymentContextTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.reactive.core.context;
 
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,6 +24,7 @@ import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import java.util.List;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,8 +75,10 @@ class DefaultDeploymentContextTest {
     void shouldInitializeTemplateEngineOnlyOnce() {
         final TemplateEngine templateEngine = cut.getTemplateEngine();
 
+        var soft = new SoftAssertions();
         for (int i = 0; i < 10; i++) {
-            assertSame(templateEngine, cut.getTemplateEngine());
+            soft.assertThat(templateEngine).as("check %d th getTemplate()", i).isSameAs(cut.getTemplateEngine());
         }
+        soft.assertAll();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/hook/HookHelperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/hook/HookHelperTest.java
@@ -41,10 +41,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class HookHelperTest {
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private PolicyMessageHook mockHook;
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private PolicyMessageHook mockHook2;
 
     @Mock
@@ -52,16 +52,16 @@ class HookHelperTest {
 
     @BeforeEach
     public void beforeEach() {
-        lenient().when(mockHook.pre(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook.post(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook.error(any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook.interrupt(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook.interruptWith(any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook2.pre(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook2.post(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook2.error(any(), any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook2.interrupt(any(), any(), any())).thenReturn(Completable.complete());
-        lenient().when(mockHook2.interruptWith(any(), any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook.pre(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook.post(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook.error(any(), any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook.interrupt(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook.interruptWith(any(), any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook2.pre(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook2.post(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook2.error(any(), any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook2.interrupt(any(), any(), any())).thenReturn(Completable.complete());
+        when(mockHook2.interruptWith(any(), any(), any(), any())).thenReturn(Completable.complete());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/processor/ProcessorChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/processor/ProcessorChainTest.java
@@ -22,21 +22,20 @@ import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(MockitoExtension.class)
 class ProcessorChainTest {
 
+    @Mock
     private Processor mockProcessor;
-
-    @BeforeEach
-    public void init() {
-        mockProcessor = mock(Processor.class);
-    }
 
     @Test
     public void shouldCompleteWithNullProcessors() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/loadbalancer/LoadBalancerStrategyFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/loadbalancer/LoadBalancerStrategyFactoryTest.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.reactive.core.v4.endpoint.loadbalancer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.gravitee.definition.model.v4.endpointgroup.loadbalancer.LoadBalancerType;
 import java.util.List;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/TcpEndpointInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/TcpEndpointInvokerTest.java
@@ -59,7 +59,6 @@ class TcpEndpointInvokerTest {
 
     @Test
     void should_not_connect_to_endpoint_connector_not_resolved() {
-        final TcpEntrypointConnector tcpEntrypointConnector = mock(TcpEntrypointConnector.class);
         when(endpointManager.next()).thenReturn(null);
         cut
             .invoke(ctx)
@@ -73,8 +72,6 @@ class TcpEndpointInvokerTest {
 
     @Test
     void should_connect_to_endpoint_connector() {
-        final TcpEntrypointConnector tcpEntrypointConnector = mock(TcpEntrypointConnector.class);
-
         final ManagedEndpoint managedEndpoint = mock(ManagedEndpoint.class);
         when(endpointManager.next()).thenReturn(managedEndpoint);
         final TcpEndpointConnector endpoint = mock(TcpEndpointConnector.class);


### PR DESCRIPTION
**Issue** No issue related

## Description

Just little PR to remove junit4 usages and use assertj in `gravitee-apim-gateway-core`.

In DefaultExecutionContextTest I create dedicated test case for float
because the test is broken since JDK19 related to a fix in Double.toString()

https://inside.java/2022/09/23/quality-heads-up/
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hyroeqptzm.chromatic.com)
<!-- Storybook placeholder end -->
