### PR TITLE
Apim 7444 enable documentation mode for portal

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -29,6 +29,9 @@ export function fakePortalSettings(attributes?: Partial<PortalSettings>): Portal
         tilesMode: {
           enabled: true,
         },
+        documentationOnlyMode: {
+          enabled: false,
+        },
         categoryMode: {
           enabled: true,
         },

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -70,6 +70,9 @@ export interface PortalSettingsPortal {
     tilesMode: {
       enabled: boolean;
     };
+    documentationOnlyMode: {
+      enabled: boolean;
+    };
     categoryMode: {
       enabled: boolean;
     };

--- a/gravitee-apim-console-webui/src/management/settings/api-portal-header/api-portal-header.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/api-portal-header/api-portal-header.component.spec.ts
@@ -111,6 +111,9 @@ describe('ApiPortalHeaderComponent', () => {
             apiHeaderShowTags: {
               enabled: true,
             },
+            documentationOnlyMode: {
+              enabled: true,
+            },
             apiHeaderShowCategories: {
               enabled: false,
             },
@@ -162,6 +165,9 @@ describe('ApiPortalHeaderComponent', () => {
         portal: {
           apis: {
             apiHeaderShowTags: {
+              enabled: true,
+            },
+            documentationOnlyMode: {
               enabled: true,
             },
             apiHeaderShowCategories: {
@@ -218,6 +224,9 @@ describe('ApiPortalHeaderComponent', () => {
               enabled: true,
             },
             tilesMode: {
+              enabled: true,
+            },
+            documentationOnlyMode: {
               enabled: true,
             },
             categoryMode: {
@@ -295,6 +304,9 @@ describe('ApiPortalHeaderComponent', () => {
             tilesMode: {
               enabled: true,
             },
+            documentationOnlyMode: {
+              enabled: true,
+            },
             categoryMode: {
               enabled: true,
             },
@@ -368,6 +380,9 @@ describe('ApiPortalHeaderComponent', () => {
             tilesMode: {
               enabled: true,
             },
+            documentationOnlyMode: {
+              enabled: true,
+            },
             categoryMode: {
               enabled: true,
             },
@@ -439,6 +454,9 @@ describe('ApiPortalHeaderComponent', () => {
               enabled: true,
             },
             tilesMode: {
+              enabled: true,
+            },
+            documentationOnlyMode: {
               enabled: true,
             },
             categoryMode: {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -229,6 +229,25 @@
               aria-label="Use Tiles Mode for apis by default (if not overridden by user)"
             ></mat-slide-toggle>
           </gio-form-slide-toggle>
+          <gio-form-slide-toggle
+            formGroupName="documentationOnlyMode"
+            [matTooltip]="
+              'Toggling documentation-only mode restricts access to applications, dashboards, and API subscriptions in the developer portal.'
+            "
+            [matTooltipDisabled]="!isReadonly('portal.apis.documentationOnlyMode.enabled')"
+            class="portal__form__card__form-field"
+          >
+            <gio-form-label
+              >Use documentation-only mode to restrict access to applications, dashboards, and API subscriptions in the developer
+              portal</gio-form-label
+            >
+            <mat-slide-toggle
+              formControlName="enabled"
+              gioFormSlideToggle
+              aria-label="Toggling documentation-only mode restricts access to applications, dashboards, and API subscriptions in the developer portal."
+            >
+            </mat-slide-toggle>
+          </gio-form-slide-toggle>
         </div>
         <gio-form-slide-toggle
           formGroupName="support"

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -77,6 +77,9 @@ interface PortalForm {
       tilesMode: FormGroup<{
         enabled: FormControl<boolean>;
       }>;
+      documentationOnlyMode: FormGroup<{
+        enabled: FormControl<boolean>;
+      }>;
     }>;
     support: FormGroup<{
       enabled: FormControl<boolean>;
@@ -313,6 +316,12 @@ export class PortalSettingsComponent implements OnInit {
             enabled: new FormControl({
               value: this.settings.portal.apis.tilesMode.enabled,
               disabled: this.isReadonly('portal.apis.tilesMode.enabled'),
+            }),
+          }),
+          documentationOnlyMode: new FormGroup({
+            enabled: new FormControl({
+              value: this.settings.portal.apis.documentationOnlyMode.enabled,
+              disabled: this.isReadonly('portal.apis.documentationOnlyMode.enabled'),
             }),
           }),
         }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -56,6 +56,11 @@ public enum Key {
     PORTAL_ANALYTICS_ENABLED("portal.analytics.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_ANALYTICS_TRACKINGID("portal.analytics.trackingId", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
     PORTAL_APIS_TILESMODE_ENABLED("portal.apis.tilesMode.enabled", "true", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    PORTAL_APIS_DOCUMENTATIONONLYMODE_ENABLED(
+        "portal.apis.documentationOnlyMode.enabled",
+        "false",
+        Set.of(ENVIRONMENT, ORGANIZATION, SYSTEM)
+    ),
     PORTAL_APIS_CATEGORY_ENABLED(
         "portal.apis.categoryMode.enabled",
         "true",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Portal.java
@@ -109,6 +109,9 @@ public class Portal {
         @ParameterKey(Key.PORTAL_APIS_TILESMODE_ENABLED)
         private Enabled tilesMode;
 
+        @ParameterKey(Key.PORTAL_APIS_DOCUMENTATIONONLYMODE_ENABLED)
+        private Enabled documentationOnlyMode;
+
         @ParameterKey(Key.PORTAL_APIS_CATEGORY_ENABLED)
         private Enabled categoryMode;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7444

## Description

This pull request includes changes required to enable document-only mode in the console portal APIs settings. It does not include the complete changes to build the feature. The changes it includes are :

1. Adding a UI element to enable/disable the document-only mode in the console settings.
2. Read/update the boolean field `documentOnlyMode` via already available portal settings resources.

## Additional context
The changes required to show/hide/restrict certain features in developer portal based on the value of `documentOnlyMode` will be merged via a separate pull request.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xpkszsthqa.chromatic.com)
<!-- Storybook placeholder end -->
