### PR TITLE
feat: improved API Score status handling

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-score/dashboard/api-score-dashboard.component.html
+++ b/gravitee-apim-console-webui/src/management/api-score/dashboard/api-score-dashboard.component.html
@@ -157,7 +157,7 @@
         <ng-container matColumnDef="score">
           <th mat-header-cell *matHeaderCellDef id="score">Score</th>
           <td mat-cell *matCellDef="let element">
-            @if (element.score == null) {
+            @if (element.score == null || element.score < 0) {
               <span class="gio-badge-neutral">Not available</span>
             } @else if (element.score >= 0.8) {
               <span class="gio-badge-success"

--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.html
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.html
@@ -26,27 +26,30 @@
       <mat-card-title>
         {{ api.name }}
 
-        @if (apiScoring.summary.score == null) {
-          <span></span>
-        } @else if (apiScoring.summary.score >= 0.8) {
+        @if (apiScoreNeverEvaluated || !apiScoreAvailable) {
+          <span class="gio-badge-neutral">Not available</span>
+        } @else if (apiScoreAvailable && apiScoring?.summary.score >= 0.8) {
           <span class="gio-badge-success"
             ><mat-icon class="gio-left" svgIcon="gio:shield-check"></mat-icon> {{ apiScoring.summary.score * 100 | number: '1.0-0' }}%
           </span>
-        } @else if (apiScoring.summary.score >= 0.4) {
+        } @else if (apiScoreAvailable && apiScoring?.summary.score >= 0.4) {
           <span class="gio-badge-warning"
             ><mat-icon class="gio-left" svgIcon="gio:shield-check"></mat-icon> {{ apiScoring.summary.score * 100 | number: '1.0-0' }}%
           </span>
-        } @else if (apiScoring.summary.score >= 0) {
+        } @else if (apiScoreAvailable && apiScoring?.summary.score >= 0) {
           <span class="gio-badge-error"
             ><mat-icon class="gio-left" svgIcon="gio:shield-check"></mat-icon> {{ apiScoring.summary.score * 100 | number: '1.0-0' }}%
           </span>
+        }
+        @if (this.evaluationErrors.length > 0) {
+          <span class="gio-badge-error"><mat-icon svgIcon="gio:shield-alert"></mat-icon></span>
         }
 
         <!-- Uncomment when BE ready -->
         <!-- <span class="gio-badge-success"><mat-icon class="gio-left" svgIcon="gio:trending-up"></mat-icon>+0.7</span>-->
       </mat-card-title>
 
-      @if (apiScoring.createdAt) {
+      @if (apiScoreAvailable && apiScoring.createdAt) {
         <mat-card-subtitle> Last evaluated {{ apiScoring.createdAt | dateAgo }}</mat-card-subtitle>
       }
 
@@ -66,7 +69,7 @@
         </gio-banner-warning>
       }
 
-      @if (apiScoring.summary.all !== 0) {
+      @if (apiScoreAvailable && apiScoring.summary.all !== 0) {
         <section>
           <mat-button-toggle-group
             [hideSingleSelectionIndicator]="true"
@@ -94,11 +97,23 @@
       }
 
       <section class="api-scores-lists">
-        @if (apiScoring.summary.all === 0) {
+        @if (apiScoreNeverEvaluated) {
+          <gio-card-empty-state
+            icon="search"
+            title="This API has never been scored before"
+            [subtitle]="'Click on the Evaluate button to get the first score.'"
+          ></gio-card-empty-state>
+        } @else if (apiScoreAvailable && apiScoring.summary.all === 0 && apiScoring.summary.score === 1) {
           <gio-card-empty-state
             icon="rocket"
             title="All clear"
             [subtitle]="'There is no recommendations or issues for your API. \n Everything looks great!'"
+          ></gio-card-empty-state>
+        } @else if (!apiScoreAvailable && evaluationErrors.length === 0) {
+          <gio-card-empty-state
+            icon="shield-minus"
+            title="No scorable assets"
+            [subtitle]="'This API\'s assets did not match any rulesets.'"
           ></gio-card-empty-state>
         }
         @for (asset of apiScoring.assets; track asset.name) {

--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
@@ -51,6 +51,10 @@ export class ApiScoringComponent implements OnInit {
   public pendingScoreRequest: boolean;
   protected readonly ScoringSeverity = ScoringSeverity;
 
+  public apiScoreNeverEvaluated = false;
+  public apiScoreAvailable = false;
+  public evaluationErrors: ScoreEvaluationErrors[] = [];
+
   constructor(
     public readonly activatedRoute: ActivatedRoute,
     private readonly apiService: ApiV2Service,
@@ -116,9 +120,14 @@ export class ApiScoringComponent implements OnInit {
           if (!this.pendingScoreRequest) {
             this.stopPolling$.next();
 
-            const evaluationErrors = this.getEvaluationErrors(apiScoring);
-            if (evaluationErrors.length) {
-              this.snackBarService.error(this.formatEvaluationErrors(evaluationErrors));
+            if (apiScoring === undefined) {
+              this.apiScoreNeverEvaluated = true;
+            } else {
+              this.evaluationErrors = this.getEvaluationErrors(apiScoring);
+              if (this.evaluationErrors.length) {
+                this.snackBarService.error(this.formatEvaluationErrors(this.evaluationErrors));
+              }
+              this.apiScoreAvailable = this.apiScoring.summary !== undefined;
             }
           }
         },

--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.model.ts
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.model.ts
@@ -38,7 +38,7 @@ export enum ScoringSeverity {
 
 export interface ApiScoring {
   createdAt: Date;
-  summary: ApiScoringSummary;
+  summary?: ApiScoringSummary;
   assets: ScoringAsset[];
 }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcScoringReportRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcScoringReportRepository.java
@@ -255,7 +255,7 @@ class JdbcScoringReportRepository extends JdbcAbstractRepository<JdbcScoringRow>
         var result = jdbcTemplate.query(
             "select " +
             "environment_id, " +
-            "AVG(score) AS averageScore," +
+            "AVG(CASE WHEN score != -1 THEN score ELSE NULL END) AS averageScore," +
             "SUM(errors) AS totalErrors," +
             "SUM(warnings) AS totalWarnings," +
             "SUM(infos) AS totalInfos," +

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringReportMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/score/ScoringReportMongoRepositoryImpl.java
@@ -19,6 +19,7 @@ import static com.mongodb.client.model.Accumulators.avg;
 import static com.mongodb.client.model.Accumulators.sum;
 import static com.mongodb.client.model.Aggregates.*;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.ne;
 import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 
@@ -36,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -129,6 +129,7 @@ public class ScoringReportMongoRepositoryImpl implements ScoringReportMongoRepos
     public ScoringEnvironmentSummary getScoringEnvironmentSummary(String environmentId) {
         List<Bson> aggregations = new ArrayList<>();
         aggregations.add(match(eq("environmentId", environmentId)));
+        aggregations.add(match(ne("summary.score", -1)));
         aggregations.add(
             group(
                 "$environmentId",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
@@ -19,18 +19,9 @@ import io.gravitee.apim.core.scoring.use_case.GetLatestReportUseCase;
 import io.gravitee.apim.core.scoring.use_case.ScoreApiRequestUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.ScoringReportMapper;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoring;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringAsset;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringAssetType;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringDiagnostic;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringDiagnosticRange;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringPosition;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringSeverity;
-import io.gravitee.rest.api.management.v2.rest.model.ApiScoringSummary;
 import io.gravitee.rest.api.management.v2.rest.model.ApiScoringTriggerResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ScoringStatus;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -40,15 +31,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 
 public class ApiScoringResource extends AbstractResource {
-
-    static final ApiScoring EMPTY_REPORT = ApiScoring
-        .builder()
-        .summary(ApiScoringSummary.builder().all(0).errors(0).hints(0).infos(0).warnings(0).build())
-        .assets(List.of())
-        .build();
 
     @Inject
     private ScoreApiRequestUseCase scoreApiRequestUseCase;
@@ -73,11 +57,11 @@ public class ApiScoringResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public ApiScoring getApiScoring() {
+    public Response getApiScoring() {
         var report = getLatestReportUseCase.execute(new GetLatestReportUseCase.Input(apiId)).report();
         if (report == null) {
-            return EMPTY_REPORT;
+            return Response.status(Response.Status.NOT_FOUND).build();
         }
-        return ScoringReportMapper.INSTANCE.map(report);
+        return Response.ok(ScoringReportMapper.INSTANCE.map(report)).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2617,6 +2617,8 @@ paths:
             summary: Get API Scoring
             description: |-
                 Get API Scoring.
+                
+                Return a 404 HTTP Response status if API was never evaluated.
             operationId: getApiScoring
             responses:
                 "200":
@@ -7330,7 +7332,6 @@ components:
                     type: integer
                     description: An integer that represents the character position within the line where the issue starts or ends. The value is zero indexed.
                     example: 12
-
         # Async Jobs
         AsyncJob:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResourceTest.java
@@ -124,10 +124,10 @@ public class ApiScoringResourceTest extends ApiResourceTest {
     class GetLatestReport {
 
         @Test
-        void should_return_empty_response_if_no_report_found() {
+        void should_return_404_response_if_no_report_found() {
             final Response response = latestReportTarget.request().get();
 
-            MAPIAssertions.assertThat(response).hasStatus(OK_200).asEntity(ApiScoring.class).isEqualTo(ApiScoringResource.EMPTY_REPORT);
+            MAPIAssertions.assertThat(response).hasStatus(NOT_FOUND_404);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetLatestReportUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/GetLatestReportUseCase.java
@@ -45,21 +45,17 @@ public class GetLatestReportUseCase {
             })
             .toList();
 
-        return new Output(
-            new ScoringReportView(
-                report.id(),
-                report.apiId(),
-                report.createdAt(),
-                assets,
-                new ScoringReportView.Summary(
-                    report.summary().score(),
-                    report.summary().errors(),
-                    report.summary().warnings(),
-                    report.summary().infos(),
-                    report.summary().hints()
-                )
+        var summary = report.summary().score() != -1
+            ? new ScoringReportView.Summary(
+                report.summary().score(),
+                report.summary().errors(),
+                report.summary().warnings(),
+                report.summary().infos(),
+                report.summary().hints()
             )
-        );
+            : null;
+
+        return new Output(new ScoringReportView(report.id(), report.apiId(), report.createdAt(), assets, summary));
     }
 
     public record Input(String apiId) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCase.java
@@ -29,7 +29,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -97,6 +96,7 @@ public class SaveScoringResponseUseCase {
                 );
             });
 
+        var SCORING_NOT_AVAILABLE = -1.0;
         var averageScore = BigDecimal
             .valueOf(
                 assetsSummary
@@ -104,7 +104,7 @@ public class SaveScoringResponseUseCase {
                     .filter(summary -> summary.score() != null)
                     .mapToDouble(ScoringReport.Summary::score)
                     .average()
-                    .orElse(0.0)
+                    .orElse(SCORING_NOT_AVAILABLE)
             )
             .setScale(2, RoundingMode.HALF_EVEN);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -104,9 +104,6 @@ public class ScoreApiRequestUseCase {
                     )
             )
             .flatMapCompletable(request -> {
-                if (request.assets().isEmpty()) {
-                    return Completable.complete();
-                }
                 var job = newScoringJob(request.jobId(), input.auditInfo, input.apiId);
                 return scoringProvider.requestScore(request).doOnComplete(() -> asyncJobCrudService.create(job));
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/GetLatestReportUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/GetLatestReportUseCaseTest.java
@@ -181,9 +181,24 @@ class GetLatestReportUseCaseTest {
                             VALIDATION_ERROR_ASSET.errors()
                         )
                     ),
-                    new ScoringReportView.Summary(0D, 0L, 0L, 0L, 0L)
+                    null
                 )
             );
+    }
+
+    @Test
+    void should_return_no_summary_when_no_scoreable_asset() {
+        // Given
+        givenExistingScoringReports(noScoreableAssetReport());
+
+        // When
+        var report = useCase.execute(new GetLatestReportUseCase.Input(API_ID));
+
+        // Then
+        Assertions
+            .assertThat(report)
+            .extracting(GetLatestReportUseCase.Output::report)
+            .isEqualTo(new ScoringReportView(REPORT_ID, API_ID, CREATED_AT, List.of(), null));
     }
 
     private static ScoringReport aReport() {
@@ -205,8 +220,20 @@ class GetLatestReportUseCaseTest {
             .id(REPORT_ID)
             .apiId(API_ID)
             .createdAt(CREATED_AT)
-            .summary(new ScoringReport.Summary(0D, 0L, 0L, 0L, 0L))
+            .summary(new ScoringReport.Summary(-1.0D, 0L, 0L, 0L, 0L))
             .assets(List.of(VALIDATION_ERROR_ASSET))
+            .build();
+    }
+
+    private static ScoringReport noScoreableAssetReport() {
+        return ScoringReportFixture
+            .aScoringReport()
+            .toBuilder()
+            .id(REPORT_ID)
+            .apiId(API_ID)
+            .createdAt(CREATED_AT)
+            .summary(new ScoringReport.Summary(-1.0D, 0L, 0L, 0L, 0L))
+            .assets(List.of())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/SaveScoringResponseUseCaseTest.java
@@ -230,7 +230,7 @@ class SaveScoringResponseUseCaseTest {
         // Then
         assertThat(scoringReportCrudService.storage())
             .extracting(ScoringReport::summary)
-            .contains((new ScoringReport.Summary(0.0D, 0L, 0L, 0L, 0L)));
+            .contains((new ScoringReport.Summary(-1.0D, 0L, 0L, 0L, 0L)));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8301

## Description

The task was initially made as part of https://gravitee.atlassian.net/browse/APIM-7712 but eventually moved to a separate issue. The purpose of this task is to handle better some API Scoring status scenarios.


## Additional Info 

### API Never Scored 
![image](https://github.com/user-attachments/assets/1d2176d8-ba39-4b8d-a03d-a86d6a4b0569)

### API Score with only execution errors
![image](https://github.com/user-attachments/assets/0a2a081d-f695-493c-a8b2-9eaa22c85fc8)

### API Score evaluated but no scoreable asset found
![image](https://github.com/user-attachments/assets/686d8325-3304-40f0-9bbc-d4136ed1c83b)

### Hybrid scenario where some assets were successfully evaluated but some returned technical issues
![image](https://github.com/user-attachments/assets/8c0a88a5-c4c2-488f-9f34-6fa367556888)




<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aoatqlhdbw.chromatic.com)
<!-- Storybook placeholder end -->
