### PR TITLE
fix: add word break styles to container for text wrapping

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/page/_page.scss
@@ -383,6 +383,9 @@
 
 .toastui-editor-contents table td {
   border: 1px solid #eaeaea;
+  word-break: break-all; /* Break text at any character, including between letters */
+  overflow-wrap: break-word; /* Ensure text will break in the middle of words if needed */
+  white-space: normal;
 }
 
 .toastui-editor-contents table th {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-markdown/gv-page-markdown.component.css
@@ -100,3 +100,9 @@ app-gv-markdown-toc {
   color: var(--gv-theme-font-color-light, #ffffff);
   padding-top: 6px;
 }
+
+:host ::ng-deep table td {
+  word-break: break-all; /* Break text at any character, including between letters */
+  overflow-wrap: break-word; /* Ensure text will break in the middle of words if needed */
+  white-space: normal;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-7688

## Description
Added text overflow property to the API documentation

## Additional context

Before:
<img width="1728" alt="Screenshot 2025-01-24 at 4 07 21 PM" src="https://github.com/user-attachments/assets/88a1b56d-92c1-42c5-8876-d640c1531e0f" />

<img width="1728" alt="Screenshot 2025-01-24 at 4 02 54 PM" src="https://github.com/user-attachments/assets/feb12d23-8e94-4e38-a9d7-c7849d0d2cc1" />



After:
<img width="1728" alt="Screenshot 2025-01-24 at 3 56 24 PM" src="https://github.com/user-attachments/assets/e6781d45-b5da-492d-ba7f-7e05b09ca8f1" />

<img width="1728" alt="Screenshot 2025-01-24 at 3 57 19 PM" src="https://github.com/user-attachments/assets/cf1fbc9f-8474-47bd-9f56-d8166c402dad" />

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vndsdzyrud.chromatic.com)
<!-- Storybook placeholder end -->
