### PR TITLE
fix: enforce to create not empty ruleset

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentScoringRulesetsResource.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.environment;
 
-import io.gravitee.apim.core.scoring.model.ScoreRequest;
-import io.gravitee.apim.core.scoring.model.ScoringRuleset;
 import io.gravitee.apim.core.scoring.use_case.GetEnvironmentRulesetsUseCase;
 import io.gravitee.apim.core.scoring.use_case.ImportEnvironmentRulesetUseCase;
 import io.gravitee.common.http.MediaType;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -592,12 +592,15 @@ components:
             properties:
                 name:
                     type: string
+                    minLength: 1
                     description: The name of ruleset
                 description:
                     type: string
+                    minLength: 1
                     description: The description of ruleset
                 payload:
                     type: string
+                    minLength: 1
                     description: The ruleset payload
                 format:
                     type: string
@@ -606,6 +609,11 @@ components:
                         - GRAVITEE_FEDERATION
                         - GRAVITEE_MESSAGE
                         - GRAVITEE_PROXY
+            required:
+              - name
+              - description
+              - payload
+              - format
         UpdateScoringRuleset:
             type: object
             description: The scoring ruleset to update


### PR DESCRIPTION
**Issue** [APIM-8021](https://gravitee.atlassian.net/browse/APIM-8021)

## Description

Forbid to create a ruleset without payload



[APIM-8021]: https://gravitee.atlassian.net/browse/APIM-8021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vtoljypurz.chromatic.com)
<!-- Storybook placeholder end -->
