### PR TITLE
refactor execution context

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractBaseExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractBaseExecutionContext.java
@@ -17,10 +17,12 @@ package io.gravitee.gateway.reactive.core.context;
 
 import io.gravitee.common.util.ListUtils;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +36,8 @@ public abstract class AbstractBaseExecutionContext implements BaseExecutionConte
     protected Map<String, Object> internalAttributes = new HashMap<>();
     protected ComponentProvider componentProvider;
     protected TemplateEngine templateEngine;
+    protected Collection<TemplateVariableProvider> templateVariableProviders;
+
     protected Tracer tracer;
     private final long timestamp = System.currentTimeMillis();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.reactive.core.context;
 import io.gravitee.common.util.ListUtils;
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
-import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
@@ -35,7 +34,6 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +45,6 @@ public abstract class AbstractExecutionContext<RQ extends MutableRequest, RS ext
     protected RQ request;
     protected RS response;
     protected Metrics metrics;
-    protected Collection<TemplateVariableProvider> templateVariableProviders;
 
     private EvaluableRequest evaluableRequest;
     private EvaluableResponse evaluableResponse;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
@@ -20,7 +20,6 @@ import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
@@ -37,7 +36,6 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,11 +46,7 @@ public abstract class AbstractExecutionContext<RQ extends MutableRequest, RS ext
 
     protected RQ request;
     protected RS response;
-    protected Map<String, Object> attributes = new ContextAttributeMap();
-    protected Map<String, Object> internalAttributes = new HashMap<>();
     protected Metrics metrics;
-    protected ComponentProvider componentProvider;
-    protected TemplateEngine templateEngine;
     protected Collection<TemplateVariableProvider> templateVariableProviders;
 
     private EvaluableRequest evaluableRequest;


### PR DESCRIPTION
## Issue

N/A

## Description

 - remove useless declaration in `AbstractExecutionContext` because they are already defined in `AbstractBaseExecutionContext`
 - move `templateVariableProviders` collection in parent class `AbstractBaseExecutionContext`