### PR TITLE
chore: update gravitee-policy-json-validation to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <gravitee-policy-javascript.version>1.3.3</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>1.4.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
-        <gravitee-policy-json-validation.version>1.7.1</gravitee-policy-json-validation.version>
+        <gravitee-policy-json-validation.version>2.0.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.6.1</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>6.0.0</gravitee-policy-jwt.version>


### PR DESCRIPTION
**Issue** [APIM-7216](https://gravitee.atlassian.net/browse/APIM-7216)

## Description

Now the json validation policy should be usable with async API



[APIM-7216]: https://gravitee.atlassian.net/browse/APIM-7216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hzoapbmoqq.chromatic.com)
<!-- Storybook placeholder end -->
