### PR TITLE
fix: missing never evaluated info for newly created APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.html
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.html
@@ -116,8 +116,10 @@
             [subtitle]="'This API\'s assets did not match any rulesets.'"
           ></gio-card-empty-state>
         }
-        @for (asset of apiScoring.assets; track asset.name) {
-          <app-api-scoring-list [asset]="asset"></app-api-scoring-list>
+        @if (apiScoreAvailable) {
+          @for (asset of apiScoring.assets; track asset.name) {
+            <app-api-scoring-list [asset]="asset"></app-api-scoring-list>
+          }
         }
       </section>
     </mat-card-content>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8388

## Description

This is a fix for a case when a newly created API has never been scored and we want to display proper information to the customer. 




<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yhbgvtdtik.chromatic.com)
<!-- Storybook placeholder end -->
