### PR TITLE
feat(helm): improve api and gateway scalability configuration

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.3.21
+
+- Improve HPA by allowing custom annotation, custom metrics and define the behavior spec (APIM-8186)
+
 ### 4.3.16
 
 - add missing haproxy mapping attribute

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -23,4 +23,5 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - "Improve HPA by allowing custom annotation, custom metrics and define the behavior spec (APIM-8186)"

--- a/helm/templates/api/api-autoscaler.yaml
+++ b/helm/templates/api/api-autoscaler.yaml
@@ -22,6 +22,11 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.api.autoscaling.annotations }}
+    {{- range $key, $value := .Values.api.autoscaling.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -29,6 +34,7 @@ spec:
     name: {{ template "gravitee.api.fullname" . }}
   minReplicas: {{ .Values.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.api.autoscaling.maxReplicas }}
+{{- if not .Values.api.autoscaling.metrics }}
   metrics:
 {{- if .Values.api.autoscaling.targetMemoryAverageUtilization }}
   - type: Resource
@@ -52,4 +58,12 @@ spec:
       {{ else }}
       targetAverageUtilization: {{ .Values.api.autoscaling.targetAverageUtilization }}
       {{- end -}}
+{{ else }}
+  metrics:
+    {{ toYaml .Values.api.autoscaling.metrics | indent 4 | trim }}
+{{- end -}}
+{{- if .Values.api.autoscaling.behavior }}
+  behavior:
+    {{ toYaml .Values.api.autoscaling.behavior | indent 4 | trim }}
+{{- end -}}
 {{- end -}}

--- a/helm/templates/gateway/gateway-autoscaler.yaml
+++ b/helm/templates/gateway/gateway-autoscaler.yaml
@@ -24,6 +24,11 @@ metadata:
     {{- range $key, $value := $annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.gateway.autoscaling.annotations }}
+    {{- range $key, $value := .Values.gateway.autoscaling.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -31,6 +36,7 @@ spec:
     name: {{ template "gravitee.gateway.fullname" . }}
   minReplicas: {{ .Values.gateway.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.gateway.autoscaling.maxReplicas }}
+{{- if not .Values.gateway.autoscaling.metrics }}
   metrics:
 {{- if .Values.gateway.autoscaling.targetMemoryAverageUtilization }}
   - type: Resource
@@ -54,4 +60,12 @@ spec:
       {{ else }}
       targetAverageUtilization: {{ .Values.gateway.autoscaling.targetAverageUtilization }}
       {{- end -}}
+{{ else }}
+  metrics:
+    {{ toYaml .Values.gateway.autoscaling.metrics | indent 4 | trim }}
+{{- end -}}
+{{- if .Values.gateway.autoscaling.behavior }}
+  behavior:
+    {{ toYaml .Values.gateway.autoscaling.behavior | indent 4 | trim }}
+{{- end -}}
 {{- end -}}

--- a/helm/templates/portal/portal-autoscaler.yaml
+++ b/helm/templates/portal/portal-autoscaler.yaml
@@ -22,6 +22,11 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.portal.autoscaling.annotations }}
+    {{- range $key, $value := .Values.portal.autoscaling.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -29,6 +34,7 @@ spec:
     name: {{ template "gravitee.portal.fullname" . }}
   minReplicas: {{ .Values.portal.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.portal.autoscaling.maxReplicas }}
+{{- if not .Values.portal.autoscaling.metrics }}
   metrics:
 {{- if .Values.portal.autoscaling.targetMemoryAverageUtilization }}
   - type: Resource
@@ -52,4 +58,12 @@ spec:
       {{ else }}
       targetAverageUtilization: {{ .Values.portal.autoscaling.targetAverageUtilization }}
       {{- end -}}
+{{ else }}
+  metrics:
+    {{ toYaml .Values.portal.autoscaling.metrics | indent 4 | trim }}
+{{- end -}}
+{{- if .Values.portal.autoscaling.behavior }}
+  behavior:
+    {{ toYaml .Values.portal.autoscaling.behavior | indent 4 | trim }}
+{{- end -}}
 {{- end -}}

--- a/helm/templates/ui/ui-autoscaler.yaml
+++ b/helm/templates/ui/ui-autoscaler.yaml
@@ -22,6 +22,11 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.ui.autoscaling.annotations }}
+    {{- range $key, $value := .Values.ui.autoscaling.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -29,6 +34,7 @@ spec:
     name: {{ template "gravitee.ui.fullname" . }}
   minReplicas: {{ .Values.ui.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.ui.autoscaling.maxReplicas }}
+{{- if not .Values.ui.autoscaling.metrics }}
   metrics:
 {{- if .Values.ui.autoscaling.targetMemoryAverageUtilization }}
   - type: Resource
@@ -52,4 +58,12 @@ spec:
       {{ else }}
       targetAverageUtilization: {{ .Values.ui.autoscaling.targetAverageUtilization }}
       {{- end -}}
+{{ else }}
+  metrics:
+    {{ toYaml .Values.ui.autoscaling.metrics | indent 4 | trim }}
+{{- end -}}
+{{- if .Values.ui.autoscaling.behavior }}
+  behavior:
+    {{ toYaml .Values.ui.autoscaling.behavior | indent 4 | trim }}
+{{- end -}}
 {{- end -}}

--- a/helm/tests/api/autoscaler_test.yaml
+++ b/helm/tests/api/autoscaler_test.yaml
@@ -47,3 +47,121 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Check custom annotations
+    set:
+      global:
+        kubeVersion: 1.23.0
+      api:
+        enabled: true
+        autoscaling:
+          enabled: true
+          annotations:
+            custom-annotation: "custom-value"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: "custom-value"
+
+  - it: Check metrics overwrite
+    set:
+      global:
+        kubeVersion: 1.23.0
+      api:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 50
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 30
+
+  - it: Check behavior definition
+    set:
+      global:
+        kubeVersion: 1.23.0
+      api:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+          behavior:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: spec.behavior
+          content:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60

--- a/helm/tests/gateway/autoscaler_test.yaml
+++ b/helm/tests/gateway/autoscaler_test.yaml
@@ -51,3 +51,121 @@ tests:
           of: HorizontalPodAutoscaler
       - isAPIVersion:
           of: autoscaling/v2
+
+  - it: Check custom annotations
+    set:
+      global:
+        kubeVersion: 1.23.0
+      gateway:
+        enabled: true
+        autoscaling:
+          enabled: true
+          annotations:
+            custom-annotation: "custom-value"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: "custom-value"
+
+  - it: Check metrics overwrite
+    set:
+      global:
+        kubeVersion: 1.23.0
+      gateway:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 50
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 30
+
+  - it: Check behavior definition
+    set:
+      global:
+        kubeVersion: 1.23.0
+      gateway:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+          behavior:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: spec.behavior
+          content:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60

--- a/helm/tests/portal/autoscaler_test.yaml
+++ b/helm/tests/portal/autoscaler_test.yaml
@@ -47,3 +47,121 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: Check custom annotations
+    set:
+      global:
+        kubeVersion: 1.23.0
+      portal:
+        enabled: true
+        autoscaling:
+          enabled: true
+          annotations:
+            custom-annotation: "custom-value"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: "custom-value"
+
+  - it: Check metrics overwrite
+    set:
+      global:
+        kubeVersion: 1.23.0
+      portal:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 50
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 30
+
+  - it: Check behavior definition
+    set:
+      global:
+        kubeVersion: 1.23.0
+      portal:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+          behavior:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: spec.behavior
+          content:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60

--- a/helm/tests/ui/autoscaler_test.yaml
+++ b/helm/tests/ui/autoscaler_test.yaml
@@ -48,3 +48,120 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: Check custom annotations
+    set:
+      global:
+        kubeVersion: 1.23.0
+      ui:
+        enabled: true
+        autoscaling:
+          enabled: true
+          annotations:
+            custom-annotation: "custom-value"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: metadata.annotations
+          content:
+            custom-annotation: "custom-value"
+
+  - it: Check metrics overwrite
+    set:
+      global:
+        kubeVersion: 1.23.0
+      ui:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 50
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 30
+
+  - it: Check behavior definition
+    set:
+      global:
+        kubeVersion: 1.23.0
+      ui:
+        enabled: true
+        autoscaling:
+          enabled: true
+          metrics:
+            - type: Resource
+              resource:
+                name: memory
+                target:
+                  type: Utilization
+                  averageUtilization: 50
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 30
+          behavior:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isSubset:
+          path: spec.behavior
+          content:
+            scaleDown:
+              policies:
+                - type: Pods
+                  value: 4
+                  periodSeconds: 60
+                - type: Percent
+                  value: 10
+                  periodSeconds: 60

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -688,11 +688,21 @@ api:
 #    appProtocol: http
   # annotations:
   autoscaling:
+    # When api.autoscaling.enabled is true, a HorizontalPodAutoscaler is created
     enabled: true
     minReplicas: 1
     maxReplicas: 3
+    # warning: these two target utilization will be overwritten if api.autoscaling.metrics is defined.
     targetAverageUtilization: 50
     targetMemoryAverageUtilization: 80
+    # here you can add specific annotations to this HPA
+#    annotations:
+    # If default CPU and Memory utilisation is not enough, you can here overwrite the metrics with your settings
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+#    metrics:
+    # Optionnaly you can also add behavior
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+#    behavior:
   ingress:
     management:
       enabled: true
@@ -1156,11 +1166,21 @@ gateway:
 #    appProtocol: http
   # annotations:
   autoscaling:
+    # When gateway.autoscaling.enabled is true, a HorizontalPodAutoscaler is created
     enabled: true
     minReplicas: 1
     maxReplicas: 3
+    # warning: these two target utilization will be overwritten if gateway.autoscaling.metrics is defined.
     targetAverageUtilization: 50
     targetMemoryAverageUtilization: 80
+    # here you can add specific annotations to this HPA
+#    annotations:
+    # If default CPU and Memory utilisation is not enough, you can here overwrite the metrics with your settings
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+#    metrics:
+    # Optionnaly you can also add behavior
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+#    behavior:
   ingress:
     enabled: true
     pathType: Prefix
@@ -1316,11 +1336,21 @@ portal:
   #         name: special-config
   #         key: SPECIAL_LEVEL
   autoscaling:
+    # When portal.autoscaling.enabled is true, a HorizontalPodAutoscaler is created
     enabled: true
     minReplicas: 1
     maxReplicas: 3
+    # warning: these two target utilization will be overwritten if portal.autoscaling.metrics is defined.
     targetAverageUtilization: 50
     targetMemoryAverageUtilization: 80
+    # here you can add specific annotations to this HPA
+#    annotations:
+    # If default CPU and Memory utilisation is not enough, you can here overwrite the metrics with your settings
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+#    metrics:
+    # Optionnaly you can also add behavior
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+#    behavior:
   service:
     name: nginx
     type: ClusterIP
@@ -1503,11 +1533,21 @@ ui:
   #         name: special-config
   #         key: SPECIAL_LEVEL
   autoscaling:
+    # When ui.autoscaling.enabled is true, a HorizontalPodAutoscaler is created
     enabled: true
     minReplicas: 1
     maxReplicas: 3
+    # warning: these two target utilization will be overwritten if ui.autoscaling.metrics is defined.
     targetAverageUtilization: 50
     targetMemoryAverageUtilization: 80
+    # here you can add specific annotations to this HPA
+#    annotations:
+    # If default CPU and Memory utilisation is not enough, you can here overwrite the metrics with your settings
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+#    metrics:
+    # Optionnaly you can also add behavior
+    # @see: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior
+#    behavior:
   service:
     name: nginx
     type: ClusterIP


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8186
https://gravitee.atlassian.net/browse/TT-5778

## Description

When `autoscaling` is enable, an `HorizontalPodAutoscaler` is created.
However the existing one only set CPU and Memory metrics and doesn't
allow custom definition neither `behavior` setting.

This commit add the capability to overwrite metrics, define a behavior
and as a bonus define specific annotation if needed.

For more information you can read official documentation:

* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
* https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
