### PR TITLE
Try to fix sqlserver 2017 repo tests

### DIFF
--- a/.circleci/ci/src/executors/executor-ubuntu.ts
+++ b/.circleci/ci/src/executors/executor-ubuntu.ts
@@ -19,8 +19,12 @@ import { Executor } from '@circleci/circleci-config-sdk/dist/src/lib/Components/
 import { MachineResourceClass } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Executors/types/MachineExecutor.types';
 
 export class UbuntuExecutor {
-  public static create(resource: MachineResourceClass = 'medium', useDockerLayerCaching: boolean = false): Executor {
-    const image = `ubuntu-${config.executor.ubuntu.version}:${config.executor.ubuntu.tag}`;
+  public static create(
+    resource: MachineResourceClass = 'medium',
+    useDockerLayerCaching: boolean = false,
+    imageTag: string = config.executor.ubuntu.tag,
+  ): Executor {
+    const image = `ubuntu-${config.executor.ubuntu.version}:${imageTag}`;
     return new executors.MachineExecutor(resource, image, useDockerLayerCaching);
   }
 }

--- a/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
@@ -33,7 +33,7 @@ export class JdbcTestContainerJob extends AbstractTestContainerJob {
         command: `cd gravitee-apim-repository
 mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../${config.maven.settingsFile} clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.jdbcType>> -T 2C`,
       }),
-      UbuntuExecutor.create('medium', true),
+      UbuntuExecutor.create('medium', true, '2024.08.1'),
     );
   }
 }

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -121,7 +121,7 @@ jobs:
         default: ""
         description: "Type and version of the database to test. Example: mariadb:10.5"
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2024.08.1
       docker_layer_caching: true
     resource_class: medium
     steps:


### PR DESCRIPTION
## Issue

N/A

## Description

Since 1st of December 2024, the Ubuntu executor used in our CicleCI pipeline for repository tests is in version 2024.11.1 (before it was 2024.08.1), see https://discuss.circleci.com/t/ubuntu-20-04-22-04-24-04-q4-edge-release/52429

Hard-coding the version of the executor fix the issue we have regarding SQLServer 2017.
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/49050/workflows/2adb4b83-f7b0-454c-af1d-fa79b52e8fb7

One of the difference between executors version is that docker version has been updated from 26.1.4 to 27.3.1. It could be the reason why the DB container is not starting
 - https://github.com/microsoft/mssql-docker/issues/858
 - https://github.com/microsoft/mssql-docker/issues/868

```
10:49:36.897 ERROR: [main] [t.m.m.com/mssql/server:2017-latest] : Log output from the failed container:
SQL Server 2017 will run as non-root by default.
This container is running as user root.
To learn more visit https://go.microsoft.com/fwlink/?linkid=2099216.
This program has encountered a fatal error and cannot continue running at Wed Jan 15 10:45:37 2025
The following diagnostic information is available:

         Reason: 0x00000001
         Signal: SIGABRT - Aborted (6)
          Stack:
                 IP               Function
                 ---------------- --------------------------------------
                 000060bc16be1dbc <unknown>
                 000060bc16be1802 <unknown>
                 000060bc16be0e11 <unknown>
                 0000773148613f10 killpg+0x40
                 0000773148613e87 gsignal+0xc7
                 00007731486157f1 abort+0x141
                 000060bc16b63242 <unknown>
                 000060bc16bf3c14 <unknown>
                 000060bc16c241f8 <unknown>
                 000060bc16c23fda <unknown>
                 000060bc16b6f0ba <unknown>
                 000060bc16b6ed0f <unknown>
        Process: 8 - sqlservr
         Thread: 13 (application thread 0x8)
    Instance Id: f66bc71b-12af-4697-9c49-21704657ad20
       Crash Id: 2c81b799-50cf-4263-b317-c3fa6564b253
    Build stamp: d277ec5d156ed2c28745014dfc4c14e2f46d731c05c5ca459ea00c9760516508
   Distribution: Ubuntu 18.04.6 LTS
     Processors: 2
   Total Memory: 8158879744 bytes
      Timestamp: Wed Jan 15 10:45:37 2025
     Last errno: 2
Last errno text: No such file or directory
```

This PR introduce a new parameter in the CI to allow specifying the machine executor version. It is then used to fix the version of the JDBC repository tests job.