### PR TITLE
fix: bump gravitee-endpoint-kafka to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
         <gravitee-entrypoint-sse.version>5.0.0</gravitee-entrypoint-sse.version>
         <gravitee-entrypoint-webhook.version>4.0.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
-        <gravitee-endpoint-kafka.version>3.0.0</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>4.0.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>3.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>2.0.0</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>2.0.0</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7502

## Description

Bump kafka endpoint version with support secret feature.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tiuxfoqamc.chromatic.com)
<!-- Storybook placeholder end -->
