### PR TITLE
Revert "fix: do not append colon in endpoint name for EL resolution"

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManager.java
@@ -250,8 +250,8 @@ public class DefaultEndpointManager extends AbstractService<EndpointManager> imp
             final ManagedEndpoint managedEndpoint = new DefaultManagedEndpoint(endpoint, managedEndpointGroup, connector);
             managedEndpointGroup.addManagedEndpoint(managedEndpoint);
             endpointsByName.put(endpoint.getName(), managedEndpoint);
-            endpointVariables.put(endpoint.getName(), endpoint.getName());
-            endpointVariables.put(managedEndpointGroup.getDefinition().getName(), managedEndpointGroup.getDefinition().getName());
+            endpointVariables.put(endpoint.getName(), endpoint.getName() + ":");
+            endpointVariables.put(managedEndpointGroup.getDefinition().getName(), managedEndpointGroup.getDefinition().getName() + ":");
 
             listeners.values().forEach(l -> l.accept(Event.ADD, managedEndpoint));
         } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/endpoint/DefaultEndpointManagerTest.java
@@ -175,12 +175,12 @@ class DefaultEndpointManagerTest {
             verify(templateContext).setVariable(eq("endpoints"), endpointsCaptor.capture());
 
             assertThat(endpointsCaptor.getValue())
-                .containsEntry("group1", "group1")
-                .containsEntry("endpoint1", "endpoint1")
-                .containsEntry("endpoint2", "endpoint2")
-                .containsEntry("group2", "group2")
-                .containsEntry("endpoint3", "endpoint3")
-                .containsEntry("endpoint4", "endpoint4");
+                .containsEntry("group1", "group1:")
+                .containsEntry("endpoint1", "endpoint1:")
+                .containsEntry("endpoint2", "endpoint2:")
+                .containsEntry("group2", "group2:")
+                .containsEntry("endpoint3", "endpoint3:")
+                .containsEntry("endpoint4", "endpoint4:");
         }
 
         @Test


### PR DESCRIPTION
## Description

This reverts commit c932923d08a14f30dc08082b7e78e07eb406ec74 from https://github.com/gravitee-io/gravitee-api-management/pull/10347

This was breaking the Failover feature


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

