### PR TITLE
APIM 8138 fix: add validation for retry configuration while creating subscription

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -31,6 +31,7 @@ import { ConnectorPluginsV2Service } from '../../../../../../services-ngx/connec
 import { IconService } from '../../../../../../services-ngx/icon.service';
 import { SubscriptionService } from '../../../../../../services-ngx/subscription.service';
 import { SubscriptionPage } from '../../../../../../entities/subscription/subscription';
+import { SnackBarService } from '../../../../../../services-ngx/snack-bar.service';
 
 export type ApiPortalSubscriptionCreationDialogData = {
   availableSubscriptionEntrypoints?: Entrypoint[];
@@ -74,6 +75,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
     private readonly subscriptionService: SubscriptionService,
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
     private readonly iconService: IconService,
+    private readonly snackBarService: SnackBarService,
   ) {
     this.plans = dialogData.plans.filter((plan) => plan.security?.type !== 'KEY_LESS');
     this.availableSubscriptionEntrypoints = dialogData.availableSubscriptionEntrypoints.map((entrypoint) => ({ type: entrypoint.type }));
@@ -122,7 +124,17 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
           : undefined),
       },
     };
-    this.dialogRef.close(dialogResult);
+    // Validate retry configuration
+    const retryConfiguration = this.form.getRawValue().entrypointConfiguration?.retry;
+    if (
+      retryConfiguration &&
+      retryConfiguration?.retryOption === 'Retry On Fail' &&
+      retryConfiguration?.initialDelaySeconds > retryConfiguration?.maxDelaySeconds
+    ) {
+      this.snackBarService.error('Initial retry delay should be less than maximum delay between attempts.');
+    } else {
+      this.dialogRef.close(dialogResult);
+    }
   }
 
   ngOnDestroy() {

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.harness.ts
@@ -43,6 +43,19 @@ export class ApiPortalSubscriptionCreationDialogHarness extends MatDialogHarness
   protected getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__cancelBtn' }));
   public getCreateButton = this.locatorFor(MatButtonHarness.with({ selector: '.actions__createBtn' }));
 
+  protected getInitialDelayInput = this.locatorForOptional(MatInputHarness.with({ selector: '[id*="initialDelaySeconds"]' }));
+  protected getMaxDelayInput = this.locatorForOptional(MatInputHarness.with({ selector: '[id*="maxDelaySeconds"]' }));
+
+  public async addInitialDelay(initialDelay: string) {
+    const matInputHarness = await this.getInitialDelayInput();
+    return await matInputHarness.setValue(initialDelay);
+  }
+
+  public async addMaxDelay(maxDelay: string) {
+    const matInputHarness = await this.getMaxDelayInput();
+    return await matInputHarness.setValue(maxDelay);
+  }
+
   // Applications
   public async searchApplication(applicationNameToSearch: string) {
     const matInputHarness = await this.getInputApplicationSearch();

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.0</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>4.0.0</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>4.0.1</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>4.0.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>3.0.0</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8138

## Description

Added validation for retry configuration that is initial Delay should be less than maxDelay.
If validated, dialog is closed and subscription is created else dialog remains open with a snack bar error (User can close the dialog via cancel though).

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xjsdupdnsg.chromatic.com)
<!-- Storybook placeholder end -->
