### PR TITLE
make PS can set the queryParams apiProtocolType to get schema & documentation

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/apiProtocolType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plugin/apiProtocolType.ts
@@ -13,4 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ApiV4 } from '../api';
+
 export type ApiProtocolType = 'HTTP_PROXY' | 'HTTP_MESSAGE' | 'NATIVE_KAFKA';
+
+export const getApiProtocolTypeFromApi = (api: ApiV4): ApiProtocolType => {
+  switch (api.type) {
+    case 'PROXY':
+      return 'HTTP_PROXY';
+    case 'MESSAGE':
+      return 'HTTP_MESSAGE';
+    case 'NATIVE':
+      return 'NATIVE_KAFKA';
+  }
+};

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -40,6 +40,7 @@ import { PolicyV2Service } from '../../../../services-ngx/policy-v2.service';
 import { ResourceTypeService } from '../../../../shared/components/form-json-schema-extended/resource-type.service';
 import { ApimFeature, UTMTags } from '../../../../shared/components/gio-license/gio-license-data';
 import { SharedPolicyGroupsService } from '../../../../services-ngx/shared-policy-groups.service';
+import { getApiProtocolTypeFromApi } from '../../../../entities/management-api-v2/plugin/apiProtocolType';
 
 @Component({
   selector: 'api-v4-policy-studio-design',
@@ -62,9 +63,9 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
 
   public trialURL: string;
 
-  public policySchemaFetcher: PolicySchemaFetcher = (policy) => this.policyV2Service.getSchema(policy.id);
+  public policySchemaFetcher: PolicySchemaFetcher;
 
-  public policyDocumentationFetcher: PolicyDocumentationFetcher = (policy) => this.policyV2Service.getDocumentation(policy.id);
+  public policyDocumentationFetcher: PolicyDocumentationFetcher;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -102,6 +103,9 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
       .subscribe(([api, entrypoints, endpoints, plans, policies, sharedPolicyGroupPolicyPlugins]) => {
         this.apiType = api.type;
         this.flowExecution = api.flowExecution;
+
+        this.policySchemaFetcher = (policy) => this.policyV2Service.getSchema(policy.id, getApiProtocolTypeFromApi(api));
+        this.policyDocumentationFetcher = (policy) => this.policyV2Service.getDocumentation(policy.id, getApiProtocolTypeFromApi(api));
 
         this.entrypointsInfo = api.listeners.flatMap((listener) =>
           listener.entrypoints.map((entrypoint) => {

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
@@ -65,6 +65,23 @@ describe('PolicyV2Service', () => {
 
       req.flush(policySchema);
     });
+
+    it('should call the API with apiProtocolType', (done) => {
+      const policyId = 'policy#1';
+      const policySchema = {};
+
+      policyService.getSchema(policyId, 'NATIVE_KAFKA').subscribe((response) => {
+        expect(response).toStrictEqual(policySchema);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/policy#1/schema?apiProtocolType=NATIVE_KAFKA`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(policySchema);
+    });
   });
 
   describe('getDocumentation', () => {
@@ -78,6 +95,23 @@ describe('PolicyV2Service', () => {
       });
 
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/policy#1/documentation`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(policyDocumentation);
+    });
+
+    it('should call the API with apiProtocolType', (done) => {
+      const policyId = 'policy#1';
+      const policyDocumentation = 'The Doc';
+
+      policyService.getDocumentation(policyId, 'NATIVE_KAFKA').subscribe((response) => {
+        expect(response).toStrictEqual(policyDocumentation);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/policy#1/documentation?apiProtocolType=NATIVE_KAFKA`,
+      );
       expect(req.request.method).toEqual('GET');
 
       req.flush(policyDocumentation);

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -21,6 +21,7 @@ import { map } from 'rxjs/operators';
 import { Constants } from '../entities/Constants';
 import { PolicyDocumentation, PolicyListItem, PolicySchema } from '../entities/policy';
 import { PolicyPlugin } from '../entities/management-api-v2';
+import { ApiProtocolType } from '../entities/management-api-v2/plugin/apiProtocolType';
 
 @Injectable({
   providedIn: 'root',
@@ -35,14 +36,23 @@ export class PolicyV2Service {
     return this.http.get<PolicyListItem[]>(`${this.constants.org.v2BaseURL}/plugins/policies`);
   }
 
-  getSchema(policyId: string): Observable<PolicySchema> {
-    return this.http.get<PolicySchema>(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/schema`);
+  getSchema(policyId: string, apiProtocolType?: ApiProtocolType): Observable<PolicySchema> {
+    let params = new HttpParams();
+    if (apiProtocolType) {
+      params = params.append('apiProtocolType', apiProtocolType);
+    }
+    return this.http.get<PolicySchema>(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/schema`, { params });
   }
 
-  getDocumentation(policyId: string): Observable<PolicyDocumentation> {
+  getDocumentation(policyId: string, apiProtocolType?: ApiProtocolType): Observable<PolicyDocumentation> {
+    let params = new HttpParams();
+    if (apiProtocolType) {
+      params = params.append('apiProtocolType', apiProtocolType);
+    }
     return this.http
       .get(`${this.constants.org.v2BaseURL}/plugins/policies/${policyId}/documentation`, {
         responseType: 'text',
+        params,
       })
       .pipe(map((buffer) => buffer.toString()));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -288,8 +288,8 @@
         <gravitee-service-secrets.version>1.0.0</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
 
-        <gravitee-policy-kafka-quota.version>1.0.1</gravitee-policy-kafka-quota.version>
-        <gravitee-policy-kafka-topic-mapping.version>1.0.1</gravitee-policy-kafka-topic-mapping.version>
+        <gravitee-policy-kafka-quota.version>1.0.2</gravitee-policy-kafka-quota.version>
+        <gravitee-policy-kafka-topic-mapping.version>1.0.2</gravitee-policy-kafka-topic-mapping.version>
         <gravitee-policy-kafka-acl.version>1.1.1</gravitee-policy-kafka-acl.version>
     </properties>
 


### PR DESCRIPTION
## Issue
n/a or already done

## Description

Use `apiProtocolType` to give a "preference" when retrieving a plugin's schema and documentation

chore: bump policy-kafka-quota & policy-kafka-topic-mapping to save bundle size , haha

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-slygbrcpak.chromatic.com)
<!-- Storybook placeholder end -->
