### PR TITLE
feat: add new custom ruleset formats: OPENAPI, ASYNCAPI

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringRuleset.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ScoringRuleset.java
@@ -49,5 +49,7 @@ public final class ScoringRuleset {
         GRAVITEE_FEDERATION,
         GRAVITEE_MESSAGE,
         GRAVITEE_PROXY,
+        OPENAPI,
+        ASYNCAPI,
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ScoringRulesetMongo.java
@@ -31,6 +31,8 @@ public class ScoringRulesetMongo extends Auditable {
         GRAVITEE_FEDERATION,
         GRAVITEE_MESSAGE,
         GRAVITEE_PROXY,
+        OPENAPI,
+        ASYNCAPI,
     }
 
     @Id

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -603,14 +603,17 @@ components:
                     description: The ruleset payload
                 format:
                     type: string
-                    description: Format is required only for rulesets that should be applied to a Gravitee definition. For native oas/async api rulesets this property must be null.
+                    description: The format of the ruleset
                     enum:
                         - GRAVITEE_FEDERATION
                         - GRAVITEE_MESSAGE
                         - GRAVITEE_PROXY
+                        - OPENAPI
+                        - ASYNCAPI
             required:
               - name
               - payload
+              - format
         UpdateScoringRuleset:
             type: object
             description: The scoring ruleset to update
@@ -645,6 +648,8 @@ components:
                         - GRAVITEE_FEDERATION
                         - GRAVITEE_MESSAGE
                         - GRAVITEE_PROXY
+                        - OPENAPI
+                        - ASYNCAPI
                 createdAt:
                     type: string
                     format: date-time

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoringRuleset.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/model/ScoringRuleset.java
@@ -39,5 +39,7 @@ public record ScoringRuleset(
         GRAVITEE_FEDERATION,
         GRAVITEE_MESSAGE,
         GRAVITEE_PROXY,
+        OPENAPI,
+        ASYNCAPI,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -145,16 +145,18 @@ public class ScoreApiRequestUseCase {
         if (StringUtils.isEmpty(scoringRuleset.payload())) {
             return Maybe.empty();
         }
-        return scoringRuleset.format() != null
-            ? Maybe.just(new ScoreRequest.CustomRuleset(scoringRuleset.payload(), format(scoringRuleset.format())))
-            : Maybe.just(new ScoreRequest.CustomRuleset(scoringRuleset.payload()));
+        return Maybe.just(new ScoreRequest.CustomRuleset(scoringRuleset.payload(), format(scoringRuleset.format())));
     }
 
     private ScoreRequest.Format format(ScoringRuleset.Format format) {
+        if (format == null) {
+            return null;
+        }
         return switch (format) {
             case GRAVITEE_FEDERATION -> ScoreRequest.Format.GRAVITEE_FEDERATED;
             case GRAVITEE_MESSAGE -> ScoreRequest.Format.GRAVITEE_MESSAGE;
             case GRAVITEE_PROXY -> ScoreRequest.Format.GRAVITEE_PROXY;
+            case OPENAPI, ASYNCAPI -> null;
         };
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
@@ -74,6 +74,9 @@ class ScoreApiRequestUseCaseTest {
         .aRuleset("ruleset1", ScoringRuleset.Format.GRAVITEE_FEDERATION)
         .withReferenceId(ENVIRONMENT_ID);
     private static final ScoringRuleset CUSTOM_RULESET_2 = ScoringRulesetFixture.aRuleset("ruleset2", null).withReferenceId(ENVIRONMENT_ID);
+    private static final ScoringRuleset CUSTOM_RULESET_3 = ScoringRulesetFixture
+        .aRuleset("ruleset3", ScoringRuleset.Format.ASYNCAPI)
+        .withReferenceId(ENVIRONMENT_ID);
 
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     AsyncJobCrudServiceInMemory asyncJobCrudService = new AsyncJobCrudServiceInMemory();
@@ -318,7 +321,7 @@ class ScoreApiRequestUseCaseTest {
     public void should_trigger_scoring_with_custom_rulesets() {
         // Given
         var api = givenExistingApi(ApiFixtures.aFederatedApi());
-        givenExistingRulesets(CUSTOM_RULESET_1, CUSTOM_RULESET_2);
+        givenExistingRulesets(CUSTOM_RULESET_1, CUSTOM_RULESET_2, CUSTOM_RULESET_3);
 
         // When
         scoreApiRequestUseCase
@@ -337,7 +340,8 @@ class ScoreApiRequestUseCaseTest {
                     .hasApiId(api.getId())
                     .hasCustomRulesets(
                         new ScoreRequest.CustomRuleset(CUSTOM_RULESET_1.payload(), ScoreRequest.Format.GRAVITEE_FEDERATED),
-                        new ScoreRequest.CustomRuleset(CUSTOM_RULESET_2.payload())
+                        new ScoreRequest.CustomRuleset(CUSTOM_RULESET_2.payload()),
+                        new ScoreRequest.CustomRuleset(CUSTOM_RULESET_3.payload())
                     );
             });
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8299

## Description

Add new formats for API Score custom rulesets: OPENAPI and ASYNCAPI 

## Additional context

These custom ruleset formats are just for APIM purposes and user convenience. We don't send them to Spectral since they wouldn't be respected by it anyway. Users can still upload the OPEANAPI format custom ruleset containing rules for openapi and asyncapi in a single file. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vuqovpfufp.chromatic.com)
<!-- Storybook placeholder end -->
