### PR TITLE
fix: set proper status after evaluating API Score

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/scoring/api-scoring.component.ts
@@ -120,9 +120,8 @@ export class ApiScoringComponent implements OnInit {
           if (!this.pendingScoreRequest) {
             this.stopPolling$.next();
 
-            if (apiScoring === undefined) {
-              this.apiScoreNeverEvaluated = true;
-            } else {
+            this.apiScoreNeverEvaluated = apiScoring === undefined;
+            if (!this.apiScoreNeverEvaluated) {
               this.evaluationErrors = this.getEvaluationErrors(apiScoring);
               if (this.evaluationErrors.length) {
                 this.snackBarService.error(this.formatEvaluationErrors(this.evaluationErrors));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-8436

## Description

The variable `apiScoreNeverEvaluated` wasn't set again after evaluating the API score, so to see the proper status, you had to refresh the Page. Now, it is set every time the evaluate button is hit. 



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rbewdxheuu.chromatic.com)
<!-- Storybook placeholder end -->
