### PR TITLE
fix(gateway): fix memory leak on acceptors while deploy and undeploy API

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -79,6 +79,8 @@ public class ApiReactorHandler extends AbstractReactorHandler<Api> {
 
     private final AtomicInteger pendingRequests = new AtomicInteger(0);
 
+    private List<Acceptor<?>> acceptors;
+
     private long pendingRequestsTimeout;
     private final Configuration configuration;
     private final AccessPointManager accessPointManager;
@@ -443,30 +445,35 @@ public class ApiReactorHandler extends AbstractReactorHandler<Api> {
 
     @Override
     public List<Acceptor<?>> acceptors() {
-        return reactable
-            .getDefinition()
-            .getProxy()
-            .getVirtualHosts()
-            .stream()
-            .map(virtualHost -> {
-                if (virtualHost.getHost() != null) {
-                    return new DefaultHttpAcceptor(
-                        virtualHost.getHost(),
-                        virtualHost.getPath(),
-                        this,
-                        reactable.getDefinition().getProxy().getServers()
-                    );
-                } else {
-                    return new AccessPointHttpAcceptor(
-                        eventManager,
-                        reactable.getEnvironmentId(),
-                        accessPointManager.getByEnvironmentId(reactable.getEnvironmentId()),
-                        virtualHost.getPath(),
-                        this,
-                        reactable.getDefinition().getProxy().getServers()
-                    );
-                }
-            })
-            .collect(Collectors.toList());
+        if (acceptors == null) {
+            acceptors =
+                reactable
+                    .getDefinition()
+                    .getProxy()
+                    .getVirtualHosts()
+                    .stream()
+                    .map(virtualHost -> {
+                        if (virtualHost.getHost() != null) {
+                            return new DefaultHttpAcceptor(
+                                virtualHost.getHost(),
+                                virtualHost.getPath(),
+                                this,
+                                reactable.getDefinition().getProxy().getServers()
+                            );
+                        } else {
+                            return new AccessPointHttpAcceptor(
+                                eventManager,
+                                reactable.getEnvironmentId(),
+                                accessPointManager.getByEnvironmentId(reactable.getEnvironmentId()),
+                                virtualHost.getPath(),
+                                this,
+                                reactable.getDefinition().getProxy().getServers()
+                            );
+                        }
+                    })
+                    .collect(Collectors.toList());
+        }
+
+        return acceptors;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -116,6 +116,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     private final long pendingRequestsTimeout;
     protected AnalyticsContext analyticsContext;
     protected SecurityChain securityChain;
+    protected List<Acceptor<?>> acceptors;
 
     public SyncApiReactor(
         final Api api,
@@ -376,31 +377,36 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     @Override
     public List<Acceptor<?>> acceptors() {
         try {
-            return api
-                .getDefinition()
-                .getProxy()
-                .getVirtualHosts()
-                .stream()
-                .map(virtualHost -> {
-                    if (virtualHost.getHost() != null) {
-                        return new DefaultHttpAcceptor(
-                            virtualHost.getHost(),
-                            virtualHost.getPath(),
-                            this,
-                            api.getDefinition().getProxy().getServers()
-                        );
-                    } else {
-                        return new AccessPointHttpAcceptor(
-                            eventManager,
-                            api.getEnvironmentId(),
-                            accessPointManager.getByEnvironmentId(api.getEnvironmentId()),
-                            virtualHost.getPath(),
-                            this,
-                            api.getDefinition().getProxy().getServers()
-                        );
-                    }
-                })
-                .collect(Collectors.toList());
+            if (acceptors == null) {
+                acceptors =
+                    api
+                        .getDefinition()
+                        .getProxy()
+                        .getVirtualHosts()
+                        .stream()
+                        .map(virtualHost -> {
+                            if (virtualHost.getHost() != null) {
+                                return new DefaultHttpAcceptor(
+                                    virtualHost.getHost(),
+                                    virtualHost.getPath(),
+                                    this,
+                                    api.getDefinition().getProxy().getServers()
+                                );
+                            } else {
+                                return new AccessPointHttpAcceptor(
+                                    eventManager,
+                                    api.getEnvironmentId(),
+                                    accessPointManager.getByEnvironmentId(api.getEnvironmentId()),
+                                    virtualHost.getPath(),
+                                    this,
+                                    api.getDefinition().getProxy().getServers()
+                                );
+                            }
+                        })
+                        .collect(Collectors.toList());
+            }
+
+            return acceptors;
         } catch (Exception ex) {
             return Collections.emptyList();
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactor.java
@@ -105,13 +105,17 @@ public class DebugSyncApiReactor extends SyncApiReactor {
     @Override
     public List<Acceptor<?>> acceptors() {
         try {
-            return api
-                .getDefinition()
-                .getProxy()
-                .getVirtualHosts()
-                .stream()
-                .map(virtualHost -> new DefaultHttpAcceptor(null, virtualHost.getPath(), this, null))
-                .collect(Collectors.toList());
+            if (acceptors == null) {
+                acceptors =
+                    api
+                        .getDefinition()
+                        .getProxy()
+                        .getVirtualHosts()
+                        .stream()
+                        .map(virtualHost -> new DefaultHttpAcceptor(null, virtualHost.getPath(), this, null))
+                        .collect(Collectors.toList());
+            }
+            return acceptors;
         } catch (Exception ex) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7786

## Description

every time when V2 with and without emulation engine is being deployed or undeployed the AccessPointHttpAcceptor is recreated causing memory leak and in the end out of memory error 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

