### PR TITLE
chore: bump http-get and http-post entrypoints version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,8 +269,8 @@
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>
 
         <!-- Enterprise plugins -->
-        <gravitee-entrypoint-http-get.version>2.0.0</gravitee-entrypoint-http-get.version>
-        <gravitee-entrypoint-http-post.version>2.0.0</gravitee-entrypoint-http-post.version>
+        <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
+        <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.0</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>4.0.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8052

## Description

Bump http-get and http-post entrypoints to latest.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qxoiclhjsg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://pr.team-apim.gravitee.dev/10287/console](https://pr.team-apim.gravitee.dev/10287/console)
      Portal: [https://pr.team-apim.gravitee.dev/10287/portal](https://pr.team-apim.gravitee.dev/10287/portal)
      Management-api: [https://pr.team-apim.gravitee.dev/10287/api/management](https://pr.team-apim.gravitee.dev/10287/api/management)
      Gateway v4: [https://pr.team-apim.gravitee.dev/10287](https://pr.team-apim.gravitee.dev/10287)
      Gateway v3: [https://pr.gateway-v3.team-apim.gravitee.dev/10287](https://pr.gateway-v3.team-apim.gravitee.dev/10287)

<!-- Environment placeholder end -->
