### PR TITLE
test: add integration test using Kafka endpoint and secret

### DIFF
--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-get/http-get-entrypoint-kafka-endpoint-secret.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-get/http-get-entrypoint-kafka-endpoint-secret.json
@@ -1,0 +1,57 @@
+{
+  "id": "http-get-entrypoint-kafka-endpoint-secret",
+  "name": "my-api-secret-conf",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using HTTP-GET entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount": 3,
+            "messagesLimitDurationMs": 10000,
+            "headersInPayload": true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "kafka",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "{#secrets.get('/vault/secret/kafka:bootstrap')}"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"],
+              "autoOffsetReset": "earliest"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7502

## Description

Add one integration test to validate Kafka endpoint with secret feature (using Vault). The Kafka bootstrap server is declared as a secret in the API definition and stored in Vault.

