### PR TITLE
fix: update ProxyEndpointResolver to resolve endpoint using simple name

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolver.java
@@ -106,9 +106,19 @@ public class ProxyEndpointResolver implements EndpointResolver {
         } else {
             int refSeparatorIdx = uri.indexOf(':');
 
+            String endpointName;
+            String uriPath;
+
+            if (refSeparatorIdx > 0) {
+                endpointName = uri.substring(0, refSeparatorIdx);
+                uriPath = uri.substring(refSeparatorIdx + 1);
+            } else {
+                endpointName = uri;
+                uriPath = "";
+            }
+
             // Get the full reference
-            String sRef = uri.substring(0, refSeparatorIdx);
-            final Reference reference = referenceRegister.lookup(sRef);
+            final Reference reference = referenceRegister.lookup(endpointName);
 
             // A null reference has been found (unknown reference ?), returning null to the caller
             if (reference == null) {
@@ -122,7 +132,7 @@ public class ProxyEndpointResolver implements EndpointResolver {
                 return null;
             }
 
-            return new UserDefinedProxyEndpoint(endpoint, getMergedTarget(endpoint.target(), uri.substring(refSeparatorIdx + 1)));
+            return new UserDefinedProxyEndpoint(endpoint, getMergedTarget(endpoint.target(), uriPath));
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManager.java
@@ -250,8 +250,8 @@ public class DefaultEndpointManager extends AbstractService<EndpointManager> imp
             final ManagedEndpoint managedEndpoint = new DefaultManagedEndpoint(endpoint, managedEndpointGroup, connector);
             managedEndpointGroup.addManagedEndpoint(managedEndpoint);
             endpointsByName.put(endpoint.getName(), managedEndpoint);
-            endpointVariables.put(endpoint.getName(), endpoint.getName() + ":");
-            endpointVariables.put(managedEndpointGroup.getDefinition().getName(), managedEndpointGroup.getDefinition().getName() + ":");
+            endpointVariables.put(endpoint.getName(), endpoint.getName());
+            endpointVariables.put(managedEndpointGroup.getDefinition().getName(), managedEndpointGroup.getDefinition().getName());
 
             listeners.values().forEach(l -> l.accept(Event.ADD, managedEndpoint));
         } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolverTest.java
@@ -66,6 +66,40 @@ public class ProxyEndpointResolverTest {
     }
 
     @Test
+    public void shouldResolveUserDefinedEndpoint() {
+        var endpointName = "my-endpoint";
+        var expectedUri = "http://endpoint:8080/test";
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.name()).thenReturn(endpointName);
+        when(endpoint.target()).thenReturn(expectedUri);
+        referenceRegister.add(new EndpointReference(endpoint));
+
+        ProxyEndpoint proxyEndpoint = resolver.resolve(endpointName);
+        assertThat(proxyEndpoint).isNotNull();
+
+        ProxyRequest proxyRequest = proxyEndpoint.createProxyRequest(mock((Request.class)));
+        assertThat(proxyRequest.uri()).isEqualTo(expectedUri);
+    }
+
+    @Test
+    public void shouldResolveUserDefinedEndpoint_withPath() {
+        var endpointName = "my-endpoint";
+        var endpointTarget = "http://endpoint:8080/test";
+
+        Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.name()).thenReturn(endpointName);
+        when(endpoint.target()).thenReturn(endpointTarget);
+        referenceRegister.add(new EndpointReference(endpoint));
+
+        ProxyEndpoint proxyEndpoint = resolver.resolve(endpointName + ":/echo");
+        assertThat(proxyEndpoint).isNotNull();
+
+        ProxyRequest proxyRequest = proxyEndpoint.createProxyRequest(mock((Request.class)));
+        assertThat(proxyRequest.uri()).isEqualTo(endpointTarget + "/echo");
+    }
+
+    @Test
     // : is forbidden thanks to https://github.com/gravitee-io/issues/issues/1939
     public void shouldResolveUserDefinedEndpoint_withPointsInName() {
         String requestEndpoint = "lo:cal:";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManagerTest.java
@@ -175,12 +175,12 @@ class DefaultEndpointManagerTest {
             verify(templateContext).setVariable(eq("endpoints"), endpointsCaptor.capture());
 
             assertThat(endpointsCaptor.getValue())
-                .containsEntry("group1", "group1:")
-                .containsEntry("endpoint1", "endpoint1:")
-                .containsEntry("endpoint2", "endpoint2:")
-                .containsEntry("group2", "group2:")
-                .containsEntry("endpoint3", "endpoint3:")
-                .containsEntry("endpoint4", "endpoint4:");
+                .containsEntry("group1", "group1")
+                .containsEntry("endpoint1", "endpoint1")
+                .containsEntry("endpoint2", "endpoint2")
+                .containsEntry("group2", "group2")
+                .containsEntry("endpoint3", "endpoint3")
+                .containsEntry("endpoint4", "endpoint4");
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- update ProxyEndpointResolver to resolve endpoint using simple name:

To resolve the endpoint, we needed to provide a string "my-endpoint:." The colon was mandatory.
This change allows you to search for an endpoint with a simple name.
This will allow the Traffic Shadowing policy to use a simple endpoint name in its configuration instead of using an EL:
"{#endpoints['myendpoint'}"

- do not append colon in endpoint name for EL resolution

A colon was appended to the endpoint name in the map used by EL resolution. With Jeoffrey we didn't find why (we think it was copied from the v3 engine)

This change is required to migrate the Traffic Shadowing policy for
reactive engine.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

